### PR TITLE
Migrate to new substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 dependencies = [
  "block-cipher-trait",
- "byteorder 1.3.4",
+ "byteorder",
  "opaque-debug",
 ]
 
@@ -89,6 +89,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alga"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits 0.2.11",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +133,15 @@ dependencies = [
  "shell32-sys",
  "winapi 0.2.8",
  "xdg",
+]
+
+[[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -240,9 +260,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce6977f57fa68da77ffe5542950d47e9c23d65f5bc7cb0a9f8700996913eec7"
 dependencies = [
  "futures 0.3.4",
- "rustls",
+ "rustls 0.16.0",
  "webpki",
  "webpki-roots 0.17.0",
+]
+
+[[package]]
+name = "async-tls"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95fd83426b89b034bf4e9ceb9c533c2f2386b813fd3dcae0a425ec6f1837d78a"
+dependencies = [
+ "futures 0.3.4",
+ "rustls 0.17.0",
+ "webpki",
+ "webpki-roots 0.19.0",
 ]
 
 [[package]]
@@ -308,7 +340,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "safemem",
 ]
 
@@ -318,7 +350,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
 ]
 
 [[package]]
@@ -402,6 +434,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.1",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.1",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,7 +463,7 @@ checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder",
  "generic-array",
 ]
 
@@ -525,12 +579,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95ee6bba9d950218b6cc910cf62bc9e0a171d0f4537e3627b0f54d08549b188"
-
-[[package]]
-name = "bs58"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
@@ -564,12 +612,6 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-
-[[package]]
-name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
@@ -580,7 +622,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "either",
  "iovec",
 ]
@@ -637,7 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
- "num-traits",
+ "num-traits 0.2.11",
  "time 0.1.42",
 ]
 
@@ -714,29 +756,13 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
-dependencies = [
- "core-foundation-sys 0.6.2",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -856,35 +882,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cuckoofilter"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd43f7cfaffe0a386636a10baea2ee05cc50df3b77bea4a456c9572a939bf1f"
-dependencies = [
- "byteorder 0.5.3",
- "rand 0.3.23",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
-dependencies = [
- "byteorder 1.3.4",
- "clear_on_drop",
- "digest",
- "rand_core 0.3.1",
- "subtle 2.2.2",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "digest",
  "rand_core 0.5.1",
  "subtle 2.2.2",
@@ -929,7 +932,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "quick-error",
 ]
 
@@ -946,7 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 dependencies = [
  "clear_on_drop",
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "rand 0.7.3",
  "sha2",
 ]
@@ -956,6 +959,17 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
+dependencies = [
+ "num-traits 0.1.43",
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
 
 [[package]]
 name = "env_logger"
@@ -1051,7 +1065,7 @@ dependencies = [
  "linked-hash-map",
  "log 0.4.8",
  "node-primitives",
- "num-traits",
+ "num-traits 0.2.11",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -1177,7 +1191,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 2.0.2",
  "log 0.4.8",
- "num-traits",
+ "num-traits 0.2.11",
  "parity-scale-codec",
  "parking_lot 0.9.0",
 ]
@@ -1188,8 +1202,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 dependencies = [
- "byteorder 1.3.4",
- "libc",
+ "byteorder",
  "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
@@ -1201,7 +1214,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32529fc42e86ec06e5047092082aab9ad459b070c5d2a76b14f4f5ce70bf2e84"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
@@ -1249,28 +1262,33 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
+ "frame-support",
+ "frame-system",
+ "linregress",
  "parity-scale-codec",
+ "paste",
  "sp-api",
  "sp-io",
+ "sp-runtime",
  "sp-runtime-interface",
  "sp-std",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1279,12 +1297,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "frame-metadata"
-version = "11.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "11.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1294,8 +1313,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1313,13 +1332,13 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
- "tracing",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.10",
@@ -1329,8 +1348,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1341,8 +1360,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -1351,8 +1370,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1367,8 +1386,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1558,7 +1577,6 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab 0.4.2",
- "tokio-io",
 ]
 
 [[package]]
@@ -1658,7 +1676,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "bytes 0.4.12",
  "fnv",
  "futures 0.1.29",
@@ -1922,15 +1940,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ea6215c7314d450ee45970ab8b3851ab447a0e6bafdd19e31b20a42dbb7faf"
+checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
  "bytes 0.5.4",
  "ct-logs",
  "futures-util",
  "hyper 0.13.4",
- "rustls",
+ "log 0.4.8",
+ "rustls 0.17.0",
  "rustls-native-certs",
  "tokio 0.2.16",
  "tokio-rustls",
@@ -2051,6 +2070,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
 
 [[package]]
+name = "intervalier"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
+dependencies = [
+ "futures 0.3.4",
+ "futures-timer 2.0.2",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2087,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ip_network"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee15951c035f79eddbef745611ec962f63f4558f1dadf98ab723cc603487c6f"
 
 [[package]]
 name = "ipnet"
@@ -2202,8 +2237,8 @@ version = "1.0.0"
 source = "git+https://github.com/paritytech/jsonrpsee.git#62da58d12321355aac76975bfedfbc3ab0fe08e3"
 dependencies = [
  "async-std",
- "async-tls",
- "bs58 0.3.0",
+ "async-tls 0.6.0",
+ "bs58",
  "bytes 0.5.4",
  "fnv",
  "futures 0.3.4",
@@ -2266,20 +2301,19 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03080afe6f42cd996da9f568d6add5d7fb5ee2ea7fb7802d2d2cbd836958fd87"
+checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
 dependencies = [
- "parity-bytes",
  "parity-util-mem",
  "smallvec 1.2.0",
 ]
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9355274e5a9e0a7e8ef43916950eae3949024de2a8dffe4d5a6c13974a37c8e"
+checksum = "4aa954d12cfac958822dfd77aab34f3eec71f103b918c4ab79ab59a36ee594ea"
 dependencies = [
  "kvdb",
  "parity-util-mem",
@@ -2288,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af36fd66ccd99f3f771ae39b75aaba28b952372b6debfb971134bf1f03466ab2"
+checksum = "b3f14c3a10c8894d26175e57e9e26032e6d6c49c30cbe2468c5bf5f6b64bb0be"
 dependencies = [
  "fs-swap",
  "interleaved-ordered",
@@ -2330,6 +2364,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
+name = "libflate"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "rle-decode-fast",
+ "take_mut",
+]
+
+[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,37 +2386,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p"
-version = "0.16.2"
+name = "libm"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba17ee9cac4bb89de5812159877d9b4f0a993bf41697a5a875940cd1eb71f24"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "libp2p"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ea742c86405b659c358223a8f0f9f5a9eb27bb6083894c6340959b05269662"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
- "libp2p-deflate",
  "libp2p-dns",
- "libp2p-floodsub",
- "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
- "libp2p-plaintext",
- "libp2p-pnet",
- "libp2p-secio",
  "libp2p-swarm",
  "libp2p-tcp",
- "libp2p-uds",
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "parity-multiaddr 0.7.3",
- "parity-multihash 0.2.3",
+ "multihash",
+ "parity-multiaddr 0.8.0",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.2.0",
@@ -2379,22 +2424,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b874594c4b29de1a29f27871feba8e6cd13aa54a8a1e8f8c7cf3dfac5ca287c"
+checksum = "a1d2c17158c4dca984a77a5927aac6f0862d7f50c013470a415f93be498b5739"
 dependencies = [
  "asn1_der",
- "bs58 0.3.0",
+ "bs58",
  "ed25519-dalek",
+ "either",
  "fnv",
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
  "log 0.4.8",
+ "multihash",
  "multistream-select",
- "parity-multiaddr 0.7.3",
- "parity-multihash 0.2.3",
+ "parity-multiaddr 0.8.0",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2405,90 +2451,37 @@ dependencies = [
  "sha2",
  "smallvec 1.2.0",
  "thiserror",
- "unsigned-varint 0.3.2",
+ "unsigned-varint",
  "void",
  "zeroize 1.1.0",
 ]
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d472e9d522f588805c77801de10b957be84e10f019ca5f869fa1825b15ea9b"
+checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
  "quote 1.0.3",
  "syn 1.0.17",
 ]
 
 [[package]]
-name = "libp2p-deflate"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e25004d4d9837b44b22c5f1a69be1724a5168fef6cff1716b5176a972c3aa62"
-dependencies = [
- "flate2",
- "futures 0.3.4",
- "libp2p-core",
-]
-
-[[package]]
 name = "libp2p-dns"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99e552f9939b606eb4b59f7f64d9b01e3f96752f47e350fc3c5fc646ed3f649"
+checksum = "c0d0993481203d68e5ce2f787d033fb0cac6b850659ed6c784612db678977c71"
 dependencies = [
  "futures 0.3.4",
  "libp2p-core",
  "log 0.4.8",
-]
-
-[[package]]
-name = "libp2p-floodsub"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3234f12e44f9a50351a9807b97fe7de11eb9ae4482370392ba10da6dc90722"
-dependencies = [
- "cuckoofilter",
- "fnv",
- "futures 0.3.4",
- "libp2p-core",
- "libp2p-swarm",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "smallvec 1.2.0",
-]
-
-[[package]]
-name = "libp2p-gossipsub"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cb3e0841bd951cbf4feae56cdc081e6347836a644fb260c3ec554149b4006"
-dependencies = [
- "base64 0.11.0",
- "byteorder 1.3.4",
- "bytes 0.5.4",
- "fnv",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core",
- "libp2p-swarm",
- "log 0.4.8",
- "lru",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "sha2",
- "smallvec 1.2.0",
- "unsigned-varint 0.3.2",
- "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfeb935a9bd41263e4f3a24b988e9f4a044f3ae89ac284e83c17fe2f84e0d66b"
+checksum = "a38ca3eb807789e26f41c82ca7cd2b3843c66c5587b8b5f709a2f421f3061414"
 dependencies = [
  "futures 0.3.4",
  "libp2p-core",
@@ -2502,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464dc8412978d40f0286be72ed9ab5e0e1386a4a06e7f174526739b5c3c1f041"
+checksum = "a92cda1fb8149ea64d092a2b99d2bd7a2c309eee38ea322d02e4480bd6ee1759"
 dependencies = [
  "arrayvec 0.5.1",
  "bytes 0.5.4",
@@ -2515,23 +2508,23 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log 0.4.8",
- "parity-multihash 0.2.3",
+ "multihash",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "sha2",
  "smallvec 1.2.0",
  "uint",
- "unsigned-varint 0.3.2",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881fcfb360c2822db9f0e6bb6f89529621556ed9a8b038313414eda5107334de"
+checksum = "41e908d2aaf8ff0ec6ad1f02fe1844fd777fb0b03a68a226423630750ab99471"
 dependencies = [
  "async-std",
  "data-encoding",
@@ -2551,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8507b37ad0eed275efcde67a023c3d85af6c80768b193845b9288e848e1af95"
+checksum = "0832882b06619b2e81d74e71447753ea3c068164a0bca67847d272e856a04a02"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -2562,16 +2555,16 @@ dependencies = [
  "libp2p-core",
  "log 0.4.8",
  "parking_lot 0.10.2",
- "unsigned-varint 0.3.2",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15a8a3d71f898beb6f854c8aae27aa1d198e0d1f2e49412261c2d90ef39675a"
+checksum = "918e94a649e1139c24ee9f1f8c1f2adaba6d157b9471af787f2d9beac8c29c77"
 dependencies = [
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "futures 0.3.4",
  "lazy_static",
  "libp2p-core",
@@ -2588,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d22f2f228b3a828dca1cb8aa9fa331e0bc9c36510cb2c1916956e20dc85e8c"
+checksum = "f9bfbf87eebb492d040f9899c5c81c9738730465ac5e78d9b7a7d086d0f07230"
 dependencies = [
  "futures 0.3.4",
  "libp2p-core",
@@ -2602,76 +2595,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-plaintext"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56126a204d7b3382bac163143ff4125a14570b3ba76ba979103d1ae1abed1923"
-dependencies = [
- "bytes 0.5.4",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core",
- "log 0.4.8",
- "prost",
- "prost-build",
- "rw-stream-sink",
- "unsigned-varint 0.3.2",
- "void",
-]
-
-[[package]]
-name = "libp2p-pnet"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b916938a8868f75180aeeffcc6a516a922d165e8fa2a90b57bad989d1ccbb57a"
-dependencies = [
- "futures 0.3.4",
- "log 0.4.8",
- "pin-project",
- "rand 0.7.3",
- "salsa20",
- "sha3",
-]
-
-[[package]]
-name = "libp2p-secio"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1219e9ecb4945d7331a05f5ffe96a1f6e28051bfa1223d4c60353c251de0354e"
-dependencies = [
- "aes-ctr",
- "ctr",
- "futures 0.3.4",
- "hmac",
- "js-sys",
- "lazy_static",
- "libp2p-core",
- "log 0.4.8",
- "parity-send-wrapper",
- "pin-project",
- "prost",
- "prost-build",
- "quicksink",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2",
- "static_assertions",
- "twofish",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "libp2p-swarm"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275471e7c0e88ae004660866cd54f603bd8bd1f4caef541a27f50dd8640c4d4c"
+checksum = "44ab289ae44cc691da0a6fe96aefa43f26c86c6c7813998e203f6d80f1860f18"
 dependencies = [
  "futures 0.3.4",
  "libp2p-core",
  "log 0.4.8",
+ "rand 0.7.3",
  "smallvec 1.2.0",
  "void",
  "wasm-timer",
@@ -2679,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e80ad4e3535345f3d666554ce347d3100453775611c05c60786bf9a1747a10"
+checksum = "b37ea44823d3ed223e4605da94b50177bc520f05ae2452286700549a32d81669"
 dependencies = [
  "async-std",
  "futures 0.3.4",
@@ -2693,22 +2625,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-uds"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d329564a43da9d0e055a5b938633c4a8ceab1f59cec133fbc4647917c07341"
-dependencies = [
- "async-std",
- "futures 0.3.4",
- "libp2p-core",
- "log 0.4.8",
-]
-
-[[package]]
 name = "libp2p-wasm-ext"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923581c055bc4b8c5f42d4ce5ef43e52fe5216f1ea4bc26476cb8a966ce6220b"
+checksum = "e3ac7dbde0f88cad191dcdfd073b8bae28d01823e8ca313f117b6ecb914160c3"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
@@ -2720,18 +2640,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5351ca9eea122081c1c0f9323164d2918cac29b5a6bfe5054d4ba8ec9447cf42"
+checksum = "6874c9069ce93d899df9dc7b29f129c706b2a0fdc048f11d878935352b580190"
 dependencies = [
- "async-tls",
+ "async-tls 0.7.0",
  "bytes 0.5.4",
  "either",
  "futures 0.3.4",
  "libp2p-core",
  "log 0.4.8",
  "quicksink",
- "rustls",
+ "rustls 0.17.0",
  "rw-stream-sink",
  "soketto",
  "url 2.1.1",
@@ -2741,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dac30de24ccde0e67f363d71a125c587bbe6589503f664947e9b084b68a34f1"
+checksum = "02f91aea50f6571e0bc6c058dc0e9b270afd41ec28dd94e9e4bf607e78b9ab87"
 dependencies = [
  "futures 0.3.4",
  "libp2p-core",
@@ -2808,6 +2728,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "linregress"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9290cf6f928576eeb9c096c6fad9d8d452a0a1a70a2bbffa6e36064eedc0aac9"
+dependencies = [
+ "failure",
+ "nalgebra",
+ "statrs",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,6 +2781,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f7ec66360130972f34830bfad9ef05c6610a43938a467bcc9ab9369ab3478f"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,6 +2802,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,9 +2822,9 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198831fe8722331a395bc199a5d08efbc197497ef354cb4c77b969c02ffc0fc4"
+checksum = "be512cb2ccb4ecbdca937fdd4a62ea5f09f8e7195466a85e4632b3d5bcce82e6"
 dependencies = [
  "ahash 0.2.18",
  "hash-db",
@@ -2890,13 +2840,13 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 
 [[package]]
 name = "merlin"
-version = "1.3.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e"
+checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "keccak",
- "rand_core 0.4.2",
+ "rand_core 0.5.1",
  "zeroize 1.1.0",
 ]
 
@@ -2973,6 +2923,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "multihash"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47fbc227f7e2b1cb701f95404579ecb2668abbdd3c7ef7a6cbb3cc0d3b236869"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "digest",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,16 +2945,33 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "multistream-select"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f938ffe420493e77c8b6cbcc3f282283f68fc889c5dcbc8e51668d5f3a01ad94"
+checksum = "74cdcf7cfb3402881e15a1f95116cb033d69b33c83d481e1234777f5ef0c3d2c"
 dependencies = [
  "bytes 0.5.4",
- "futures 0.1.29",
+ "futures 0.3.4",
  "log 0.4.8",
+ "pin-project",
  "smallvec 1.2.0",
- "tokio-io",
- "unsigned-varint 0.3.2",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa9fddbc34c8c35dd2108515587b8ce0cab396f17977b8c738568e4edb521a2"
+dependencies = [
+ "alga",
+ "approx",
+ "generic-array",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits 0.2.11",
+ "rand 0.6.5",
+ "typenum",
 ]
 
 [[package]]
@@ -3014,8 +2996,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 0.4.2",
- "security-framework-sys 0.4.2",
+ "security-framework",
+ "security-framework-sys",
  "tempfile",
 ]
 
@@ -3028,6 +3010,20 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "netstat2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29449d242064c48d3057a194b049a2bdcccadda16faa18a91468677b44e8d422"
+dependencies = [
+ "bitflags 1.2.1",
+ "byteorder",
+ "enum-primitive-derive",
+ "libc",
+ "num-traits 0.2.11",
+ "thiserror",
 ]
 
 [[package]]
@@ -3045,8 +3041,8 @@ dependencies = [
 
 [[package]]
 name = "node-primitives"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -3075,6 +3071,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26e041cd983acbc087e30fcba770380cfa352d0e392e175b2344ebaf7ea0602"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,7 +3087,17 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.11",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -3092,7 +3107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits",
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -3104,7 +3119,16 @@ dependencies = [
  "autocfg 1.0.0",
  "num-bigint",
  "num-integer",
- "num-traits",
+ "num-traits 0.2.11",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.11",
 ]
 
 [[package]]
@@ -3114,6 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
  "autocfg 1.0.0",
+ "libm",
 ]
 
 [[package]]
@@ -3195,8 +3220,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3216,8 +3241,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3264,8 +3289,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3280,8 +3305,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3298,8 +3323,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3311,8 +3336,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3329,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3343,8 +3368,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3353,7 +3378,6 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-inherents",
- "sp-io",
  "sp-runtime",
  "sp-std",
  "sp-timestamp",
@@ -3361,8 +3385,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3374,8 +3398,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3439,21 +3463,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-multiaddr"
-version = "0.5.0"
+name = "parity-db"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
+checksum = "00d595e372d119261593297debbe4193811a4dc811d2a1ccbb8caaa6666ad7ab"
 dependencies = [
- "arrayref",
- "bs58 0.2.5",
- "byteorder 1.3.4",
- "bytes 0.4.12",
- "data-encoding",
- "parity-multihash 0.1.3",
- "percent-encoding 1.0.1",
- "serde",
- "unsigned-varint 0.2.3",
- "url 1.7.2",
+ "blake2-rfc",
+ "crc32fast",
+ "libc",
+ "log 0.4.8",
+ "memmap",
+ "parking_lot 0.10.2",
 ]
 
 [[package]]
@@ -3463,30 +3483,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
 dependencies = [
  "arrayref",
- "bs58 0.3.0",
- "byteorder 1.3.4",
+ "bs58",
+ "byteorder",
  "data-encoding",
- "parity-multihash 0.2.3",
+ "parity-multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.3.2",
+ "unsigned-varint",
  "url 2.1.1",
 ]
 
 [[package]]
-name = "parity-multihash"
-version = "0.1.3"
+name = "parity-multiaddr"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3a17dc27848fd99e4f87eb0f8c9baba6ede0a6d555400c850ca45254ef4ce3"
+checksum = "4db35e222f783ef4e6661873f6c165c4eb7b65e0c408349818517d5705c2d7d3"
 dependencies = [
- "blake2",
- "bytes 0.4.12",
- "rand 0.6.5",
- "sha-1",
- "sha2",
- "sha3",
- "unsigned-varint 0.2.3",
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -3501,7 +3524,7 @@ dependencies = [
  "sha-1",
  "sha2",
  "sha3",
- "unsigned-varint 0.3.2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3537,15 +3560,15 @@ checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parity-util-mem"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9344bc978467339b9ae688f9dcf279d1aaa0ccfc88e9a780c729b765a82d57d5"
+checksum = "2c6e2583649a3ca84894d1d71da249abcfda54d5aca24733d72ca10d0f02361c"
 dependencies = [
  "cfg-if",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
- "primitive-types 0.6.2",
+ "primitive-types 0.7.0",
  "smallvec 1.2.0",
  "winapi 0.3.8",
 ]
@@ -3646,7 +3669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "base64 0.9.3",
- "byteorder 1.3.4",
+ "byteorder",
  "crypto-mac",
  "hmac",
  "rand 0.5.6",
@@ -3728,6 +3751,12 @@ checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "platforms"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "ppv-lite86"
@@ -3827,31 +3856,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.7.0"
+name = "procfs"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
+checksum = "fe50036aa1b71e553a4a0c48ab7baabf8aa8c7a5a61aae06bf38c2eab7430475"
+dependencies = [
+ "bitflags 1.2.1",
+ "byteorder",
+ "chrono",
+ "hex",
+ "lazy_static",
+ "libc",
+ "libflate",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0575e258dab62268e7236d7307caa38848acbda7ec7ab87bd9093791e999d20"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
  "protobuf",
- "quick-error",
  "spin",
-]
-
-[[package]]
-name = "prometheus-exporter"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
-dependencies = [
- "async-std",
- "derive_more",
- "futures-util",
- "hyper 0.13.4",
- "log 0.4.8",
- "prometheus",
- "tokio 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -3930,6 +3960,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+
+[[package]]
+name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -4002,7 +4038,7 @@ dependencies = [
  "rand_isaac",
  "rand_jitter",
  "rand_os",
- "rand_pcg",
+ "rand_pcg 0.1.2",
  "rand_xorshift",
  "winapi 0.3.8",
 ]
@@ -4018,6 +4054,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -4127,6 +4164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,6 +4180,12 @@ checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -4173,6 +4225,26 @@ name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+
+[[package]]
+name = "ref-cast"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a214c7875e1b63fc1618db7c80efc0954f6156c9ff07699fd9039e255accdd1"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn 1.0.17",
+]
 
 [[package]]
 name = "regex"
@@ -4226,6 +4298,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rlp"
@@ -4297,15 +4375,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.1.0"
+name = "rustls"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ffebdbb48c14f84eba0b715197d673aff1dd22cc1007ca647e28483bbcc307"
+checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+dependencies = [
+ "base64 0.11.0",
+ "log 0.4.8",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.17.0",
  "schannel",
- "security-framework 0.3.4",
+ "security-framework",
 ]
 
 [[package]]
@@ -4352,35 +4443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
-name = "salsa20"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2324b0e8c3bb9a586a571fdb3136f70e7e2c748de00a78043f86e0cff91f91fe"
-dependencies = [
- "byteorder 1.3.4",
- "salsa20-core",
- "stream-cipher",
-]
-
-[[package]]
-name = "salsa20-core"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe6cc1b9f5a5867853ade63099de70f042f7679e408d1ffe52821c9248e6e69"
-dependencies = [
- "stream-cipher",
-]
-
-[[package]]
 name = "sc-basic-authorship"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "futures 0.3.4",
+ "futures-timer 3.0.2",
  "log 0.4.8",
  "parity-scale-codec",
  "sc-block-builder",
- "sc-client",
  "sc-client-api",
  "sc-telemetry",
  "sp-api",
@@ -4395,8 +4466,8 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4411,8 +4482,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -4420,14 +4491,15 @@ dependencies = [
  "sc-telemetry",
  "serde",
  "serde_json",
+ "sp-chain-spec",
  "sp-core",
  "sp-runtime",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.10",
@@ -4437,8 +4509,8 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -4452,8 +4524,8 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "names",
+ "nix",
  "parity-util-mem",
- "prometheus-exporter",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -4469,15 +4541,18 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-state-machine",
+ "sp-utils",
+ "sp-version",
  "structopt",
+ "substrate-prometheus-endpoint",
  "time 0.1.42",
  "tokio 0.2.16",
 ]
 
 [[package]]
 name = "sc-client"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "fnv",
@@ -4488,6 +4563,7 @@ dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.2",
+ "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
  "sc-executor",
@@ -4496,6 +4572,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-database",
  "sp-externalities",
  "sp-inherents",
  "sp-keyring",
@@ -4503,14 +4580,16 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-trie",
+ "sp-utils",
  "sp-version",
+ "substrate-prometheus-endpoint",
  "tracing",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "fnv",
@@ -4518,6 +4597,7 @@ dependencies = [
  "hash-db",
  "hex-literal",
  "kvdb",
+ "lazy_static",
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -4533,26 +4613,30 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-trie",
+ "sp-utils",
  "sp-version",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
+ "blake2-rfc",
  "hash-db",
  "kvdb",
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "linked-hash-map",
  "log 0.4.8",
+ "parity-db",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "rand 0.7.3",
  "sc-client",
  "sc-client-api",
  "sc-executor",
@@ -4560,15 +4644,17 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-database",
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -4576,6 +4662,7 @@ dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.2",
+ "sc-block-builder",
  "sc-client",
  "sc-client-api",
  "sc-consensus-slots",
@@ -4597,8 +4684,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -4618,8 +4705,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -4630,6 +4717,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "sc-executor-common",
  "sc-executor-wasmi",
+ "sp-api",
  "sp-core",
  "sp-externalities",
  "sp-io",
@@ -4644,12 +4732,13 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "log 0.4.8",
  "parity-scale-codec",
+ "parity-wasm",
  "sp-allocator",
  "sp-core",
  "sp-runtime-interface",
@@ -4660,12 +4749,11 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
- "parity-wasm",
  "sc-executor-common",
  "sp-allocator",
  "sp-core",
@@ -4676,8 +4764,8 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "assert_matches",
  "finality-grandpa",
@@ -4689,6 +4777,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "pin-project",
  "rand 0.7.3",
+ "sc-block-builder",
  "sc-client",
  "sc-client-api",
  "sc-keystore",
@@ -4696,6 +4785,7 @@ dependencies = [
  "sc-network-gossip",
  "sc-telemetry",
  "serde_json",
+ "sp-api",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -4704,12 +4794,14 @@ dependencies = [
  "sp-finality-tracker",
  "sp-inherents",
  "sp-runtime",
+ "sp-utils",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -4725,8 +4817,8 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "hex",
@@ -4740,8 +4832,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "bitflags 1.2.1",
  "bytes 0.5.4",
@@ -4753,6 +4845,8 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "futures_codec",
+ "hex",
+ "ip_network",
  "libp2p",
  "linked-hash-map",
  "linked_hash_set",
@@ -4765,7 +4859,6 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "rustc-hex",
  "sc-block-builder",
  "sc-client",
  "sc-client-api",
@@ -4781,8 +4874,10 @@ dependencies = [
  "sp-consensus-babe",
  "sp-core",
  "sp-runtime",
+ "sp-utils",
+ "substrate-prometheus-endpoint",
  "thiserror",
- "unsigned-varint 0.3.2",
+ "unsigned-varint",
  "void",
  "wasm-timer",
  "zeroize 1.1.0",
@@ -4790,24 +4885,24 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "libp2p",
  "log 0.4.8",
  "lru",
- "parking_lot 0.10.2",
  "sc-network",
  "sp-runtime",
+ "sp-utils",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -4827,25 +4922,27 @@ dependencies = [
  "sp-core",
  "sp-offchain",
  "sp-runtime",
+ "sp-utils",
  "threadpool",
 ]
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
  "log 0.4.8",
  "serde_json",
+ "sp-utils",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "futures 0.3.4",
  "hash-db",
@@ -4854,6 +4951,7 @@ dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.2",
+ "sc-block-builder",
  "sc-client",
  "sc-client-api",
  "sc-executor",
@@ -4862,6 +4960,7 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-blockchain",
+ "sp-chain-spec",
  "sp-core",
  "sp-offchain",
  "sp-rpc",
@@ -4869,13 +4968,14 @@ dependencies = [
  "sp-session",
  "sp-state-machine",
  "sp-transaction-pool",
+ "sp-utils",
  "sp-version",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -4888,6 +4988,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "serde",
  "serde_json",
+ "sp-chain-spec",
  "sp-core",
  "sp-rpc",
  "sp-runtime",
@@ -4897,8 +4998,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -4912,22 +5013,23 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "exit-future",
  "futures 0.1.29",
  "futures 0.3.4",
- "futures-diagnose",
  "futures-timer 3.0.2",
  "lazy_static",
  "log 0.4.8",
- "parity-multiaddr 0.5.0",
+ "netstat2",
+ "parity-multiaddr 0.7.3",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "prometheus-exporter",
+ "pin-project",
+ "procfs",
  "sc-chain-spec",
  "sc-client",
  "sc-client-api",
@@ -4953,27 +5055,31 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-transaction-pool",
+ "sp-utils",
+ "substrate-prometheus-endpoint",
  "sysinfo",
- "target_info",
  "tracing",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
+ "parity-util-mem",
+ "parity-util-mem-derive",
  "parking_lot 0.10.2",
+ "sc-client-api",
  "sp-core",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -4994,8 +5100,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -5009,8 +5115,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -5023,18 +5129,19 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-transaction-pool",
+ "sp-utils",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
  "futures-diagnose",
- "futures-timer 2.0.2",
+ "intervalier",
  "log 0.4.8",
  "parity-scale-codec",
  "parity-util-mem",
@@ -5045,7 +5152,10 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
+ "sp-utils",
+ "substrate-prometheus-endpoint",
  "wasm-timer",
 ]
 
@@ -5061,19 +5171,20 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
+checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
- "curve25519-dalek 1.2.3",
- "failure",
+ "arrayref",
+ "arrayvec 0.5.1",
+ "curve25519-dalek",
+ "getrandom",
  "merlin",
- "rand 0.6.5",
- "rand_core 0.4.2",
- "rand_os",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "sha2",
  "subtle 2.2.2",
- "zeroize 0.9.3",
+ "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -5095,7 +5206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656c79d0e90d0ab28ac86bf3c3d10bfbbac91450d3f190113b4e76d9fec3cfdd"
 dependencies = [
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder",
  "hmac",
  "pbkdf2",
  "sha2",
@@ -5142,36 +5253,15 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
-dependencies = [
- "core-foundation 0.6.4",
- "core-foundation-sys 0.6.2",
- "libc",
- "security-framework-sys 0.3.3",
-]
-
-[[package]]
-name = "security-framework"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
 dependencies = [
  "bitflags 1.2.1",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
+ "core-foundation",
+ "core-foundation-sys",
  "libc",
- "security-framework-sys 0.4.2",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
-dependencies = [
- "core-foundation-sys 0.6.2",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -5180,7 +5270,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
 dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -5426,8 +5516,8 @@ dependencies = [
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -5438,8 +5528,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -5453,8 +5543,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -5465,8 +5555,8 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -5477,12 +5567,13 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "integer-sqrt",
- "num-traits",
+ "num-traits 0.2.11",
  "parity-scale-codec",
+ "primitive-types 0.7.0",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -5490,8 +5581,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5502,8 +5593,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -5540,9 +5631,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-chain-spec"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sp-consensus"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -5558,13 +5658,14 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
+ "sp-utils",
  "sp-version",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5577,14 +5678,14 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
- "schnorrkel",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
+ "sp-consensus-vrf",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -5592,14 +5693,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-vrf"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
+dependencies = [
+ "parity-scale-codec",
+ "schnorrkel",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-core"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "base58",
  "blake2-rfc",
- "byteorder 1.3.4",
+ "byteorder",
  "ed25519-dalek",
+ "futures 0.3.4",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -5607,14 +5721,14 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log 0.4.8",
- "num-traits",
+ "merlin",
+ "num-traits 0.2.11",
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "primitive-types 0.6.2",
+ "primitive-types 0.7.0",
  "rand 0.7.3",
  "regex",
- "rustc-hex",
  "schnorrkel",
  "serde",
  "sha2",
@@ -5632,9 +5746,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-database"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
+dependencies = [
+ "kvdb",
+ "parking_lot 0.10.2",
+]
+
+[[package]]
 name = "sp-debug-derive"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -5643,18 +5766,19 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "environmental",
+ "parity-scale-codec",
  "sp-std",
  "sp-storage",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -5666,8 +5790,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -5676,8 +5800,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5688,13 +5812,15 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
+ "futures 0.3.4",
  "hash-db",
  "libsecp256k1",
  "log 0.4.8",
  "parity-scale-codec",
+ "parking_lot 0.10.2",
  "sp-core",
  "sp-externalities",
  "sp-runtime-interface",
@@ -5706,8 +5832,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -5717,17 +5843,18 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "sp-api",
+ "sp-core",
  "sp-runtime",
 ]
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -5735,8 +5862,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "serde",
  "sp-core",
@@ -5744,9 +5871,10 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
+ "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log 0.4.8",
  "parity-scale-codec",
@@ -5764,22 +5892,23 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
- "primitive-types 0.6.2",
+ "primitive-types 0.7.0",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
+ "sp-tracing",
  "sp-wasm-interface",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -5790,8 +5919,8 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "serde",
  "serde_json",
@@ -5799,8 +5928,8 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -5810,8 +5939,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -5820,12 +5949,12 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "hash-db",
  "log 0.4.8",
- "num-traits",
+ "num-traits 0.2.11",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
@@ -5839,15 +5968,16 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "impl-serde 0.2.3",
+ "ref-cast",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -5855,8 +5985,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5868,9 +5998,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-tracing"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -5879,12 +6017,13 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-runtime",
+ "sp-utils",
 ]
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -5896,9 +6035,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-utils"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
+dependencies = [
+ "futures 0.3.4",
+ "futures-core",
+ "lazy_static",
+ "prometheus",
+]
+
+[[package]]
 name = "sp-version"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -5909,8 +6059,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5941,6 +6091,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10102ac8d55e35db2b3fafc26f81ba8647da2e15879ab686a67e6d19af2685e8"
+dependencies = [
+ "rand 0.5.6",
+]
 
 [[package]]
 name = "stdweb"
@@ -6062,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
+checksum = "c004e8166d6e0aa3a9d5fa673e5b7098ff25f930de1013a21341988151e681bb"
 dependencies = [
  "hmac",
  "pbkdf2",
@@ -6093,13 +6252,16 @@ dependencies = [
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
+dependencies = [
+ "platforms",
+]
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "2.0.0-alpha.2"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+version = "2.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.4",
@@ -6118,9 +6280,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-prometheus-endpoint"
+version = "0.8.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
+dependencies = [
+ "async-std",
+ "derive_more",
+ "futures-util",
+ "hyper 0.13.4",
+ "log 0.4.8",
+ "prometheus",
+ "tokio 0.2.16",
+]
+
+[[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.5"
-source = "git+https://github.com/paritytech/substrate.git?rev=2afecf81ee19b8a6edb364b419190ea47c4a4a31#2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 
 [[package]]
 name = "subtle"
@@ -6133,6 +6309,17 @@ name = "subtle"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
 
 [[package]]
 name = "syn"
@@ -6168,6 +6355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6193,13 +6389,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.9.6"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4b2468c629cffba39c0a4425849ab3cdb03d9dfacba69684609aea04d08ff9"
+checksum = "1cac193374347e7c263c5f547524f36ff8ec6702d56c8799c8331d26dffe8c1e"
 dependencies = [
  "cfg-if",
  "doc-comment",
  "libc",
+ "ntapi",
+ "once_cell",
  "rayon",
  "winapi 0.3.8",
 ]
@@ -6209,12 +6407,6 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
-name = "target_info"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
 
 [[package]]
 name = "tempfile"
@@ -6529,12 +6721,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141afec0978abae6573065a48882c6bae44c5cc61db9b511ac4abf6a09bfd9cc"
+checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
- "rustls",
+ "rustls 0.17.0",
  "tokio 0.2.16",
  "webpki",
 ]
@@ -6741,9 +6933,9 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "trie-db"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9222c50cc325855621271157c973da27a0dcd26fa06f8edf81020bd2333df0"
+checksum = "bcc309f34008563989045a4c4dbcc5770467f3a3785ee80a9b5cc0d83362475f"
 dependencies = [
  "hash-db",
  "hashbrown 0.6.3",
@@ -6778,17 +6970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
-name = "twofish"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
-dependencies = [
- "block-cipher-trait",
- "byteorder 1.3.4",
- "opaque-debug",
-]
-
-[[package]]
 name = "twox-hash"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6815,7 +6996,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "crunchy",
  "rustc-hex",
  "static_assertions",
@@ -6871,6 +7052,12 @@ checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
@@ -6880,12 +7067,6 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 
 [[package]]
 name = "unsigned-varint"
@@ -7085,7 +7266,7 @@ dependencies = [
  "libc",
  "memory_units",
  "num-rational",
- "num-traits",
+ "num-traits 0.2.11",
  "parity-wasm",
  "wasmi-validation",
 ]
@@ -7169,6 +7350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "websocket"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7176,7 +7366,7 @@ checksum = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 dependencies = [
  "base64 0.9.3",
  "bitflags 0.9.1",
- "byteorder 1.3.4",
+ "byteorder",
  "bytes 0.4.12",
  "futures 0.1.29",
  "hyper 0.10.16",
@@ -7248,7 +7438,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "bytes 0.4.12",
  "httparse",
  "log 0.4.8",
@@ -7276,7 +7466,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize 1.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,12 +72,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0989268a37e128d4d7a8028f1c60099430113fdbc70419010601ce51a228e4fe"
-dependencies = [
- "const-random",
-]
+checksum = "35b909d1c126f78ace756fc337133356c499eebeefcce930fa5fb018823f2b2d"
 
 [[package]]
 name = "aho-corasick"
@@ -146,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
+checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
 name = "arrayref"
@@ -187,7 +184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -238,9 +235,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -314,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 dependencies = [
  "cc",
  "libc",
@@ -360,6 +357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+
+[[package]]
 name = "bindgen"
 version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +378,7 @@ dependencies = [
  "lazycell",
  "log 0.4.8",
  "peeking_take_while",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
  "regex",
  "rustc-hash",
@@ -506,6 +509,7 @@ dependencies = [
  "sc-basic-authorship",
  "sc-cli",
  "sc-client",
+ "sc-client-api",
  "sc-consensus-aura",
  "sc-executor",
  "sc-finality-grandpa",
@@ -579,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
+checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bstr"
@@ -680,7 +684,7 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits 0.2.11",
- "time 0.1.42",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -891,7 +895,7 @@ dependencies = [
  "digest",
  "rand_core 0.5.1",
  "subtle 2.2.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -906,9 +910,9 @@ version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1000,27 +1004,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
-dependencies = [
- "version_check 0.9.1",
-]
-
-[[package]]
 name = "ethabi"
-version = "9.0.1"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965126c64662832991f5a748893577630b558e47fa94e7f35aefcd20d737cef7"
+checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
 dependencies = [
- "error-chain",
- "ethereum-types 0.8.0",
+ "ethereum-types",
  "rustc-hex",
  "serde",
- "serde_derive",
  "serde_json",
  "tiny-keccak 1.5.0",
+ "uint",
 ]
 
 [[package]]
@@ -1032,18 +1026,17 @@ dependencies = [
  "crunchy",
  "fixed-hash 0.5.2",
  "impl-rlp",
- "impl-serde 0.2.3",
  "tiny-keccak 1.5.0",
 ]
 
 [[package]]
 name = "ethbloom"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7abcddbdd5db30aeed4deb586adc4824e6c247e2f7238d1187f752893f096b"
+checksum = "befe713756981dbbda28e23f5c65c85de512915db695284342cc2ee36b7a184f"
 dependencies = [
  "crunchy",
- "fixed-hash 0.6.0",
+ "fixed-hash 0.6.1",
  "impl-rlp",
  "impl-serde 0.3.0",
  "tiny-keccak 2.0.2",
@@ -1076,64 +1069,22 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "time 0.2.10",
+ "time 0.2.11",
  "web3",
 ]
 
 [[package]]
-name = "ethereum-transaction"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6689c8377635a1878c1216b8cb5496a36c3009e85425f55e4a562421b35df38d"
-dependencies = [
- "ethereum-types 0.8.0",
- "impl-serde 0.1.1",
- "log 0.4.8",
- "rlp",
- "serde",
- "tiny-keccak 1.5.0",
-]
-
-[[package]]
 name = "ethereum-types"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
+checksum = "8616dc6a7bc7d81ab8a6425635299ee3582975d4ddeb9312b8b0b8ea54dfecf8"
 dependencies = [
- "ethbloom 0.8.1",
- "fixed-hash 0.5.2",
- "impl-rlp",
- "impl-serde 0.2.3",
- "primitive-types 0.6.2",
- "uint",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964c23cdee0ca07d5be2a628b46d5c11a2134ce554a8c16d8dbc2db647e4fd4d"
-dependencies = [
- "ethbloom 0.9.0",
- "fixed-hash 0.6.0",
+ "ethbloom 0.9.1",
+ "fixed-hash 0.6.1",
  "impl-rlp",
  "impl-serde 0.3.0",
- "primitive-types 0.7.0",
+ "primitive-types",
  "uint",
-]
-
-[[package]]
-name = "ethsign"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b656fefa0b59f41b39000532c69359e927c0f1850186808ccf1586734ac3365f"
-dependencies = [
- "parity-crypto 0.4.2",
- "rand 0.7.3",
- "rustc-hex",
- "secp256k1 0.15.5",
- "serde",
- "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -1161,10 +1112,10 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
- "synstructure 0.12.3",
+ "syn 1.0.18",
+ "synstructure",
 ]
 
 [[package]]
@@ -1210,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32529fc42e86ec06e5047092082aab9ad459b070c5d2a76b14f4f5ce70bf2e84"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
@@ -1341,9 +1292,9 @@ version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "frame-support-procedural-tools",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1353,9 +1304,9 @@ source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf0
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1363,9 +1314,9 @@ name = "frame-support-procedural-tools-derive"
 version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1530,9 +1481,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -1703,7 +1654,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab 0.4.2",
- "tokio 0.2.16",
+ "tokio 0.2.19",
  "tokio-util",
 ]
 
@@ -1734,11 +1685,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479e9d9a1a3f8c489868a935b557ab5710e3e223836da2ecd52901d88935cb56"
+checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
 dependencies = [
- "ahash 0.3.2",
+ "ahash 0.3.3",
  "autocfg 1.0.0",
 ]
 
@@ -1753,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -1877,7 +1828,7 @@ dependencies = [
  "log 0.3.9",
  "mime",
  "num_cpus",
- "time 0.1.42",
+ "time 0.1.43",
  "traitobject",
  "typeable",
  "unicase 1.4.2",
@@ -1902,7 +1853,7 @@ dependencies = [
  "log 0.4.8",
  "net2",
  "rustc_version",
- "time 0.1.42",
+ "time 0.1.43",
  "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor 0.1.10",
@@ -1916,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6081100e960d9d74734659ffc9cc91daf1c0fc7aceb8eaa94ee1a3f5046f2e"
+checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
@@ -1932,8 +1883,8 @@ dependencies = [
  "log 0.4.8",
  "net2",
  "pin-project",
- "time 0.1.42",
- "tokio 0.2.16",
+ "time 0.1.43",
+ "tokio 0.2.19",
  "tower-service",
  "want 0.3.0",
 ]
@@ -1947,11 +1898,11 @@ dependencies = [
  "bytes 0.5.4",
  "ct-logs",
  "futures-util",
- "hyper 0.13.4",
+ "hyper 0.13.5",
  "log 0.4.8",
  "rustls 0.17.0",
  "rustls-native-certs",
- "tokio 0.2.16",
+ "tokio 0.2.19",
  "tokio-rustls",
  "webpki",
 ]
@@ -2011,16 +1962,6 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5158079de9d4158e0ce1de3ae0bd7be03904efc40b3d7dd8b8c301cbf6b52b56"
-dependencies = [
- "rustc-hex",
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
@@ -2043,9 +1984,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2126,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9ae166c4d1f702d297cd76d4b55758ace80272ffc6dbb139fdc1bf810de40b"
+checksum = "2307a7e78cf969759e390a8a2151ea12e783849a45bb00aa871b468ba58ea79e"
 dependencies = [
  "failure",
  "futures 0.1.29",
@@ -2155,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080dc110be17701097df238fad3c816d4a478a1899dfbcf8ec8957dd40ec7304"
+checksum = "87f9382e831a6d630c658df103aac3f971da096deb57c136ea2b760d3b4e3f9f"
 dependencies = [
  "jsonrpc-client-transports",
 ]
@@ -2169,16 +2110,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "14.0.6"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816d63997ea45d3634608edbef83ddb35e661f7c0b27b5b72f237e321f0e9807"
+checksum = "d52860f0549694aa4abb12766856f56952ab46d3fb9f0815131b2db3d9cc2f29"
 dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
@@ -2191,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.0.6"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b31c9b90731276fdd24d896f31bb10aecf2e5151733364ae81123186643d939"
+checksum = "c4ca5e391d6c6a2261d4adca029f427fe63ea546ad6cef2957c654c08495ec16"
 dependencies = [
  "jsonrpc-core",
  "log 0.4.8",
@@ -2203,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.0.5"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b7635e618a0edbbe0d2a2bbbc69874277c49383fcf6c3c0414491cfb517d22"
+checksum = "1f06add502b48351e05dd95814835327fb115e4e9f834ca42fd522d3b769d4d2"
 dependencies = [
  "bytes 0.4.12",
  "globset",
@@ -2219,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.0.6"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94e5773b2ae66e0e02c80775ce6bbba6f15d5bb47c14ec36a36fcf94f8df851"
+checksum = "017a7dd5083d9ed62c5e1dd3e317975c33c3115dac5447f4480fe05a8c354754"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2244,8 +2185,8 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "globset",
- "hashbrown 0.7.1",
- "hyper 0.13.4",
+ "hashbrown 0.7.2",
+ "hyper 0.13.5",
  "jsonrpsee-proc-macros",
  "lazy_static",
  "log 0.4.8",
@@ -2254,10 +2195,10 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "soketto",
  "thiserror",
- "tokio 0.2.16",
+ "tokio 0.2.19",
  "unicase 2.6.0",
  "url 2.1.1",
  "webpki",
@@ -2269,9 +2210,9 @@ version = "1.0.0"
 source = "git+https://github.com/paritytech/jsonrpsee.git#62da58d12321355aac76975bfedfbc3ab0fe08e3"
 dependencies = [
  "Inflector",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2306,7 +2247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -2336,7 +2277,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -2359,9 +2300,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
 name = "libflate"
@@ -2418,7 +2359,7 @@ dependencies = [
  "parity-multiaddr 0.8.0",
  "parking_lot 0.10.2",
  "pin-project",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "wasm-timer",
 ]
 
@@ -2449,11 +2390,11 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "thiserror",
  "unsigned-varint",
  "void",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2463,7 +2404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -2489,7 +2430,7 @@ dependencies = [
  "log 0.4.8",
  "prost",
  "prost-build",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "wasm-timer",
 ]
 
@@ -2513,7 +2454,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "uint",
  "unsigned-varint",
  "void",
@@ -2537,7 +2478,7 @@ dependencies = [
  "log 0.4.8",
  "net2",
  "rand 0.7.3",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "void",
  "wasm-timer",
 ]
@@ -2576,7 +2517,7 @@ dependencies = [
  "snow",
  "static_assertions",
  "x25519-dalek",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2604,7 +2545,7 @@ dependencies = [
  "libp2p-core",
  "log 0.4.8",
  "rand 0.7.3",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "void",
  "wasm-timer",
 ]
@@ -2674,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.6.4"
+version = "6.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3b727e2dd20ec2fb7ed93f23d9fd5328a0871185485ebdaff007b47d3e27e4"
+checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
 dependencies = [
  "bindgen",
  "cc",
@@ -2847,7 +2788,7 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.5.1",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2953,7 +2894,7 @@ dependencies = [
  "futures 0.3.4",
  "log 0.4.8",
  "pin-project",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "unsigned-varint",
 ]
 
@@ -3143,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -3178,9 +3119,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.28"
+version = "0.10.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
+checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
 dependencies = [
  "bitflags 1.2.1",
  "cfg-if",
@@ -3198,9 +3139,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.54"
+version = "0.9.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
+checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -3278,7 +3219,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-crypto 0.6.1",
+ "parity-crypto",
  "parity-scale-codec",
  "serde",
  "sp-bridge-eth-poa",
@@ -3417,28 +3358,6 @@ checksum = "16b56e3a2420138bdb970f84dfb9c774aea80fa0e7371549eedec0d80c209c67"
 
 [[package]]
 name = "parity-crypto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a9c2b525c93d717a234eb220c26474f8d97b08ac50d79faeac4cb6c74bf0b9"
-dependencies = [
- "aes",
- "aes-ctr",
- "block-modes",
- "digest",
- "hmac",
- "pbkdf2",
- "rand 0.7.3",
- "ripemd160",
- "rustc-hex",
- "scrypt",
- "sha2",
- "subtle 2.2.2",
- "tiny-keccak 1.5.0",
- "zeroize 0.9.3",
-]
-
-[[package]]
-name = "parity-crypto"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b7f19c1acc7fc6c5256a2f4f0c5af022044b9bdfdd0a218ff79f8cbb29779a5"
@@ -3447,7 +3366,7 @@ dependencies = [
  "aes-ctr",
  "block-modes",
  "digest",
- "ethereum-types 0.9.0",
+ "ethereum-types",
  "hmac",
  "lazy_static",
  "pbkdf2",
@@ -3455,11 +3374,11 @@ dependencies = [
  "ripemd160",
  "rustc-hex",
  "scrypt",
- "secp256k1 0.17.2",
+ "secp256k1",
  "sha2",
  "subtle 2.2.2",
  "tiny-keccak 2.0.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3547,9 +3466,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3568,8 +3487,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
- "primitive-types 0.7.0",
- "smallvec 1.2.0",
+ "primitive-types",
+ "smallvec 1.4.0",
  "winapi 0.3.8",
 ]
 
@@ -3579,9 +3498,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.10",
- "syn 1.0.17",
- "synstructure 0.12.3",
+ "proc-macro2",
+ "syn 1.0.18",
+ "synstructure",
 ]
 
 [[package]]
@@ -3608,7 +3527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.7.1",
+ "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -3628,23 +3547,23 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e136c1904604defe99ce5fd71a28d473fa60a12255d511aa78a9ddf11237aeb"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "paste"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4fb1930692d1b6a9cfabdde3d06ea0a7d186518e2f4d67660d8970e2fa647a"
+checksum = "a3c897744f63f34f7ae3a024d9162bb5001f4ad661dd24bea0dc9f075d2de1c6"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -3652,14 +3571,14 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
+checksum = "66fd6f92e3594f2dd7b3fc23e42d82e292f7bcda6d8e5dcd167072327234ab89"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3707,22 +3626,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
+checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3733,9 +3652,9 @@ checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3766,24 +3685,11 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "primitive-types"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
+checksum = "d3dedac218327b6b55fff5ef05f63ce5127024e1a36342836da7e92cbfac4531"
 dependencies = [
- "fixed-hash 0.5.2",
- "impl-codec",
- "impl-rlp",
- "impl-serde 0.3.0",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
-dependencies = [
- "fixed-hash 0.6.0",
+ "fixed-hash 0.6.1",
  "impl-codec",
  "impl-rlp",
  "impl-serde 0.3.0",
@@ -3806,9 +3712,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "version_check 0.9.1",
 ]
 
@@ -3818,9 +3724,9 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "syn-mid",
  "version_check 0.9.1",
 ]
@@ -3836,15 +3742,6 @@ name = "proc-macro-nested"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -3920,9 +3817,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -3937,9 +3834,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71964f34fd51cf04882d7ae3325fa0794d4cad66a03d0003f38d8ae4f63ba126"
+checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
 
 [[package]]
 name = "quick-error"
@@ -3949,9 +3846,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quicksink"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8461ef7445f61fd72d8dcd0629ce724b9131b3c2eb36e83a5d3d4161c127530"
+checksum = "77de3c815e5a160b1539c6592796801df2043ae35e123b46d73380cfa57af858"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3966,20 +3863,11 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -4241,16 +4129,16 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4400,17 +4288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-dependencies = [
- "proc-macro2 1.0.10",
- "quote 1.0.3",
- "syn 1.0.17",
-]
-
-[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4423,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "safe-mix"
@@ -4502,9 +4379,9 @@ version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -4545,8 +4422,8 @@ dependencies = [
  "sp-version",
  "structopt",
  "substrate-prometheus-endpoint",
- "time 0.1.42",
- "tokio 0.2.16",
+ "time 0.1.43",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -4880,7 +4757,7 @@ dependencies = [
  "unsigned-varint",
  "void",
  "wasm-timer",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -4908,7 +4785,7 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "hyper 0.13.4",
+ "hyper 0.13.5",
  "hyper-rustls",
  "log 0.4.8",
  "num_cpus",
@@ -5184,7 +5061,7 @@ dependencies = [
  "rand_core 0.5.1",
  "sha2",
  "subtle 2.2.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5224,16 +5101,6 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d311229f403d64002e9eed9964dfa5a0a0c1ac443344f7546bf48e916c6053a"
-dependencies = [
- "cc",
- "rand 0.6.5",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
@@ -5253,9 +5120,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -5266,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5320,16 +5187,16 @@ version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -5456,9 +5323,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5472,9 +5339,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "snow"
@@ -5509,7 +5376,7 @@ dependencies = [
  "log 0.4.8",
  "rand 0.7.3",
  "sha1",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
  "static_assertions",
  "thiserror",
 ]
@@ -5548,9 +5415,9 @@ source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf0
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5573,7 +5440,7 @@ dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
  "parity-scale-codec",
- "primitive-types 0.7.0",
+ "primitive-types",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -5619,7 +5486,7 @@ dependencies = [
  "parity-bytes",
  "parity-scale-codec",
  "plain_hasher",
- "primitive-types 0.6.2",
+ "primitive-types",
  "rlp",
  "serde",
  "serde-big-array",
@@ -5726,7 +5593,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "primitive-types 0.7.0",
+ "primitive-types",
  "rand 0.7.3",
  "regex",
  "schnorrkel",
@@ -5742,7 +5609,7 @@ dependencies = [
  "tiny-keccak 2.0.2",
  "twox-hash",
  "wasmi",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5759,9 +5626,9 @@ name = "sp-debug-derive"
 version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -5896,7 +5763,7 @@ version = "2.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf07897c2aa062b917d520520#c13ad41634d0bd7cf07897c2aa062b917d520520"
 dependencies = [
  "parity-scale-codec",
- "primitive-types 0.7.0",
+ "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -5912,9 +5779,9 @@ source = "git+https://github.com/paritytech/substrate.git?rev=c13ad41634d0bd7cf0
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6082,9 +5949,9 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "standback"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eca17d57aac1688897d4c5e519ed600fc6f28aeabc7b1abb188e945deb0732"
+checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
 
 [[package]]
 name = "static_assertions"
@@ -6121,11 +5988,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
  "serde",
  "serde_derive",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6135,13 +6002,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6193,9 +6060,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6214,9 +6081,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6287,10 +6154,10 @@ dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.4",
+ "hyper 0.13.5",
  "log 0.4.8",
  "prometheus",
- "tokio 0.2.16",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -6323,22 +6190,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
-dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
@@ -6349,9 +6205,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6365,25 +6221,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "unicode-xid 0.2.0",
 ]
 
@@ -6442,22 +6286,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6471,36 +6315,35 @@ dependencies = [
 
 [[package]]
 name = "threadpool"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
+checksum = "e8dae184447c15d5a6916d973c642aec485105a13cd238192a6927ae3e077d66"
 dependencies = [
  "num_cpus",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "time"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cacbd5ebf7b211db6d9500b8b033c20b6e333a68368a9e8d3a1d073bb1f0a12a"
+checksum = "6af7dfc707e7aed400b39ac00ad1408ea0847cea2bed42174d8dd24c480c55b3"
 dependencies = [
  "cfg-if",
  "libc",
- "rustversion",
  "standback",
  "stdweb",
  "time-macros",
+ "version_check 0.9.1",
  "winapi 0.3.8",
 ]
 
@@ -6516,14 +6359,15 @@ dependencies = [
 
 [[package]]
 name = "time-macros-impl"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987cfe0537f575b5fc99909de6185f6c19c3ad8889e2275e686a873d0869ba1"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "standback",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6586,9 +6430,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5a0dd887e37d37390c13ff8ac830f992307fe30a1fff0ab8427af67211ba28"
+checksum = "7d9c43f1bb96970e153bcbae39a65e249ccb942bd9d36dbdf086024920417c9c"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -6727,7 +6571,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls 0.17.0",
- "tokio 0.2.16",
+ "tokio 0.2.19",
  "webpki",
 ]
 
@@ -6877,7 +6721,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.16",
+ "tokio 0.2.19",
 ]
 
 [[package]]
@@ -6913,7 +6757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
 ]
 
 [[package]]
@@ -6941,7 +6785,7 @@ dependencies = [
  "hashbrown 0.6.3",
  "log 0.4.8",
  "rustc-hex",
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -6986,15 +6830,15 @@ checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
+checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -7035,7 +6879,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.2.0",
+ "smallvec 1.4.0",
 ]
 
 [[package]]
@@ -7058,21 +6902,15 @@ checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38e01ad4b98f042e166c1bf9a13f9873a99d79eaa171ce7ca81e6dd0f895d8a"
+checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 dependencies = [
  "bytes 0.5.4",
  "futures-io",
@@ -7194,9 +7032,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.8",
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -7228,9 +7066,9 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7292,33 +7130,34 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.8.0"
-source = "git+https://github.com/svyatonik/rust-web3.git?branch=fix_receipt#0d061ab0642c0def7e32f586ebff8fb145d29cd6"
+version = "0.10.0"
+source = "git+https://github.com/svyatonik/rust-web3.git?branch=add-receipt-root#38aa215d1764df747c9ef8832f5abb15f95f3fec"
 dependencies = [
  "arrayvec 0.5.1",
- "base64 0.11.0",
+ "base64 0.12.0",
  "derive_more",
  "ethabi",
- "ethereum-transaction",
- "ethereum-types 0.8.0",
- "ethsign",
+ "ethereum-types",
  "futures 0.1.29",
  "hyper 0.12.35",
  "hyper-tls",
  "jsonrpc-core",
  "log 0.4.8",
  "native-tls",
- "parity-crypto 0.4.2",
  "parking_lot 0.10.2",
+ "rlp",
  "rustc-hex",
+ "secp256k1",
  "serde",
  "serde_json",
+ "tiny-keccak 2.0.2",
  "tokio-core",
  "tokio-io",
  "tokio-timer 0.1.2",
  "tokio-uds 0.1.7",
  "url 2.1.1",
  "websocket",
+ "zeroize",
 ]
 
 [[package]]
@@ -7419,9 +7258,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi 0.3.8",
 ]
@@ -7468,7 +7307,7 @@ checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -7499,32 +7338,11 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
-dependencies = [
- "zeroize_derive 0.9.3",
-]
-
-[[package]]
-name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 dependencies = [
- "zeroize_derive 1.0.0",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080616bd0e31f36095288bb0acdf1f78ef02c2fa15527d7e993f2a6c7591643e"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "synstructure 0.10.2",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -7533,8 +7351,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.10",
+ "proc-macro2",
  "quote 1.0.3",
- "syn 1.0.17",
- "synstructure 0.12.3",
+ "syn 1.0.18",
+ "synstructure",
 ]

--- a/bin/node/node/Cargo.toml
+++ b/bin/node/node/Cargo.toml
@@ -20,94 +20,94 @@ sp-bridge-eth-poa = { version = "0.1.0", path = "../../../primitives/ethereum-po
 
 [dependencies.sc-cli]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-rpc]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-core]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-executor]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-service]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-inherents]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-transaction-pool]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-transaction-pool]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-network]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus-aura]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus-aura]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa]
 package = "sc-finality-grandpa"
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa-primitives]
 package = "sp-finality-grandpa"
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-client]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-basic-authorship]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.substrate-frame-rpc-system]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [build-dependencies]
@@ -116,5 +116,5 @@ vergen = "3.1.0"
 [build-dependencies.build-script-utils]
 package = "substrate-build-script-utils"
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"

--- a/bin/node/node/Cargo.toml
+++ b/bin/node/node/Cargo.toml
@@ -19,94 +19,99 @@ bridge-node-runtime = { version = "0.1.0", path = "../runtime" }
 sp-bridge-eth-poa = { version = "0.1.0", path = "../../../primitives/ethereum-poa" }
 
 [dependencies.sc-cli]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-rpc]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-core]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-executor]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-service]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-inherents]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-transaction-pool]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-transaction-pool]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-network]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus-aura]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus-aura]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa]
 package = "sc-finality-grandpa"
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa-primitives]
 package = "sp-finality-grandpa"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
+git = "https://github.com/paritytech/substrate.git"
+
+[dependencies.sc-client-api]
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-client]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-basic-authorship]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.substrate-frame-rpc-system]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
@@ -115,6 +120,6 @@ vergen = "3.1.0"
 
 [build-dependencies.build-script-utils]
 package = "substrate-build-script-utils"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"

--- a/bin/node/node/src/chain_spec.rs
+++ b/bin/node/node/src/chain_spec.rs
@@ -25,7 +25,7 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
-pub type ChainSpec = sc_service::ChainSpec<GenesisConfig>;
+pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
 
 /// The chain specification option. This is expected to come in from the CLI and
 /// is little more than one of a number of alternatives which can easily be converted
@@ -71,6 +71,7 @@ impl Alternative {
 			Alternative::Development => ChainSpec::from_genesis(
 				"Development",
 				"dev",
+				sc_service::ChainType::Development,
 				|| {
 					testnet_genesis(
 						vec![get_authority_keys_from_seed("Alice")],
@@ -93,6 +94,7 @@ impl Alternative {
 			Alternative::LocalTestnet => ChainSpec::from_genesis(
 				"Local Testnet",
 				"local_testnet",
+				sc_service::ChainType::Local,
 				|| {
 					testnet_genesis(
 						vec![
@@ -127,14 +129,6 @@ impl Alternative {
 				None,
 			),
 		})
-	}
-
-	pub(crate) fn from(s: &str) -> Option<Self> {
-		match s {
-			"" | "dev" => Some(Alternative::Development),
-			"local" => Some(Alternative::LocalTestnet),
-			_ => None,
-		}
 	}
 }
 
@@ -171,13 +165,6 @@ fn testnet_genesis(
 				.collect::<Vec<_>>(),
 		}),
 	}
-}
-
-pub fn load_spec(id: &str) -> Result<Option<ChainSpec>, String> {
-	Ok(match Alternative::from(id) {
-		Some(spec) => Some(spec.load()?),
-		None => None,
-	})
 }
 
 fn load_kovan_config() -> Option<BridgeEthPoAConfig> {

--- a/bin/node/node/src/command.rs
+++ b/bin/node/node/src/command.rs
@@ -30,28 +30,65 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::chain_spec;
 use crate::cli::Cli;
 use crate::service;
-use sc_cli::VersionInfo;
+use sc_cli::SubstrateCli;
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 
+impl SubstrateCli for Cli {
+	fn impl_name() -> &'static str {
+		"Bridge Node"
+	}
+
+	fn impl_version() -> &'static str {
+		env!("CARGO_PKG_VERSION")
+	}
+
+	fn description() -> &'static str {
+		"Bridge Node"
+	}
+
+	fn author() -> &'static str {
+		"Parity Technologies"
+	}
+
+	fn support_url() -> &'static str {
+		"https://github.com/paritytech/parity-bridges-common/"
+	}
+
+	fn copyright_start_year() -> i32 {
+		2019
+	}
+
+	fn executable_name() -> &'static str {
+		"bridge-node"
+	}
+
+	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
+		Ok(Box::new(match id {
+			"" | "dev" => crate::chain_spec::Alternative::Development,
+			"local" => crate::chain_spec::Alternative::LocalTestnet,
+			_ => return Err(format!("Unsupported chain specification: {}", id)),
+		}.load()?))
+	}
+}
+
 /// Parse and run command line arguments
-pub fn run(version: VersionInfo) -> sc_cli::Result<()> {
-	let opt = sc_cli::from_args::<Cli>(&version);
+pub fn run() -> sc_cli::Result<()> {
+	let cli = Cli::from_args();
 
-	let mut config = sc_service::Configuration::from_version(&version);
-
-	match opt.subcommand {
+	match &cli.subcommand {
 		Some(subcommand) => {
-			subcommand.init(&version)?;
-			subcommand.update_config(&mut config, chain_spec::load_spec, &version)?;
-			subcommand.run(config, |config: _| Ok(new_full_start!(config).0))
+			let runner = cli.create_runner(subcommand)?;
+			runner.run_subcommand(subcommand, |config| Ok(new_full_start!(config).0))
 		}
 		None => {
-			opt.run.init(&version)?;
-			opt.run.update_config(&mut config, chain_spec::load_spec, &version)?;
-			opt.run.run(config, service::new_light, service::new_full, &version)
+			let runner = cli.create_runner(&cli.run)?;
+			runner.run_node(
+				service::new_light,
+				service::new_full,
+				bridge_node_runtime::VERSION
+			)
 		}
 	}
 }

--- a/bin/node/node/src/command.rs
+++ b/bin/node/node/src/command.rs
@@ -65,11 +65,14 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
-		Ok(Box::new(match id {
-			"" | "dev" => crate::chain_spec::Alternative::Development,
-			"local" => crate::chain_spec::Alternative::LocalTestnet,
-			_ => return Err(format!("Unsupported chain specification: {}", id)),
-		}.load()?))
+		Ok(Box::new(
+			match id {
+				"" | "dev" => crate::chain_spec::Alternative::Development,
+				"local" => crate::chain_spec::Alternative::LocalTestnet,
+				_ => return Err(format!("Unsupported chain specification: {}", id)),
+			}
+			.load()?,
+		))
 	}
 }
 
@@ -84,11 +87,7 @@ pub fn run() -> sc_cli::Result<()> {
 		}
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
-			runner.run_node(
-				service::new_light,
-				service::new_full,
-				bridge_node_runtime::VERSION
-			)
+			runner.run_node(service::new_light, service::new_full, bridge_node_runtime::VERSION)
 		}
 	}
 }

--- a/bin/node/node/src/main.rs
+++ b/bin/node/node/src/main.rs
@@ -24,16 +24,5 @@ mod cli;
 mod command;
 
 fn main() -> sc_cli::Result<()> {
-	let version = sc_cli::VersionInfo {
-		name: "Bridge Node",
-		commit: env!("VERGEN_SHA_SHORT"),
-		version: env!("CARGO_PKG_VERSION"),
-		executable_name: "bridge-node",
-		author: "Parity Technologies",
-		description: "Bridge Node",
-		support_url: "https://github.com/paritytech/parity-bridges-common/",
-		copyright_start_year: 2019,
-	};
-
-	command::run(version)
+	command::run()
 }

--- a/bin/node/node/src/service.rs
+++ b/bin/node/node/src/service.rs
@@ -16,9 +16,10 @@
 
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
-use bridge_node_runtime::{self, opaque::Block, GenesisConfig, RuntimeApi};
-use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
+use bridge_node_runtime::{self, opaque::Block, RuntimeApi};
+use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider, StorageAndProofProvider};
 use sc_client::LongestChain;
+use sc_client_api::ExecutorProvider;
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sc_service::{error::Error as ServiceError, AbstractService, Configuration, ServiceBuilder};
@@ -40,6 +41,8 @@ native_executor_instance!(
 /// be able to perform chain operations.
 macro_rules! new_full_start {
 	($config:expr) => {{
+		use std::sync::Arc;
+
 		let mut import_setup = None;
 		let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 
@@ -49,11 +52,12 @@ macro_rules! new_full_start {
 			crate::service::Executor,
 		>($config)?
 		.with_select_chain(|_config, backend| Ok(sc_client::LongestChain::new(backend.clone())))?
-		.with_transaction_pool(|config, client, _fetcher| {
+		.with_transaction_pool(|config, client, _fetcher, prometheus_registry| {
 			let pool_api = sc_transaction_pool::FullChainApi::new(client.clone());
 			Ok(sc_transaction_pool::BasicPool::new(
 				config,
 				std::sync::Arc::new(pool_api),
+				prometheus_registry,
 			))
 		})?
 		.with_import_queue(|_config, client, mut select_chain, _transaction_pool| {
@@ -61,7 +65,7 @@ macro_rules! new_full_start {
 				.take()
 				.ok_or_else(|| sc_service::Error::SelectChainRequired)?;
 
-			let (grandpa_block_import, grandpa_link) = grandpa::block_import(client.clone(), &*client, select_chain)?;
+			let (grandpa_block_import, grandpa_link) = grandpa::block_import(client.clone(), &(client.clone() as Arc<_>), select_chain)?;
 
 			let aura_block_import = sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(
 				grandpa_block_import.clone(),
@@ -97,16 +101,11 @@ macro_rules! new_full_start {
 }
 
 /// Builds a new service for a full client.
-pub fn new_full(config: Configuration<GenesisConfig>) -> Result<impl AbstractService, ServiceError> {
-	let is_authority = config.roles.is_authority();
+pub fn new_full(config: Configuration) -> Result<impl AbstractService, ServiceError> {
+	let role = config.role.clone();
 	let force_authoring = config.force_authoring;
-	let name = config.name.clone();
+	let name = config.network.node_name.clone();
 	let disable_grandpa = config.disable_grandpa;
-
-	// sentry nodes announce themselves as authorities to the network
-	// and should run the same protocols authorities do, but it should
-	// never actively participate in any consensus process.
-	let participates_in_consensus = is_authority && !config.sentry_mode;
 
 	let (builder, mut import_setup, inherent_data_providers) = new_full_start!(config);
 
@@ -116,15 +115,14 @@ pub fn new_full(config: Configuration<GenesisConfig>) -> Result<impl AbstractSer
 
 	let service = builder
 		.with_finality_proof_provider(|client, backend| {
-			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, client)) as _)
+			let provider = client as Arc<dyn StorageAndProofProvider<_, _>>;
+			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, provider)) as _)
 		})?
 		.build()?;
 
-	if participates_in_consensus {
-		let proposer = sc_basic_authorship::ProposerFactory {
-			client: service.client(),
-			transaction_pool: service.transaction_pool(),
-		};
+	if role.is_authority() {
+		let proposer =
+			sc_basic_authorship::ProposerFactory::new(service.client(), service.transaction_pool());
 
 		let client = service.client();
 		let select_chain = service.select_chain().ok_or(ServiceError::SelectChainRequired)?;
@@ -151,7 +149,7 @@ pub fn new_full(config: Configuration<GenesisConfig>) -> Result<impl AbstractSer
 
 	// if the node isn't actively participating in consensus then it doesn't
 	// need a keystore, regardless of which protocol we use below.
-	let keystore = if participates_in_consensus {
+	let keystore = if role.is_authority() {
 		Some(service.keystore())
 	} else {
 		None
@@ -164,7 +162,7 @@ pub fn new_full(config: Configuration<GenesisConfig>) -> Result<impl AbstractSer
 		name: Some(name),
 		observer_enabled: false,
 		keystore,
-		is_authority,
+		is_authority: role.is_network_authority(),
 	};
 
 	let enable_grandpa = !disable_grandpa;
@@ -180,9 +178,9 @@ pub fn new_full(config: Configuration<GenesisConfig>) -> Result<impl AbstractSer
 			link: grandpa_link,
 			network: service.network(),
 			inherent_data_providers: inherent_data_providers.clone(),
-			on_exit: service.on_exit(),
 			telemetry_on_connect: Some(service.telemetry_on_connect_stream()),
 			voting_rule: grandpa::VotingRulesBuilder::default().build(),
+			prometheus_registry: service.prometheus_registry()
 		};
 
 		// the GRANDPA voter task is considered infallible, i.e.
@@ -196,18 +194,19 @@ pub fn new_full(config: Configuration<GenesisConfig>) -> Result<impl AbstractSer
 }
 
 /// Builds a new service for a light client.
-pub fn new_light(config: Configuration<GenesisConfig>) -> Result<impl AbstractService, ServiceError> {
+pub fn new_light(config: Configuration) -> Result<impl AbstractService, ServiceError> {
 	let inherent_data_providers = InherentDataProviders::new();
 
 	ServiceBuilder::new_light::<Block, RuntimeApi, Executor>(config)?
 		.with_select_chain(|_config, backend| Ok(LongestChain::new(backend.clone())))?
-		.with_transaction_pool(|config, client, fetcher| {
+		.with_transaction_pool(|config, client, fetcher, prometheus_registry| {
 			let fetcher = fetcher.ok_or_else(|| "Trying to start light transaction pool without active fetcher")?;
 
 			let pool_api = sc_transaction_pool::LightChainApi::new(client.clone(), fetcher.clone());
 			let pool = sc_transaction_pool::BasicPool::with_revalidation_type(
 				config,
 				Arc::new(pool_api),
+				prometheus_registry,
 				sc_transaction_pool::RevalidationType::Light,
 			);
 			Ok(pool)
@@ -217,7 +216,7 @@ pub fn new_light(config: Configuration<GenesisConfig>) -> Result<impl AbstractSe
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
 			let grandpa_block_import =
-				grandpa::light_block_import(client.clone(), backend, &*client.clone(), Arc::new(fetch_checker))?;
+				grandpa::light_block_import(client.clone(), backend, &(client.clone() as Arc<_>), Arc::new(fetch_checker))?;
 			let finality_proof_import = grandpa_block_import.clone();
 			let finality_proof_request_builder = finality_proof_import.create_finality_proof_request_builder();
 
@@ -233,7 +232,8 @@ pub fn new_light(config: Configuration<GenesisConfig>) -> Result<impl AbstractSe
 			Ok((import_queue, finality_proof_request_builder))
 		})?
 		.with_finality_proof_provider(|client, backend| {
-			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, client)) as _)
+			let provider = client as Arc<dyn StorageAndProofProvider<_, _>>;
+			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, provider)) as _)
 		})?
 		.build()
 }

--- a/bin/node/node/src/service.rs
+++ b/bin/node/node/src/service.rs
@@ -65,7 +65,8 @@ macro_rules! new_full_start {
 				.take()
 				.ok_or_else(|| sc_service::Error::SelectChainRequired)?;
 
-			let (grandpa_block_import, grandpa_link) = grandpa::block_import(client.clone(), &(client.clone() as Arc<_>), select_chain)?;
+			let (grandpa_block_import, grandpa_link) =
+				grandpa::block_import(client.clone(), &(client.clone() as Arc<_>), select_chain)?;
 
 			let aura_block_import = sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(
 				grandpa_block_import.clone(),
@@ -121,8 +122,7 @@ pub fn new_full(config: Configuration) -> Result<impl AbstractService, ServiceEr
 		.build()?;
 
 	if role.is_authority() {
-		let proposer =
-			sc_basic_authorship::ProposerFactory::new(service.client(), service.transaction_pool());
+		let proposer = sc_basic_authorship::ProposerFactory::new(service.client(), service.transaction_pool());
 
 		let client = service.client();
 		let select_chain = service.select_chain().ok_or(ServiceError::SelectChainRequired)?;
@@ -180,7 +180,7 @@ pub fn new_full(config: Configuration) -> Result<impl AbstractService, ServiceEr
 			inherent_data_providers: inherent_data_providers.clone(),
 			telemetry_on_connect: Some(service.telemetry_on_connect_stream()),
 			voting_rule: grandpa::VotingRulesBuilder::default().build(),
-			prometheus_registry: service.prometheus_registry()
+			prometheus_registry: service.prometheus_registry(),
 		};
 
 		// the GRANDPA voter task is considered infallible, i.e.
@@ -215,8 +215,12 @@ pub fn new_light(config: Configuration) -> Result<impl AbstractService, ServiceE
 			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
-			let grandpa_block_import =
-				grandpa::light_block_import(client.clone(), backend, &(client.clone() as Arc<_>), Arc::new(fetch_checker))?;
+			let grandpa_block_import = grandpa::light_block_import(
+				client.clone(),
+				backend,
+				&(client.clone() as Arc<_>),
+				Arc::new(fetch_checker),
+			)?;
 			let finality_proof_import = grandpa_block_import.clone();
 			let finality_proof_request_builder = finality_proof_import.create_finality_proof_request_builder();
 

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -21,13 +21,13 @@ features = ["derive"]
 [dependencies.pallet-aura]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-balances]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-bridge-eth-poa]
@@ -38,74 +38,74 @@ path = "../../../modules/ethereum"
 [dependencies.frame-support]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-grandpa]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-randomness-collective-flip]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-sudo]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system-rpc-runtime-api]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-timestamp]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-executive]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 # Substrate Primitives
 [dependencies.sp-api]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-block-builder]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-bridge-eth-poa]
@@ -116,73 +116,73 @@ path = "../../../primitives/ethereum-poa"
 [dependencies.sp-consensus-aura]
 version = "0.8.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-inherents]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-offchain]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-session]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-staking]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-transaction-pool]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-version]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [build-dependencies.wasm-builder-runner]
 version = "1.0.5"
 package = "substrate-wasm-builder-runner"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [features]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -19,13 +19,13 @@ features = ["derive"]
 
 # Substrate Dependencies
 [dependencies.pallet-aura]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-balances]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
@@ -36,74 +36,74 @@ default-features = false
 path = "../../../modules/ethereum"
 
 [dependencies.frame-support]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-grandpa]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-randomness-collective-flip]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-sudo]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system-rpc-runtime-api]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-timestamp]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-executive]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 # Substrate Primitives
 [dependencies.sp-api]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-block-builder]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
@@ -114,67 +114,67 @@ default-features = false
 path = "../../../primitives/ethereum-poa"
 
 [dependencies.sp-consensus-aura]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-inherents]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-offchain]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-session]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-staking]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-transaction-pool]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-version]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -34,7 +34,7 @@ use sp_runtime::traits::{
 	BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, IdentityLookup, OpaqueKeys, Verify,
 };
 use sp_runtime::{
-	create_runtime_str, generic, impl_opaque_keys, transaction_validity::TransactionValidity, ApplyExtrinsicResult,
+	create_runtime_str, generic, impl_opaque_keys, transaction_validity::{TransactionSource, TransactionValidity}, ApplyExtrinsicResult,
 	MultiSignature,
 };
 use sp_std::prelude::*;
@@ -43,7 +43,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
-pub use frame_support::{construct_runtime, parameter_types, traits::Randomness, weights::Weight, StorageValue};
+pub use frame_support::{construct_runtime, parameter_types, traits::Randomness, weights::{RuntimeDbWeight, Weight}, StorageValue};
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_bridge_eth_poa::Call as BridgeEthPoACall;
 pub use pallet_timestamp::Call as TimestampCall;
@@ -109,6 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 1,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
+	transaction_version: 1,
 };
 
 pub const MILLISECS_PER_BLOCK: u64 = 6000;
@@ -131,10 +132,15 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 1_000_000;
+	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
+	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
+	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
+		read: 60_000_000, // ~0.06 ms = ~60 µs
+		write: 200_000_000, // ~0.2 ms = 200 µs
+	};
 }
 
 impl frame_system::Trait for Runtime {
@@ -162,6 +168,14 @@ impl frame_system::Trait for Runtime {
 	type BlockHashCount = BlockHashCount;
 	/// Maximum weight of each block.
 	type MaximumBlockWeight = MaximumBlockWeight;
+	/// The weight of database operations that the runtime can invoke.
+	type DbWeight = DbWeight;
+	/// The weight of the overhead invoked on the block import process, independent of the
+	/// extrinsics included in that block.
+	type BlockExecutionWeight = ();
+	/// The base weight of any extrinsic processed by the runtime, independent of the
+	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
+	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
@@ -225,7 +239,6 @@ parameter_types! {
 impl pallet_transaction_payment::Trait for Runtime {
 	type Currency = pallet_balances::Module<Runtime>;
 	type OnTransactionPayment = ();
-	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = ConvertInto;
 	type FeeMultiplierUpdate = ();
@@ -246,6 +259,7 @@ impl pallet_session::Trait for Runtime {
 	type ValidatorId = <Self as frame_system::Trait>::AccountId;
 	type ValidatorIdOf = ();
 	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type SessionManager = ShiftSessionManager;
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
@@ -279,6 +293,7 @@ impl ShiftSessionManager {
 
 impl pallet_session::SessionManager<AccountId> for ShiftSessionManager {
 	fn end_session(_: sp_staking::SessionIndex) {}
+	fn start_session(_: sp_staking::SessionIndex) {}
 	fn new_session(session_index: sp_staking::SessionIndex) -> Option<Vec<AccountId>> {
 		// can't access genesis config here :/
 		if session_index == 0 || session_index == 1 {
@@ -376,10 +391,6 @@ impl_runtime_apis! {
 			Executive::apply_extrinsic(extrinsic)
 		}
 
-		fn apply_trusted_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-			Executive::apply_trusted_extrinsic(extrinsic)
-		}
-
 		fn finalize_block() -> <Block as BlockT>::Header {
 			Executive::finalize_block()
 		}
@@ -421,8 +432,11 @@ impl_runtime_apis! {
 	}
 
 	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
-		fn validate_transaction(tx: <Block as BlockT>::Extrinsic) -> TransactionValidity {
-			Executive::validate_transaction(tx)
+		fn validate_transaction(
+			source: TransactionSource,
+			tx: <Block as BlockT>::Extrinsic,
+		) -> TransactionValidity {
+			Executive::validate_transaction(source, tx)
 		}
 	}
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -34,8 +34,9 @@ use sp_runtime::traits::{
 	BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, IdentityLookup, OpaqueKeys, Verify,
 };
 use sp_runtime::{
-	create_runtime_str, generic, impl_opaque_keys, transaction_validity::{TransactionSource, TransactionValidity}, ApplyExtrinsicResult,
-	MultiSignature,
+	create_runtime_str, generic, impl_opaque_keys,
+	transaction_validity::{TransactionSource, TransactionValidity},
+	ApplyExtrinsicResult, MultiSignature,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -43,7 +44,12 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
-pub use frame_support::{construct_runtime, parameter_types, traits::Randomness, weights::{RuntimeDbWeight, Weight}, StorageValue};
+pub use frame_support::{
+	construct_runtime, parameter_types,
+	traits::Randomness,
+	weights::{RuntimeDbWeight, Weight},
+	StorageValue,
+};
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_bridge_eth_poa::Call as BridgeEthPoACall;
 pub use pallet_timestamp::Call as TimestampCall;

--- a/modules/ethereum/Cargo.toml
+++ b/modules/ethereum/Cargo.toml
@@ -12,31 +12,31 @@ primitives = { package = "sp-bridge-eth-poa", path = "../../primitives/ethereum-
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"

--- a/modules/ethereum/Cargo.toml
+++ b/modules/ethereum/Cargo.toml
@@ -14,31 +14,31 @@ primitives = { package = "sp-bridge-eth-poa", path = "../../primitives/ethereum-
 [dependencies.frame-support]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies

--- a/modules/ethereum/src/lib.rs
+++ b/modules/ethereum/src/lib.rs
@@ -293,7 +293,7 @@ pub trait Trait: frame_system::Trait {
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		/// Import single Aura header. Requires transaction to be **UNSIGNED**.
-		#[weight = 0]
+		#[weight = 0] // TODO: update me (https://github.com/paritytech/parity-bridges-common/issues/78)
 		pub fn import_unsigned_header(origin, header: Header, receipts: Option<Vec<Receipt>>) {
 			frame_system::ensure_none(origin)?;
 
@@ -314,7 +314,7 @@ decl_module! {
 		///
 		/// This should be used with caution - passing too many headers could lead to
 		/// enormous block production/import time.
-		#[weight = 0]
+		#[weight = 0] // TODO: update me (https://github.com/paritytech/parity-bridges-common/issues/78)
 		pub fn import_signed_headers(origin, headers_with_receipts: Vec<(Header, Option<Vec<Receipt>>)>) {
 			let submitter = frame_system::ensure_signed(origin)?;
 			let mut finalized_headers = BTreeMap::new();

--- a/modules/ethereum/src/lib.rs
+++ b/modules/ethereum/src/lib.rs
@@ -21,8 +21,8 @@ use frame_support::{decl_module, decl_storage};
 use primitives::{Address, Header, Receipt, H256, U256};
 use sp_runtime::{
 	transaction_validity::{
-		InvalidTransaction, TransactionLongevity, TransactionPriority, TransactionSource,
-		TransactionValidity, UnknownTransaction, ValidTransaction,
+		InvalidTransaction, TransactionLongevity, TransactionPriority, TransactionSource, TransactionValidity,
+		UnknownTransaction, ValidTransaction,
 	},
 	RuntimeDebug,
 };

--- a/modules/ethereum/src/lib.rs
+++ b/modules/ethereum/src/lib.rs
@@ -361,19 +361,19 @@ decl_storage! {
 		/// Oldest unpruned block(s) number.
 		OldestUnprunedBlock: u64;
 		/// Map of imported headers by hash.
-		Headers: map hasher(blake2_128_concat) H256 => Option<StoredHeader<T::AccountId>>;
+		Headers: map hasher(identity) H256 => Option<StoredHeader<T::AccountId>>;
 		/// Map of imported header hashes by number.
 		HeadersByNumber: map hasher(blake2_128_concat) u64 => Option<Vec<H256>>;
 		/// The ID of next validator set.
 		NextValidatorsSetId: u64;
 		/// Map of validators sets by their id.
-		ValidatorsSets: map hasher(blake2_128_concat) u64 => Option<ValidatorsSet>;
+		ValidatorsSets: map hasher(twox_64_concat) u64 => Option<ValidatorsSet>;
 		/// Validators sets reference count. Each header that is authored by this set increases
 		/// the reference count. When we prune this header, we decrease the reference count.
 		/// When it reaches zero, we are free to prune validator set as well.
-		ValidatorsSetsRc: map hasher(blake2_128_concat) u64 => Option<u64>;
+		ValidatorsSetsRc: map hasher(twox_64_concat) u64 => Option<u64>;
 		/// Map of validators set changes scheduled by given header.
-		ScheduledChanges: map hasher(blake2_128_concat) H256 => Option<ScheduledChange>;
+		ScheduledChanges: map hasher(identity) H256 => Option<ScheduledChange>;
 	}
 	add_extra_genesis {
 		config(initial_header): Header;

--- a/modules/ethereum/src/lib.rs
+++ b/modules/ethereum/src/lib.rs
@@ -21,8 +21,8 @@ use frame_support::{decl_module, decl_storage};
 use primitives::{Address, Header, Receipt, H256, U256};
 use sp_runtime::{
 	transaction_validity::{
-		InvalidTransaction, TransactionLongevity, TransactionPriority, TransactionValidity, UnknownTransaction,
-		ValidTransaction,
+		InvalidTransaction, TransactionLongevity, TransactionPriority, TransactionSource,
+		TransactionValidity, UnknownTransaction, ValidTransaction,
 	},
 	RuntimeDebug,
 };
@@ -293,6 +293,7 @@ pub trait Trait: frame_system::Trait {
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		/// Import single Aura header. Requires transaction to be **UNSIGNED**.
+		#[weight = 0]
 		pub fn import_unsigned_header(origin, header: Header, receipts: Option<Vec<Receipt>>) {
 			frame_system::ensure_none(origin)?;
 
@@ -313,6 +314,7 @@ decl_module! {
 		///
 		/// This should be used with caution - passing too many headers could lead to
 		/// enormous block production/import time.
+		#[weight = 0]
 		pub fn import_signed_headers(origin, headers_with_receipts: Vec<(Header, Option<Vec<Receipt>>)>) {
 			let submitter = frame_system::ensure_signed(origin)?;
 			let mut finalized_headers = BTreeMap::new();
@@ -359,19 +361,19 @@ decl_storage! {
 		/// Oldest unpruned block(s) number.
 		OldestUnprunedBlock: u64;
 		/// Map of imported headers by hash.
-		Headers: map hasher(blake2_256) H256 => Option<StoredHeader<T::AccountId>>;
+		Headers: map hasher(blake2_128_concat) H256 => Option<StoredHeader<T::AccountId>>;
 		/// Map of imported header hashes by number.
-		HeadersByNumber: map hasher(blake2_256) u64 => Option<Vec<H256>>;
+		HeadersByNumber: map hasher(blake2_128_concat) u64 => Option<Vec<H256>>;
 		/// The ID of next validator set.
 		NextValidatorsSetId: u64;
 		/// Map of validators sets by their id.
-		ValidatorsSets: map hasher(blake2_256) u64 => Option<ValidatorsSet>;
+		ValidatorsSets: map hasher(blake2_128_concat) u64 => Option<ValidatorsSet>;
 		/// Validators sets reference count. Each header that is authored by this set increases
 		/// the reference count. When we prune this header, we decrease the reference count.
 		/// When it reaches zero, we are free to prune validator set as well.
-		ValidatorsSetsRc: map hasher(blake2_256) u64 => Option<u64>;
+		ValidatorsSetsRc: map hasher(blake2_128_concat) u64 => Option<u64>;
 		/// Map of validators set changes scheduled by given header.
-		ScheduledChanges: map hasher(blake2_256) H256 => Option<ScheduledChange>;
+		ScheduledChanges: map hasher(blake2_128_concat) H256 => Option<ScheduledChange>;
 	}
 	add_extra_genesis {
 		config(initial_header): Header;
@@ -434,7 +436,7 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 	type Call = Call<T>;
 
-	fn validate_unsigned(call: &Self::Call) -> TransactionValidity {
+	fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
 		match *call {
 			Self::Call::import_unsigned_header(ref header, ref receipts) => {
 				let accept_result = verification::accept_aura_header_into_pool(

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -13,56 +13,56 @@ hash-db = { version = "0.15.2", default-features = false }
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-trie]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies
 [dev-dependencies.sp-io]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-state-machine]
-version = "0.8.0-alpha.2"
+version = "0.8.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -15,55 +15,55 @@ hash-db = { version = "0.15.2", default-features = false }
 [dependencies.frame-support]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-trie]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies
 [dev-dependencies.sp-io]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-state-machine]
 version = "0.8.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [features]

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -96,11 +96,11 @@ pub trait Trait: system::Trait {}
 decl_storage! {
 	trait Store for Module<T: Trait> as Bridge {
 		/// The number of current bridges managed by the module.
-		pub NumBridges get(num_bridges) config(): BridgeId;
+		pub NumBridges get(fn num_bridges) config(): BridgeId;
 
 		/// Maps a bridge id to a bridge struct. Allows a single
 		/// `bridge` module to manage multiple bridges.
-		pub TrackedBridges get(tracked_bridges): map hasher(blake2_256) BridgeId => Option<BridgeInfo<T>>;
+		pub TrackedBridges get(fn tracked_bridges): map hasher(blake2_128_concat) BridgeId => Option<BridgeInfo<T>>;
 	}
 }
 
@@ -108,6 +108,7 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		type Error = Error<T>;
 
+		#[weight = 0]
 		fn initialize_bridge(
 			origin,
 			block_header: T::Header,
@@ -131,6 +132,7 @@ decl_module! {
 			NumBridges::put(new_bridge_id);
 		}
 
+		#[weight = 0]
 		fn submit_finalized_headers(origin) {
 			let _sender = ensure_signed(origin)?;
 		}

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -108,7 +108,7 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		type Error = Error<T>;
 
-		#[weight = 0]
+		#[weight = 0] // TODO: update me
 		fn initialize_bridge(
 			origin,
 			block_header: T::Header,
@@ -132,7 +132,7 @@ decl_module! {
 			NumBridges::put(new_bridge_id);
 		}
 
-		#[weight = 0]
+		#[weight = 0] // TODO: update me
 		fn submit_finalized_headers(origin) {
 			let _sender = ensure_signed(origin)?;
 		}

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -158,7 +158,7 @@ impl<T: Trait> Module<T> {
 		validator_set: &Vec<(AuthorityId, AuthorityWeight)>,
 	) -> DispatchResult {
 		let checker =
-			<StorageProofChecker<<T::Hashing as sp_runtime::traits::Hash>::Hasher>>::new(*state_root, proof.clone());
+			<StorageProofChecker<T::Hashing>>::new(*state_root, proof.clone());
 
 		let checker = checker.map_err(Self::map_storage_err)?;
 
@@ -261,6 +261,9 @@ mod tests {
 		type Event = ();
 		type BlockHashCount = ();
 		type MaximumBlockWeight = ();
+		type DbWeight = ();
+		type BlockExecutionWeight = ();
+		type ExtrinsicBaseWeight = ();
 		type AvailableBlockRatio = ();
 		type MaximumBlockLength = ();
 		type Version = ();

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -157,8 +157,7 @@ impl<T: Trait> Module<T> {
 		proof: StorageProof,
 		validator_set: &Vec<(AuthorityId, AuthorityWeight)>,
 	) -> DispatchResult {
-		let checker =
-			<StorageProofChecker<T::Hashing>>::new(*state_root, proof.clone());
+		let checker = <StorageProofChecker<T::Hashing>>::new(*state_root, proof.clone());
 
 		let checker = checker.map_err(Self::map_storage_err)?;
 

--- a/primitives/ethereum-poa/Cargo.toml
+++ b/primitives/ethereum-poa/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0", optional = true }
 serde-big-array = { version = "0.2", optional = true }
 ethbloom = { version = "0.8", default-features = false }
 parity-bytes = { version = "0.1", default-features = false }
-primitive-types = { version = "0.6", default-features = false, features = ["codec", "rlp"] }
+primitive-types = { version = "0.7", default-features = false, features = ["codec", "rlp"] }
 fixed-hash = { version = "0.5", default-features = false }
 impl-rlp = { version = "0.2", default-features = false }
 impl-serde = { version = "0.2.3", optional = true }
@@ -22,25 +22,25 @@ plain_hasher = { version = "0.2.2", default-features = false }
 
 # Substrate Based Dependencies
 [dependencies.sp-api]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-std]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-io]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 default-features = false
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"

--- a/primitives/ethereum-poa/Cargo.toml
+++ b/primitives/ethereum-poa/Cargo.toml
@@ -24,25 +24,25 @@ plain_hasher = { version = "0.2.2", default-features = false }
 [dependencies.sp-api]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-std]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-io]
 version = "2.0.0-alpha.2"
 default-features = false
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [features]

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -27,35 +27,35 @@ web3 = { git = "https://github.com/svyatonik/rust-web3.git", branch = "fix_recei
 # Substrate Based Dependencies
 [dependencies.frame-system]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 # I think this is used for sr-io and stuff
 [dependencies.node-primitives]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 # Branch used for keccack256 hasher code
 # Could probably move the keccack hasher stuff to our own primitives
 [dependencies.sp-core]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-keyring]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 # This should get moved to our `bin` folder

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -22,39 +22,39 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.51"
 sp-bridge-eth-poa = { path = "../../primitives/ethereum-poa" }
 time = "0.2"
-web3 = { git = "https://github.com/svyatonik/rust-web3.git", branch = "fix_receipt" }
+web3 = { git = "https://github.com/svyatonik/rust-web3.git", branch = "add-receipt-root" }
 
 # Substrate Based Dependencies
 [dependencies.frame-system]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 # I think this is used for sr-io and stuff
 [dependencies.node-primitives]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 # Branch used for keccack256 hasher code
 # Could probably move the keccack hasher stuff to our own primitives
 [dependencies.sp-core]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-keyring]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate.git"
 

--- a/relays/substrate/Cargo.toml
+++ b/relays/substrate/Cargo.toml
@@ -17,16 +17,16 @@ serde_json = "1.0.51"
 url = "2.1.0"
 
 [dependencies.sp-core]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-rpc]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.node-primitives]
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.6"
 rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"

--- a/relays/substrate/Cargo.toml
+++ b/relays/substrate/Cargo.toml
@@ -18,15 +18,15 @@ url = "2.1.0"
 
 [dependencies.sp-core]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-rpc]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.node-primitives]
 version = "2.0.0-alpha.2"
-rev = "2afecf81ee19b8a6edb364b419190ea47c4a4a31"
+rev = "c13ad41634d0bd7cf07897c2aa062b917d520520"
 git = "https://github.com/paritytech/substrate/"


### PR DESCRIPTION
I need that to be able to continue #69 (especially `GrandpaJustification::decode_and_verify_finalizes`). It seems that the update that made that fn public isn't yet on crates.io, so I've changed suffix from `-alpha.2` to `-alpha.6` (that's the last published version) && updated commit to the latest commit of Substrate (not sure why we specify suffixes if we're pointing to the specific commit anyway? :) ).

So whenever actual 2.0 beta will be released on crates.io, we'll need another round of updates, but:
1) it would be much easier (probably just replacing these `[dependencies.*]` with simple crates references);
2) this PR would allow us to continue working without depending on Substrate release schedule.

P.S.: this PR also includes `cargo update`