### PR TITLE
Use `CallRequest` type from rust-web3 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7190,8 +7190,7 @@ dependencies = [
 [[package]]
 name = "web3"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a681e8d15deced7c510db88c59133d2eafa7b6298b6e91b545e2a3fed93b3fe"
+source = "git+https://github.com/tomusdrw/rust-web3#a3e5a5315f0a6bf907183322844f7d6650fa8da7"
 dependencies = [
  "arrayvec 0.5.1",
  "base64 0.12.0",

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.53"
 sp-bridge-eth-poa = { path = "../../primitives/ethereum-poa" }
 time = "0.2"
-web3 = "0.11"
+web3 = { git = "https://github.com/tomusdrw/rust-web3" }
 
 # Substrate Based Dependencies
 [dependencies.frame-system]

--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -216,12 +216,9 @@ pub async fn best_substrate_block(
 	let (encoded_call, call_decoder) = bridge_contract::functions::best_known_header::call();
 	let call_request = bail_on_arg_error!(
 		to_value(CallRequest {
-			to: contract_address,
+			to: Some(contract_address),
 			data: Some(encoded_call.into()),
-			from: None,
-			gas: None,
-			gas_price: None,
-			value: None,
+			..Default::default()
 		})
 		.map_err(|e| Error::RequestSerialization(e)),
 		client
@@ -253,12 +250,9 @@ pub async fn substrate_header_known(
 	let (encoded_call, call_decoder) = bridge_contract::functions::is_known_header::call(id.1);
 	let call_request = bail_on_arg_error!(
 		to_value(CallRequest {
-			to: contract_address,
+			to: Some(contract_address),
 			data: Some(encoded_call.into()),
-			from: None,
-			gas: None,
-			gas_price: None,
-			value: None,
+			..Default::default()
 		})
 		.map_err(|e| Error::RequestSerialization(e)),
 		client
@@ -310,12 +304,9 @@ pub async fn incomplete_substrate_headers(
 	let (encoded_call, call_decoder) = bridge_contract::functions::incomplete_headers::call();
 	let call_request = bail_on_arg_error!(
 		to_value(CallRequest {
-			to: contract_address,
+			to: Some(contract_address),
 			data: Some(encoded_call.into()),
-			from: None,
-			gas: None,
-			gas_price: None,
-			value: None,
+			..Default::default()
 		})
 		.map_err(|e| Error::RequestSerialization(e)),
 		client
@@ -401,12 +392,9 @@ async fn submit_ethereum_transaction(
 		estimate_gas(
 			client,
 			CallRequest {
-				to: contract_address.unwrap_or_default(),
+				to: contract_address,
 				data: Some(encoded_call.clone().into()),
-				from: None,
-				gas: None,
-				gas_price: None,
-				value: None,
+				..Default::default()
 			}
 		)
 		.await

--- a/relays/ethereum/src/ethereum_types.rs
+++ b/relays/ethereum/src/ethereum_types.rs
@@ -18,7 +18,7 @@ use crate::substrate_types::{into_substrate_ethereum_header, into_substrate_ethe
 use crate::sync_types::{HeaderId, HeadersSyncPipeline, QueuedHeader, SourceHeader};
 use codec::Encode;
 
-pub use web3::types::{Address, Bytes, H256, U128, U256, U64};
+pub use web3::types::{Address, Bytes, CallRequest, H256, U128, U256, U64};
 
 /// When header is just received from the Ethereum node, we check that it has
 /// both number and hash fields filled.


### PR DESCRIPTION
I think we should be moving towards using "standardized" types where possible, this is a small step towards that.

Bit of a side note - right now it's a little ugly to have four `None` fields added to each call, but `CallRequest` doesn't implement `Default` so I can't change it to be something like this:

```rust
CallRequest {
	to: contract_address,
	data: Some(encoded_call.into()),
        ..Default::default()
}
```

Something for the future, but not a big deal.