### PR TITLE
Mute warnings from Substrate <-> Substrate runtime module and relay

### DIFF
--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -49,7 +49,6 @@
 
 // TODO: when (if) this module will be resurrected, remove this
 #![allow(dead_code)]
-
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -47,6 +47,9 @@
 //!                ||     ||
 //!```
 
+// TODO: when (if) this module will be resurrected, remove this
+#![allow(dead_code)]
+
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/relays/substrate/src/main.rs
+++ b/relays/substrate/src/main.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
+// TODO: when (if) this relay will be resurrected, remove this
+#![allow(unused_variables)]
+#![allow(dead_code)]
+
 mod bridge;
 mod error;
 mod params;


### PR DESCRIPTION
afaik noone currently works on this module+relay && it is pretty annoying to see warnings during `cargo --test --all`, because it may be valid warnings from other crates.