### PR TITLE
Rollback Rust nightly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rust:
   - beta
   - nightly
 before_install:
-  - rustup install nightly
-  - rustup target add wasm32-unknown-unknown --toolchain nightly
+  - rustup install nightly-2020-05-14
+  - rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-14
   - rustup component add rustfmt
 before_script:
   - cargo fmt --all -- --check


### PR DESCRIPTION
The runtime requires nightly to build, but there's an issue with the
nightly releases from 2020-05-25 and onwards which is causing builds
to fail. This rolls back the version of the nightly compiler so that
builds pass until a fix is found.