### PR TITLE
Add async_trait to SourceClient and TargetClient

### DIFF
--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -284,7 +284,7 @@ pub async fn submit_substrate_headers(
 				Some(contract_address),
 				Some(nonce),
 				false,
-				bridge_contract::functions::import_header::encode_input(header.extract().0.encode(),),
+				bridge_contract::functions::import_header::encode_input(header.header().encode(),),
 			)
 			.await
 		)

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -184,7 +184,7 @@ impl TargetClient<EthereumHeadersSyncPipeline> for SubstrateHeadersTarget {
 	}
 
 	async fn incomplete_headers_ids(self) -> SubstrateFutureOutput<HashSet<EthereumHeaderId>> {
-		ready((self, Ok(HashSet::new()))).await
+		(self, Ok(HashSet::new()))
 	}
 
 	async fn complete_header(self, id: EthereumHeaderId, _completion: ()) -> SubstrateFutureOutput<EthereumHeaderId> {

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -105,7 +105,7 @@ impl SourceClient<EthereumHeadersSyncPipeline> for EthereumHeadersSource {
 	}
 
 	async fn header_completion(self, id: EthereumHeaderId) -> EthereumFutureOutput<(EthereumHeaderId, Option<()>)> {
-		ready((self, Ok((id, None)))).await
+		(self, Ok((id, None)))
 	}
 
 	async fn header_extra(

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -23,7 +23,7 @@ use crate::sync::{HeadersSyncParams, TargetTransactionMode};
 use crate::sync_loop::{OwnedSourceFutureOutput, OwnedTargetFutureOutput, SourceClient, TargetClient};
 
 use async_trait::async_trait;
-use futures::future::{ready, FutureExt};
+use futures::future::FutureExt;
 use std::{collections::HashSet, time::Duration};
 use web3::types::H256;
 

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -188,7 +188,7 @@ impl TargetClient<EthereumHeadersSyncPipeline> for SubstrateHeadersTarget {
 	}
 
 	async fn complete_header(self, id: EthereumHeaderId, _completion: ()) -> SubstrateFutureOutput<EthereumHeaderId> {
-		ready((self, Ok(id))).await
+		(self, Ok(id))
 	}
 
 	async fn requires_extra(self, header: QueuedEthereumHeader) -> SubstrateFutureOutput<(EthereumHeaderId, bool)> {

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -380,10 +380,9 @@ fn create_signed_submit_transaction(
 			headers
 				.into_iter()
 				.map(|header| {
-					let (header, receipts) = header.extract();
 					(
-						into_substrate_ethereum_header(&header),
-						into_substrate_ethereum_receipts(&receipts),
+						into_substrate_ethereum_header(header.header()),
+						into_substrate_ethereum_receipts(header.extra()),
 					)
 				})
 				.collect(),
@@ -422,11 +421,10 @@ fn create_signed_submit_transaction(
 
 /// Create unsigned Substrate transaction for submitting Ethereum header.
 fn create_unsigned_submit_transaction(header: QueuedEthereumHeader) -> bridge_node_runtime::UncheckedExtrinsic {
-	let (header, receipts) = header.extract();
 	let function =
 		bridge_node_runtime::Call::BridgeEthPoA(bridge_node_runtime::BridgeEthPoACall::import_unsigned_header(
-			into_substrate_ethereum_header(&header),
-			into_substrate_ethereum_receipts(&receipts),
+			into_substrate_ethereum_header(header.header()),
+			into_substrate_ethereum_receipts(header.extra()),
 		));
 
 	bridge_node_runtime::UncheckedExtrinsic::new_unsigned(function)

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -89,41 +89,40 @@ struct SubstrateHeadersSource {
 
 type SubstrateFutureOutput<T> = OwnedSourceFutureOutput<SubstrateHeadersSource, SubstrateHeadersSyncPipeline, T>;
 
+#[async_trait]
 impl SourceClient<SubstrateHeadersSyncPipeline> for SubstrateHeadersSource {
 	type Error = substrate_client::Error;
-	type BestBlockNumberFuture = Pin<Box<dyn Future<Output = SubstrateFutureOutput<Number>>>>;
-	type HeaderByHashFuture = Pin<Box<dyn Future<Output = SubstrateFutureOutput<Header>>>>;
-	type HeaderByNumberFuture = Pin<Box<dyn Future<Output = SubstrateFutureOutput<Header>>>>;
 	type HeaderExtraFuture = Ready<SubstrateFutureOutput<(SubstrateHeaderId, ())>>;
-	type HeaderCompletionFuture =
-		Pin<Box<dyn Future<Output = SubstrateFutureOutput<(SubstrateHeaderId, Option<GrandpaJustification>)>>>>;
 
-	fn best_block_number(self) -> Self::BestBlockNumberFuture {
+	async fn best_block_number(self) -> SubstrateFutureOutput<Number> {
 		substrate_client::best_header(self.client)
 			.map(|(client, result)| (SubstrateHeadersSource { client }, result.map(|header| header.number)))
-			.boxed()
+			.await
 	}
 
-	fn header_by_hash(self, hash: Hash) -> Self::HeaderByHashFuture {
+	async fn header_by_hash(self, hash: Hash) -> SubstrateFutureOutput<Header> {
 		substrate_client::header_by_hash(self.client, hash)
 			.map(|(client, result)| (SubstrateHeadersSource { client }, result))
-			.boxed()
+			.await
 	}
 
-	fn header_by_number(self, number: Number) -> Self::HeaderByNumberFuture {
+	async fn header_by_number(self, number: Number) -> SubstrateFutureOutput<Header> {
 		substrate_client::header_by_number(self.client, number)
 			.map(|(client, result)| (SubstrateHeadersSource { client }, result))
-			.boxed()
+			.await
 	}
 
 	fn header_extra(self, id: SubstrateHeaderId, _header: &Header) -> Self::HeaderExtraFuture {
 		ready((self, Ok((id, ()))))
 	}
 
-	fn header_completion(self, id: SubstrateHeaderId) -> Self::HeaderCompletionFuture {
+	async fn header_completion(
+		self,
+		id: SubstrateHeaderId,
+	) -> SubstrateFutureOutput<(SubstrateHeaderId, Option<GrandpaJustification>)> {
 		substrate_client::grandpa_justification(self.client, id)
 			.map(|(client, result)| (SubstrateHeadersSource { client }, result))
-			.boxed()
+			.await
 	}
 }
 

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -142,16 +142,11 @@ struct EthereumHeadersTarget {
 
 type EthereumFutureOutput<T> = OwnedTargetFutureOutput<EthereumHeadersTarget, SubstrateHeadersSyncPipeline, T>;
 
+#[async_trait]
 impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 	type Error = ethereum_client::Error;
-	type BestHeaderIdFuture = Pin<Box<dyn Future<Output = EthereumFutureOutput<SubstrateHeaderId>>>>;
-	type IsKnownHeaderFuture = Pin<Box<dyn Future<Output = EthereumFutureOutput<(SubstrateHeaderId, bool)>>>>;
-	type RequiresExtraFuture = Ready<EthereumFutureOutput<(SubstrateHeaderId, bool)>>;
-	type SubmitHeadersFuture = Pin<Box<dyn Future<Output = EthereumFutureOutput<Vec<SubstrateHeaderId>>>>>;
-	type IncompleteHeadersFuture = Pin<Box<dyn Future<Output = EthereumFutureOutput<HashSet<SubstrateHeaderId>>>>>;
-	type CompleteHeadersFuture = Pin<Box<dyn Future<Output = EthereumFutureOutput<SubstrateHeaderId>>>>;
 
-	fn best_header_id(self) -> Self::BestHeaderIdFuture {
+	async fn best_header_id(self) -> EthereumFutureOutput<SubstrateHeaderId> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
 		ethereum_client::best_substrate_block(self.client, contract)
 			.map(move |(client, result)| {
@@ -164,10 +159,10 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 					result,
 				)
 			})
-			.boxed()
+			.await
 	}
 
-	fn is_known_header(self, id: SubstrateHeaderId) -> Self::IsKnownHeaderFuture {
+	async fn is_known_header(self, id: SubstrateHeaderId) -> EthereumFutureOutput<(SubstrateHeaderId, bool)> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
 		ethereum_client::substrate_header_known(self.client, contract, id)
 			.map(move |(client, result)| {
@@ -180,14 +175,14 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 					result,
 				)
 			})
-			.boxed()
+			.await
 	}
 
-	fn requires_extra(self, header: &QueuedSubstrateHeader) -> Self::RequiresExtraFuture {
-		ready((self, Ok((header.header().id(), false))))
+	async fn requires_extra(self, header: &QueuedSubstrateHeader) -> EthereumFutureOutput<(SubstrateHeaderId, bool)> {
+		ready((self, Ok((header.header().id(), false)))).await
 	}
 
-	fn submit_headers(self, headers: Vec<QueuedSubstrateHeader>) -> Self::SubmitHeadersFuture {
+	async fn submit_headers(self, headers: Vec<QueuedSubstrateHeader>) -> EthereumFutureOutput<Vec<SubstrateHeaderId>> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
 		ethereum_client::submit_substrate_headers(self.client, sign_params.clone(), contract, headers)
 			.map(move |(client, result)| {
@@ -200,10 +195,10 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 					result,
 				)
 			})
-			.boxed()
+			.await
 	}
 
-	fn incomplete_headers_ids(self) -> Self::IncompleteHeadersFuture {
+	async fn incomplete_headers_ids(self) -> EthereumFutureOutput<HashSet<SubstrateHeaderId>> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
 		ethereum_client::incomplete_substrate_headers(self.client, contract)
 			.map(move |(client, result)| {
@@ -216,10 +211,10 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 					result,
 				)
 			})
-			.boxed()
+			.await
 	}
 
-	fn complete_header(self, id: SubstrateHeaderId, completion: GrandpaJustification) -> Self::CompleteHeadersFuture {
+	async fn complete_header(self, id: SubstrateHeaderId, completion: GrandpaJustification) -> EthereumFutureOutput<SubstrateHeaderId> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
 		ethereum_client::complete_substrate_header(self.client, sign_params.clone(), contract, id, completion)
 			.map(move |(client, result)| {
@@ -232,7 +227,7 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 					result,
 				)
 			})
-			.boxed()
+			.await
 	}
 }
 

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -59,17 +59,21 @@ pub trait SourceClient<P: HeadersSyncPipeline>: Sized {
 
 	/// Get best block number.
 	async fn best_block_number(self) -> OwnedSourceFutureOutput<Self, P, P::Number>;
+
 	/// Get header by hash.
 	async fn header_by_hash(self, hash: P::Hash) -> OwnedSourceFutureOutput<Self, P, P::Header>;
+
 	/// Get canonical header by number.
 	async fn header_by_number(self, number: P::Number) -> OwnedSourceFutureOutput<Self, P, P::Header>;
-	/// Get extra data by header hash.
-	fn header_extra(self, id: HeaderId<P::Hash, P::Number>, header: &P::Header) -> Self::HeaderExtraFuture;
+
 	/// Get completion data by header hash.
 	async fn header_completion(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
 	) -> OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>;
+
+	/// Get extra data by header hash.
+	fn header_extra(self, id: HeaderId<P::Hash, P::Number>, header: &P::Header) -> Self::HeaderExtraFuture;
 }
 
 /// Target client trait.
@@ -82,26 +86,32 @@ pub trait TargetClient<P: HeadersSyncPipeline>: Sized {
 
 	/// Returns ID of best header known to the target node.
 	async fn best_header_id(self) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
+
 	/// Returns true if header is known to the target node.
 	async fn is_known_header(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
 	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
-	/// Returns true if header requires extra data to be submitted.
-	fn requires_extra(self, header: &QueuedHeader<P>) -> Self::RequiresExtraFuture;
+
+
 	/// Submit headers.
 	async fn submit_headers(
 		self,
 		headers: Vec<QueuedHeader<P>>,
 	) -> OwnedTargetFutureOutput<Self, P, Vec<HeaderId<P::Hash, P::Number>>>;
+
 	/// Returns ID of headers that require to be 'completed' before children can be submitted.
 	async fn incomplete_headers_ids(self) -> OwnedTargetFutureOutput<Self, P, HashSet<HeaderId<P::Hash, P::Number>>>;
+
 	/// Submit completion data for header.
 	async fn complete_header(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
 		completion: P::Completion,
 	) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
+
+	/// Returns true if header requires extra data to be submitted.
+	fn requires_extra(self, header: &QueuedHeader<P>) -> Self::RequiresExtraFuture;
 }
 
 /// Run headers synchronization.

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -50,32 +50,26 @@ pub type OwnedSourceFutureOutput<Client, P, T> = (Client, Result<T, <Client as S
 pub type OwnedTargetFutureOutput<Client, P, T> = (Client, Result<T, <Client as TargetClient<P>>::Error>);
 
 /// Source client trait.
+#[async_trait]
 pub trait SourceClient<P: HeadersSyncPipeline>: Sized {
 	/// Type of error this clients returns.
 	type Error: std::fmt::Debug + MaybeConnectionError;
-	/// Future that returns best block number.
-	type BestBlockNumberFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Number>>;
-	/// Future that returns header by hash.
-	type HeaderByHashFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Header>>;
-	/// Future that returns header by number.
-	type HeaderByNumberFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Header>>;
 	/// Future that returns extra data associated with header.
 	type HeaderExtraFuture: Future<Output = OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, P::Extra)>>;
-	/// Future that returns data required to 'complete' header.
-	type HeaderCompletionFuture: Future<
-		Output = OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>,
-	>;
 
 	/// Get best block number.
-	fn best_block_number(self) -> Self::BestBlockNumberFuture;
+	async fn best_block_number(self) -> OwnedSourceFutureOutput<Self, P, P::Number>;
 	/// Get header by hash.
-	fn header_by_hash(self, hash: P::Hash) -> Self::HeaderByHashFuture;
+	async fn header_by_hash(self, hash: P::Hash) -> OwnedSourceFutureOutput<Self, P, P::Header>;
 	/// Get canonical header by number.
-	fn header_by_number(self, number: P::Number) -> Self::HeaderByNumberFuture;
+	async fn header_by_number(self, number: P::Number) -> OwnedSourceFutureOutput<Self, P, P::Header>;
 	/// Get extra data by header hash.
 	fn header_extra(self, id: HeaderId<P::Hash, P::Number>, header: &P::Header) -> Self::HeaderExtraFuture;
 	/// Get completion data by header hash.
-	fn header_completion(self, id: HeaderId<P::Hash, P::Number>) -> Self::HeaderCompletionFuture;
+	async fn header_completion(
+		self,
+		id: HeaderId<P::Hash, P::Number>,
+	) -> OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>;
 }
 
 /// Target client trait.

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -93,7 +93,6 @@ pub trait TargetClient<P: HeadersSyncPipeline>: Sized {
 		id: HeaderId<P::Hash, P::Number>,
 	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
 
-
 	/// Submit headers.
 	async fn submit_headers(
 		self,

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -16,7 +16,6 @@
 
 use crate::sync::HeadersSyncParams;
 use crate::sync_types::{HeaderId, HeaderStatus, HeadersSyncPipeline, MaybeConnectionError, QueuedHeader};
-use async_trait::async_trait;
 use futures::{future::FutureExt, stream::StreamExt};
 use num_traits::{Saturating, Zero};
 use std::{
@@ -49,61 +48,69 @@ pub type OwnedSourceFutureOutput<Client, P, T> = (Client, Result<T, <Client as S
 pub type OwnedTargetFutureOutput<Client, P, T> = (Client, Result<T, <Client as TargetClient<P>>::Error>);
 
 /// Source client trait.
-#[async_trait]
 pub trait SourceClient<P: HeadersSyncPipeline>: Sized {
 	/// Type of error this clients returns.
 	type Error: std::fmt::Debug + MaybeConnectionError;
+	/// Future that returns best block number.
+	type BestBlockNumberFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Number>>;
+	/// Future that returns header by hash.
+	type HeaderByHashFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Header>>;
+	/// Future that returns header by number.
+	type HeaderByNumberFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Header>>;
+	/// Future that returns extra data associated with header.
+	type HeaderExtraFuture: Future<Output = OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, P::Extra)>>;
+	/// Future that returns data required to 'complete' header.
+	type HeaderCompletionFuture: Future<
+		Output = OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>,
+	>;
 
 	/// Get best block number.
-	async fn best_block_number(self) -> OwnedSourceFutureOutput<Self, P, P::Number>;
+	fn best_block_number(self) -> Self::BestBlockNumberFuture;
 	/// Get header by hash.
-	async fn header_by_hash(self, hash: P::Hash) -> OwnedSourceFutureOutput<Self, P, P::Header>;
+	fn header_by_hash(self, hash: P::Hash) -> Self::HeaderByHashFuture;
 	/// Get canonical header by number.
-	async fn header_by_number(self, number: P::Number) -> OwnedSourceFutureOutput<Self, P, P::Header>;
+	fn header_by_number(self, number: P::Number) -> Self::HeaderByNumberFuture;
 	/// Get extra data by header hash.
-	async fn header_extra(
-		self,
-		id: HeaderId<P::Hash, P::Number>,
-		header: &P::Header,
-	) -> OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, P::Extra)>;
+	fn header_extra(self, id: HeaderId<P::Hash, P::Number>, header: &P::Header) -> Self::HeaderExtraFuture;
 	/// Get completion data by header hash.
-	async fn header_completion(
-		self,
-		id: HeaderId<P::Hash, P::Number>,
-	) -> OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>;
+	fn header_completion(self, id: HeaderId<P::Hash, P::Number>) -> Self::HeaderCompletionFuture;
 }
 
 /// Target client trait.
-#[async_trait]
 pub trait TargetClient<P: HeadersSyncPipeline>: Sized {
 	/// Type of error this clients returns.
 	type Error: std::fmt::Debug + MaybeConnectionError;
+	/// Future that returns best header id.
+	type BestHeaderIdFuture: Future<Output = OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>>;
+	/// Future that returns known header check result.
+	type IsKnownHeaderFuture: Future<Output = OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>>;
+	/// Future that returns extra check result.
+	type RequiresExtraFuture: Future<Output = OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>>;
+	/// Future that returns header submission result.
+	type SubmitHeadersFuture: Future<Output = OwnedTargetFutureOutput<Self, P, Vec<HeaderId<P::Hash, P::Number>>>>;
+	/// Future that returns incomplete headers ids.
+	type IncompleteHeadersFuture: Future<
+		Output = OwnedTargetFutureOutput<Self, P, HashSet<HeaderId<P::Hash, P::Number>>>,
+	>;
+	/// Future that returns header completion result.
+	type CompleteHeadersFuture: Future<Output = OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>>;
 
 	/// Returns ID of best header known to the target node.
-	async fn best_header_id(self) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
+	fn best_header_id(self) -> Self::BestHeaderIdFuture;
 	/// Returns true if header is known to the target node.
-	async fn is_known_header(
-		self,
-		id: HeaderId<P::Hash, P::Number>,
-	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
+	fn is_known_header(self, id: HeaderId<P::Hash, P::Number>) -> Self::IsKnownHeaderFuture;
 	/// Returns true if header requires extra data to be submitted.
-	async fn requires_extra(
-		self,
-		header: &QueuedHeader<P>,
-	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
+	fn requires_extra(self, header: &QueuedHeader<P>) -> Self::RequiresExtraFuture;
 	/// Submit headers.
-	async fn submit_headers(
-		self,
-		headers: Vec<QueuedHeader<P>>,
-	) -> OwnedTargetFutureOutput<Self, P, Vec<HeaderId<P::Hash, P::Number>>>;
+	fn submit_headers(self, headers: Vec<QueuedHeader<P>>) -> Self::SubmitHeadersFuture;
 	/// Returns ID of headers that require to be 'completed' before children can be submitted.
-	async fn incomplete_headers_ids(self) -> OwnedTargetFutureOutput<Self, P, HashSet<HeaderId<P::Hash, P::Number>>>;
+	fn incomplete_headers_ids(self) -> Self::IncompleteHeadersFuture;
 	/// Submit completion data for header.
-	async fn complete_header(
+	fn complete_header(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
 		completion: P::Completion,
-	) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
+	) -> Self::CompleteHeadersFuture;
 }
 
 /// Run headers synchronization.

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -16,6 +16,7 @@
 
 use crate::sync::HeadersSyncParams;
 use crate::sync_types::{HeaderId, HeaderStatus, HeadersSyncPipeline, MaybeConnectionError, QueuedHeader};
+use async_trait::async_trait;
 use futures::{future::FutureExt, stream::StreamExt};
 use num_traits::{Saturating, Zero};
 use std::{
@@ -48,32 +49,28 @@ pub type OwnedSourceFutureOutput<Client, P, T> = (Client, Result<T, <Client as S
 pub type OwnedTargetFutureOutput<Client, P, T> = (Client, Result<T, <Client as TargetClient<P>>::Error>);
 
 /// Source client trait.
+#[async_trait]
 pub trait SourceClient<P: HeadersSyncPipeline>: Sized {
 	/// Type of error this clients returns.
 	type Error: std::fmt::Debug + MaybeConnectionError;
-	/// Future that returns best block number.
-	type BestBlockNumberFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Number>>;
-	/// Future that returns header by hash.
-	type HeaderByHashFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Header>>;
-	/// Future that returns header by number.
-	type HeaderByNumberFuture: Future<Output = OwnedSourceFutureOutput<Self, P, P::Header>>;
-	/// Future that returns extra data associated with header.
-	type HeaderExtraFuture: Future<Output = OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, P::Extra)>>;
-	/// Future that returns data required to 'complete' header.
-	type HeaderCompletionFuture: Future<
-		Output = OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>,
-	>;
 
 	/// Get best block number.
-	fn best_block_number(self) -> Self::BestBlockNumberFuture;
+	async fn best_block_number(self) -> OwnedSourceFutureOutput<Self, P, P::Number>;
 	/// Get header by hash.
-	fn header_by_hash(self, hash: P::Hash) -> Self::HeaderByHashFuture;
+	async fn header_by_hash(self, hash: P::Hash) -> OwnedSourceFutureOutput<Self, P, P::Header>;
 	/// Get canonical header by number.
-	fn header_by_number(self, number: P::Number) -> Self::HeaderByNumberFuture;
+	async fn header_by_number(self, number: P::Number) -> OwnedSourceFutureOutput<Self, P, P::Header>;
 	/// Get extra data by header hash.
-	fn header_extra(self, id: HeaderId<P::Hash, P::Number>, header: &P::Header) -> Self::HeaderExtraFuture;
+	async fn header_extra(
+		self,
+		id: HeaderId<P::Hash, P::Number>,
+		header: &P::Header,
+	) -> OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, P::Extra)>;
 	/// Get completion data by header hash.
-	fn header_completion(self, id: HeaderId<P::Hash, P::Number>) -> Self::HeaderCompletionFuture;
+	async fn header_completion(
+		self,
+		id: HeaderId<P::Hash, P::Number>,
+	) -> OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>;
 }
 
 /// Target client trait.

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -74,40 +74,36 @@ pub trait SourceClient<P: HeadersSyncPipeline>: Sized {
 }
 
 /// Target client trait.
+#[async_trait]
 pub trait TargetClient<P: HeadersSyncPipeline>: Sized {
 	/// Type of error this clients returns.
 	type Error: std::fmt::Debug + MaybeConnectionError;
-	/// Future that returns best header id.
-	type BestHeaderIdFuture: Future<Output = OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>>;
-	/// Future that returns known header check result.
-	type IsKnownHeaderFuture: Future<Output = OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>>;
-	/// Future that returns extra check result.
-	type RequiresExtraFuture: Future<Output = OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>>;
-	/// Future that returns header submission result.
-	type SubmitHeadersFuture: Future<Output = OwnedTargetFutureOutput<Self, P, Vec<HeaderId<P::Hash, P::Number>>>>;
-	/// Future that returns incomplete headers ids.
-	type IncompleteHeadersFuture: Future<
-		Output = OwnedTargetFutureOutput<Self, P, HashSet<HeaderId<P::Hash, P::Number>>>,
-	>;
-	/// Future that returns header completion result.
-	type CompleteHeadersFuture: Future<Output = OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>>;
 
 	/// Returns ID of best header known to the target node.
-	fn best_header_id(self) -> Self::BestHeaderIdFuture;
+	async fn best_header_id(self) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
 	/// Returns true if header is known to the target node.
-	fn is_known_header(self, id: HeaderId<P::Hash, P::Number>) -> Self::IsKnownHeaderFuture;
+	async fn is_known_header(
+		self,
+		id: HeaderId<P::Hash, P::Number>,
+	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
 	/// Returns true if header requires extra data to be submitted.
-	fn requires_extra(self, header: &QueuedHeader<P>) -> Self::RequiresExtraFuture;
+	async fn requires_extra(
+		self,
+		header: &QueuedHeader<P>,
+	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
 	/// Submit headers.
-	fn submit_headers(self, headers: Vec<QueuedHeader<P>>) -> Self::SubmitHeadersFuture;
+	async fn submit_headers(
+		self,
+		headers: Vec<QueuedHeader<P>>,
+	) -> OwnedTargetFutureOutput<Self, P, Vec<HeaderId<P::Hash, P::Number>>>;
 	/// Returns ID of headers that require to be 'completed' before children can be submitted.
-	fn incomplete_headers_ids(self) -> Self::IncompleteHeadersFuture;
+	async fn incomplete_headers_ids(self) -> OwnedTargetFutureOutput<Self, P, HashSet<HeaderId<P::Hash, P::Number>>>;
 	/// Submit completion data for header.
-	fn complete_header(
+	async fn complete_header(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
 		completion: P::Completion,
-	) -> Self::CompleteHeadersFuture;
+	) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
 }
 
 /// Run headers synchronization.


### PR DESCRIPTION
This is mainly a readability improvement, as it removes the hard to read associated types from these traits.

There were two methods which I wasn't able to `async`-ify:`SourceClient::header_extra()` and `TargetClient::requires_extra()`. Changing those resulted in a firehose of ownership errors. Maybe Slava and I can work though those together? If you're curious as to what the errors are try building 2c15755. 