### PR TITLE
Move pruning strategy to runtime level

### DIFF
--- a/bin/node/runtime/src/kovan.rs
+++ b/bin/node/runtime/src/kovan.rs
@@ -113,11 +113,11 @@ pub fn kovan_genesis_header() -> Header {
 /// We do not prune unfinalized headers because exchange module only accepts
 /// claims from finalized headers. And if we're pruning unfinalized headers, then
 /// some claims may never be accepted.
-#[derive(RuntimeDebug)]
+#[derive(Default, RuntimeDebug)]
 pub struct KovanPruningStrategy;
 
 impl PruningStrategy for KovanPruningStrategy {
-	fn pruning_upper_bound(_best_number: u64, best_finalized_number: u64) -> u64 {
+	fn pruning_upper_bound(&mut self, _best_number: u64, best_finalized_number: u64) -> u64 {
 		best_finalized_number
 			.checked_sub(FINALIZED_HEADERS_TO_KEEP)
 			.unwrap_or(0)
@@ -131,19 +131,19 @@ mod tests {
 	#[test]
 	fn pruning_strategy_keeps_enough_headers() {
 		assert_eq!(
-			KovanPruningStrategy::pruning_upper_bound(100_000, 10_000),
+			KovanPruningStrategy::default().pruning_upper_bound(100_000, 10_000),
 			0,
 			"10_000 <= 20_000 => nothing should be pruned yet",
 		);
 
 		assert_eq!(
-			KovanPruningStrategy::pruning_upper_bound(100_000, 20_000),
+			KovanPruningStrategy::default().pruning_upper_bound(100_000, 20_000),
 			0,
 			"20_000 <= 20_000 => nothing should be pruned yet",
 		);
 
 		assert_eq!(
-			KovanPruningStrategy::pruning_upper_bound(100_000, 30_000),
+			KovanPruningStrategy::default().pruning_upper_bound(100_000, 30_000),
 			10_000,
 			"20_000 <= 30_000 => we're ready to prune first 10_000 headers",
 		);

--- a/bin/node/runtime/src/kovan.rs
+++ b/bin/node/runtime/src/kovan.rs
@@ -14,10 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
+use frame_support::RuntimeDebug;
 use hex_literal::hex;
-use pallet_bridge_eth_poa::{AuraConfiguration, ValidatorsConfiguration, ValidatorsSource};
+use pallet_bridge_eth_poa::{AuraConfiguration, PruningStrategy, ValidatorsConfiguration, ValidatorsSource};
 use sp_bridge_eth_poa::{Address, Header, U256};
 use sp_std::prelude::*;
+
+/// Max number of finalized headers to keep. It is equivalent of ~24 hours of
+/// finalized blocks on current Kovan chain.
+const FINALIZED_HEADERS_TO_KEEP: u64 = 20_000;
 
 /// Aura engine configuration for Kovan chain.
 pub fn kovan_aura_configuration() -> AuraConfiguration {
@@ -100,5 +105,45 @@ pub fn kovan_genesis_header() -> Header {
 			]
 			.into(),
 		],
+	}
+}
+
+/// Kovan headers pruning strategy.
+///
+/// We do not prune unfinalized headers because exchange module only accepts
+/// claims from finalized headers. And if we're pruning unfinalized headers, then
+/// some claims may never be accepted.
+#[derive(RuntimeDebug)]
+pub struct KovanPruningStrategy;
+
+impl PruningStrategy for KovanPruningStrategy {
+	fn pruning_upper_bound(_best_number: u64, best_finalized_number: u64) -> u64 {
+		best_finalized_number.checked_sub(FINALIZED_HEADERS_TO_KEEP).unwrap_or(0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn pruning_strategy_keeps_enough_headers() {
+		assert_eq!(
+			KovanPruningStrategy::pruning_upper_bound(100_000, 10_000),
+			0,
+			"10_000 <= 20_000 => nothing should be pruned yet",
+		);
+
+		assert_eq!(
+			KovanPruningStrategy::pruning_upper_bound(100_000, 20_000),
+			0,
+			"20_000 <= 20_000 => nothing should be pruned yet",
+		);
+
+		assert_eq!(
+			KovanPruningStrategy::pruning_upper_bound(100_000, 30_000),
+			10_000,
+			"20_000 <= 30_000 => we're ready to prune first 10_000 headers",
+		);
 	}
 }

--- a/bin/node/runtime/src/kovan.rs
+++ b/bin/node/runtime/src/kovan.rs
@@ -118,7 +118,9 @@ pub struct KovanPruningStrategy;
 
 impl PruningStrategy for KovanPruningStrategy {
 	fn pruning_upper_bound(_best_number: u64, best_finalized_number: u64) -> u64 {
-		best_finalized_number.checked_sub(FINALIZED_HEADERS_TO_KEEP).unwrap_or(0)
+		best_finalized_number
+			.checked_sub(FINALIZED_HEADERS_TO_KEEP)
+			.unwrap_or(0)
 	}
 }
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -225,6 +225,7 @@ impl pallet_bridge_eth_poa::Trait for Runtime {
 	type AuraConfiguration = KovanAuraConfiguration;
 	type FinalityVotesCachingInterval = FinalityVotesCachingInterval;
 	type ValidatorsConfiguration = KovanValidatorsConfiguration;
+	type PruningStrategy = kovan::KovanPruningStrategy;
 	type OnHeadersSubmitted = ();
 }
 

--- a/modules/ethereum/src/import.rs
+++ b/modules/ethereum/src/import.rs
@@ -128,15 +128,8 @@ pub fn import_header<S: Storage, PS: PruningStrategy>(
 	));
 
 	// compute upper border of updated pruning range
-	let new_best_block_id = if is_best {
-		header_id
-	} else {
-		best_id
-	};
-	let new_best_finalized_block_id = finalized_blocks
-		.finalized_headers
-		.last()
-		.map(|(id, _)| *id);
+	let new_best_block_id = if is_best { header_id } else { best_id };
+	let new_best_finalized_block_id = finalized_blocks.finalized_headers.last().map(|(id, _)| *id);
 	let pruning_upper_bound = PS::pruning_upper_bound(
 		new_best_block_id.number,
 		new_best_finalized_block_id
@@ -145,10 +138,7 @@ pub fn import_header<S: Storage, PS: PruningStrategy>(
 	);
 
 	// now mark finalized headers && prune old headers
-	storage.finalize_headers(
-		new_best_finalized_block_id,
-		pruning_upper_bound,
-	);
+	storage.finalize_headers(new_best_finalized_block_id, pruning_upper_bound);
 
 	Ok((header_id, finalized_blocks.finalized_headers))
 }

--- a/modules/ethereum/src/import.rs
+++ b/modules/ethereum/src/import.rs
@@ -138,7 +138,7 @@ pub fn import_header<S: Storage, PS: PruningStrategy>(
 	);
 
 	// now mark finalized headers && prune old headers
-	storage.finalize_headers(new_best_finalized_block_id, pruning_upper_bound);
+	storage.finalize_and_prune_headers(new_best_finalized_block_id, pruning_upper_bound);
 
 	Ok((header_id, finalized_blocks.finalized_headers))
 }
@@ -170,7 +170,7 @@ mod tests {
 	fn rejects_finalized_block_competitors() {
 		custom_test_ext(genesis(), validators_addresses(3)).execute_with(|| {
 			let mut storage = BridgeStorage::<TestRuntime>::new();
-			storage.finalize_headers(
+			storage.finalize_and_prune_headers(
 				Some(HeaderId {
 					number: 100,
 					..Default::default()

--- a/modules/ethereum/src/lib.rs
+++ b/modules/ethereum/src/lib.rs
@@ -293,7 +293,7 @@ pub trait Storage {
 	/// It is the storage duty to ensure that unfinalized headers that have
 	/// scheduled changes won't be pruned until they or their competitors
 	/// are finalized.
-	fn finalize_headers(&mut self, finalized: Option<HeaderId>, prune_end: u64);
+	fn finalize_and_prune_headers(&mut self, finalized: Option<HeaderId>, prune_end: u64);
 }
 
 /// Headers pruning strategy.
@@ -786,7 +786,7 @@ impl<T: Trait> Storage for BridgeStorage<T> {
 		);
 	}
 
-	fn finalize_headers(&mut self, finalized: Option<HeaderId>, prune_end: u64) {
+	fn finalize_and_prune_headers(&mut self, finalized: Option<HeaderId>, prune_end: u64) {
 		// remember just finalized block
 		let finalized_number = finalized
 			.as_ref()
@@ -1087,7 +1087,7 @@ pub(crate) mod tests {
 				oldest_unpruned_block: interval - 1,
 				oldest_block_to_keep: interval - 1,
 			});
-			storage.finalize_headers(None, interval + 1);
+			storage.finalize_and_prune_headers(None, interval + 1);
 			assert_eq!(FinalityCache::<TestRuntime>::get(&header_with_entry_hash), None);
 		});
 	}
@@ -1168,7 +1168,7 @@ pub(crate) mod tests {
 			let mut storage = BridgeStorage::<TestRuntime>::new();
 			insert_header(&mut storage, example_header_parent());
 			insert_header(&mut storage, example_header());
-			storage.finalize_headers(Some(example_header().compute_id()), 0);
+			storage.finalize_and_prune_headers(Some(example_header().compute_id()), 0);
 			assert_eq!(
 				verify_transaction_finalized(&storage, example_header_parent().compute_hash(), 0, &vec![example_tx()],),
 				true,
@@ -1222,7 +1222,7 @@ pub(crate) mod tests {
 			insert_header(&mut storage, example_header_parent());
 			insert_header(&mut storage, example_header());
 			insert_header(&mut storage, finalized_header_sibling);
-			storage.finalize_headers(Some(example_header().compute_id()), 0);
+			storage.finalize_and_prune_headers(Some(example_header().compute_id()), 0);
 			assert_eq!(
 				verify_transaction_finalized(&storage, finalized_header_sibling_hash, 0, &vec![example_tx()],),
 				false,
@@ -1241,7 +1241,7 @@ pub(crate) mod tests {
 			insert_header(&mut storage, example_header_parent());
 			insert_header(&mut storage, finalized_header_uncle);
 			insert_header(&mut storage, example_header());
-			storage.finalize_headers(Some(example_header().compute_id()), 0);
+			storage.finalize_and_prune_headers(Some(example_header().compute_id()), 0);
 			assert_eq!(
 				verify_transaction_finalized(&storage, finalized_header_uncle_hash, 0, &vec![example_tx()],),
 				false,

--- a/modules/ethereum/src/lib.rs
+++ b/modules/ethereum/src/lib.rs
@@ -286,15 +286,31 @@ pub trait Storage {
 	fn scheduled_change(&self, hash: &H256) -> Option<ScheduledChange>;
 	/// Insert imported header.
 	fn insert_header(&mut self, header: HeaderToImport<Self::Submitter>);
-	/// Finalize given block and prune all headers with number < prune_end.
+	/// Finalize given block and prune schedules pruning of all headers
+	/// with number < prune_end.
+	///
 	/// The headers in the pruning range could be either finalized, or not.
 	/// It is the storage duty to ensure that unfinalized headers that have
 	/// scheduled changes won't be pruned until they or their competitors
 	/// are finalized.
-	fn finalize_headers(&mut self, finalized: Option<HeaderId>, prune_end: Option<u64>);
+	fn finalize_headers(&mut self, finalized: Option<HeaderId>, prune_end: u64);
 }
 
-/// Decides whether the session should be ended.
+/// Headers pruning strategy.
+pub trait PruningStrategy {
+	/// Return upper bound (exclusive) of headers pruning range.
+	///
+	/// Every value that is returned from this function, must be greater or equal to the
+	/// previous value. Otherwise it will be ignored (we can't revert pruning).
+	///
+	/// Module may prune both finalized and unfinalized blocks. But it can't give any
+	/// guarantees on when it will happen. Example: if some unfinalized block at height N
+	/// has scheduled validators set change, then the module won't prune any blocks with
+	/// number >= N even if strategy allows that.
+	fn pruning_upper_bound(best_number: u64, best_finalized_number: u64) -> u64;
+}
+
+/// Callbacks for header submission rewards/penalties.
 pub trait OnHeadersSubmitted<AccountId> {
 	/// Called when valid headers have been submitted.
 	///
@@ -322,6 +338,9 @@ impl<AccountId> OnHeadersSubmitted<AccountId> for () {
 pub trait Trait: frame_system::Trait {
 	/// Aura configuration.
 	type AuraConfiguration: Get<AuraConfiguration>;
+	/// Validators configuration.
+	type ValidatorsConfiguration: Get<validators::ValidatorsConfiguration>;
+
 	/// Interval (in blocks) for for finality votes caching.
 	/// If None, cache is disabled.
 	///
@@ -329,8 +348,9 @@ pub trait Trait: frame_system::Trait {
 	/// be any significant finalization delays), or something that is bit larger
 	/// than average finalization delay.
 	type FinalityVotesCachingInterval: Get<Option<u64>>;
-	/// Validators configuration.
-	type ValidatorsConfiguration: Get<validators::ValidatorsConfiguration>;
+	/// Headers pruning strategy.
+	type PruningStrategy: PruningStrategy;
+
 	/// Handler for headers submission result.
 	type OnHeadersSubmitted: OnHeadersSubmitted<Self::AccountId>;
 }
@@ -342,11 +362,10 @@ decl_module! {
 		pub fn import_unsigned_header(origin, header: Header, receipts: Option<Vec<Receipt>>) {
 			frame_system::ensure_none(origin)?;
 
-			import::import_header(
+			import::import_header::<_, T::PruningStrategy>(
 				&mut BridgeStorage::<T>::new(),
 				&T::AuraConfiguration::get(),
 				&T::ValidatorsConfiguration::get(),
-				crate::import::PRUNE_DEPTH,
 				None,
 				header,
 				receipts,
@@ -363,11 +382,10 @@ decl_module! {
 		pub fn import_signed_headers(origin, headers_with_receipts: Vec<(Header, Option<Vec<Receipt>>)>) {
 			let submitter = frame_system::ensure_signed(origin)?;
 			let mut finalized_headers = BTreeMap::new();
-			let import_result = import::import_headers(
+			let import_result = import::import_headers::<_, T::PruningStrategy>(
 				&mut BridgeStorage::<T>::new(),
 				&T::AuraConfiguration::get(),
 				&T::ValidatorsConfiguration::get(),
-				crate::import::PRUNE_DEPTH,
 				Some(submitter.clone()),
 				headers_with_receipts,
 				&mut finalized_headers,
@@ -539,15 +557,13 @@ impl<T: Trait> BridgeStorage<T> {
 	}
 
 	/// Prune old blocks.
-	fn prune_blocks(&self, mut max_blocks_to_prune: u64, finalized_number: u64, prune_end: Option<u64>) {
+	fn prune_blocks(&self, mut max_blocks_to_prune: u64, finalized_number: u64, prune_end: u64) {
 		let pruning_range = BlocksToPrune::get();
 		let mut new_pruning_range = pruning_range.clone();
 
 		// update oldest block we want to keep
-		if let Some(prune_end) = prune_end {
-			if prune_end > new_pruning_range.oldest_block_to_keep {
-				new_pruning_range.oldest_block_to_keep = prune_end;
-			}
+		if prune_end > new_pruning_range.oldest_block_to_keep {
+			new_pruning_range.oldest_block_to_keep = prune_end;
 		}
 
 		// start pruning blocks
@@ -770,7 +786,7 @@ impl<T: Trait> Storage for BridgeStorage<T> {
 		);
 	}
 
-	fn finalize_headers(&mut self, finalized: Option<HeaderId>, prune_end: Option<u64>) {
+	fn finalize_headers(&mut self, finalized: Option<HeaderId>, prune_end: u64) {
 		// remember just finalized block
 		let finalized_number = finalized
 			.as_ref()
@@ -928,7 +944,7 @@ pub(crate) mod tests {
 			});
 
 			// try to prune blocks [5; 10)
-			storage.prune_blocks(0xFFFF, 10, Some(5));
+			storage.prune_blocks(0xFFFF, 10, 5);
 			assert_eq!(HeadersByNumber::get(&5).unwrap().len(), 5);
 			assert_eq!(
 				BlocksToPrune::get(),
@@ -949,7 +965,7 @@ pub(crate) mod tests {
 			});
 
 			// try to prune blocks [5; 10)
-			storage.prune_blocks(0xFFFF, 10, Some(3));
+			storage.prune_blocks(0xFFFF, 10, 3);
 			assert_eq!(
 				BlocksToPrune::get(),
 				PruningRange {
@@ -964,7 +980,7 @@ pub(crate) mod tests {
 	fn blocks_are_not_pruned_if_limit_is_zero() {
 		with_headers_to_prune(|storage| {
 			// try to prune blocks [0; 10)
-			storage.prune_blocks(0, 10, Some(10));
+			storage.prune_blocks(0, 10, 10);
 			assert!(HeadersByNumber::get(&0).is_some());
 			assert!(HeadersByNumber::get(&1).is_some());
 			assert!(HeadersByNumber::get(&2).is_some());
@@ -983,7 +999,7 @@ pub(crate) mod tests {
 	fn blocks_are_pruned_if_limit_is_non_zero() {
 		with_headers_to_prune(|storage| {
 			// try to prune blocks [0; 10)
-			storage.prune_blocks(7, 10, Some(10));
+			storage.prune_blocks(7, 10, 10);
 			// 1 headers with number = 0 is pruned (1 total)
 			assert!(HeadersByNumber::get(&0).is_none());
 			// 5 headers with number = 1 are pruned (6 total)
@@ -999,7 +1015,7 @@ pub(crate) mod tests {
 			);
 
 			// try to prune blocks [2; 10)
-			storage.prune_blocks(11, 10, Some(10));
+			storage.prune_blocks(11, 10, 10);
 			// 4 headers with number = 2 are pruned (4 total)
 			assert!(HeadersByNumber::get(&2).is_none());
 			// 5 headers with number = 3 are pruned (9 total)
@@ -1023,7 +1039,7 @@ pub(crate) mod tests {
 			// last finalized block is 5
 			// and one of blocks#7 has scheduled change
 			// => we won't prune any block#7 at all
-			storage.prune_blocks(0xFFFF, 5, Some(10));
+			storage.prune_blocks(0xFFFF, 5, 10);
 			assert!(HeadersByNumber::get(&0).is_none());
 			assert!(HeadersByNumber::get(&1).is_none());
 			assert!(HeadersByNumber::get(&2).is_none());
@@ -1071,7 +1087,7 @@ pub(crate) mod tests {
 				oldest_unpruned_block: interval - 1,
 				oldest_block_to_keep: interval - 1,
 			});
-			storage.finalize_headers(None, Some(interval + 1));
+			storage.finalize_headers(None, interval + 1);
 			assert_eq!(FinalityCache::<TestRuntime>::get(&header_with_entry_hash), None);
 		});
 	}
@@ -1152,7 +1168,7 @@ pub(crate) mod tests {
 			let mut storage = BridgeStorage::<TestRuntime>::new();
 			insert_header(&mut storage, example_header_parent());
 			insert_header(&mut storage, example_header());
-			storage.finalize_headers(Some(example_header().compute_id()), None);
+			storage.finalize_headers(Some(example_header().compute_id()), 0);
 			assert_eq!(
 				verify_transaction_finalized(&storage, example_header_parent().compute_hash(), 0, &vec![example_tx()],),
 				true,
@@ -1206,7 +1222,7 @@ pub(crate) mod tests {
 			insert_header(&mut storage, example_header_parent());
 			insert_header(&mut storage, example_header());
 			insert_header(&mut storage, finalized_header_sibling);
-			storage.finalize_headers(Some(example_header().compute_id()), None);
+			storage.finalize_headers(Some(example_header().compute_id()), 0);
 			assert_eq!(
 				verify_transaction_finalized(&storage, finalized_header_sibling_hash, 0, &vec![example_tx()],),
 				false,
@@ -1225,7 +1241,7 @@ pub(crate) mod tests {
 			insert_header(&mut storage, example_header_parent());
 			insert_header(&mut storage, finalized_header_uncle);
 			insert_header(&mut storage, example_header());
-			storage.finalize_headers(Some(example_header().compute_id()), None);
+			storage.finalize_headers(Some(example_header().compute_id()), 0);
 			assert_eq!(
 				verify_transaction_finalized(&storage, finalized_header_uncle_hash, 0, &vec![example_tx()],),
 				false,

--- a/modules/ethereum/src/mock.rs
+++ b/modules/ethereum/src/mock.rs
@@ -80,7 +80,7 @@ impl Trait for TestRuntime {
 	type AuraConfiguration = TestAuraConfiguration;
 	type ValidatorsConfiguration = TestValidatorsConfiguration;
 	type FinalityVotesCachingInterval = TestFinalityVotesCachingInterval;
-	type PruningStrategy = Keep10HeadersBehindBest;
+	type PruningStrategy = KeepSomeHeadersBehindBest;
 	type OnHeadersSubmitted = ();
 }
 
@@ -185,10 +185,16 @@ pub fn insert_header<S: Storage>(storage: &mut S, header: Header) {
 }
 
 /// Pruning strategy that keeps 10 headers behind best block.
-pub struct Keep10HeadersBehindBest;
+pub struct KeepSomeHeadersBehindBest(pub u64);
 
-impl PruningStrategy for Keep10HeadersBehindBest {
-	fn pruning_upper_bound(best_number: u64, _: u64) -> u64 {
-		best_number.checked_sub(10).unwrap_or(0)
+impl Default for KeepSomeHeadersBehindBest {
+	fn default() -> KeepSomeHeadersBehindBest {
+		KeepSomeHeadersBehindBest(10)
+	}
+}
+
+impl PruningStrategy for KeepSomeHeadersBehindBest {
+	fn pruning_upper_bound(&mut self, best_number: u64, _: u64) -> u64 {
+		best_number.checked_sub(self.0).unwrap_or(0)
 	}
 }

--- a/modules/ethereum/src/mock.rs
+++ b/modules/ethereum/src/mock.rs
@@ -16,7 +16,7 @@
 
 use crate::finality::FinalityVotes;
 use crate::validators::{ValidatorsConfiguration, ValidatorsSource};
-use crate::{AuraConfiguration, GenesisConfig, HeaderToImport, HeadersByNumber, Storage, Trait};
+use crate::{AuraConfiguration, GenesisConfig, HeaderToImport, HeadersByNumber, PruningStrategy, Storage, Trait};
 use frame_support::StorageMap;
 use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
 use parity_crypto::publickey::{sign, KeyPair, Secret};
@@ -78,8 +78,9 @@ parameter_types! {
 
 impl Trait for TestRuntime {
 	type AuraConfiguration = TestAuraConfiguration;
-	type FinalityVotesCachingInterval = TestFinalityVotesCachingInterval;
 	type ValidatorsConfiguration = TestValidatorsConfiguration;
+	type FinalityVotesCachingInterval = TestFinalityVotesCachingInterval;
+	type PruningStrategy = Keep10HeadersBehindBest;
 	type OnHeadersSubmitted = ();
 }
 
@@ -181,4 +182,13 @@ pub fn insert_header<S: Storage>(storage: &mut S, header: Header) {
 		scheduled_change: None,
 		finality_votes: FinalityVotes::default(),
 	});
+}
+
+/// Pruning strategy that keeps 10 headers behind best block.
+pub struct Keep10HeadersBehindBest;
+
+impl PruningStrategy for Keep10HeadersBehindBest {
+	fn pruning_upper_bound(best_number: u64, _: u64) -> u64 {
+		best_number.checked_sub(10).unwrap_or(0)
+	}
 }

--- a/modules/ethereum/src/mock.rs
+++ b/modules/ethereum/src/mock.rs
@@ -84,6 +84,9 @@ impl Trait for TestRuntime {
 	type OnHeadersSubmitted = ();
 }
 
+/// Step of genesis header.
+pub const GENESIS_STEP: u64 = 42;
+
 /// Aura configuration that is used in tests by default.
 pub fn test_aura_config() -> AuraConfiguration {
 	AuraConfiguration {
@@ -106,7 +109,7 @@ pub fn test_validators_config() -> ValidatorsConfiguration {
 /// Genesis header that is used in tests by default.
 pub fn genesis() -> Header {
 	Header {
-		seal: vec![vec![42].into(), vec![].into()],
+		seal: vec![vec![GENESIS_STEP as _].into(), vec![].into()],
 		..Default::default()
 	}
 }
@@ -124,12 +127,12 @@ pub fn custom_block_i(number: u64, validators: &[KeyPair], customize: impl FnOnc
 		parent_hash: HeadersByNumber::get(number - 1).unwrap()[0].clone(),
 		gas_limit: 0x2000.into(),
 		author: validator(validator_index).address(),
-		seal: vec![vec![number as u8 + 42].into(), vec![].into()],
+		seal: vec![vec![(number + GENESIS_STEP) as u8].into(), vec![].into()],
 		difficulty: number.into(),
 		..Default::default()
 	};
 	customize(&mut header);
-	signed_header(validators, header, number + 42)
+	signed_header(validators, header, number + GENESIS_STEP)
 }
 
 /// Build signed header from given header.


### PR DESCRIPTION
This PR implements option (1) from this discussion:
https://github.com/paritytech/parity-bridges-common/pull/91#issuecomment-638854485
https://github.com/paritytech/parity-bridges-common/pull/91#issuecomment-638923992

New runtime gives ~24 hours (which is ~20000 blocks on current Kovan chain) after 'mining' block `B` with funds-lock transaction to:
1) PoA validators to finalize block `B`;
2) relay to synchronize this header of `B` and finality proof (i.e. some headers built on top of `B`);
3) claimant to prepare and submit proof-of-funds-lock transaction;
4) Substrate validators to 'mine' block with proof-of-funds-lock transaction.

===

This, however doesn't solve the problem discussed in:
https://github.com/paritytech/parity-bridges-common/pull/91#issuecomment-639339730

Why? Mostly because of technical difficulties. I've moved pruning strategy to the runtime level, because imo different bridges may have different strategies. So to support pruning that is timestamp-dependent, we need to: (1) read hashes of all headers at given depth (2) read all headers and compute `max(timestamp)` (or at least read timestamp of canonical header) (3) go to depth + 1 if we have decided to prune headers at `depth` (4) continue until we'll met header that we do not want to prune, or unfinalized header. It seems too heavy for me - I'd better implement option (2) from https://github.com/paritytech/parity-bridges-common/pull/91#issuecomment-638854485 in near future. At least it is heavy in more convenient (mostly for claimant) way.

Another option would be to maintain some additional map like `[ at 12:00 => prune headers with depth < 1000, at 13:00 => prune headers with depth < 1100, ... ]`, but this map also needs to be updated on every header insertion/canonicalization and it needs to reside at runtime level, because other pruning strategies might not need that info. And I have found no easy way to organize map on runtime level (other than introducing some module inside runime and declaring map there).

That said, I'm ready to implement something like that ^^^ if you find that current `KovanPruningStrategy` doesn't match our requirements.

===

I'm also not sure if we 100% need to introduce what is described in this comment: https://github.com/paritytech/parity-bridges-common/pull/91#issuecomment-639560578 . First, I've realized that noone is actually going to sync PoA from the scratch - so we'll most probably will start with near-best PoA block. Then, if we'll disable claims, the claimant will still be able to lock his funds on PoA chain and then just won't have an option to submit proof-of-lock.