### PR TITLE
Update Substrate to latest master (rc3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -224,7 +224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -269,7 +269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1c13101a3224fb178860ae372a031ce350bbd92d39968518f016744dde0bf7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -378,7 +378,7 @@ dependencies = [
  "log 0.4.8",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "regex",
  "rustc-hash",
  "shlex",
@@ -914,7 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -1057,7 +1057,7 @@ dependencies = [
  "ethabi",
  "heck",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -1196,7 +1196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
  "synstructure",
 ]
@@ -1297,16 +1297,16 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1322,8 +1322,8 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1337,8 +1337,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "11.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "11.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1348,8 +1348,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1373,41 +1373,41 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "frame-system"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1422,8 +1422,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1567,7 +1567,7 @@ checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -2074,7 +2074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -2150,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2307a7e78cf969759e390a8a2151ea12e783849a45bb00aa871b468ba58ea79e"
+checksum = "ecbdaacc17243168d9d1fa6b2bd7556a27e1e60a621d8a2a6e590ae2b145d158"
 dependencies = [
  "failure",
  "futures 0.1.29",
@@ -2179,30 +2179,30 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f9382e831a6d630c658df103aac3f971da096deb57c136ea2b760d3b4e3f9f"
+checksum = "34221123bc79b66279a3fde2d3363553835b43092d629b34f2e760c44dc94713"
 dependencies = [
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.0.5"
+version = "14.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
+checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52860f0549694aa4abb12766856f56952ab46d3fb9f0815131b2db3d9cc2f29"
+checksum = "0da906d682799df05754480dac1b9e70ec92e12c19ebafd2662a5ea1c9fd6522"
 dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
@@ -2215,21 +2215,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ca5e391d6c6a2261d4adca029f427fe63ea546ad6cef2957c654c08495ec16"
+checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
 dependencies = [
  "jsonrpc-core",
  "log 0.4.8",
  "parking_lot 0.10.2",
+ "rand 0.7.3",
  "serde",
 ]
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f06add502b48351e05dd95814835327fb115e4e9f834ca42fd522d3b769d4d2"
+checksum = "56cbfb462e7f902e21121d9f0d1c2b77b2c5b642e1a4e8f4ebfa2e15b94402bb"
 dependencies = [
  "bytes 0.4.12",
  "globset",
@@ -2243,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017a7dd5083d9ed62c5e1dd3e317975c33c3115dac5447f4480fe05a8c354754"
+checksum = "903d3109fe7c4acb932b567e1e607e0f524ed04741b09fb0e61841bc40a022fc"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2294,7 +2295,7 @@ source = "git+https://github.com/paritytech/jsonrpsee.git#62da58d12321355aac7697
 dependencies = [
  "Inflector",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -2485,7 +2486,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f09548626b737ed64080fde595e06ce1117795b8b9fc4d2629fa36561c583171"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -3065,8 +3066,8 @@ dependencies = [
 
 [[package]]
 name = "node-primitives"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -3237,8 +3238,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3256,8 +3257,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3318,8 +3319,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3334,8 +3335,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3354,8 +3355,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3367,8 +3368,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3385,8 +3386,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3399,8 +3400,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3416,8 +3417,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3430,8 +3431,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3558,7 +3559,7 @@ checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -3668,7 +3669,7 @@ checksum = "66fd6f92e3594f2dd7b3fc23e42d82e292f7bcda6d8e5dcd167072327234ab89"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -3731,7 +3732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -3804,7 +3805,7 @@ checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
  "version_check 0.9.1",
 ]
@@ -3816,7 +3817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
  "syn-mid",
  "version_check 0.9.1",
@@ -3909,7 +3910,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -3954,9 +3955,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -4232,7 +4233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -4435,8 +4436,8 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4459,8 +4460,8 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4475,8 +4476,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -4491,25 +4492,24 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "chrono",
  "derive_more",
- "directories",
  "env_logger",
  "fdlimit",
  "futures 0.3.5",
@@ -4543,8 +4543,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "fnv",
@@ -4579,8 +4579,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -4608,8 +4608,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -4619,8 +4619,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -4650,8 +4650,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4672,8 +4672,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -4699,8 +4699,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -4716,8 +4716,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -4731,8 +4731,8 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -4754,6 +4754,7 @@ dependencies = [
  "sc-telemetry",
  "serde_json",
  "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -4768,8 +4769,8 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -4777,16 +4778,17 @@ dependencies = [
  "parity-util-mem",
  "sc-client-api",
  "sc-network",
- "sc-service",
  "sp-blockchain",
  "sp-runtime",
+ "sp-transaction-pool",
+ "sp-utils",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "hex",
@@ -4799,9 +4801,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-light"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+dependencies = [
+ "hash-db",
+ "lazy_static",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sc-client-api",
+ "sc-executor",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
+]
+
+[[package]]
 name = "sc-network"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "bitflags 1.2.1",
  "bs58",
@@ -4852,8 +4873,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4867,8 +4888,8 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -4894,8 +4915,8 @@ dependencies = [
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -4907,8 +4928,8 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "log 0.4.8",
  "substrate-prometheus-endpoint",
@@ -4916,8 +4937,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -4948,8 +4969,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -4972,8 +4993,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -4987,15 +5008,17 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
+ "directories",
  "exit-future",
  "futures 0.1.29",
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "hash-db",
+ "jsonrpc-pubsub",
  "lazy_static",
  "log 0.4.8",
  "netstat2",
@@ -5011,7 +5034,9 @@ dependencies = [
  "sc-client-api",
  "sc-client-db",
  "sc-executor",
+ "sc-informant",
  "sc-keystore",
+ "sc-light",
  "sc-network",
  "sc-offchain",
  "sc-rpc",
@@ -5039,14 +5064,15 @@ dependencies = [
  "sp-version",
  "substrate-prometheus-endpoint",
  "sysinfo",
+ "tempfile",
  "tracing",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -5059,8 +5085,8 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
@@ -5081,8 +5107,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "erased-serde",
  "log 0.4.8",
@@ -5096,8 +5122,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5116,8 +5142,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5292,7 +5318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -5418,7 +5444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -5489,8 +5515,8 @@ dependencies = [
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -5501,8 +5527,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -5516,20 +5542,20 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -5540,8 +5566,8 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
@@ -5553,8 +5579,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5565,8 +5591,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "log 0.4.8",
@@ -5605,8 +5631,8 @@ dependencies = [
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "serde",
  "serde_json",
@@ -5614,8 +5640,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5637,8 +5663,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5651,8 +5677,8 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -5702,8 +5728,8 @@ dependencies = [
 
 [[package]]
 name = "sp-database"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -5711,18 +5737,18 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -5732,8 +5758,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "finality-grandpa",
  "log 0.4.8",
@@ -5748,8 +5774,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -5758,8 +5784,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5770,8 +5796,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5790,8 +5816,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -5801,8 +5827,8 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -5811,8 +5837,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "backtrace",
  "log 0.4.8",
@@ -5820,8 +5846,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "serde",
  "sp-core",
@@ -5829,9 +5855,10 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
+ "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log 0.4.8",
@@ -5850,8 +5877,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -5865,20 +5892,20 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "serde",
  "serde_json",
@@ -5886,8 +5913,8 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5899,8 +5926,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -5909,8 +5936,8 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "hash-db",
  "log 0.4.8",
@@ -5928,13 +5955,13 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -5945,8 +5972,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5959,16 +5986,16 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5976,14 +6003,15 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-api",
+ "sp-blockchain",
  "sp-runtime",
  "sp-utils",
 ]
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -5996,8 +6024,8 @@ dependencies = [
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -6007,8 +6035,8 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -6019,8 +6047,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6082,7 +6110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "serde",
  "serde_derive",
  "syn 1.0.18",
@@ -6096,7 +6124,7 @@ checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6154,7 +6182,7 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -6175,7 +6203,7 @@ checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -6212,16 +6240,16 @@ dependencies = [
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "platforms",
 ]
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "2.0.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -6241,8 +6269,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.0-rc1"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 dependencies = [
  "async-std",
  "derive_more",
@@ -6256,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate.git?rev=599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee#599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
 
 [[package]]
 name = "subtle"
@@ -6288,7 +6316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "unicode-xid 0.2.0",
 ]
 
@@ -6299,7 +6327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -6319,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
  "unicode-xid 0.2.0",
 ]
@@ -6393,7 +6421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -6458,7 +6486,7 @@ checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "standback",
  "syn 1.0.18",
 ]
@@ -6849,7 +6877,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
 ]
 
@@ -7126,7 +7154,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
  "wasm-bindgen-shared",
 ]
@@ -7149,7 +7177,7 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
 dependencies = [
- "quote 1.0.3",
+ "quote 1.0.7",
  "wasm-bindgen-macro-support",
 ]
 
@@ -7160,7 +7188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -7439,7 +7467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.3",
+ "quote 1.0.7",
  "syn 1.0.18",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/jsonrpsee.git#62da58d12321355aac76975bfedfbc3ab0fe08e3"
+source = "git+https://github.com/paritytech/jsonrpsee.git#6bcb8efe3953f5882890d83bfcf1da223cf7eab0"
 dependencies = [
  "async-std",
  "async-tls 0.6.0",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-proc-macros"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/jsonrpsee.git#62da58d12321355aac76975bfedfbc3ab0fe08e3"
+source = "git+https://github.com/paritytech/jsonrpsee.git#6bcb8efe3953f5882890d83bfcf1da223cf7eab0"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/bin/node/node/Cargo.toml
+++ b/bin/node/node/Cargo.toml
@@ -19,100 +19,100 @@ bridge-node-runtime = { version = "0.1.0", path = "../runtime" }
 sp-bridge-eth-poa = { version = "0.1.0", path = "../../../primitives/ethereum-poa" }
 
 [dependencies.sc-cli]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-rpc]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-core]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-executor]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-service]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-inherents]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-transaction-pool]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-transaction-pool]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-network]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus-aura]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus-aura]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa]
 package = "sc-finality-grandpa"
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa-primitives]
 package = "sp-finality-grandpa"
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-client-api]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-basic-authorship]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.substrate-frame-rpc-system]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [build-dependencies]
@@ -120,6 +120,6 @@ vergen = "3.1.0"
 
 [build-dependencies.build-script-utils]
 package = "substrate-build-script-utils"
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -25,15 +25,15 @@ features = ["derive"]
 
 # Substrate Dependencies
 [dependencies.pallet-aura]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-balances]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-bridge-eth-poa]
@@ -47,76 +47,76 @@ default-features = false
 path = "../../../modules/currency-exchange"
 
 [dependencies.frame-support]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-grandpa]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-randomness-collective-flip]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-sudo]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system-rpc-runtime-api]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-timestamp]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-executive]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 # Substrate Primitives
 [dependencies.sp-api]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-block-builder]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-bridge-eth-poa]
@@ -130,75 +130,75 @@ default-features = false
 path = "../../../primitives/currency-exchange"
 
 [dependencies.sp-consensus-aura]
-version = "0.8.0-rc1"
+version = "0.8.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-inherents]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-offchain]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-session]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-staking]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-transaction-pool]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-version]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [build-dependencies.wasm-builder-runner]
 version = "1.0.5"
 package = "substrate-wasm-builder-runner"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [features]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -146,7 +146,7 @@ parameter_types! {
 	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	/// Assume 10% of weight for average on_initialize calls.
-	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+	pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
 		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
@@ -217,8 +217,8 @@ impl pallet_aura::Trait for Runtime {
 
 parameter_types! {
 	pub const FinalityVotesCachingInterval: Option<u64> = Some(16);
-	pub const KovanAuraConfiguration: pallet_bridge_eth_poa::AuraConfiguration = kovan::kovan_aura_configuration();
-	pub const KovanValidatorsConfiguration: pallet_bridge_eth_poa::ValidatorsConfiguration = kovan::kovan_validators_configuration();
+	pub KovanAuraConfiguration: pallet_bridge_eth_poa::AuraConfiguration = kovan::kovan_aura_configuration();
+	pub KovanValidatorsConfiguration: pallet_bridge_eth_poa::ValidatorsConfiguration = kovan::kovan_validators_configuration();
 }
 
 impl pallet_bridge_eth_poa::Trait for Runtime {

--- a/modules/currency-exchange/Cargo.toml
+++ b/modules/currency-exchange/Cargo.toml
@@ -12,37 +12,37 @@ sp-currency-exchange = { path = "../../primitives/currency-exchange", default-fe
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-core]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-io]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [features]

--- a/modules/ethereum-contract/builtin/Cargo.toml
+++ b/modules/ethereum-contract/builtin/Cargo.toml
@@ -18,29 +18,29 @@ finality-grandpa = "0.12.3"
 bridge-node-runtime = { path = "../../../bin/node/runtime" }
 
 [dependencies.sp-blockchain]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sc-finality-grandpa]
 version = "0.8.0-dev"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies]
 hex = "0.4"
 
 [dev-dependencies.sp-core]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"

--- a/modules/ethereum/Cargo.toml
+++ b/modules/ethereum/Cargo.toml
@@ -12,33 +12,33 @@ primitives = { package = "sp-bridge-eth-poa", path = "../../primitives/ethereum-
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies

--- a/modules/ethereum/src/mock.rs
+++ b/modules/ethereum/src/mock.rs
@@ -72,8 +72,8 @@ impl frame_system::Trait for TestRuntime {
 
 parameter_types! {
 	pub const TestFinalityVotesCachingInterval: Option<u64> = Some(16);
-	pub const TestAuraConfiguration: AuraConfiguration = test_aura_config();
-	pub const TestValidatorsConfiguration: ValidatorsConfiguration = test_validators_config();
+	pub TestAuraConfiguration: AuraConfiguration = test_aura_config();
+	pub TestValidatorsConfiguration: ValidatorsConfiguration = test_validators_config();
 }
 
 impl Trait for TestRuntime {

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -13,57 +13,57 @@ hash-db = { version = "0.15.2", default-features = false }
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-trie]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies
 [dev-dependencies.sp-io]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-state-machine]
-version = "0.8.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "0.8.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [features]

--- a/primitives/currency-exchange/Cargo.toml
+++ b/primitives/currency-exchange/Cargo.toml
@@ -11,15 +11,15 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 # Substrate Based Dependencies
 
 [dependencies.sp-std]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-support]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [features]

--- a/primitives/ethereum-poa/Cargo.toml
+++ b/primitives/ethereum-poa/Cargo.toml
@@ -25,27 +25,27 @@ hex-literal = "0.2"
 
 # Substrate Based Dependencies
 [dependencies.sp-api]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-std]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-io]
-version = "2.0.0-rc1"
+version = "2.0.0-rc3"
 default-features = false
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [features]

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -33,36 +33,36 @@ web3 = { git = "https://github.com/tomusdrw/rust-web3" }
 
 # Substrate Based Dependencies
 [dependencies.frame-system]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 # I think this is used for sr-io and stuff
 [dependencies.node-primitives]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 # Branch used for keccack256 hasher code
 # Could probably move the keccack hasher stuff to our own primitives
 [dependencies.sp-core]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-keyring]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate.git"
 
 # This should get moved to our `bin` folder

--- a/relays/substrate/Cargo.toml
+++ b/relays/substrate/Cargo.toml
@@ -17,16 +17,16 @@ serde_json = "1.0.53"
 url = "2.1.0"
 
 [dependencies.sp-core]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-rpc]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.node-primitives]
-version = "2.0.0-rc1"
-rev = "599ba75bc2b5acd238c21c5c7efe8e2ad8d401ee"
+version = "2.0.0-rc3"
+rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"

--- a/relays/substrate/src/rpc.rs
+++ b/relays/substrate/src/rpc.rs
@@ -18,7 +18,7 @@ use jsonrpsee::{
 	raw::client::{RawClient, RawClientError},
 	transport::TransportClient,
 };
-use node_primitives::{BlockNumber, Hash, Header};
+use node_primitives::{Hash, Header};
 use sp_core::Bytes;
 use sp_rpc::number::NumberOrHex;
 
@@ -31,7 +31,7 @@ jsonrpsee::rpc_api! {
 		fn chain_finalized_head() -> Hash;
 
 		#[rpc(method = "chain_getBlockHash", positional_params)]
-		fn chain_block_hash(id: Option<NumberOrHex<BlockNumber>>) -> Option<Hash>;
+		fn chain_block_hash(id: Option<NumberOrHex>) -> Option<Hash>;
 
 		#[rpc(method = "chain_getHeader", positional_params)]
 		fn chain_header(hash: Option<Hash>) -> Option<Header>;


### PR DESCRIPTION
closes #98 

There's some black magic behind this PR - there was dependencies conflict between `sc-rpc-api` and `sc-network` - they were depending on different version of `quote` (1.0.6/7 vs 1.0.3). I have manually changed versions in Cargo.lock to 1.0.7 for now. The reason why I want this PR in, is that I'm starting to write weight-related benchmarks and wanted to have up-to-date runtime for that.