### PR TITLE
Switch to new RPC interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
  "frame-system",
  "futures 0.3.5",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 1.0.0 (git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api)",
  "linked-hash-map",
  "log 0.4.8",
  "node-primitives",
@@ -2271,7 +2271,7 @@ dependencies = [
  "globset",
  "hashbrown 0.7.2",
  "hyper 0.13.5",
- "jsonrpsee-proc-macros",
+ "jsonrpsee-proc-macros 1.0.0 (git+https://github.com/paritytech/jsonrpsee.git)",
  "lazy_static",
  "log 0.4.8",
  "parking_lot 0.10.2",
@@ -2289,9 +2289,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "1.0.0"
+source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#aed5c25a1850196f86e046228d2439b42c84ce6a"
+dependencies = [
+ "async-std",
+ "bs58",
+ "fnv",
+ "futures 0.3.5",
+ "futures-timer 3.0.2",
+ "globset",
+ "hashbrown 0.7.2",
+ "hyper 0.13.5",
+ "jsonrpsee-proc-macros 1.0.0 (git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api)",
+ "lazy_static",
+ "log 0.4.8",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "smallvec 1.4.0",
+ "thiserror",
+ "tokio 0.2.19",
+ "unicase 2.6.0",
+]
+
+[[package]]
 name = "jsonrpsee-proc-macros"
 version = "1.0.0"
 source = "git+https://github.com/paritytech/jsonrpsee.git#6bcb8efe3953f5882890d83bfcf1da223cf7eab0"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.18",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "1.0.0"
+source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#aed5c25a1850196f86e046228d2439b42c84ce6a"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -6229,7 +6267,7 @@ dependencies = [
  "derive_more",
  "env_logger",
  "futures 0.3.5",
- "jsonrpsee",
+ "jsonrpsee 1.0.0 (git+https://github.com/paritytech/jsonrpsee.git)",
  "log 0.4.8",
  "node-primitives",
  "serde_json",

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -18,7 +18,6 @@ ethabi-derive = "12.0"
 ethereum-tx-sign = "3.0"
 futures = "0.3.5"
 hex = "0.4"
-jsonrpsee = { git = "https://github.com/svyatonik/jsonrpsee.git", branch = "shared-client-in-rpc-api", default-features = false, features = ["http"] }
 linked-hash-map = "0.5.3"
 log = "0.4.8"
 num-traits = "0.2"
@@ -30,6 +29,12 @@ serde_json = "1.0.53"
 sp-bridge-eth-poa = { path = "../../primitives/ethereum-poa" }
 time = "0.2"
 web3 = { git = "https://github.com/tomusdrw/rust-web3" }
+
+[dependencies.jsonrpsee]
+git = "https://github.com/svyatonik/jsonrpsee.git"
+branch = "shared-client-in-rpc-api"
+default-features = false
+features = ["http"]
 
 # Substrate Based Dependencies
 [dependencies.frame-system]

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -18,7 +18,7 @@ ethabi-derive = "12.0"
 ethereum-tx-sign = "3.0"
 futures = "0.3.5"
 hex = "0.4"
-jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee.git", default-features = false, features = ["http"] }
+jsonrpsee = { git = "https://github.com/svyatonik/jsonrpsee.git", branch = "shared-client-in-rpc-api", default-features = false, features = ["http"] }
 linked-hash-map = "0.5.3"
 log = "0.4.8"
 num-traits = "0.2"

--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -111,7 +111,8 @@ impl EthereumRpc for EthereumRpcClient {
 	}
 
 	async fn header_by_number(&self, block_number: u64) -> Result<Header> {
-		let header = Ethereum::get_block_by_number(&self.client, block_number, false).await?;
+		let get_full_tx_objects = false;
+		let header = Ethereum::get_block_by_number(&self.client, block_number, get_full_tx_objects).await?;
 		match header.number.is_some() && header.hash.is_some() && header.logs_bloom.is_some() {
 			true => Ok(header),
 			false => Err(RpcError::Ethereum(EthereumNodeError::IncompleteHeader)),

--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -35,13 +35,6 @@ use std::collections::HashSet;
 // to encode/decode contract calls
 ethabi_contract::use_contract!(bridge_contract, "res/substrate-bridge-abi.json");
 
-/// Proof of hash serialization success.
-const HASH_SERIALIZATION_PROOF: &'static str = "hash serialization never fails; qed";
-/// Proof of integer serialization success.
-const INT_SERIALIZATION_PROOF: &'static str = "integer serialization never fails; qed";
-/// Proof of bool serialization success.
-const BOOL_SERIALIZATION_PROOF: &'static str = "bool serialization never fails; qed";
-
 type Result<T> = std::result::Result<T, RpcError>;
 
 /// Ethereum connection params.
@@ -326,8 +319,12 @@ impl HigherLevelCalls for EthereumRpcClient {
 		double_gas: bool,
 		encoded_call: Vec<u8>,
 	) -> Result<()> {
-		let address: Address = params.signer.address().as_fixed_bytes().into();
-		let nonce = self.account_nonce(address).await?;
+		let nonce = if let Some(n) = nonce {
+			n
+		} else {
+			let address: Address = params.signer.address().as_fixed_bytes().into();
+			self.account_nonce(address).await?
+		};
 
 		let call_request = CallRequest {
 			to: contract_address,

--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -111,7 +111,7 @@ impl EthereumRpc for EthereumRpcClient {
 	}
 
 	async fn header_by_number(&self, block_number: u64) -> Result<Header> {
-		let header = Ethereum::get_block_by_number(&self.client, block_number).await?;
+		let header = Ethereum::get_block_by_number(&self.client, block_number, false).await?;
 		match header.number.is_some() && header.hash.is_some() && header.logs_bloom.is_some() {
 			true => Ok(header),
 			false => Err(RpcError::Ethereum(EthereumNodeError::IncompleteHeader)),

--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -38,7 +38,7 @@ ethabi_contract::use_contract!(bridge_contract, "res/substrate-bridge-abi.json")
 type Result<T> = std::result::Result<T, RpcError>;
 
 /// Ethereum connection params.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EthereumConnectionParams {
 	/// Ethereum RPC host.
 	pub host: String,

--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -20,13 +20,13 @@ use crate::ethereum_types::{
 use crate::rpc::{Ethereum, EthereumRpc};
 use crate::rpc_errors::{EthereumNodeError, RpcError};
 use crate::substrate_types::{GrandpaJustification, Hash as SubstrateHash, QueuedSubstrateHeader, SubstrateHeaderId};
-use crate::sync_types::{HeaderId, MaybeConnectionError};
+use crate::sync_types::HeaderId;
 
 use async_trait::async_trait;
 use codec::{Decode, Encode};
 use ethabi::FunctionOutputDecoder;
-use jsonrpsee::raw::{RawClient, RawClientError};
-use jsonrpsee::transport::http::{HttpTransportClient, RequestError};
+use jsonrpsee::raw::RawClient;
+use jsonrpsee::transport::http::HttpTransportClient;
 use parity_crypto::publickey::KeyPair;
 
 use std::collections::HashSet;

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -61,13 +61,13 @@ pub fn run(params: EthereumDeployContractParams) {
 	let mut local_pool = futures::executor::LocalPool::new();
 
 	let result = local_pool.run_until(async move {
-		let mut eth_client = EthereumRpcClient::new(params.eth); // ethereum_client::client(params.eth);
-		let mut sub_client = SubstrateRpcClient::new(params.sub); // substrate_client::client(params.sub);
+		let eth_client = EthereumRpcClient::new(params.eth);
+		let sub_client = SubstrateRpcClient::new(params.sub);
 
-		let (initial_header_hash, initial_header) = prepare_initial_header(&mut sub_client, params.sub_initial_header).await?;
+		let (initial_header_hash, initial_header) = prepare_initial_header(&sub_client, params.sub_initial_header).await?;
 		let initial_set_id = params.sub_initial_authorities_set_id.unwrap_or(0);
 		let initial_set = prepare_initial_authorities_set(
-			&mut sub_client,
+			&sub_client,
 			initial_header_hash,
 			params.sub_initial_authorities_set,
 		).await?;
@@ -97,7 +97,7 @@ pub fn run(params: EthereumDeployContractParams) {
 
 /// Prepare initial header.
 async fn prepare_initial_header(
-	sub_client: &mut SubstrateRpcClient,
+	sub_client: &SubstrateRpcClient,
 	sub_initial_header: Option<Vec<u8>>,
 ) -> Result<(SubstrateHash, Vec<u8>), String> {
 	match sub_initial_header {
@@ -116,7 +116,7 @@ async fn prepare_initial_header(
 
 /// Prepare initial GRANDPA authorities set.
 async fn prepare_initial_authorities_set(
-	sub_client: &mut SubstrateRpcClient,
+	sub_client: &SubstrateRpcClient,
 	sub_initial_header_hash: SubstrateHash,
 	sub_initial_authorities_set: Option<Vec<u8>>,
 ) -> Result<Vec<u8>, String> {

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -16,7 +16,7 @@
 
 use crate::ethereum_client::{DeployContract, EthereumConnectionParams, EthereumRpcClient, EthereumSigningParams};
 use crate::rpc::SubstrateRpc;
-use crate::substrate_client::{self, SubstrateConnectionParams, SubstrateRpcClient};
+use crate::substrate_client::{SubstrateConnectionParams, SubstrateRpcClient};
 use crate::substrate_types::{Hash as SubstrateHash, Header as SubstrateHeader};
 
 use codec::{Decode, Encode};
@@ -81,7 +81,6 @@ pub fn run(params: EthereumDeployContractParams) {
 			hex::encode(&initial_set),
 		);
 
-		// ethereum_client::deploy_bridge_contract(
 		eth_client.deploy_bridge_contract(
 			&params.eth_sign,
 			params.eth_contract_code,

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -64,12 +64,7 @@ pub fn run(params: EthereumDeployContractParams) {
 
 	let result = local_pool.run_until(async move {
 		let eth_client = EthereumRpcClient::new(params.eth);
-		let sub_client = SubstrateRpcClient::new(params.sub).await;
-
-		let sub_client = match sub_client {
-			Ok(s) => s,
-			Err(e) => return Err(e.into()),
-		};
+		let sub_client = SubstrateRpcClient::new(params.sub).await?;
 
 		let (initial_header_hash, initial_header) = prepare_initial_header(&sub_client, params.sub_initial_header).await?;
 		let initial_set_id = params.sub_initial_authorities_set_id.unwrap_or(0);

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -15,7 +15,7 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::ethereum_client::{
-	EthereumConnectionParams, EthereumHighLevelRpc, EthereumRpcClient, EthereumSigningParams,
+	bridge_contract, EthereumConnectionParams, EthereumHighLevelRpc, EthereumRpcClient, EthereumSigningParams,
 };
 use crate::rpc::SubstrateRpc;
 use crate::substrate_client::{SubstrateConnectionParams, SubstrateRpcClient};
@@ -23,9 +23,6 @@ use crate::substrate_types::{Hash as SubstrateHash, Header as SubstrateHeader};
 
 use codec::{Decode, Encode};
 use num_traits::Zero;
-
-// to encode/decode contract calls
-ethabi_contract::use_contract!(bridge_contract, "res/substrate-bridge-abi.json");
 
 /// Ethereum synchronization parameters.
 #[derive(Debug)]

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -64,7 +64,12 @@ pub fn run(params: EthereumDeployContractParams) {
 
 	let result = local_pool.run_until(async move {
 		let eth_client = EthereumRpcClient::new(params.eth);
-		let sub_client = SubstrateRpcClient::new(params.sub).await.expect("What do?");
+		let sub_client = SubstrateRpcClient::new(params.sub).await;
+
+		let sub_client = match sub_client {
+			Ok(s) => s,
+			Err(e) => return Err(e.into()),
+		};
 
 		let (initial_header_hash, initial_header) = prepare_initial_header(&sub_client, params.sub_initial_header).await?;
 		let initial_set_id = params.sub_initial_authorities_set_id.unwrap_or(0);

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::ethereum_client::{self, EthereumConnectionParams, EthereumSigningParams};
-use crate::substrate_client::{self, SubstrateConnectionParams};
+use crate::ethereum_client::{DeployContract, EthereumConnectionParams, EthereumRpcClient, EthereumSigningParams};
+use crate::rpc::SubstrateRpc;
+use crate::substrate_client::{self, SubstrateConnectionParams, SubstrateRpcClient};
 use crate::substrate_types::{Hash as SubstrateHash, Header as SubstrateHeader};
+
 use codec::{Decode, Encode};
 use num_traits::Zero;
 
@@ -59,18 +61,16 @@ pub fn run(params: EthereumDeployContractParams) {
 	let mut local_pool = futures::executor::LocalPool::new();
 
 	let result = local_pool.run_until(async move {
-		let eth_client = ethereum_client::client(params.eth);
-		let sub_client = substrate_client::client(params.sub);
+		let mut eth_client = EthereumRpcClient::new(params.eth); // ethereum_client::client(params.eth);
+		let mut sub_client = SubstrateRpcClient::new(params.sub); // substrate_client::client(params.sub);
 
-		let (sub_client, initial_header) = prepare_initial_header(sub_client, params.sub_initial_header).await;
-		let (initial_header_hash, initial_header) = initial_header?;
+		let (initial_header_hash, initial_header) = prepare_initial_header(&mut sub_client, params.sub_initial_header).await?;
 		let initial_set_id = params.sub_initial_authorities_set_id.unwrap_or(0);
-		let (_, initial_set) = prepare_initial_authorities_set(
-			sub_client,
+		let initial_set = prepare_initial_authorities_set(
+			&mut sub_client,
 			initial_header_hash,
 			params.sub_initial_authorities_set,
-		).await;
-		let initial_set = initial_set?;
+		).await?;
 
 		log::info!(
 			target: "bridge",
@@ -81,14 +81,14 @@ pub fn run(params: EthereumDeployContractParams) {
 			hex::encode(&initial_set),
 		);
 
-		ethereum_client::deploy_bridge_contract(
-			eth_client,
+		// ethereum_client::deploy_bridge_contract(
+		eth_client.deploy_bridge_contract(
 			&params.eth_sign,
 			params.eth_contract_code,
 			initial_header,
 			initial_set_id,
 			initial_set,
-		).await.1.map_err(|error| format!("Error deploying contract: {:?}", error))
+		).await.map_err(|error| format!("Error deploying contract: {:?}", error))
 	});
 
 	if let Err(error) = result {
@@ -98,39 +98,33 @@ pub fn run(params: EthereumDeployContractParams) {
 
 /// Prepare initial header.
 async fn prepare_initial_header(
-	sub_client: substrate_client::Client,
+	sub_client: &mut SubstrateRpcClient,
 	sub_initial_header: Option<Vec<u8>>,
-) -> (substrate_client::Client, Result<(SubstrateHash, Vec<u8>), String>) {
+) -> Result<(SubstrateHash, Vec<u8>), String> {
 	match sub_initial_header {
 		Some(raw_initial_header) => match SubstrateHeader::decode(&mut &raw_initial_header[..]) {
-			Ok(initial_header) => (sub_client, Ok((initial_header.hash(), raw_initial_header))),
-			Err(error) => (sub_client, Err(format!("Error decoding initial header: {}", error))),
+			Ok(initial_header) => Ok((initial_header.hash(), raw_initial_header)),
+			Err(error) => Err(format!("Error decoding initial header: {}", error)),
 		},
 		None => {
-			let (sub_client, initial_header) = substrate_client::header_by_number(sub_client, Zero::zero()).await;
-			(
-				sub_client,
-				initial_header
-					.map(|header| (header.hash(), header.encode()))
-					.map_err(|error| format!("Error reading Substrate genesis header: {:?}", error)),
-			)
+			let initial_header = sub_client.header_by_number(Zero::zero()).await;
+			initial_header
+				.map(|header| (header.hash(), header.encode()))
+				.map_err(|error| format!("Error reading Substrate genesis header: {:?}", error))
 		}
 	}
 }
 
 /// Prepare initial GRANDPA authorities set.
 async fn prepare_initial_authorities_set(
-	sub_client: substrate_client::Client,
+	sub_client: &mut SubstrateRpcClient,
 	sub_initial_header_hash: SubstrateHash,
 	sub_initial_authorities_set: Option<Vec<u8>>,
-) -> (substrate_client::Client, Result<Vec<u8>, String>) {
-	let (sub_client, initial_authorities_set) = match sub_initial_authorities_set {
-		Some(initial_authorities_set) => (sub_client, Ok(initial_authorities_set)),
-		None => substrate_client::grandpa_authorities_set(sub_client, sub_initial_header_hash).await,
+) -> Result<Vec<u8>, String> {
+	let initial_authorities_set = match sub_initial_authorities_set {
+		Some(initial_authorities_set) => Ok(initial_authorities_set),
+		None => sub_client.grandpa_authorities_set(sub_initial_header_hash).await,
 	};
 
-	(
-		sub_client,
-		initial_authorities_set.map_err(|error| format!("Error reading GRANDPA authorities set: {:?}", error)),
-	)
+	initial_authorities_set.map_err(|error| format!("Error reading GRANDPA authorities set: {:?}", error))
 }

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -64,7 +64,7 @@ pub fn run(params: EthereumDeployContractParams) {
 
 	let result = local_pool.run_until(async move {
 		let eth_client = EthereumRpcClient::new(params.eth);
-		let sub_client = SubstrateRpcClient::new(params.sub);
+		let sub_client = SubstrateRpcClient::new(params.sub).await.expect("What do?");
 
 		let (initial_header_hash, initial_header) = prepare_initial_header(&sub_client, params.sub_initial_header).await?;
 		let initial_set_id = params.sub_initial_authorities_set_id.unwrap_or(0);

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -16,12 +16,12 @@
 
 //! Ethereum PoA -> Substrate synchronization.
 
-use crate::ethereum_client::{self, EthereumConnectionParams, EthereumRpcClient, HigherLevelCalls};
+use crate::ethereum_client::{EthereumConnectionParams, EthereumRpcClient, HigherLevelCalls};
 use crate::ethereum_types::{EthereumHeaderId, EthereumHeadersSyncPipeline, Header, QueuedEthereumHeader, Receipt};
 use crate::rpc::{EthereumRpc, SubstrateRpc};
 use crate::rpc_errors::RpcError;
 use crate::substrate_client::{
-	self, AlsoHigherLevelCalls, SubstrateConnectionParams, SubstrateRpcClient, SubstrateSigningParams,
+	AlsoHigherLevelCalls, SubstrateConnectionParams, SubstrateRpcClient, SubstrateSigningParams,
 };
 use crate::sync::{HeadersSyncParams, TargetTransactionMode};
 use crate::sync_loop::{OwnedSourceFutureOutput, OwnedTargetFutureOutput, SourceClient, TargetClient};

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -181,12 +181,11 @@ impl TargetClient<EthereumHeadersSyncPipeline> for SubstrateHeadersTarget {
 }
 
 /// Run Ethereum headers synchronization.
-pub fn run(params: EthereumSyncParams) {
+pub fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
 	let sub_params = params.clone();
 
 	let eth_client = EthereumRpcClient::new(params.eth);
-	let sub_client =
-		async_std::task::block_on(async { SubstrateRpcClient::new(sub_params.sub).await.expect("What do?") });
+	let sub_client = async_std::task::block_on(async { SubstrateRpcClient::new(sub_params.sub).await })?;
 
 	let sign_sub_transactions = match params.sync_params.target_tx_mode {
 		TargetTransactionMode::Signed | TargetTransactionMode::Backup => true,
@@ -203,4 +202,6 @@ pub fn run(params: EthereumSyncParams) {
 		SUBSTRATE_TICK_INTERVAL,
 		params.sync_params,
 	);
+
+	Ok(())
 }

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -96,15 +96,15 @@ impl SourceClient<EthereumHeadersSyncPipeline> for EthereumHeadersSource {
 	type Error = RpcError;
 
 	async fn best_block_number(&self) -> Result<u64, Self::Error> {
-		Ok(self.client.best_block_number().await?)
+		self.client.best_block_number().await
 	}
 
 	async fn header_by_hash(&self, hash: H256) -> Result<Header, Self::Error> {
-		Ok(self.client.header_by_hash(hash).await?)
+		self.client.header_by_hash(hash).await
 	}
 
 	async fn header_by_number(&self, number: u64) -> Result<Header, Self::Error> {
-		Ok(self.client.header_by_number(number).await?)
+		self.client.header_by_number(number).await
 	}
 
 	async fn header_completion(&self, id: EthereumHeaderId) -> Result<(EthereumHeaderId, Option<()>), Self::Error> {
@@ -116,10 +116,9 @@ impl SourceClient<EthereumHeadersSyncPipeline> for EthereumHeadersSource {
 		id: EthereumHeaderId,
 		header: QueuedEthereumHeader,
 	) -> Result<(EthereumHeaderId, Vec<Receipt>), Self::Error> {
-		Ok(self
-			.client
+		self.client
 			.transaction_receipts(id, header.header().transactions.clone())
-			.await?)
+			.await
 	}
 }
 
@@ -147,7 +146,7 @@ impl TargetClient<EthereumHeadersSyncPipeline> for SubstrateHeadersTarget {
 	type Error = RpcError;
 
 	async fn best_header_id(&self) -> Result<EthereumHeaderId, Self::Error> {
-		Ok(self.client.best_ethereum_block().await?)
+		self.client.best_ethereum_block().await
 	}
 
 	async fn is_known_header(&self, id: EthereumHeaderId) -> Result<(EthereumHeaderId, bool), Self::Error> {
@@ -156,10 +155,9 @@ impl TargetClient<EthereumHeadersSyncPipeline> for SubstrateHeadersTarget {
 
 	async fn submit_headers(&self, headers: Vec<QueuedEthereumHeader>) -> Result<Vec<EthereumHeaderId>, Self::Error> {
 		let (sign_params, sign_transactions) = (self.sign_params.clone(), self.sign_transactions.clone());
-		Ok(self
-			.client
+		self.client
 			.submit_ethereum_headers(sign_params, headers, sign_transactions)
-			.await?)
+			.await
 	}
 
 	async fn incomplete_headers_ids(&self) -> Result<HashSet<EthereumHeaderId>, Self::Error> {

--- a/relays/ethereum/src/main.rs
+++ b/relays/ethereum/src/main.rs
@@ -46,28 +46,38 @@ fn main() {
 	let matches = clap::App::from_yaml(yaml).get_matches();
 	match matches.subcommand() {
 		("eth-to-sub", Some(eth_to_sub_matches)) => {
-			ethereum_sync_loop::run(match ethereum_sync_params(&eth_to_sub_matches) {
+			if ethereum_sync_loop::run(match ethereum_sync_params(&eth_to_sub_matches) {
 				Ok(ethereum_sync_params) => ethereum_sync_params,
 				Err(err) => {
 					log::error!(target: "bridge", "Error parsing parameters: {}", err);
 					return;
 				}
-			});
+			})
+			.is_err()
+			{
+				log::error!(target: "bridge", "Unable to get Substrate genesis block for Ethereum sync.");
+				return;
+			};
 		}
 		("sub-to-eth", Some(sub_to_eth_matches)) => {
-			substrate_sync_loop::run(match substrate_sync_params(&sub_to_eth_matches) {
+			if substrate_sync_loop::run(match substrate_sync_params(&sub_to_eth_matches) {
 				Ok(substrate_sync_params) => substrate_sync_params,
 				Err(err) => {
 					log::error!(target: "bridge", "Error parsing parameters: {}", err);
 					return;
 				}
-			});
+			})
+			.is_err()
+			{
+				log::error!(target: "bridge", "Unable to get Substrate genesis block for Substrate sync.");
+				return;
+			};
 		}
 		("eth-deploy-contract", Some(eth_deploy_matches)) => {
 			ethereum_deploy_contract::run(match ethereum_deploy_contract_params(&eth_deploy_matches) {
 				Ok(ethereum_deploy_matches) => ethereum_deploy_matches,
 				Err(err) => {
-					log::error!(target: "bridge", "Error parsing parameters: {}", err);
+					log::error!(target: "bridge", "Error during contract deployment: {}", err);
 					return;
 				}
 			});

--- a/relays/ethereum/src/rpc.rs
+++ b/relays/ethereum/src/rpc.rs
@@ -74,52 +74,52 @@ jsonrpsee::rpc_api! {
 #[async_trait]
 pub trait EthereumRpc {
 	/// Estimate gas usage for the given call.
-	async fn estimate_gas(&mut self, call_request: CallRequest) -> Result<U256>;
+	async fn estimate_gas(&self, call_request: CallRequest) -> Result<U256>;
 	/// Retrieve number of the best known block from the Ethereum node.
-	async fn best_block_number(&mut self) -> Result<u64>;
+	async fn best_block_number(&self) -> Result<u64>;
 	/// Retrieve block header by its number from Ethereum node.
-	async fn header_by_number(&mut self, block_number: u64) -> Result<EthereumHeader>;
+	async fn header_by_number(&self, block_number: u64) -> Result<EthereumHeader>;
 	/// Retrieve block header by its hash from Ethereum node.
-	async fn header_by_hash(&mut self, hash: H256) -> Result<EthereumHeader>;
+	async fn header_by_hash(&self, hash: H256) -> Result<EthereumHeader>;
 	/// Retrieve transaction receipt by transaction hash.
-	async fn transaction_receipt(&mut self, transaction_hash: H256) -> Result<Receipt>;
+	async fn transaction_receipt(&self, transaction_hash: H256) -> Result<Receipt>;
 	/// Get the nonce of the given account.
-	async fn account_nonce(&mut self, address: EthAddress) -> Result<U256>;
+	async fn account_nonce(&self, address: EthAddress) -> Result<U256>;
 	/// Submit an Ethereum transaction.
 	///
 	/// The transaction must already be signed before sending it through this method.
-	async fn submit_transaction(&mut self, signed_raw_tx: SignedRawTx) -> Result<EthereumTxHash>;
+	async fn submit_transaction(&self, signed_raw_tx: SignedRawTx) -> Result<EthereumTxHash>;
 	/// Submit a call to an Ethereum smart contract.
-	async fn eth_call(&mut self, call_transaction: CallRequest) -> Result<Bytes>;
+	async fn eth_call(&self, call_transaction: CallRequest) -> Result<Bytes>;
 }
 
 /// The API for the supported Substrate RPC methods.
 #[async_trait]
 pub trait SubstrateRpc {
 	/// Returns the best Substrate header.
-	async fn best_header(&mut self) -> Result<SubstrateHeader>;
+	async fn best_header(&self) -> Result<SubstrateHeader>;
 	/// Get a Substrate block from its hash.
-	async fn get_block(&mut self, block_hash: Option<SubstrateHash>) -> Result<SubstrateBlock>;
+	async fn get_block(&self, block_hash: Option<SubstrateHash>) -> Result<SubstrateBlock>;
 	/// Get a Substrate header by its hash.
-	async fn header_by_hash(&mut self, hash: SubstrateHash) -> Result<SubstrateHeader>;
+	async fn header_by_hash(&self, hash: SubstrateHash) -> Result<SubstrateHeader>;
 	/// Get a Substrate block hash by its number.
-	async fn block_hash_by_number(&mut self, number: SubBlockNumber) -> Result<SubstrateHash>;
+	async fn block_hash_by_number(&self, number: SubBlockNumber) -> Result<SubstrateHash>;
 	/// Get a Substrate header by its number.
-	async fn header_by_number(&mut self, block_number: SubBlockNumber) -> Result<SubstrateHeader>;
+	async fn header_by_number(&self, block_number: SubBlockNumber) -> Result<SubstrateHeader>;
 	/// Get the nonce of the given Substrate account.
 	///
 	/// Note: It's the caller's responsibility to make sure `account` is a valid ss58 address.
-	async fn next_account_index(&mut self, account: node_primitives::AccountId) -> Result<node_primitives::Index>;
+	async fn next_account_index(&self, account: node_primitives::AccountId) -> Result<node_primitives::Index>;
 	/// Returns best Ethereum block that Substrate runtime knows of.
-	async fn best_ethereum_block(&mut self) -> Result<EthereumHeaderId>;
+	async fn best_ethereum_block(&self) -> Result<EthereumHeaderId>;
 	/// Returns whether or not transactions receipts are required for Ethereum header submission.
-	async fn ethereum_receipts_required(&mut self, header: SubstrateEthereumHeader) -> Result<bool>;
+	async fn ethereum_receipts_required(&self, header: SubstrateEthereumHeader) -> Result<bool>;
 	/// Returns whether or not the given Ethereum header is known to the Substrate runtime.
-	async fn ethereum_header_known(&mut self, header_id: EthereumHeaderId) -> Result<bool>;
+	async fn ethereum_header_known(&self, header_id: EthereumHeaderId) -> Result<bool>;
 	/// Submit an extrinsic for inclusion in a block.
 	///
 	/// Note: The given transaction does not need be SCALE encoded beforehand.
-	async fn submit_extrinsic(&mut self, transaction: Bytes) -> Result<SubstrateHash>;
+	async fn submit_extrinsic(&self, transaction: Bytes) -> Result<SubstrateHash>;
 	/// Get the GRANDPA authority set at given block.
-	async fn grandpa_authorities_set(&mut self, block: SubstrateHash) -> Result<GrandpaAuthorityList>;
+	async fn grandpa_authorities_set(&self, block: SubstrateHash) -> Result<GrandpaAuthorityList>;
 }

--- a/relays/ethereum/src/rpc.rs
+++ b/relays/ethereum/src/rpc.rs
@@ -36,36 +36,36 @@ type GrandpaAuthorityList = Vec<u8>;
 
 jsonrpsee::rpc_api! {
 	pub(crate) Ethereum {
-		#[rpc(method = "eth_estimateGas")]
+		#[rpc(method = "eth_estimateGas", positional_params)]
 		fn estimate_gas(call_request: CallRequest) -> U256;
-		#[rpc(method = "eth_blockNumber")]
+		#[rpc(method = "eth_blockNumber", positional_params)]
 		fn block_number() -> U64;
-		#[rpc(method = "eth_getBlockByNumber")]
-		fn get_block_by_number(block_number: u64) -> EthereumHeader;
-		#[rpc(method = "eth_getBlockByHash")]
+		#[rpc(method = "eth_getBlockByNumber", positional_params)]
+		fn get_block_by_number(block_number: U64, extended: bool) -> EthereumHeader;
+		#[rpc(method = "eth_getBlockByHash", positional_params)]
 		fn get_block_by_hash(hash: H256) -> EthereumHeader;
-		#[rpc(method = "eth_getTransactionReceipt")]
+		#[rpc(method = "eth_getTransactionReceipt", positional_params)]
 		fn get_transaction_receipt(transaction_hash: H256) -> Receipt;
-		#[rpc(method = "eth_getTransactionCount")]
+		#[rpc(method = "eth_getTransactionCount", positional_params)]
 		fn get_transaction_count(address: EthAddress) -> U256;
-		#[rpc(method = "eth_submitTransaction")]
+		#[rpc(method = "eth_submitTransaction", positional_params)]
 		fn submit_transaction(transaction: Bytes) -> EthereumTxHash;
-		#[rpc(method = "eth_call")]
+		#[rpc(method = "eth_call", positional_params)]
 		fn call(transaction_call: CallRequest) -> Bytes;
 	}
 
 	pub(crate) Substrate {
-		#[rpc(method = "chain_getHeader")]
+		#[rpc(method = "chain_getHeader", positional_params)]
 		fn chain_get_header(block_hash: Option<SubstrateHash>) -> SubstrateHeader;
-		#[rpc(method = "chain_getBlock")]
+		#[rpc(method = "chain_getBlock", positional_params)]
 		fn chain_get_block(block_hash: Option<SubstrateHash>) -> SubstrateBlock;
-		#[rpc(method = "chain_getBlockHash")]
+		#[rpc(method = "chain_getBlockHash", positional_params)]
 		fn chain_get_block_hash(block_number: Option<SubBlockNumber>) -> SubstrateHash;
-		#[rpc(method = "system_accountNextIndex")]
+		#[rpc(method = "system_accountNextIndex", positional_params)]
 		fn system_account_next_index(account_id: node_primitives::AccountId) -> node_primitives::Index;
-		#[rpc(method = "author_submitExtrinsic")]
+		#[rpc(method = "author_submitExtrinsic", positional_params)]
 		fn author_submit_extrinsic(extrinsic: Bytes) -> SubstrateHash;
-		#[rpc(method = "state_call")]
+		#[rpc(method = "state_call", positional_params)]
 		fn state_call(method: String, data: Bytes, at_block: Option<SubstrateHash>) -> Bytes;
 	}
 }

--- a/relays/ethereum/src/rpc.rs
+++ b/relays/ethereum/src/rpc.rs
@@ -17,6 +17,11 @@
 //! RPC Module
 
 #![warn(missing_docs)]
+
+// The compiler doesn't think we're using the
+// code from rpc_api!
+#![allow(dead_code)]
+#![allow(unused_variables)]
 use std::result;
 
 use crate::ethereum_types::{

--- a/relays/ethereum/src/rpc.rs
+++ b/relays/ethereum/src/rpc.rs
@@ -16,9 +16,7 @@
 
 //! RPC Module
 
-#![allow(dead_code)]
-#![allow(unused_variables)]
-#[warn(missing_docs)]
+#![warn(missing_docs)]
 use std::result;
 
 use crate::ethereum_types::{

--- a/relays/ethereum/src/rpc.rs
+++ b/relays/ethereum/src/rpc.rs
@@ -41,7 +41,7 @@ jsonrpsee::rpc_api! {
 		#[rpc(method = "eth_blockNumber", positional_params)]
 		fn block_number() -> U64;
 		#[rpc(method = "eth_getBlockByNumber", positional_params)]
-		fn get_block_by_number(block_number: U64, extended: bool) -> EthereumHeader;
+		fn get_block_by_number(block_number: U64, full_tx_objs: bool) -> EthereumHeader;
 		#[rpc(method = "eth_getBlockByHash", positional_params)]
 		fn get_block_by_hash(hash: H256) -> EthereumHeader;
 		#[rpc(method = "eth_getTransactionReceipt", positional_params)]

--- a/relays/ethereum/src/rpc_errors.rs
+++ b/relays/ethereum/src/rpc_errors.rs
@@ -35,6 +35,17 @@ pub enum RpcError {
 	Request(RequestError),
 }
 
+impl From<RpcError> for String {
+	fn from(err: RpcError) -> Self {
+		match err {
+			RpcError::Serialization(e) => e.to_string(),
+			RpcError::Ethereum(e) => e.to_string(),
+			RpcError::Substrate(e) => e.to_string(),
+			RpcError::Request(e) => e.to_string(),
+		}
+	}
+}
+
 impl From<serde_json::Error> for RpcError {
 	fn from(err: serde_json::Error) -> Self {
 		Self::Serialization(err)
@@ -95,10 +106,30 @@ pub enum EthereumNodeError {
 	InvalidSubstrateBlockNumber,
 }
 
+impl ToString for EthereumNodeError {
+	fn to_string(&self) -> String {
+		match self {
+			Self::ResponseParseFailed(e) => e,
+			Self::IncompleteHeader => "Incomplete Ethereum Header Received",
+			Self::IncompleteReceipt => "Incomplete Ethereum Receipt Recieved",
+			Self::InvalidSubstrateBlockNumber => "Received an invalid Substrate block from Ethereum Node",
+		}
+		.to_string()
+	}
+}
+
 /// Errors that can occur only when interacting with
 /// a Substrate node through RPC.
 #[derive(Debug)]
 pub enum SubstrateNodeError {
 	/// The response from the client could not be SCALE decoded.
 	Decoding(codec::Error),
+}
+
+impl ToString for SubstrateNodeError {
+	fn to_string(&self) -> String {
+		match self {
+			Self::Decoding(e) => e.what().to_string(),
+		}
+	}
 }

--- a/relays/ethereum/src/rpc_errors.rs
+++ b/relays/ethereum/src/rpc_errors.rs
@@ -19,7 +19,6 @@
 
 use crate::sync_types::MaybeConnectionError;
 
-use ethabi::Error;
 use jsonrpsee::raw::client::RawClientError;
 use jsonrpsee::transport::http::RequestError;
 use serde_json;
@@ -69,7 +68,7 @@ impl From<RpcHttpError> for RpcError {
 }
 
 impl From<ethabi::Error> for RpcError {
-	fn from (err: ethabi::Error) -> Self {
+	fn from(err: ethabi::Error) -> Self {
 		Self::Ethereum(EthereumNodeError::ResponseParseFailed(format!("{}", err)))
 	}
 }

--- a/relays/ethereum/src/rpc_errors.rs
+++ b/relays/ethereum/src/rpc_errors.rs
@@ -33,8 +33,6 @@ pub enum RpcError {
 	/// An error that can occur when making an HTTP request to
 	/// an JSON-RPC client.
 	Request(RequestError),
-	/// The response from the client could not be SCALE decoded.
-	Decoding(codec::Error),
 }
 
 impl From<serde_json::Error> for RpcError {
@@ -70,8 +68,7 @@ impl From<ethabi::Error> for RpcError {
 impl MaybeConnectionError for RpcError {
 	fn is_connection_error(&self) -> bool {
 		match *self {
-			RpcError::Substrate(SubstrateNodeError::StartRequestFailed(_))
-			| RpcError::Request(RequestError::TransportError(_)) => true,
+			RpcError::Request(RequestError::TransportError(_)) => true,
 			_ => false,
 		}
 	}
@@ -79,7 +76,7 @@ impl MaybeConnectionError for RpcError {
 
 impl From<codec::Error> for RpcError {
 	fn from(err: codec::Error) -> Self {
-		Self::Decoding(err)
+		Self::Substrate(SubstrateNodeError::Decoding(err))
 	}
 }
 
@@ -102,10 +99,6 @@ pub enum EthereumNodeError {
 /// a Substrate node through RPC.
 #[derive(Debug)]
 pub enum SubstrateNodeError {
-	/// Request start failed.
-	StartRequestFailed(RequestError),
-	/// Error serializing request.
-	RequestSerialization(serde_json::Error),
-	/// Failed to parse response.
-	ResponseParseFailed,
+	/// The response from the client could not be SCALE decoded.
+	Decoding(codec::Error),
 }

--- a/relays/ethereum/src/rpc_errors.rs
+++ b/relays/ethereum/src/rpc_errors.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-// TODO: Remove this
-#![allow(dead_code)]
-
 use crate::sync_types::MaybeConnectionError;
 
 use jsonrpsee::raw::client::RawClientError;

--- a/relays/ethereum/src/rpc_errors.rs
+++ b/relays/ethereum/src/rpc_errors.rs
@@ -16,11 +16,9 @@
 
 use crate::sync_types::MaybeConnectionError;
 
+use jsonrpsee::client::RequestError;
 use jsonrpsee::raw::client::RawClientError;
-use jsonrpsee::transport::http::RequestError;
 use serde_json;
-
-type RpcHttpError = RawClientError<RequestError>;
 
 /// Contains common errors that can occur when
 /// interacting with a Substrate or Ethereum node
@@ -35,7 +33,7 @@ pub enum RpcError {
 	Substrate(SubstrateNodeError),
 	/// An error that can occur when making an HTTP request to
 	/// an JSON-RPC client.
-	Request(RpcHttpError),
+	Request(RequestError),
 	/// The response from the client could not be SCALE decoded.
 	Decoding(codec::Error),
 }
@@ -58,8 +56,8 @@ impl From<SubstrateNodeError> for RpcError {
 	}
 }
 
-impl From<RpcHttpError> for RpcError {
-	fn from(err: RpcHttpError) -> Self {
+impl From<RequestError> for RpcError {
+	fn from(err: RequestError) -> Self {
 		Self::Request(err)
 	}
 }

--- a/relays/ethereum/src/rpc_errors.rs
+++ b/relays/ethereum/src/rpc_errors.rs
@@ -70,8 +70,8 @@ impl From<ethabi::Error> for RpcError {
 impl MaybeConnectionError for RpcError {
 	fn is_connection_error(&self) -> bool {
 		match *self {
-			// Q: Is blanket handling `Request` too broad?
-			RpcError::Substrate(SubstrateNodeError::StartRequestFailed(_)) | RpcError::Request(_) => true,
+			RpcError::Substrate(SubstrateNodeError::StartRequestFailed(_))
+			| RpcError::Request(RequestError::TransportError(_)) => true,
 			_ => false,
 		}
 	}

--- a/relays/ethereum/src/rpc_errors.rs
+++ b/relays/ethereum/src/rpc_errors.rs
@@ -17,7 +17,6 @@
 use crate::sync_types::MaybeConnectionError;
 
 use jsonrpsee::client::RequestError;
-use jsonrpsee::raw::client::RawClientError;
 use serde_json;
 
 /// Contains common errors that can occur when
@@ -68,11 +67,6 @@ impl From<ethabi::Error> for RpcError {
 	}
 }
 
-// TODO: Should also look into implementing this director for SubstrateNodeError and
-// EthereumSync Error
-//
-// Would allow us to have TargetClient/SourceClient::Error = SubstrateNodeError instead
-// of RpcError
 impl MaybeConnectionError for RpcError {
 	fn is_connection_error(&self) -> bool {
 		match *self {

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -101,30 +101,6 @@ impl SubstrateRpcClient {
 	}
 }
 
-/// All possible errors that can occur during interacting with Ethereum node.
-#[derive(Debug)]
-pub enum Error {
-	/// Request start failed.
-	StartRequestFailed(RequestError),
-	/// Error serializing request.
-	RequestSerialization(serde_json::Error),
-	/// Request not found (should never occur?).
-	RequestNotFound,
-	/// Failed to receive response.
-	ResponseRetrievalFailed(RawClientError<RequestError>),
-	/// Failed to parse response.
-	ResponseParseFailed,
-}
-
-impl MaybeConnectionError for Error {
-	fn is_connection_error(&self) -> bool {
-		match *self {
-			Error::StartRequestFailed(_) | Error::ResponseRetrievalFailed(_) => true,
-			_ => false,
-		}
-	}
-}
-
 #[async_trait]
 impl SubstrateRpc for SubstrateRpcClient {
 	async fn best_header(&mut self) -> Result<SubstrateHeader> {
@@ -320,7 +296,7 @@ impl AlsoHigherLevelCalls for SubstrateRpcClient {
 		&mut self,
 		id: SubstrateHeaderId,
 	) -> Result<(SubstrateHeaderId, Option<GrandpaJustification>)> {
-		let hash = id.1; // bail_on_arg_error!(to_value(id.1).map_err(|e| Error::RequestSerialization(e)), client);
+		let hash = id.1;
 		let signed_block = self.get_block(Some(hash)).await?;
 		Ok((id, signed_block.justification))
 	}

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -101,6 +101,10 @@ impl SubstrateRpcClient {
 			genesis_hash: None,
 		}
 	}
+
+	pub(crate) fn set_genesis_hash(&mut self, genesis_hash: Option<H256>) {
+		self.genesis_hash = genesis_hash;
+	}
 }
 
 #[async_trait]
@@ -234,9 +238,9 @@ impl SubmitEthereumHeaders for SubstrateRpcClient {
 		let genesis_hash = match self.genesis_hash {
 			Some(genesis_hash) => genesis_hash,
 			None => {
+				// NOTE: If we do continue after the `expect()` during setup, we can maybe just take
+				// the L and call this every time we submit headers
 				let genesis_hash = self.block_hash_by_number(Zero::zero()).await?;
-				// TODO: Fix, need &mut
-				// self.genesis_hash = Some(genesis_hash);
 				genesis_hash
 			}
 		};

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -28,9 +28,9 @@ use codec::{Decode, Encode};
 use jsonrpsee::raw::{RawClient, RawClientError};
 use jsonrpsee::transport::http::{HttpTransportClient, RequestError};
 use num_traits::Zero;
+use sp_bridge_eth_poa::Header as SubstrateEthereumHeader;
 use sp_core::crypto::Pair;
 use sp_runtime::traits::IdentifyAccount;
-use sp_bridge_eth_poa::Header as SubstrateEthereumHeader;
 
 const ETH_API_IMPORT_REQUIRES_RECEIPTS: &str = "EthereumHeadersApi_is_import_requires_receipts";
 const ETH_API_IS_KNOWN_BLOCK: &str = "EthereumHeadersApi_is_known_block";
@@ -248,7 +248,7 @@ pub trait AlsoHigherLevelCalls: SubstrateRpc {
 
 #[async_trait]
 impl AlsoHigherLevelCalls for SubstrateRpcClient {
-	// TODO: Fix
+	// TODO: Fix naming
 	async fn ethereum_receipts_required_high(
 		&mut self,
 		header: QueuedEthereumHeader,
@@ -259,7 +259,7 @@ impl AlsoHigherLevelCalls for SubstrateRpcClient {
 		Ok((id, receipts_required))
 	}
 
-	// TODO: Fix
+	// TODO: Fix naming
 	async fn ethereum_header_known_high(&mut self, id: EthereumHeaderId) -> Result<(EthereumHeaderId, bool)> {
 		let is_known_block = self.ethereum_header_known(id).await?;
 		Ok((id, is_known_block))
@@ -298,12 +298,7 @@ impl AlsoHigherLevelCalls for SubstrateRpcClient {
 		let nonce = self.next_account_index(account_id).await?;
 
 		let transaction = create_signed_submit_transaction(headers, &params.signer, nonce, genesis_hash);
-		let _ = self.submit_extrinsic(transaction).await?;
-
-		// let encoded_transaction = bail_on_arg_error!(
-		// 	to_value(Bytes(transaction.encode())).map_err(|e| Error::RequestSerialization(e)),
-		// 	client
-		// );
+		let _ = self.submit_extrinsic(Bytes(transaction.encode())).await?;
 
 		Ok(ids)
 	}
@@ -315,13 +310,7 @@ impl AlsoHigherLevelCalls for SubstrateRpcClient {
 		let ids = headers.iter().map(|header| header.id()).collect();
 		for header in headers {
 			let transaction = create_unsigned_submit_transaction(header);
-
-			// let encoded_transaction = bail_on_arg_error!(
-			// 	to_value(Bytes(transaction.encode())).map_err(|e| Error::RequestSerialization(e)),
-			// 	client
-			// );
-
-			let _ = self.submit_extrinsic(transaction).await?;
+			let _ = self.submit_extrinsic(Bytes(transaction.encode())).await?;
 		}
 
 		Ok(ids)

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -95,7 +95,7 @@ impl SubstrateRpcClient {
 		let uri = format!("http://{}:{}", params.host, params.port);
 		let transport = HttpTransportClient::new(&uri);
 		Self {
-			rpc_client: RawClient::new(transport),
+			client: RawClient::new(transport),
 			genesis_hash: None,
 		}
 	}
@@ -241,7 +241,7 @@ pub trait AlsoHigherLevelCalls: SubstrateRpc {
 
 	/// Get GRANDPA justification for given block.
 	async fn grandpa_justification(
-		&self,
+		&mut self,
 		id: SubstrateHeaderId,
 	) -> Result<(SubstrateHeaderId, Option<GrandpaJustification>)>;
 }
@@ -317,7 +317,7 @@ impl AlsoHigherLevelCalls for SubstrateRpcClient {
 	}
 
 	async fn grandpa_justification(
-		&self,
+		&mut self,
 		id: SubstrateHeaderId,
 	) -> Result<(SubstrateHeaderId, Option<GrandpaJustification>)> {
 		let hash = id.1; // bail_on_arg_error!(to_value(id.1).map_err(|e| Error::RequestSerialization(e)), client);

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -21,12 +21,12 @@ use crate::substrate_types::{
 	into_substrate_ethereum_header, into_substrate_ethereum_receipts, GrandpaJustification, Hash,
 	Header as SubstrateHeader, Number, SignedBlock as SignedSubstrateBlock, SubstrateHeaderId,
 };
-use crate::sync_types::{HeaderId, MaybeConnectionError, SourceHeader};
+use crate::sync_types::{HeaderId, SourceHeader};
 
 use async_trait::async_trait;
 use codec::{Decode, Encode};
-use jsonrpsee::raw::{RawClient, RawClientError};
-use jsonrpsee::transport::http::{HttpTransportClient, RequestError};
+use jsonrpsee::raw::RawClient;
+use jsonrpsee::transport::http::HttpTransportClient;
 use num_traits::Zero;
 use sp_bridge_eth_poa::Header as SubstrateEthereumHeader;
 use sp_core::crypto::Pair;

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -15,21 +15,30 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::ethereum_types::{Bytes, EthereumHeaderId, QueuedEthereumHeader, H256};
+use crate::rpc::{Substrate, SubstrateRpc};
+use crate::rpc_errors::RpcError;
 use crate::substrate_types::{
 	into_substrate_ethereum_header, into_substrate_ethereum_receipts, GrandpaJustification, Hash,
 	Header as SubstrateHeader, Number, SignedBlock as SignedSubstrateBlock, SubstrateHeaderId,
 };
 use crate::sync_types::{HeaderId, MaybeConnectionError, SourceHeader};
-use crate::{bail_on_arg_error, bail_on_error};
+
+use async_trait::async_trait;
 use codec::{Decode, Encode};
-use jsonrpsee::common::Params;
 use jsonrpsee::raw::{RawClient, RawClientError};
 use jsonrpsee::transport::http::{HttpTransportClient, RequestError};
 use num_traits::Zero;
-use serde::de::DeserializeOwned;
-use serde_json::{from_value, to_value, Value};
 use sp_core::crypto::Pair;
 use sp_runtime::traits::IdentifyAccount;
+use sp_bridge_eth_poa::Header as SubstrateEthereumHeader;
+
+const ETH_API_IMPORT_REQUIRES_RECEIPTS: &str = "EthereumHeadersApi_is_import_requires_receipts";
+const ETH_API_IS_KNOWN_BLOCK: &str = "EthereumHeadersApi_is_known_block";
+const ETH_API_BEST_BLOCK: &str = "EthereumHeadersApi_best_block";
+const SUB_API_GRANDPA_AUTHORITIES: &str = "GrandpaApi_grandpa_authorities";
+
+type Result<T> = std::result::Result<T, RpcError>;
+type GrandpaAuthorityList = Vec<u8>;
 
 /// Substrate connection params.
 #[derive(Debug)]
@@ -70,12 +79,26 @@ impl Default for SubstrateSigningParams {
 	}
 }
 
+type Client = RawClient<HttpTransportClient>;
+
 /// Substrate client type.
-pub struct Client {
+pub struct SubstrateRpcClient {
 	/// Substrate RPC client.
-	rpc_client: RawClient<HttpTransportClient>,
+	client: Client,
 	/// Genesis block hash.
 	genesis_hash: Option<H256>,
+}
+
+impl SubstrateRpcClient {
+	/// Returns client that is able to call RPCs on Substrate node.
+	pub fn new(params: SubstrateConnectionParams) -> Self {
+		let uri = format!("http://{}:{}", params.host, params.port);
+		let transport = HttpTransportClient::new(&uri);
+		Self {
+			rpc_client: RawClient::new(transport),
+			genesis_hash: None,
+		}
+	}
 }
 
 /// All possible errors that can occur during interacting with Ethereum node.
@@ -102,270 +125,216 @@ impl MaybeConnectionError for Error {
 	}
 }
 
-/// Returns client that is able to call RPCs on Substrate node.
-pub fn client(params: SubstrateConnectionParams) -> Client {
-	let uri = format!("http://{}:{}", params.host, params.port);
-	let transport = HttpTransportClient::new(&uri);
-	Client {
-		rpc_client: RawClient::new(transport),
-		genesis_hash: None,
+#[async_trait]
+impl SubstrateRpc for SubstrateRpcClient {
+	async fn best_header(&mut self) -> Result<SubstrateHeader> {
+		Ok(Substrate::chain_get_header(&mut self.client, None).await?)
 	}
-}
 
-/// Returns best Substrate header.
-pub async fn best_header(client: Client) -> (Client, Result<SubstrateHeader, Error>) {
-	call_rpc(client, "chain_getHeader", Params::None, rpc_returns_value).await
-}
+	async fn get_block(&mut self, block_hash: Option<Hash>) -> Result<SignedSubstrateBlock> {
+		Ok(Substrate::chain_get_block(&mut self.client, block_hash).await?)
+	}
 
-/// Returns Substrate header by hash.
-pub async fn header_by_hash(client: Client, hash: Hash) -> (Client, Result<SubstrateHeader, Error>) {
-	let hash = bail_on_arg_error!(to_value(hash).map_err(|e| Error::RequestSerialization(e)), client);
-	call_rpc(client, "chain_getHeader", Params::Array(vec![hash]), rpc_returns_value).await
-}
+	async fn header_by_hash(&mut self, block_hash: Hash) -> Result<SubstrateHeader> {
+		Ok(Substrate::chain_get_header(&mut self.client, block_hash).await?)
+	}
 
-/// Returns Substrate header by number.
-pub async fn header_by_number(client: Client, number: Number) -> (Client, Result<SubstrateHeader, Error>) {
-	let (client, hash) = bail_on_error!(block_hash_by_number(client, number).await);
-	header_by_hash(client, hash).await
-}
+	async fn block_hash_by_number(&mut self, number: Number) -> Result<Hash> {
+		Ok(Substrate::chain_get_block_hash(&mut self.client, number).await?)
+	}
 
-/// Returns best Ethereum block that Substrate runtime knows of.
-pub async fn best_ethereum_block(client: Client) -> (Client, Result<EthereumHeaderId, Error>) {
-	let (client, result) = call_rpc(
-		client,
-		"state_call",
-		Params::Array(vec![
-			serde_json::Value::String("EthereumHeadersApi_best_block".into()),
-			serde_json::Value::String("0x".into()),
-		]),
-		rpc_returns_encoded_value,
-	)
-	.await;
-	(client, result.map(|(num, hash)| HeaderId(num, hash)))
-}
+	async fn header_by_number(&mut self, block_number: Number) -> Result<SubstrateHeader> {
+		let block_hash = Self::block_hash_by_number(self, block_number).await?;
+		Ok(Self::header_by_hash(self, block_hash).await?)
+	}
 
-/// Returns true if transactions receipts are required for Ethereum header submission.
-pub async fn ethereum_receipts_required(
-	client: Client,
-	header: QueuedEthereumHeader,
-) -> (Client, Result<(EthereumHeaderId, bool), Error>) {
-	let id = header.header().id();
-	let header = into_substrate_ethereum_header(header.header());
-	let encoded_header = bail_on_arg_error!(
-		to_value(Bytes(header.encode())).map_err(|e| Error::RequestSerialization(e)),
-		client
-	);
-	let (client, receipts_required) = call_rpc(
-		client,
-		"state_call",
-		Params::Array(vec![
-			serde_json::Value::String("EthereumHeadersApi_is_import_requires_receipts".into()),
-			encoded_header,
-		]),
-		rpc_returns_encoded_value,
-	)
-	.await;
-	(
-		client,
-		receipts_required.map(|receipts_required| (id, receipts_required)),
-	)
-}
+	async fn next_account_index(&mut self, account: node_primitives::AccountId) -> Result<node_primitives::Index> {
+		Ok(Substrate::system_account_next_index(&mut self.client, account).await?)
+	}
 
-/// Returns true if Ethereum header is known to Substrate runtime.
-pub async fn ethereum_header_known(
-	client: Client,
-	id: EthereumHeaderId,
-) -> (Client, Result<(EthereumHeaderId, bool), Error>) {
-	// Substrate module could prune old headers. So this fn could return false even
+	async fn best_ethereum_block(&mut self) -> Result<EthereumHeaderId> {
+		let call = ETH_API_BEST_BLOCK.to_string();
+		let data = Bytes("0x".into());
+
+		let encoded_response = Substrate::state_call(&mut self.client, call, data, None).await?;
+		let decoded_response: (u64, sp_bridge_eth_poa::H256) = Decode::decode(&mut &encoded_response.0[..])?;
+
+		let best_header_id = HeaderId(decoded_response.0, decoded_response.1);
+		Ok(best_header_id)
+	}
+
+	async fn ethereum_receipts_required(&mut self, header: SubstrateEthereumHeader) -> Result<bool> {
+		let call = ETH_API_IMPORT_REQUIRES_RECEIPTS.to_string();
+		let data = Bytes(header.encode());
+
+		let encoded_response = Substrate::state_call(&mut self.client, call, data, None).await?;
+		let receipts_required: bool = Decode::decode(&mut &encoded_response.0[..])?;
+
+		// Gonna make it the responsibility of the caller to return (receipts_required, id)
+		Ok(receipts_required)
+	}
+
+	// The Substrate module could prune old headers. So this function could return false even
 	// if header is synced. And we'll mark corresponding Ethereum header as Orphan.
 	//
-	// But when we'll read best header from Substrate next time, we will know that
-	// there's a better header => this Orphan will either be marked as synced, or
+	// But when we read the best header from Substrate next time, we will know that
+	// there's a better header. This Orphan will either be marked as synced, or
 	// eventually pruned.
-	let encoded_id = bail_on_arg_error!(
-		to_value(Bytes(id.1.encode())).map_err(|e| Error::RequestSerialization(e)),
-		client
-	);
-	let (client, is_known_block) = call_rpc(
-		client,
-		"state_call",
-		Params::Array(vec![
-			serde_json::Value::String("EthereumHeadersApi_is_known_block".into()),
-			encoded_id,
-		]),
-		rpc_returns_encoded_value,
-	)
-	.await;
-	(client, is_known_block.map(|is_known_block| (id, is_known_block)))
-}
+	async fn ethereum_header_known(&mut self, header_id: EthereumHeaderId) -> Result<bool> {
+		let call = ETH_API_IS_KNOWN_BLOCK.to_string();
+		let data = Bytes(header_id.1.encode());
 
-/// Submits Ethereum header to Substrate runtime.
-pub async fn submit_ethereum_headers(
-	client: Client,
-	params: SubstrateSigningParams,
-	headers: Vec<QueuedEthereumHeader>,
-	sign_transactions: bool,
-) -> (Client, Result<Vec<EthereumHeaderId>, Error>) {
-	match sign_transactions {
-		true => submit_signed_ethereum_headers(client, params, headers).await,
-		false => submit_unsigned_ethereum_headers(client, headers).await,
+		let encoded_response = Substrate::state_call(&mut self.client, call, data, None).await?;
+		let is_known_block: bool = Decode::decode(&mut &encoded_response.0[..])?;
+
+		// Gonna make it the responsibility of the caller to return (is_known_block, id)
+		Ok(is_known_block)
+	}
+
+	async fn submit_extrinsic(&mut self, transaction: Bytes) -> Result<Hash> {
+		let encoded_transaction = Bytes(transaction.0.encode());
+		Ok(Substrate::author_submit_extrinsic(&mut self.client, encoded_transaction).await?)
+	}
+
+	async fn grandpa_authorities_set(&mut self, block: Hash) -> Result<GrandpaAuthorityList> {
+		let call = SUB_API_GRANDPA_AUTHORITIES.to_string();
+		let data = Bytes(block.as_bytes().to_vec());
+
+		let encoded_response = Substrate::state_call(&mut self.client, call, data, None).await?;
+		let authority_list = encoded_response.0;
+
+		Ok(authority_list)
 	}
 }
 
-/// Submits signed Ethereum header to Substrate runtime.
-pub async fn submit_signed_ethereum_headers(
-	client: Client,
-	params: SubstrateSigningParams,
-	headers: Vec<QueuedEthereumHeader>,
-) -> (Client, Result<Vec<EthereumHeaderId>, Error>) {
-	let ids = headers.iter().map(|header| header.id()).collect();
-	let (client, genesis_hash) = match client.genesis_hash {
-		Some(genesis_hash) => (client, genesis_hash),
-		None => {
-			let (mut client, genesis_hash) = bail_on_error!(block_hash_by_number(client, Zero::zero()).await);
-			client.genesis_hash = Some(genesis_hash);
-			(client, genesis_hash)
+#[async_trait]
+pub trait AlsoHigherLevelCalls: SubstrateRpc {
+	/// Returns true if transactions receipts are required for Ethereum header submission.
+	async fn ethereum_receipts_required_high(
+		&mut self,
+		header: QueuedEthereumHeader,
+	) -> Result<(EthereumHeaderId, bool)>;
+
+	/// Returns true if Ethereum header is known to Substrate runtime.
+	async fn ethereum_header_known_high(&mut self, id: EthereumHeaderId) -> Result<(EthereumHeaderId, bool)>;
+
+	/// Submits Ethereum header to Substrate runtime.
+	async fn submit_ethereum_headers(
+		&mut self,
+		params: SubstrateSigningParams,
+		headers: Vec<QueuedEthereumHeader>,
+		sign_transactions: bool,
+	) -> Result<Vec<EthereumHeaderId>>;
+
+	/// Submits signed Ethereum header to Substrate runtime.
+	async fn submit_signed_ethereum_headers(
+		&mut self,
+		params: SubstrateSigningParams,
+		headers: Vec<QueuedEthereumHeader>,
+	) -> Result<Vec<EthereumHeaderId>>;
+
+	/// Submits unsigned Ethereum header to Substrate runtime.
+	async fn submit_unsigned_ethereum_headers(
+		&mut self,
+		headers: Vec<QueuedEthereumHeader>,
+	) -> Result<Vec<EthereumHeaderId>>;
+
+	/// Get GRANDPA justification for given block.
+	async fn grandpa_justification(
+		&self,
+		id: SubstrateHeaderId,
+	) -> Result<(SubstrateHeaderId, Option<GrandpaJustification>)>;
+}
+
+#[async_trait]
+impl AlsoHigherLevelCalls for SubstrateRpcClient {
+	// TODO: Fix
+	async fn ethereum_receipts_required_high(
+		&mut self,
+		header: QueuedEthereumHeader,
+	) -> Result<(EthereumHeaderId, bool)> {
+		let id = header.header().id();
+		let header = into_substrate_ethereum_header(header.header());
+		let receipts_required = self.ethereum_receipts_required(header).await?;
+		Ok((id, receipts_required))
+	}
+
+	// TODO: Fix
+	async fn ethereum_header_known_high(&mut self, id: EthereumHeaderId) -> Result<(EthereumHeaderId, bool)> {
+		let is_known_block = self.ethereum_header_known(id).await?;
+		Ok((id, is_known_block))
+	}
+
+	async fn submit_ethereum_headers(
+		&mut self,
+		params: SubstrateSigningParams,
+		headers: Vec<QueuedEthereumHeader>,
+		sign_transactions: bool,
+	) -> Result<Vec<EthereumHeaderId>> {
+		if sign_transactions {
+			self.submit_signed_ethereum_headers(params, headers).await
+		} else {
+			self.submit_unsigned_ethereum_headers(headers).await
 		}
-	};
-	let account_id = params.signer.public().as_array_ref().clone().into();
-	let (client, nonce) = bail_on_error!(next_account_index(client, account_id).await);
-
-	let transaction = create_signed_submit_transaction(headers, &params.signer, nonce, genesis_hash);
-	let encoded_transaction = bail_on_arg_error!(
-		to_value(Bytes(transaction.encode())).map_err(|e| Error::RequestSerialization(e)),
-		client
-	);
-	let (client, _) = bail_on_error!(
-		call_rpc(
-			client,
-			"author_submitExtrinsic",
-			Params::Array(vec![encoded_transaction]),
-			|_| Ok(()),
-		)
-		.await
-	);
-
-	(client, Ok(ids))
-}
-
-/// Submits unsigned Ethereum header to Substrate runtime.
-pub async fn submit_unsigned_ethereum_headers(
-	mut client: Client,
-	headers: Vec<QueuedEthereumHeader>,
-) -> (Client, Result<Vec<EthereumHeaderId>, Error>) {
-	let ids = headers.iter().map(|header| header.id()).collect();
-	for header in headers {
-		let transaction = create_unsigned_submit_transaction(header);
-
-		let encoded_transaction = bail_on_arg_error!(
-			to_value(Bytes(transaction.encode())).map_err(|e| Error::RequestSerialization(e)),
-			client
-		);
-		let (used_client, _) = bail_on_error!(
-			call_rpc(
-				client,
-				"author_submitExtrinsic",
-				Params::Array(vec![encoded_transaction]),
-				|_| Ok(()),
-			)
-			.await
-		);
-
-		client = used_client;
 	}
 
-	(client, Ok(ids))
-}
+	async fn submit_signed_ethereum_headers(
+		&mut self,
+		params: SubstrateSigningParams,
+		headers: Vec<QueuedEthereumHeader>,
+	) -> Result<Vec<EthereumHeaderId>> {
+		let ids = headers.iter().map(|header| header.id()).collect();
 
-/// Get GRANDPA justification for given block.
-pub async fn grandpa_justification(
-	client: Client,
-	id: SubstrateHeaderId,
-) -> (Client, Result<(SubstrateHeaderId, Option<GrandpaJustification>), Error>) {
-	let hash = bail_on_arg_error!(to_value(id.1).map_err(|e| Error::RequestSerialization(e)), client);
-	let (client, signed_block) = call_rpc(client, "chain_getBlock", Params::Array(vec![hash]), rpc_returns_value).await;
-	(
-		client,
-		signed_block.map(|signed_block: SignedSubstrateBlock| (id, signed_block.justification)),
-	)
-}
+		let genesis_hash = match self.genesis_hash {
+			Some(genesis_hash) => genesis_hash,
+			None => {
+				let genesis_hash = self.block_hash_by_number(Zero::zero()).await?;
+				self.genesis_hash = Some(genesis_hash);
+				genesis_hash
+			}
+		};
 
-/// Get GRANDPA authorities set at given block.
-pub async fn grandpa_authorities_set(client: Client, block: Hash) -> (Client, Result<Vec<u8>, Error>) {
-	let block = bail_on_arg_error!(to_value(block).map_err(|e| Error::RequestSerialization(e)), client);
-	call_rpc(
-		client,
-		"state_call",
-		Params::Array(vec![
-			serde_json::Value::String("GrandpaApi_grandpa_authorities".into()),
-			block,
-		]),
-		rpc_returns_bytes,
-	)
-	.await
-}
+		let account_id = params.signer.public().as_array_ref().clone().into();
+		let nonce = self.next_account_index(account_id).await?;
 
-/// Get Substrate block hash by its number.
-async fn block_hash_by_number(client: Client, number: Number) -> (Client, Result<Hash, Error>) {
-	let number = bail_on_arg_error!(to_value(number).map_err(|e| Error::RequestSerialization(e)), client);
-	call_rpc(
-		client,
-		"chain_getBlockHash",
-		Params::Array(vec![number]),
-		rpc_returns_value,
-	)
-	.await
-}
+		let transaction = create_signed_submit_transaction(headers, &params.signer, nonce, genesis_hash);
+		let _ = self.submit_extrinsic(transaction).await?;
 
-/// Get substrate account nonce.
-async fn next_account_index(
-	client: Client,
-	account: node_primitives::AccountId,
-) -> (Client, Result<node_primitives::Index, Error>) {
-	use sp_core::crypto::Ss58Codec;
+		// let encoded_transaction = bail_on_arg_error!(
+		// 	to_value(Bytes(transaction.encode())).map_err(|e| Error::RequestSerialization(e)),
+		// 	client
+		// );
 
-	let account = bail_on_arg_error!(
-		to_value(account.to_ss58check()).map_err(|e| Error::RequestSerialization(e)),
-		client
-	);
-	let (client, index) = call_rpc(client, "system_accountNextIndex", Params::Array(vec![account]), |v| {
-		rpc_returns_value::<u64>(v)
-	})
-	.await;
-	(client, index.map(|index| index as _))
-}
-
-/// Calls RPC on Substrate node that returns Bytes.
-async fn call_rpc<T>(
-	mut client: Client,
-	method: &'static str,
-	params: Params,
-	decode_value: impl Fn(Value) -> Result<T, Error>,
-) -> (Client, Result<T, Error>) {
-	async fn do_call_rpc<T>(
-		client: &mut Client,
-		method: &'static str,
-		params: Params,
-		decode_value: impl Fn(Value) -> Result<T, Error>,
-	) -> Result<T, Error> {
-		let request_id = client
-			.rpc_client
-			.start_request(method, params)
-			.await
-			.map_err(Error::StartRequestFailed)?;
-		// WARN: if there'll be need for executing >1 request at a time, we should avoid
-		// calling request_by_id
-		let response = client
-			.rpc_client
-			.request_by_id(request_id)
-			.ok_or(Error::RequestNotFound)?
-			.await
-			.map_err(Error::ResponseRetrievalFailed)?;
-		decode_value(response)
+		Ok(ids)
 	}
 
-	let result = do_call_rpc(&mut client, method, params, decode_value).await;
-	(client, result)
+	async fn submit_unsigned_ethereum_headers(
+		&mut self,
+		headers: Vec<QueuedEthereumHeader>,
+	) -> Result<Vec<EthereumHeaderId>> {
+		let ids = headers.iter().map(|header| header.id()).collect();
+		for header in headers {
+			let transaction = create_unsigned_submit_transaction(header);
+
+			// let encoded_transaction = bail_on_arg_error!(
+			// 	to_value(Bytes(transaction.encode())).map_err(|e| Error::RequestSerialization(e)),
+			// 	client
+			// );
+
+			let _ = self.submit_extrinsic(transaction).await?;
+		}
+
+		Ok(ids)
+	}
+
+	async fn grandpa_justification(
+		&self,
+		id: SubstrateHeaderId,
+	) -> Result<(SubstrateHeaderId, Option<GrandpaJustification>)> {
+		let hash = id.1; // bail_on_arg_error!(to_value(id.1).map_err(|e| Error::RequestSerialization(e)), client);
+		let signed_block = self.get_block(Some(hash)).await?;
+		Ok((id, signed_block.justification))
+	}
 }
 
 /// Create signed Substrate transaction for submitting Ethereum headers.
@@ -428,21 +397,4 @@ fn create_unsigned_submit_transaction(header: QueuedEthereumHeader) -> bridge_no
 		));
 
 	bridge_node_runtime::UncheckedExtrinsic::new_unsigned(function)
-}
-
-/// When RPC method returns encoded value.
-fn rpc_returns_encoded_value<T: Decode>(value: Value) -> Result<T, Error> {
-	let encoded_response: Bytes = from_value(value).map_err(|_| Error::ResponseParseFailed)?;
-	Decode::decode(&mut &encoded_response.0[..]).map_err(|_| Error::ResponseParseFailed)
-}
-
-/// When RPC method returns value.
-fn rpc_returns_value<T: DeserializeOwned>(value: Value) -> Result<T, Error> {
-	from_value(value).map_err(|_| Error::ResponseParseFailed)
-}
-
-/// When RPC method returns raw bytes.
-fn rpc_returns_bytes(value: Value) -> Result<Vec<u8>, Error> {
-	let encoded_response: Bytes = from_value(value).map_err(|_| Error::ResponseParseFailed)?;
-	Ok(encoded_response.0)
 }

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -168,8 +168,7 @@ impl SubstrateRpc for SubstrateRpcClient {
 	}
 
 	async fn submit_extrinsic(&self, transaction: Bytes) -> Result<Hash> {
-		let encoded_transaction = Bytes(transaction.0.encode());
-		Ok(Substrate::author_submit_extrinsic(&self.client, encoded_transaction).await?)
+		Ok(Substrate::author_submit_extrinsic(&self.client, transaction).await?)
 	}
 
 	async fn grandpa_authorities_set(&self, block: Hash) -> Result<GrandpaAuthorityList> {

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -17,12 +17,12 @@
 //! Substrate -> Ethereum synchronization.
 
 use crate::ethereum_client::{
-	self, EthereumConnectionParams, EthereumRpcClient, EthereumSigningParams, HigherLevelCalls,
+	EthereumConnectionParams, EthereumRpcClient, EthereumSigningParams, HigherLevelCalls,
 };
 use crate::ethereum_types::Address;
-use crate::rpc::{EthereumRpc, SubstrateRpc};
+use crate::rpc::SubstrateRpc;
 use crate::rpc_errors::RpcError;
-use crate::substrate_client::{self, AlsoHigherLevelCalls, SubstrateConnectionParams, SubstrateRpcClient};
+use crate::substrate_client::{AlsoHigherLevelCalls, SubstrateConnectionParams, SubstrateRpcClient};
 use crate::substrate_types::{
 	GrandpaJustification, Hash, Header, Number, QueuedSubstrateHeader, SubstrateHeaderId, SubstrateHeadersSyncPipeline,
 };
@@ -31,7 +31,6 @@ use crate::sync_loop::{OwnedSourceFutureOutput, OwnedTargetFutureOutput, SourceC
 use crate::sync_types::SourceHeader;
 
 use async_trait::async_trait;
-use futures::future::FutureExt;
 use std::{collections::HashSet, time::Duration};
 
 /// Interval at which we check new Substrate headers when we are synced/almost synced.

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -153,98 +153,52 @@ type EthereumFutureOutput<T> = OwnedTargetFutureOutput<EthereumHeadersTarget, Su
 impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 	type Error = ethereum_client::Error;
 
-	async fn best_header_id(self) -> EthereumFutureOutput<SubstrateHeaderId> {
+	async fn best_header_id(self) -> Result<SubstrateHeaderId, Self::Error> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
-		self.client.best_substrate_block(contract).await.expect("TOD");
-		// .map(move |(client, result)| {
-		// 	(
-		// 		EthereumHeadersTarget {
-		// 			client,
-		// 			contract,
-		// 			sign_params,
-		// 		},
-		// 		result,
-		// 	)
-		// })
-		// .await
+		self.client
+			.best_substrate_block(contract)
+			.await
+			.map_err(|_| ethereum_client::Error::RequestNotFound)
 	}
 
-	async fn is_known_header(self, id: SubstrateHeaderId) -> EthereumFutureOutput<(SubstrateHeaderId, bool)> {
+	async fn is_known_header(self, id: SubstrateHeaderId) -> Result<(SubstrateHeaderId, bool), Self::Error> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
-		self.client.substrate_header_known(contract, id).await.expect("D")
-		// .map(move |(client, result)| {
-		// 	(
-		// 		EthereumHeadersTarget {
-		// 			client,
-		// 			contract,
-		// 			sign_params,
-		// 		},
-		// 		result,
-		// 	)
-		// })
-		// .await
+		self.client
+			.substrate_header_known(contract, id)
+			.await
+			.map_err(|_| ethereum_client::Error::RequestNotFound)
 	}
 
-	async fn submit_headers(self, headers: Vec<QueuedSubstrateHeader>) -> EthereumFutureOutput<Vec<SubstrateHeaderId>> {
+	async fn submit_headers(self, headers: Vec<QueuedSubstrateHeader>) -> Result<Vec<SubstrateHeaderId>, Self::Error> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
 		self.client
 			.submit_substrate_headers(sign_params.clone(), contract, headers)
 			.await
-			.expect("TO")
-		// .map(move |(client, result)| {
-		// 	(
-		// 		EthereumHeadersTarget {
-		// 			client,
-		// 			contract,
-		// 			sign_params,
-		// 		},
-		// 		result,
-		// 	)
-		// })
-		// .await
+			.map_err(|_| ethereum_client::Error::RequestNotFound)
 	}
 
-	async fn incomplete_headers_ids(self) -> EthereumFutureOutput<HashSet<SubstrateHeaderId>> {
+	async fn incomplete_headers_ids(self) -> Result<HashSet<SubstrateHeaderId>, Self::Error> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
-		self.client.incomplete_substrate_headers(contract).await.expect("TOD")
-		// .map(move |(client, result)| {
-		// 	(
-		// 		EthereumHeadersTarget {
-		// 			client,
-		// 			contract,
-		// 			sign_params,
-		// 		},
-		// 		result,
-		// 	)
-		// })
-		// .await
+		self.client
+			.incomplete_substrate_headers(contract)
+			.await
+			.map_err(|_| ethereum_client::Error::RequestNotFound)
 	}
 
 	async fn complete_header(
 		self,
 		id: SubstrateHeaderId,
 		completion: GrandpaJustification,
-	) -> EthereumFutureOutput<SubstrateHeaderId> {
+	) -> Result<SubstrateHeaderId, Self::Error> {
 		let (contract, sign_params) = (self.contract, self.sign_params);
 		self.client
 			.complete_substrate_header(sign_params.clone(), contract, id, completion)
 			.await
-			.expect("TD")
-		// .map(move |(client, result)| {
-		// 	(
-		// 		EthereumHeadersTarget {
-		// 			client,
-		// 			contract,
-		// 			sign_params,
-		// 		},
-		// 		result,
-		// 	)
-		// })
-		// .await
+			.map_err(|_| ethereum_client::Error::RequestNotFound)
 	}
 
-	async fn requires_extra(self, header: QueuedSubstrateHeader) -> EthereumFutureOutput<(SubstrateHeaderId, bool)> {
-		(self, Ok((header.header().id(), false)))
+	async fn requires_extra(self, header: QueuedSubstrateHeader) -> Result<(SubstrateHeaderId, bool), Self::Error> {
+		Ok((header.header().id(), false))
 	}
 }
 

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -105,11 +105,11 @@ impl SourceClient<SubstrateHeadersSyncPipeline> for SubstrateHeadersSource {
 	}
 
 	async fn header_by_hash(&self, hash: Hash) -> Result<Header, Self::Error> {
-		Ok(self.client.header_by_hash(hash).await?)
+		self.client.header_by_hash(hash).await
 	}
 
 	async fn header_by_number(&self, number: Number) -> Result<Header, Self::Error> {
-		Ok(self.client.header_by_number(number).await?)
+		self.client.header_by_number(number).await
 	}
 
 	async fn header_completion(
@@ -157,22 +157,21 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 	type Error = RpcError;
 
 	async fn best_header_id(&self) -> Result<SubstrateHeaderId, Self::Error> {
-		Ok(self.client.best_substrate_block(self.contract).await?)
+		self.client.best_substrate_block(self.contract).await
 	}
 
 	async fn is_known_header(&self, id: SubstrateHeaderId) -> Result<(SubstrateHeaderId, bool), Self::Error> {
-		Ok(self.client.substrate_header_known(self.contract, id).await?)
+		self.client.substrate_header_known(self.contract, id).await
 	}
 
 	async fn submit_headers(&self, headers: Vec<QueuedSubstrateHeader>) -> Result<Vec<SubstrateHeaderId>, Self::Error> {
-		Ok(self
-			.client
+		self.client
 			.submit_substrate_headers(self.sign_params.clone(), self.contract, headers)
-			.await?)
+			.await
 	}
 
 	async fn incomplete_headers_ids(&self) -> Result<HashSet<SubstrateHeaderId>, Self::Error> {
-		Ok(self.client.incomplete_substrate_headers(self.contract).await?)
+		self.client.incomplete_substrate_headers(self.contract).await
 	}
 
 	async fn complete_header(
@@ -180,10 +179,9 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 		id: SubstrateHeaderId,
 		completion: GrandpaJustification,
 	) -> Result<SubstrateHeaderId, Self::Error> {
-		Ok(self
-			.client
+		self.client
 			.complete_substrate_header(self.sign_params.clone(), self.contract, id, completion)
-			.await?)
+			.await
 	}
 
 	async fn requires_extra(&self, header: QueuedSubstrateHeader) -> Result<(SubstrateHeaderId, bool), Self::Error> {

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -191,12 +191,11 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 }
 
 /// Run Substrate headers synchronization.
-pub fn run(params: SubstrateSyncParams) {
+pub fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
 	let sub_params = params.clone();
 
 	let eth_client = EthereumRpcClient::new(params.eth);
-	let sub_client =
-		async_std::task::block_on(async { SubstrateRpcClient::new(sub_params.sub).await.expect("What do?") });
+	let sub_client = async_std::task::block_on(async { SubstrateRpcClient::new(sub_params.sub).await })?;
 
 	let target = EthereumHeadersTarget::new(eth_client, params.eth_contract_address, params.eth_sign);
 	let source = SubstrateHeadersSource::new(sub_client);
@@ -208,4 +207,6 @@ pub fn run(params: SubstrateSyncParams) {
 		ETHEREUM_TICK_INTERVAL,
 		params.sync_params,
 	);
+
+	Ok(())
 }

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -16,9 +16,7 @@
 
 //! Substrate -> Ethereum synchronization.
 
-use crate::ethereum_client::{
-	EthereumConnectionParams, EthereumRpcClient, EthereumSigningParams, HigherLevelCalls,
-};
+use crate::ethereum_client::{EthereumConnectionParams, EthereumRpcClient, EthereumSigningParams, HigherLevelCalls};
 use crate::ethereum_types::Address;
 use crate::rpc::SubstrateRpc;
 use crate::rpc_errors::RpcError;
@@ -96,27 +94,27 @@ type SubstrateFutureOutput<T> = OwnedSourceFutureOutput<SubstrateHeadersSource, 
 impl SourceClient<SubstrateHeadersSyncPipeline> for SubstrateHeadersSource {
 	type Error = RpcError;
 
-	async fn best_block_number(&mut self) -> Result<Number, Self::Error> {
+	async fn best_block_number(&self) -> Result<Number, Self::Error> {
 		Ok(self.client.best_header().await?.number)
 	}
 
-	async fn header_by_hash(&mut self, hash: Hash) -> Result<Header, Self::Error> {
+	async fn header_by_hash(&self, hash: Hash) -> Result<Header, Self::Error> {
 		Ok(self.client.header_by_hash(hash).await?)
 	}
 
-	async fn header_by_number(&mut self, number: Number) -> Result<Header, Self::Error> {
+	async fn header_by_number(&self, number: Number) -> Result<Header, Self::Error> {
 		Ok(self.client.header_by_number(number).await?)
 	}
 
 	async fn header_completion(
-		&mut self,
+		&self,
 		id: SubstrateHeaderId,
 	) -> Result<(SubstrateHeaderId, Option<GrandpaJustification>), Self::Error> {
 		Ok(self.client.grandpa_justification(id).await?)
 	}
 
 	async fn header_extra(
-		&mut self,
+		&self,
 		id: SubstrateHeaderId,
 		_header: QueuedSubstrateHeader,
 	) -> Result<(SubstrateHeaderId, ()), Self::Error> {
@@ -140,30 +138,27 @@ type EthereumFutureOutput<T> = OwnedTargetFutureOutput<EthereumHeadersTarget, Su
 impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 	type Error = RpcError;
 
-	async fn best_header_id(&mut self) -> Result<SubstrateHeaderId, Self::Error> {
+	async fn best_header_id(&self) -> Result<SubstrateHeaderId, Self::Error> {
 		Ok(self.client.best_substrate_block(self.contract).await?)
 	}
 
-	async fn is_known_header(&mut self, id: SubstrateHeaderId) -> Result<(SubstrateHeaderId, bool), Self::Error> {
+	async fn is_known_header(&self, id: SubstrateHeaderId) -> Result<(SubstrateHeaderId, bool), Self::Error> {
 		Ok(self.client.substrate_header_known(self.contract, id).await?)
 	}
 
-	async fn submit_headers(
-		&mut self,
-		headers: Vec<QueuedSubstrateHeader>,
-	) -> Result<Vec<SubstrateHeaderId>, Self::Error> {
+	async fn submit_headers(&self, headers: Vec<QueuedSubstrateHeader>) -> Result<Vec<SubstrateHeaderId>, Self::Error> {
 		Ok(self
 			.client
 			.submit_substrate_headers(self.sign_params.clone(), self.contract, headers)
 			.await?)
 	}
 
-	async fn incomplete_headers_ids(&mut self) -> Result<HashSet<SubstrateHeaderId>, Self::Error> {
+	async fn incomplete_headers_ids(&self) -> Result<HashSet<SubstrateHeaderId>, Self::Error> {
 		Ok(self.client.incomplete_substrate_headers(self.contract).await?)
 	}
 
 	async fn complete_header(
-		&mut self,
+		&self,
 		id: SubstrateHeaderId,
 		completion: GrandpaJustification,
 	) -> Result<SubstrateHeaderId, Self::Error> {
@@ -173,10 +168,7 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 			.await?)
 	}
 
-	async fn requires_extra(
-		&mut self,
-		header: QueuedSubstrateHeader,
-	) -> Result<(SubstrateHeaderId, bool), Self::Error> {
+	async fn requires_extra(&self, header: QueuedSubstrateHeader) -> Result<(SubstrateHeaderId, bool), Self::Error> {
 		Ok((header.header().id(), false))
 	}
 }

--- a/relays/ethereum/src/sync.rs
+++ b/relays/ethereum/src/sync.rs
@@ -19,7 +19,7 @@ use crate::sync_types::{HeaderId, HeaderStatus, HeadersSyncPipeline, QueuedHeade
 use num_traits::{One, Saturating};
 
 /// Common sync params.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HeadersSyncParams {
 	/// Maximal number of ethereum headers to pre-download.
 	pub max_future_headers_to_download: usize,
@@ -37,7 +37,7 @@ pub struct HeadersSyncParams {
 }
 
 /// Target transaction mode.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TargetTransactionMode {
 	/// Submit new headers using signed transactions.
 	Signed,

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -55,19 +55,19 @@ pub trait SourceClient<P: HeadersSyncPipeline>: Sized {
 	type Error: std::fmt::Debug + MaybeConnectionError;
 
 	/// Get best block number.
-	async fn best_block_number(self) -> OwnedSourceFutureOutput<Self, P, P::Number>;
+	async fn best_block_number(self) -> Result<P::Number, Self::Error>;
 
 	/// Get header by hash.
-	async fn header_by_hash(self, hash: P::Hash) -> OwnedSourceFutureOutput<Self, P, P::Header>;
+	async fn header_by_hash(self, hash: P::Hash) -> Result<P::Header, Self::Error>;
 
 	/// Get canonical header by number.
-	async fn header_by_number(self, number: P::Number) -> OwnedSourceFutureOutput<Self, P, P::Header>;
+	async fn header_by_number(self, number: P::Number) -> Result<P::Header, Self::Error>;
 
 	/// Get completion data by header hash.
 	async fn header_completion(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
-	) -> OwnedSourceFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, Option<P::Completion>)>;
+	) -> Result<(HeaderId<P::Hash, P::Number>, Option<P::Completion>), Self::Error>;
 
 	/// Get extra data by header hash.
 	async fn header_extra(

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -55,23 +55,23 @@ pub trait SourceClient<P: HeadersSyncPipeline>: Sized {
 	type Error: std::fmt::Debug + MaybeConnectionError;
 
 	/// Get best block number.
-	async fn best_block_number(&mut self) -> Result<P::Number, Self::Error>;
+	async fn best_block_number(&self) -> Result<P::Number, Self::Error>;
 
 	/// Get header by hash.
-	async fn header_by_hash(&mut self, hash: P::Hash) -> Result<P::Header, Self::Error>;
+	async fn header_by_hash(&self, hash: P::Hash) -> Result<P::Header, Self::Error>;
 
 	/// Get canonical header by number.
-	async fn header_by_number(&mut self, number: P::Number) -> Result<P::Header, Self::Error>;
+	async fn header_by_number(&self, number: P::Number) -> Result<P::Header, Self::Error>;
 
 	/// Get completion data by header hash.
 	async fn header_completion(
-		&mut self,
+		&self,
 		id: HeaderId<P::Hash, P::Number>,
 	) -> Result<(HeaderId<P::Hash, P::Number>, Option<P::Completion>), Self::Error>;
 
 	/// Get extra data by header hash.
 	async fn header_extra(
-		&mut self,
+		&self,
 		id: HeaderId<P::Hash, P::Number>,
 		header: QueuedHeader<P>,
 	) -> Result<(HeaderId<P::Hash, P::Number>, P::Extra), Self::Error>;
@@ -84,33 +84,35 @@ pub trait TargetClient<P: HeadersSyncPipeline>: Sized {
 	type Error: std::fmt::Debug + MaybeConnectionError;
 
 	/// Returns ID of best header known to the target node.
-	async fn best_header_id(&mut self) -> Result<HeaderId<P::Hash, P::Number>, Self::Error>;
+	async fn best_header_id(&self) -> Result<HeaderId<P::Hash, P::Number>, Self::Error>;
 
 	/// Returns true if header is known to the target node.
 	async fn is_known_header(
-		&mut self,
+		&self,
 		id: HeaderId<P::Hash, P::Number>,
 	) -> Result<(HeaderId<P::Hash, P::Number>, bool), Self::Error>;
 
 	/// Submit headers.
 	async fn submit_headers(
-		&mut self,
+		&self,
 		headers: Vec<QueuedHeader<P>>,
 	) -> Result<Vec<HeaderId<P::Hash, P::Number>>, Self::Error>;
 
 	/// Returns ID of headers that require to be 'completed' before children can be submitted.
-	async fn incomplete_headers_ids(&mut self) -> Result<HashSet<HeaderId<P::Hash, P::Number>>, Self::Error>;
+	async fn incomplete_headers_ids(&self) -> Result<HashSet<HeaderId<P::Hash, P::Number>>, Self::Error>;
 
 	/// Submit completion data for header.
 	async fn complete_header(
-		&mut self,
+		&self,
 		id: HeaderId<P::Hash, P::Number>,
 		completion: P::Completion,
 	) -> Result<HeaderId<P::Hash, P::Number>, Self::Error>;
 
 	/// Returns true if header requires extra data to be submitted.
-	async fn requires_extra(&mut self, header: QueuedHeader<P>)
-		-> Result<(HeaderId<P::Hash, P::Number>, bool), Self::Error>;
+	async fn requires_extra(
+		&self,
+		header: QueuedHeader<P>,
+	) -> Result<(HeaderId<P::Hash, P::Number>, bool), Self::Error>;
 }
 
 /// Run headers synchronization.

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -22,11 +22,8 @@ use futures::{future::FutureExt, stream::StreamExt};
 use num_traits::{Saturating, Zero};
 use std::{
 	collections::HashSet,
-	sync::Arc,
 	time::{Duration, Instant},
 };
-
-use parking_lot::Mutex;
 
 /// When we submit headers to target node, but see no updates of best
 /// source block known to target node during STALL_SYNC_TIMEOUT seconds,

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -84,35 +84,33 @@ pub trait TargetClient<P: HeadersSyncPipeline>: Sized {
 	type Error: std::fmt::Debug + MaybeConnectionError;
 
 	/// Returns ID of best header known to the target node.
-	async fn best_header_id(self) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
+	async fn best_header_id(self) -> Result<HeaderId<P::Hash, P::Number>, Self::Error>;
 
 	/// Returns true if header is known to the target node.
 	async fn is_known_header(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
-	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
+	) -> Result<(HeaderId<P::Hash, P::Number>, bool), Self::Error>;
 
 	/// Submit headers.
 	async fn submit_headers(
 		self,
 		headers: Vec<QueuedHeader<P>>,
-	) -> OwnedTargetFutureOutput<Self, P, Vec<HeaderId<P::Hash, P::Number>>>;
+	) -> Result<Vec<HeaderId<P::Hash, P::Number>>, Self::Error>;
 
 	/// Returns ID of headers that require to be 'completed' before children can be submitted.
-	async fn incomplete_headers_ids(self) -> OwnedTargetFutureOutput<Self, P, HashSet<HeaderId<P::Hash, P::Number>>>;
+	async fn incomplete_headers_ids(self) -> Result<HashSet<HeaderId<P::Hash, P::Number>>, Self::Error>;
 
 	/// Submit completion data for header.
 	async fn complete_header(
 		self,
 		id: HeaderId<P::Hash, P::Number>,
 		completion: P::Completion,
-	) -> OwnedTargetFutureOutput<Self, P, HeaderId<P::Hash, P::Number>>;
+	) -> Result<HeaderId<P::Hash, P::Number>, Self::Error>;
 
 	/// Returns true if header requires extra data to be submitted.
-	async fn requires_extra(
-		self,
-		header: QueuedHeader<P>,
-	) -> OwnedTargetFutureOutput<Self, P, (HeaderId<P::Hash, P::Number>, bool)>;
+	async fn requires_extra(self, header: QueuedHeader<P>)
+		-> Result<(HeaderId<P::Hash, P::Number>, bool), Self::Error>;
 }
 
 /// Run headers synchronization.


### PR DESCRIPTION
This PR hooks up the changes introduced in #80 with the rest of the codebase. The motivation behind this PR is mainly to simplify the existing code, as well as making a more clear separation between the clients and the RPC.

I've split the RPCs into what I consider "base" and "high" level calls. The "base" calls are captured in the `SubstrateRpc`/`EthereumRpc` traits, and the "high" level calls in `SubstrateEthereumHeaders` and `EthereumHighLevelRpc` (creative, I know) traits. The base RPCs try to do the base minimum on top of the APIs defined in `rpc_api!`, while the high level RPCs are made up of a combination of base calls, or perform extra logic (like interacting with a smart contract).

The implementations of the RPCs introduced in #80 were moved from the `rpc` module into the respective `client` modules. I left the traits however, since I figured that they should be close to the API definitions.

Some other things to note:

Right now this fails to sync the bridge. Every now and then the relay complains about the Substrate chain missing the `EthereumHeadersApi-*` runtime APIs, and I'm not sure what's going on (the APIs exist, `master` syncs just fine).

This uses a fork of `jsonrpsee`. This is because at the moment the `jsonrpsee::rpc_api!` macro doesn't support the use of a `Client` (only `RawClient`'s). By using `Client` over `RawClient` we're able to use regular immutable references when working with the RPC, removing the headache that comes with shared mutable references + async/await.

Closes #72.