### PR TITLE
Sign PoA transactions from wasm env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,6 @@ dependencies = [
 name = "bridge-node-runtime"
 version = "0.1.0"
 dependencies = [
- "ethereum-tx-sign",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -9,9 +9,6 @@ repository = "https://github.com/paritytech/parity-bridges-common/"
 [dependencies]
 hex-literal = "0.2"
 
-[dev-dependencies]
-ethereum-tx-sign = "3.0"
-
 [dependencies.codec]
 package = "parity-scale-codec"
 version = "1.0.0"
@@ -201,6 +198,12 @@ version = "2.0.0-rc3"
 default-features = false
 rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
 git = "https://github.com/paritytech/substrate/"
+
+[dev-dependencies.sp-bridge-eth-poa]
+version = "0.1.0"
+default-features = false
+features = ["test-helpers"]
+path = "../../../primitives/ethereum-poa"
 
 [build-dependencies.wasm-builder-runner]
 version = "1.0.5"

--- a/bin/node/runtime/src/exchange.rs
+++ b/bin/node/runtime/src/exchange.rs
@@ -31,7 +31,7 @@ use codec::{Decode, Encode};
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
 use pallet_bridge_currency_exchange::Blockchain;
-use sp_bridge_eth_poa::{RawTransaction, transaction_decode};
+use sp_bridge_eth_poa::{transaction_decode, RawTransaction};
 use sp_currency_exchange::{
 	Error as ExchangeError, LockFundsTransaction, MaybeLockFundsTransaction, Result as ExchangeResult,
 };
@@ -149,7 +149,10 @@ impl MaybeLockFundsTransaction for EthTransaction {
 mod tests {
 	use super::*;
 	use hex_literal::hex;
-	use sp_bridge_eth_poa::{UnsignedTransaction, signatures::{SecretKey, SignTransaction}};
+	use sp_bridge_eth_poa::{
+		signatures::{SecretKey, SignTransaction},
+		UnsignedTransaction,
+	};
 
 	fn ferdie() -> crate::AccountId {
 		hex!("1cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c").into()
@@ -160,7 +163,10 @@ mod tests {
 		// chain id is 0x11
 		// sender secret is 0x4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7
 		let chain_id = 0x11_u64;
-		let signer = SecretKey::parse(&hex!("4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7")).unwrap();
+		let signer = SecretKey::parse(&hex!(
+			"4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7"
+		))
+		.unwrap();
 		let ferdie_id = ferdie();
 		let ferdie_raw: &[u8; 32] = ferdie_id.as_ref();
 		let mut eth_tx = UnsignedTransaction {

--- a/bin/node/runtime/src/exchange.rs
+++ b/bin/node/runtime/src/exchange.rs
@@ -31,7 +31,7 @@ use codec::{Decode, Encode};
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
 use pallet_bridge_currency_exchange::Blockchain;
-use sp_bridge_eth_poa::transaction_decode;
+use sp_bridge_eth_poa::{RawTransaction, transaction_decode};
 use sp_currency_exchange::{
 	Error as ExchangeError, LockFundsTransaction, MaybeLockFundsTransaction, Result as ExchangeResult,
 };
@@ -48,7 +48,7 @@ pub struct EthereumTransactionInclusionProof {
 	/// Index of the transaction within the block.
 	pub index: u64,
 	/// The proof itself (right now it is all RLP-encoded transactions of the block).
-	pub proof: Vec<Vec<u8>>,
+	pub proof: Vec<RawTransaction>,
 }
 
 /// We uniquely identify transfer by the pair (sender, nonce).
@@ -69,7 +69,7 @@ pub struct EthereumTransactionTag {
 pub struct EthBlockchain;
 
 impl Blockchain for EthBlockchain {
-	type Transaction = Vec<u8>;
+	type Transaction = RawTransaction;
 	type TransactionInclusionProof = EthereumTransactionInclusionProof;
 
 	fn verify_transaction_inclusion_proof(proof: &Self::TransactionInclusionProof) -> Option<Self::Transaction> {
@@ -88,7 +88,7 @@ impl Blockchain for EthBlockchain {
 pub struct EthTransaction;
 
 impl MaybeLockFundsTransaction for EthTransaction {
-	type Transaction = Vec<u8>;
+	type Transaction = RawTransaction;
 	type Id = EthereumTransactionTag;
 	type Recipient = crate::AccountId;
 	type Amount = crate::Balance;
@@ -99,19 +99,19 @@ impl MaybeLockFundsTransaction for EthTransaction {
 		let tx = transaction_decode(raw_tx).map_err(|_| ExchangeError::InvalidTransaction)?;
 
 		// we only accept transactions sending funds directly to the pre-configured address
-		if tx.to != Some(LOCK_FUNDS_ADDRESS.into()) {
+		if tx.unsigned.to != Some(LOCK_FUNDS_ADDRESS.into()) {
 			frame_support::debug::error!(
 				target: "runtime",
 				"Failed to parse fund locks transaction. Invalid peer recipient: {:?}",
-				tx.to,
+				tx.unsigned.to,
 			);
 
 			return Err(ExchangeError::InvalidTransaction);
 		}
 
 		let mut recipient_raw = sp_core::H256::default();
-		match tx.payload.len() {
-			32 => recipient_raw.as_fixed_bytes_mut().copy_from_slice(&tx.payload),
+		match tx.unsigned.payload.len() {
+			32 => recipient_raw.as_fixed_bytes_mut().copy_from_slice(&tx.unsigned.payload),
 			len => {
 				frame_support::debug::error!(
 					target: "runtime",
@@ -122,13 +122,13 @@ impl MaybeLockFundsTransaction for EthTransaction {
 				return Err(ExchangeError::InvalidRecipient);
 			}
 		}
-		let amount = tx.value.low_u128();
+		let amount = tx.unsigned.value.low_u128();
 
-		if tx.value != amount.into() {
+		if tx.unsigned.value != amount.into() {
 			frame_support::debug::error!(
 				target: "runtime",
 				"Failed to parse fund locks transaction. Invalid amount: {}",
-				tx.value,
+				tx.unsigned.value,
 			);
 
 			return Err(ExchangeError::InvalidAmount);
@@ -137,7 +137,7 @@ impl MaybeLockFundsTransaction for EthTransaction {
 		Ok(LockFundsTransaction {
 			id: EthereumTransactionTag {
 				account: *tx.sender.as_fixed_bytes(),
-				nonce: tx.nonce,
+				nonce: tx.unsigned.nonce,
 			},
 			recipient: crate::AccountId::from(*recipient_raw.as_fixed_bytes()),
 			amount,
@@ -149,29 +149,30 @@ impl MaybeLockFundsTransaction for EthTransaction {
 mod tests {
 	use super::*;
 	use hex_literal::hex;
+	use sp_bridge_eth_poa::{UnsignedTransaction, signatures::{SecretKey, SignTransaction}};
 
 	fn ferdie() -> crate::AccountId {
 		hex!("1cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c").into()
 	}
 
-	fn prepare_ethereum_transaction(editor: impl Fn(&mut ethereum_tx_sign::RawTransaction)) -> Vec<u8> {
+	fn prepare_ethereum_transaction(editor: impl Fn(&mut UnsignedTransaction)) -> Vec<u8> {
 		// prepare tx for OpenEthereum private dev chain:
 		// chain id is 0x11
 		// sender secret is 0x4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7
 		let chain_id = 0x11_u64;
-		let signer = hex!("4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7");
+		let signer = SecretKey::parse(&hex!("4d5db4107d237df6a3d58ee5f70ae63d73d7658d4026f2eefd2f204c81682cb7")).unwrap();
 		let ferdie_id = ferdie();
 		let ferdie_raw: &[u8; 32] = ferdie_id.as_ref();
-		let mut eth_tx = ethereum_tx_sign::RawTransaction {
+		let mut eth_tx = UnsignedTransaction {
 			nonce: 0.into(),
 			to: Some(LOCK_FUNDS_ADDRESS.into()),
 			value: 100.into(),
 			gas: 100_000.into(),
 			gas_price: 100_000.into(),
-			data: ferdie_raw.to_vec(),
+			payload: ferdie_raw.to_vec(),
 		};
 		editor(&mut eth_tx);
-		eth_tx.sign(&signer.into(), &chain_id)
+		eth_tx.sign_by(&signer, Some(chain_id))
 	}
 
 	#[test]
@@ -211,7 +212,7 @@ mod tests {
 	fn transaction_with_invalid_recipient_rejected() {
 		assert_eq!(
 			EthTransaction::parse(&prepare_ethereum_transaction(|tx| {
-				tx.data.clear();
+				tx.payload.clear();
 			})),
 			Err(ExchangeError::InvalidRecipient),
 		);

--- a/primitives/ethereum-poa/src/signatures.rs
+++ b/primitives/ethereum-poa/src/signatures.rs
@@ -19,9 +19,12 @@
 //!
 //! Used for testing and benchmarking.
 
-use crate::{public_to_address, rlp_encode, step_validator, Address, Header, H256, H520};
+// reexport to avoid direct secp256k1 deps by other crates
+pub use secp256k1::SecretKey;
 
-use secp256k1::{Message, PublicKey, SecretKey};
+use crate::{public_to_address, rlp_encode, step_validator, Address, Header, H256, H520, U256, RawTransaction, UnsignedTransaction};
+
+use secp256k1::{Message, PublicKey};
 
 /// Utilities for signing headers.
 pub trait SignHeader {
@@ -29,6 +32,12 @@ pub trait SignHeader {
 	fn sign_by(self, author: &SecretKey) -> Header;
 	/// Signs header by given authors set.
 	fn sign_by_set(self, authors: &[SecretKey]) -> Header;
+}
+
+/// Utilities for signing transactions.
+pub trait SignTransaction {
+	/// Sign transaction by given author.
+	fn sign_by(self, author: &SecretKey, chain_id: Option<u64>) -> RawTransaction;
 }
 
 impl SignHeader for Header {
@@ -48,6 +57,24 @@ impl SignHeader for Header {
 	}
 }
 
+impl SignTransaction for UnsignedTransaction {
+	fn sign_by(self, author: &SecretKey, chain_id: Option<u64>) -> RawTransaction {
+		let message = self.message(chain_id);
+		let signature = sign(author, message);
+		let signature_r = U256::from_big_endian(&signature.as_fixed_bytes()[..32][..]);
+		let signature_s = U256::from_big_endian(&signature.as_fixed_bytes()[32..64][..]);
+		let signature_v = signature.as_fixed_bytes()[64] as u64;
+		let signature_v = signature_v + if let Some(n) = chain_id { 35 + n * 2 } else { 27 };
+
+		let mut stream = rlp::RlpStream::new_list(9);
+		self.rlp_to(None, &mut stream);
+		stream.append(&signature_v);
+		stream.append(&signature_r);
+		stream.append(&signature_s);
+		stream.out()
+	}
+}
+
 /// Return author's signature over given message.
 pub fn sign(author: &SecretKey, message: H256) -> H520 {
 	let (signature, recovery_id) = secp256k1::sign(&Message::parse(message.as_fixed_bytes()), author);
@@ -63,4 +90,51 @@ pub fn secret_to_address(secret: &SecretKey) -> Address {
 	let mut raw_public = [0u8; 64];
 	raw_public.copy_from_slice(&public.serialize()[1..]);
 	public_to_address(&raw_public)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{Transaction, transaction_decode};
+
+	#[test]
+	fn transaction_signed_properly() {
+		// case1: with chain_id replay protection + to
+		let signer = SecretKey::parse(&[1u8; 32]).unwrap();
+		let signer_address = secret_to_address(&signer);
+		let unsigned = UnsignedTransaction {
+			nonce: 100.into(),
+			gas_price: 200.into(),
+			gas: 300.into(),
+			to: Some([42u8; 20].into()),
+			value: 400.into(),
+			payload: vec![1, 2, 3],
+		};
+		let raw_tx = unsigned.clone().sign_by(&signer, Some(42));
+		assert_eq!(
+			transaction_decode(&raw_tx),
+			Ok(Transaction {
+				sender: signer_address,
+				unsigned,
+			}),
+		);
+
+		// case2: without chain_id replay protection + contract creation
+		let unsigned = UnsignedTransaction {
+			nonce: 100.into(),
+			gas_price: 200.into(),
+			gas: 300.into(),
+			to: None,
+			value: 400.into(),
+			payload: vec![1, 2, 3],
+		};
+		let raw_tx = unsigned.clone().sign_by(&signer, None);
+		assert_eq!(
+			transaction_decode(&raw_tx),
+			Ok(Transaction {
+				sender: signer_address,
+				unsigned,
+			}),
+		);
+	}
 }

--- a/primitives/ethereum-poa/src/signatures.rs
+++ b/primitives/ethereum-poa/src/signatures.rs
@@ -22,7 +22,10 @@
 // reexport to avoid direct secp256k1 deps by other crates
 pub use secp256k1::SecretKey;
 
-use crate::{public_to_address, rlp_encode, step_validator, Address, Header, H256, H520, U256, RawTransaction, UnsignedTransaction};
+use crate::{
+	public_to_address, rlp_encode, step_validator, Address, Header, RawTransaction, UnsignedTransaction, H256, H520,
+	U256,
+};
 
 use secp256k1::{Message, PublicKey};
 
@@ -95,7 +98,7 @@ pub fn secret_to_address(secret: &SecretKey) -> Address {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{Transaction, transaction_decode};
+	use crate::{transaction_decode, Transaction};
 
 	#[test]
 	fn transaction_signed_properly() {


### PR DESCRIPTION
I'm working on exchange pallet benchmarks && need to build valid PoA transactions there (in `no_std` env). So the solution is to remove `ethereum-tx-sign` dependency && export sign-tx functionality from `sp-bridge-eth-poa` crate (most of required functionality is already there).