### PR TITLE
Revert "Rollback Rust nightly version (#109)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rust:
   - beta
   - nightly
 before_install:
-  - rustup install nightly-2020-05-14
-  - rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-14
+  - rustup install nightly
+  - rustup target add wasm32-unknown-unknown --toolchain nightly
   - rustup component add rustfmt
 before_script:
   - cargo fmt --all -- --check


### PR DESCRIPTION
This reverts commit 236d449b6fd8cb2f7c88f696232aa8552c174693.


closes #110 
(I have updated to `rustc 1.46.0-nightly (0ca7f74db 2020-06-29)` and seems that everything is fine with it - at least I'm able to run tests and benchmarks)