### PR TITLE
Update Substrate to rc4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,10 +518,10 @@ dependencies = [
  "sp-bridge-eth-poa",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-transaction-pool",
  "structopt",
  "substrate-build-script-utils",
@@ -535,8 +535,8 @@ version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "frame-system-rpc-runtime-api",
  "hex-literal",
  "pallet-aura",
@@ -555,17 +555,17 @@ dependencies = [
  "sp-block-builder",
  "sp-bridge-eth-poa",
  "sp-consensus-aura",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-currency-exchange",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-io",
  "sp-offchain",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-transaction-pool",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
  "substrate-wasm-builder-runner",
 ]
 
@@ -1122,9 +1122,9 @@ dependencies = [
  "parity-scale-codec",
  "sc-finality-grandpa",
  "sp-blockchain",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1142,7 +1142,7 @@ dependencies = [
  "ethabi-contract",
  "ethabi-derive",
  "ethereum-tx-sign",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system",
  "futures 0.3.5",
  "hex",
  "jsonrpsee 1.0.0 (git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api)",
@@ -1158,9 +1158,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-bridge-eth-poa",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-keyring",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "time 0.2.16",
  "web3",
 ]
@@ -1308,8 +1308,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824d5195e1c503e6af9fb3fdc5be7b8dd5f574f301da3a9234cdc4ebe619ffc8"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1317,26 +1316,24 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e11712f0938dbaff06035ff4651e9a84294c4fa7478413f5ba580b3f27ffcd3"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "linregress",
  "parity-scale-codec",
  "paste",
  "sp-api",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3585bcf9d4b1a278820017052797fcd80b029297a75aaa08723540167821331"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1344,60 +1341,47 @@ dependencies = [
  "sc-client-db",
  "sc-executor",
  "sc-service",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
  "structopt",
 ]
 
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11888a8b98a9586b15be00a562cd1022945706b7e91a570521edfb328bd1921"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "11.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa526891bb81881e719bf48beb1b6176f51ba664174ca39c60b1ff888ede663"
-dependencies = [
- "parity-scale-codec",
- "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-std",
 ]
 
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bitmask",
- "frame-metadata 11.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "frame-support-procedural 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "frame-metadata",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
  "once_cell",
@@ -1405,60 +1389,22 @@ dependencies = [
  "paste",
  "serde",
  "smallvec 1.4.0",
- "sp-arithmetic 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-inherents 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-state-machine 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-tracing 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "frame-support"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae2099671c1e28bef0809c87dcf68cf5dc7a35fe4d76ef2a7d135a94410db2f"
-dependencies = [
- "bitmask",
- "frame-metadata 11.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support-procedural 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-trait-for-tuples",
- "log",
- "once_cell",
- "parity-scale-codec",
- "paste",
- "serde",
- "smallvec 1.4.0",
- "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support-procedural-tools 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49a2bb4bae6ee576aefa05a7f7630ca11da65f7d347de55f2902b7b7806a6c"
-dependencies = [
- "frame-support-procedural-tools 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support-procedural-tools",
  "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.33",
@@ -1467,22 +1413,9 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support-procedural-tools-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeb27f48d98452a4f70fecb37cb1d11e045c8fdf8522d0928626037fc3559c4"
-dependencies = [
- "frame-support-procedural-tools-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
@@ -1492,18 +1425,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
-dependencies = [
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4397a5f7f660960d7e9c5cedb3c18fb1a89fcb6960e4a4ae18683ead50db967b"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1513,41 +1435,23 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-version 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "frame-system"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ea1852feb2b8ad36341b4e74ecb1fc0c3f371d63038a476bd7d4fe3f9b181d"
-dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5189dc22a6cbf1cc5e41ef0f705232784efe0233d8fa5198331c3456b7834d"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3272,13 +3176,13 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-system 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "frame-system",
  "parity-scale-codec",
- "sp-application-crypto 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3423,54 +3327,52 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6fcdd1b88dc2c326d281c5f5e9821851bde3363a34163b6e6c1e1782f60ce7"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbbd07ad108b6e3ce5dbaef238795a0f9b1758a1e62f725b8beea7501a53d98"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-bridge"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "hash-db",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
 ]
 
 [[package]]
@@ -3478,15 +3380,15 @@ name = "pallet-bridge-currency-exchange"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-currency-exchange",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -3494,152 +3396,144 @@ name = "pallet-bridge-eth-poa"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "libsecp256k1",
  "parity-scale-codec",
  "serde",
  "sp-bridge-eth-poa",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27eddec35cb5dc2a457ce9b6422d958ea09cc90c472d902a03c1c38d3e140bfa"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
  "sp-finality-tracker",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b506f63adb601391c83e433234f8ad404a8f3fda83474e5f6348265b03672a03"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "pallet-finality-tracker",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04d22101cafad5136748549fc9f7095d248d1849e1e419f00a4b6e54062af11"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "safe-mix",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dba745987765852bcbf07c2290dbea19fd0c3c21560d845aa435c865cb6311d"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
+ "sp-trie",
 ]
 
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29234f7bc4d680e4d5cbfcfdc3ed6484a9af2e42c04efa875fc2dcbeddbfb05"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fdc3aa927d3bcb876e09462dc94cbd69abcdf4ae04e6f5d2fc436f95c3b4fe"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005e41f7d3e614b4d10704aa854fee57f3eb0a5d7549f6b7b1fe984aef485df0"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
+ "frame-system",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
  "smallvec 1.4.0",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90a9356c1f1a504785bc57ee7e7fe6e6ec1f015e31618d587476b4109bc2ac4"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
  "parity-scale-codec",
  "serde",
  "sp-api",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4707,8 +4601,7 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888a24f4c9f292de46e7040a2746cd4711251c65accf8221545e86f8575500c8"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4721,9 +4614,9 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "tokio-executor 0.2.0-alpha.6",
@@ -4732,8 +4625,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0579813cd2b4bd417211e4ff0248826702ab89ef19b8002caeda264235b28af4"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4741,16 +4633,15 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98712b87a685c34af8c5197a06df72a6596933d686e21e4c3555c1ed541e5888"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -4759,15 +4650,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1890734b60f032520ebdb797dbd38d5b4605d5e6696ca0c67e33003506a5ca"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4778,8 +4668,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c8014d60eb6d3c8e936e29e1d70a33ee9b3d1b2b1444a6dd4e846a1852eb1f"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -4803,13 +4692,13 @@ dependencies = [
  "sc-tracing",
  "serde_json",
  "sp-blockchain",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-keyring",
- "sp-panic-handler 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-panic-handler",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-utils",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
  "structopt",
  "substrate-prometheus-endpoint",
  "time 0.1.43",
@@ -4819,8 +4708,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1863122575e1519d861de944becbd35a131fdce6a69f49caf41216aede928e"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "fnv",
@@ -4837,27 +4725,26 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-database",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities",
+ "sp-inherents",
  "sp-keyring",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-storage",
  "sp-transaction-pool",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie",
  "sp-utils",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b688ff7096b471f54880ef89de3398deaac60960d694f35d9c4c8b454149951e"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -4875,31 +4762,29 @@ dependencies = [
  "sc-state-db",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-database",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3fdb9e2b5fe1abcb594e1738b522da265e0fcf109cf85865315e100ee1b462f"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a7911b98afba10b0c81dfddfa6eee592251626f6770d489487ab0761ba571b"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -4913,25 +4798,24 @@ dependencies = [
  "sc-keystore",
  "sc-telemetry",
  "sp-api",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
  "sp-timestamp",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c24e5308ac7b5adce1eef22e482d7b0fba4c24cdd40f65cfc3b85caa46dbd1b"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4941,20 +4825,19 @@ dependencies = [
  "sc-client-api",
  "sc-telemetry",
  "sp-api",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f69419f3edc4f0401e3af0b9cf36f7949ece95aadad52d809fb2a42d0d05c4c"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -4966,57 +4849,54 @@ dependencies = [
  "sc-executor-common",
  "sc-executor-wasmi",
  "sp-api",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-panic-handler 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-panic-handler",
+ "sp-runtime-interface",
  "sp-serializer",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie",
+ "sp-version",
+ "sp-wasm-interface",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efb61e051bea21f62c1ffadcb0ee9f645b151a9a29b60a03ad8a520afeefe8b"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "log",
  "parity-scale-codec",
  "parity-wasm",
  "sp-allocator",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime-interface",
  "sp-serializer",
- "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c79960b158e0733ff403b1750f4393812a483d41b1f812e7d60d248a2ffc4d2"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "parity-scale-codec",
  "sc-executor-common",
  "sp-allocator",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f97158df1e9a97d3437f07c25c09bf0dabc6b486b85e6463fb9b5af2adaede"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -5038,15 +4918,15 @@ dependencies = [
  "sc-telemetry",
  "serde_json",
  "sp-api",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-finality-grandpa",
  "sp-finality-tracker",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-utils",
  "substrate-prometheus-endpoint",
 ]
@@ -5054,8 +4934,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7fd8683b28f2b6c685a6a3ff04e3ac963b6f777dadf222d0a61aa2cda5f50d"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -5065,7 +4944,7 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -5074,8 +4953,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893933b7486f25a7333fa8f71840bbe93e5e281324cdf7883dd057f952f24419"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "hex",
@@ -5083,16 +4961,15 @@ dependencies = [
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "serde_json",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-core",
  "subtle 2.2.3",
 ]
 
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a25cca4bb1720428c16d6e05ecfc05282c8ee9c7e5cbf7b7bb233a01397c97"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5102,17 +4979,16 @@ dependencies = [
  "sc-executor",
  "sp-api",
  "sp-blockchain",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b4947b8a224c6721a190735c313b6a706947ac53eafe97e34349ee5f5d598d"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bitflags",
  "bs58",
@@ -5147,11 +5023,11 @@ dependencies = [
  "slog",
  "slog_derive",
  "smallvec 0.6.13",
- "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -5164,8 +5040,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8709913fd5f301e2ad0abdc386a3fcc9a813e0be362e7fcdbc44a0adda6c85a0"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5173,15 +5048,14 @@ dependencies = [
  "log",
  "lru",
  "sc-network",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4e4fd65d9c055228f96e5ea8f685934cd2074a4e8c47725dda8c0e54726dbc"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
@@ -5198,9 +5072,9 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "sp-api",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-offchain",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-utils",
  "threadpool",
 ]
@@ -5208,8 +5082,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5edf178c5aff9e6050df1dd6f8709fd79422f5adb1fbb7353d8ff067afad119"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -5222,8 +5095,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4b517979cfcd7d2cfdafa12927b5cb37f5103c52517e7b6184a1140c83aba3"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5232,8 +5104,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1a72a924cd11606a2c77b2c899bc10f1462f69823eb3df12d3ac752580d560"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5251,22 +5122,21 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-chain-spec",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine",
  "sp-transaction-pool",
  "sp-utils",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
 ]
 
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15757eb8b18b19688e61b2f43c5e5fb5c71bceeec7fa4eefad25e4ad4a5b7e16"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5280,18 +5150,17 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-transaction-pool",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
 ]
 
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aca3dd802f39c96fdf0a4962ea1859b599f47387dd707ed64e0c6145a5df623"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5301,14 +5170,13 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c43b52b33be16215d84cdedf4b5917321e8fef39b6b12aa62a7ab073c08041"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "directories",
@@ -5347,20 +5215,20 @@ dependencies = [
  "serde_json",
  "slog",
  "sp-api",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-externalities",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine",
  "sp-transaction-pool",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie",
  "sp-utils",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
  "substrate-prometheus-endpoint",
  "sysinfo",
  "tempfile",
@@ -5371,8 +5239,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8273468d5572371be2cc2a8abd5ee647bc94a8f71ef7fe5d621b782005aeef41"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5380,14 +5247,13 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "sc-client-api",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef09ae7be2780eebb2e014800d972b56a96c2e5cee3227f90822ef4ba34c3ca"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bytes 0.5.5",
  "futures 0.3.5",
@@ -5409,8 +5275,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f1ba4cf38bbcd52734413b03000ee310ee541bc22dad261dbd63b87dbb6dca"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "erased-serde",
  "log",
@@ -5420,15 +5285,14 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e66f8e7aabcfaf6a2df0c5039856f8e2b00184bd710ac1ee8ea44fef3254cb9"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5438,8 +5302,8 @@ dependencies = [
  "parking_lot 0.10.2",
  "serde",
  "sp-blockchain",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -5448,8 +5312,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4dfad2dba9181e8f33e5c025bdfc5b1daca0ca22a7a1c0da2a54e9323a01ea"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5463,9 +5326,9 @@ dependencies = [
  "sc-transaction-graph",
  "sp-api",
  "sp-blockchain",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-utils",
  "substrate-prometheus-endpoint",
@@ -5552,15 +5415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
-dependencies = [
- "zeroize",
 ]
 
 [[package]]
@@ -5840,37 +5694,34 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91eb63d9e57670a15da379c1ffcd79c52deb436c138e48b238d61f6ae24e1643"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "log",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-std",
+ "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21f9cb8186cb9aedce1af1f2c91a6f3691f35c20559c1225af513b73193f079"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-version",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85294ff73aaca3db43c1ecd73356a907cfd98cba7e7cb021d88d55983c7f067"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -5882,73 +5733,44 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b302e550cba49331d6e7baac7456381c139e63d95e6d3848f2d2b473c7ee709"
-dependencies = [
- "parity-scale-codec",
- "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
  "parity-scale-codec",
  "serde",
- "sp-debug-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94d0aa7b308e6107cf7855c8a316385554cf89ddded868c1bf2b2829dc8d2d7"
-dependencies = [
- "integer-sqrt",
- "num-traits 0.2.12",
- "parity-scale-codec",
- "serde",
- "sp-debug-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31bac479d30cfd3107966b4509763261b8f373f4098aae11591286b06cd349e3"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59492dc00329b03efca65988453e9e725585535f6994079f0da71f9760b8b181"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "log",
@@ -5957,8 +5779,8 @@ dependencies = [
  "parking_lot 0.10.2",
  "sp-block-builder",
  "sp-consensus",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -5980,17 +5802,16 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sp-api",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
  "triehash",
 ]
 
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ca9cd7b1958d67560c14bae83d65c4b1bb9dcd95edae26c35fc691bd9dc355"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
  "serde_json",
@@ -5999,8 +5820,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb43e2ed60cd2c77583940442e4de03417adf5070903ed552a3c439c5dd8f891"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6010,13 +5830,13 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
  "sp-utils",
- "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version",
  "substrate-prometheus-endpoint",
  "wasm-timer",
 ]
@@ -6024,66 +5844,21 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03035f5ca5813e6db3f6ced9ab61177b1d2111ec4b8fe5c89668e583c8c0a329"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
-dependencies = [
- "base58",
- "blake2-rfc",
- "byteorder",
- "derive_more",
- "ed25519-dalek",
- "futures 0.3.5",
- "hash-db",
- "hash256-std-hasher",
- "hex",
- "impl-serde 0.3.1",
- "lazy_static",
- "libsecp256k1",
- "log",
- "merlin",
- "num-traits 0.2.12",
- "parity-scale-codec",
- "parity-util-mem",
- "parking_lot 0.10.2",
- "primitive-types",
- "rand 0.7.3",
- "regex",
- "schnorrkel",
- "secrecy",
- "serde",
- "sha2",
- "sp-debug-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-runtime-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-storage 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "substrate-bip39",
- "tiny-bip39",
- "tiny-keccak 2.0.2",
- "twox-hash",
- "wasmi",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cae177006e7515a1d3566433f4bcd350bf21825de33609055714347dc4eddbb"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6109,11 +5884,11 @@ dependencies = [
  "schnorrkel",
  "serde",
  "sha2",
- "sp-debug-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-std",
+ "sp-storage",
  "substrate-bip39",
  "tiny-bip39",
  "tiny-keccak 2.0.2",
@@ -6126,16 +5901,15 @@ dependencies = [
 name = "sp-currency-exchange"
 version = "0.1.0"
 dependencies = [
- "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support",
  "parity-scale-codec",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaea1668145b00ee2b2ab23087aed36baa8b81da427332b097c902a31521d823"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6144,18 +5918,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
-dependencies = [
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8df3be2c0c4e2b3868ca3e285a71d837b4b19eeb216c6fe760723d452b9560"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -6165,83 +5928,56 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-storage 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dadf74f2b30b407987c848bba8bf674bd304699c76f87a8c0b9941df58223ac8"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1023816558d2c3320b67f6e98a128e23497bcc9506cb2e6322d08267af28db"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "serde",
  "sp-api",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f058c07feb2be45d4ec5ad8c77a5b81ca692302860f54fe37b2bc2c079816d2d"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1406b4225985188709f26db1eec810881832ad3e7ea3b54441e00f33a948c0"
-dependencies = [
- "derive_more",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6249,75 +5985,41 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-runtime-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-state-machine 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-tracing 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-trie 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-wasm-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-io"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae9654c2f10db24569e7457dc087195e99a4b6766834f19201946ed4c9446a7"
-dependencies = [
- "futures 0.3.5",
- "hash-db",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-externalities",
+ "sp-runtime-interface",
+ "sp-state-machine",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie",
+ "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c789ab5b744d99acd4b2a76ed863e27e7b7f67cc7dba8908d3738508cf4cd53d"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "lazy_static",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
  "strum",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7c2a18d1bf01468ee731de5da5e144e6a86e7128766d586597e93aa3f83502"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "sp-api",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
-dependencies = [
- "backtrace",
- "log",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2028196ab3a4e0de791f23972be8ca121e706d72ea26c97f4da836381d4ecfe3"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "backtrace",
  "log",
@@ -6326,17 +6028,16 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b1b325e27962e491e0cde2f7dc925a87e6cb9bc26935e621ab66cb7ad80506"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6347,85 +6048,33 @@ dependencies = [
  "paste",
  "rand 0.7.3",
  "serde",
- "sp-application-crypto 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-arithmetic 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-inherents 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5175aa1bd3f233220233ee5e260e4662143a9b4256b6769c293458b1aaff22"
-dependencies = [
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "parity-util-mem",
- "paste",
- "rand 0.7.3",
- "serde",
- "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-runtime-interface-proc-macro 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-tracing 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-wasm-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3a46adc3e01acbf3be58eeb2c456707eb00d6f9ab56ef1b6c0a64d4064a36"
-dependencies = [
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime-interface-proc-macro 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
-dependencies = [
- "Inflector",
- "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.7",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21067e20e08be0584593958edd9935cf8e4702bda24480b667a620e92326d753"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6437,8 +6086,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860ea7fec3f31507b0795c3945bf50f093ce015d6266717bc34a59661ebd77b9"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6447,32 +6095,30 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35d8160fd1643704d2b90f4b3025159d4c297185de310efdf556602b5c9217fa"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
  "sp-staking",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc534846aa8a124b28bf43846b2f5e53bfc510732cb6ed420de9eff943681542"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -6482,32 +6128,10 @@ dependencies = [
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "smallvec 1.4.0",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-panic-handler 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-trie 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "trie-db",
- "trie-root",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c49f96c8737bf8971338a0e000ce8ac55843aedc74f5a73c121b65335489ec6"
-dependencies = [
- "hash-db",
- "itertools 0.9.0",
- "log",
- "num-traits 0.2.12",
- "parity-scale-codec",
- "parking_lot 0.10.2",
- "rand 0.7.3",
- "smallvec 1.4.0",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-panic-handler 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
+ "sp-trie",
  "trie-db",
  "trie-root",
 ]
@@ -6515,69 +6139,38 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
-
-[[package]]
-name = "sp-std"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9a60b2db0140169c0bada42bc4045be9902495f44b9f0be62499aafc0ff160"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
  "serde",
- "sp-debug-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-storage"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396ad6814b515c19bcb18f9c2d8591ad4872def41cdc00dd78894b01398bf8d"
-dependencies = [
- "impl-serde 0.2.3",
- "ref-cast",
- "serde",
- "sp-debug-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305d1fcb74c5519f47671f65eac6d7197e8b281d6bef001d6f424bd78e6c8385"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-api",
- "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
-dependencies = [
- "log",
- "rental",
- "tracing",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c35237552c9435311e59fd3e00422fb6b7128e0d2fe50c34d121a4c02001b7e"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "rental",
@@ -6587,8 +6180,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a921555b9eb2957ff2c4ffe3b599d27b7de016e851772a5f30465f6cbf0147"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6597,35 +6189,20 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
  "sp-utils",
 ]
 
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
- "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "trie-db",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc2f5a2551e2e90d71f23bea3f5c936e3b71a6ab9cf36de37668d99312c93b"
-dependencies = [
- "hash-db",
- "memory-db",
- "parity-scale-codec",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-std",
  "trie-db",
  "trie-root",
 ]
@@ -6633,8 +6210,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6e06988a1e5bcd1b30dec3984c628390f0906d74c69bdabe14e6b159f2ff94"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -6646,48 +6222,23 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
  "serde",
- "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
-]
-
-[[package]]
-name = "sp-version"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4c1963ac753da53cd781ef651d6e2993c08bb3f43150a8255d02e1bde2490b"
-dependencies = [
- "impl-serde 0.2.3",
- "parity-scale-codec",
- "serde",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
- "wasmi",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8676d1750df36bfedb098bb54131aaf4a5d973738b8a5fe645635ad29d9337"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "wasmi",
 ]
 
@@ -6871,7 +6422,7 @@ dependencies = [
  "log",
  "node-primitives",
  "serde_json",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
  "sp-rpc",
  "url 2.1.1",
 ]
@@ -6879,8 +6430,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a11136f36b24d56c5a9a7597a0fb4f8176f4408df50795777f0da2623e6c2f52"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "platforms",
 ]
@@ -6888,8 +6438,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ce6efc4b793887c53458c3512c8dc13b1f3b4a290c6d3304791e1ecc325ce5"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -6904,16 +6453,15 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core",
+ "sp-runtime",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f3115e72723df26f5b39887f0a43b27d6996e78e79836c2e706134ca9736e7"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "async-std",
  "derive_more",
@@ -6927,8 +6475,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
+source = "git+https://github.com/paritytech/substrate/#e824e8ab0fadec9949ebb8b9e14d98703d6b8d44"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,10 +518,10 @@ dependencies = [
  "sp-bridge-eth-poa",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-finality-grandpa",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
  "structopt",
  "substrate-build-script-utils",
@@ -535,8 +535,8 @@ version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "frame-system-rpc-runtime-api",
  "hex-literal",
  "pallet-aura",
@@ -555,17 +555,17 @@ dependencies = [
  "sp-block-builder",
  "sp-bridge-eth-poa",
  "sp-consensus-aura",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-currency-exchange",
- "sp-inherents",
- "sp-io",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-wasm-builder-runner",
 ]
 
@@ -1122,9 +1122,9 @@ dependencies = [
  "parity-scale-codec",
  "sc-finality-grandpa",
  "sp-blockchain",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-finality-grandpa",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1142,7 +1142,7 @@ dependencies = [
  "ethabi-contract",
  "ethabi-derive",
  "ethereum-tx-sign",
- "frame-system",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5",
  "hex",
  "jsonrpsee 1.0.0 (git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api)",
@@ -1158,9 +1158,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-bridge-eth-poa",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.2.16",
  "web3",
 ]
@@ -1307,33 +1307,36 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824d5195e1c503e6af9fb3fdc5be7b8dd5f574f301da3a9234cdc4ebe619ffc8"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e11712f0938dbaff06035ff4651e9a84294c4fa7478413f5ba580b3f27ffcd3"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "linregress",
  "parity-scale-codec",
  "paste",
  "sp-api",
- "sp-io",
- "sp-runtime",
- "sp-runtime-interface",
- "sp-std",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3585bcf9d4b1a278820017052797fcd80b029297a75aaa08723540167821331"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1341,47 +1344,60 @@ dependencies = [
  "sc-client-db",
  "sc-executor",
  "sc-service",
- "sp-core",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11888a8b98a9586b15be00a562cd1022945706b7e91a570521edfb328bd1921"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-tracing",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-metadata"
-version = "11.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "11.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-std",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "11.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fa526891bb81881e719bf48beb1b6176f51ba664174ca39c60b1ff888ede663"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "bitmask",
- "frame-metadata",
- "frame-support-procedural",
+ "frame-metadata 11.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "frame-support-procedural 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
  "impl-trait-for-tuples",
  "log",
  "once_cell",
@@ -1389,22 +1405,60 @@ dependencies = [
  "paste",
  "serde",
  "smallvec 1.4.0",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-tracing",
+ "sp-arithmetic 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-inherents 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-state-machine 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-tracing 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "frame-support"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ae2099671c1e28bef0809c87dcf68cf5dc7a35fe4d76ef2a7d135a94410db2f"
+dependencies = [
+ "bitmask",
+ "frame-metadata 11.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-support-procedural 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-trait-for-tuples",
+ "log",
+ "once_cell",
+ "parity-scale-codec",
+ "paste",
+ "serde",
+ "smallvec 1.4.0",
+ "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e49a2bb4bae6ee576aefa05a7f7630ca11da65f7d347de55f2902b7b7806a6c"
+dependencies = [
+ "frame-support-procedural-tools 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.33",
@@ -1412,10 +1466,23 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfeb27f48d98452a4f70fecb37cb1d11e045c8fdf8522d0928626037fc3559c4"
+dependencies = [
+ "frame-support-procedural-tools-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.7",
@@ -1424,8 +1491,19 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "frame-support-procedural-tools-derive"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4397a5f7f660960d7e9c5cedb3c18fb1a89fcb6960e4a4ae18683ead50db967b"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1434,24 +1512,42 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-version",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-version 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "frame-system"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ea1852feb2b8ad36341b4e74ecb1fc0c3f371d63038a476bd7d4fe3f9b181d"
+dependencies = [
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "serde",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f5189dc22a6cbf1cc5e41ef0f705232784efe0233d8fa5198331c3456b7834d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2176,6 +2272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,6 +2358,20 @@ dependencies = [
  "net2",
  "parking_lot 0.10.2",
  "unicase",
+]
+
+[[package]]
+name = "jsonrpc-ipc-server"
+version = "14.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dedccd693325d833963b549e959137f30a7a0ea650cde92feda81dc0c1393cb5"
+dependencies = [
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log",
+ "parity-tokio-ipc",
+ "parking_lot 0.10.2",
+ "tokio-service",
 ]
 
 [[package]]
@@ -2938,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be512cb2ccb4ecbdca937fdd4a62ea5f09f8e7195466a85e4632b3d5bcce82e6"
+checksum = "fb2999ff7a65d5a1d72172f6d51fa2ea03024b51aee709ba5ff81c3c629a2410"
 dependencies = [
  "ahash 0.2.18",
  "hash-db",
@@ -2988,7 +3107,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -3004,6 +3123,18 @@ dependencies = [
  "log",
  "mio",
  "slab",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3027,6 +3158,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3130,14 +3271,14 @@ dependencies = [
 
 [[package]]
 name = "node-primitives"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
- "frame-system",
+ "frame-system 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
  "parity-scale-codec",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
 ]
 
 [[package]]
@@ -3281,53 +3422,55 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6fcdd1b88dc2c326d281c5f5e9821851bde3363a34163b6e6c1e1782f60ce7"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-consensus-aura",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edbbd07ad108b6e3ce5dbaef238795a0f9b1758a1e62f725b8beea7501a53d98"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "serde",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-bridge"
 version = "0.1.0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-finality-grandpa",
- "sp-io",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3335,15 +3478,15 @@ name = "pallet-bridge-currency-exchange"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "serde",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-currency-exchange",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3351,141 +3494,152 @@ name = "pallet-bridge-eth-poa"
 version = "0.1.0"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal",
  "libsecp256k1",
  "parity-scale-codec",
  "serde",
  "sp-bridge-eth-poa",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27eddec35cb5dc2a457ce9b6422d958ea09cc90c472d902a03c1c38d3e140bfa"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
  "sp-finality-tracker",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b506f63adb601391c83e433234f8ad404a8f3fda83474e5f6348265b03672a03"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-finality-tracker",
  "pallet-session",
  "parity-scale-codec",
  "serde",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-finality-grandpa",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-session",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04d22101cafad5136748549fc9f7095d248d1849e1e419f00a4b6e54062af11"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "safe-mix",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dba745987765852bcbf07c2290dbea19fd0c3c21560d845aa435c865cb6311d"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples",
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-session",
  "sp-staking",
- "sp-std",
- "sp-trie",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b29234f7bc4d680e4d5cbfcfdc3ed6484a9af2e42c04efa875fc2dcbeddbfb05"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fdc3aa927d3bcb876e09462dc94cbd69abcdf4ae04e6f5d2fc436f95c3b4fe"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "serde",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005e41f7d3e614b4d10704aa854fee57f3eb0a5d7549f6b7b1fe984aef485df0"
 dependencies = [
- "frame-support",
- "frame-system",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "frame-system 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "serde",
  "smallvec 1.4.0",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90a9356c1f1a504785bc57ee7e7fe6e6ec1f015e31618d587476b4109bc2ac4"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "serde",
  "sp-api",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3614,6 +3768,25 @@ name = "parity-send-wrapper"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
+
+[[package]]
+name = "parity-tokio-ipc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e57fea504fea33f9fbb5f49f378359030e7e026a6ab849bb9e8f0787376f1bf"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.29",
+ "libc",
+ "log",
+ "mio-named-pipes",
+ "miow 0.3.5",
+ "rand 0.7.3",
+ "tokio 0.1.22",
+ "tokio-named-pipes",
+ "tokio-uds",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "parity-util-mem"
@@ -3979,7 +4152,7 @@ checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
  "bytes 0.5.5",
  "heck",
- "itertools",
+ "itertools 0.8.2",
  "log",
  "multimap",
  "petgraph",
@@ -3996,7 +4169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2",
  "quote 1.0.7",
  "syn 1.0.33",
@@ -4354,6 +4527,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rental"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
+dependencies = [
+ "rental-impl",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4512,8 +4706,9 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888a24f4c9f292de46e7040a2746cd4711251c65accf8221545e86f8575500c8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4526,9 +4721,9 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "tokio-executor 0.2.0-alpha.6",
@@ -4536,8 +4731,9 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0579813cd2b4bd417211e4ff0248826702ab89ef19b8002caeda264235b28af4"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4545,15 +4741,16 @@ dependencies = [
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98712b87a685c34af8c5197a06df72a6596933d686e21e4c3555c1ed541e5888"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -4562,14 +4759,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1890734b60f032520ebdb797dbd38d5b4605d5e6696ca0c67e33003506a5ca"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4579,8 +4777,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c8014d60eb6d3c8e936e29e1d70a33ee9b3d1b2b1444a6dd4e846a1852eb1f"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -4604,13 +4803,13 @@ dependencies = [
  "sc-tracing",
  "serde_json",
  "sp-blockchain",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-keyring",
- "sp-panic-handler",
- "sp-runtime",
- "sp-state-machine",
+ "sp-panic-handler 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt",
  "substrate-prometheus-endpoint",
  "time 0.1.43",
@@ -4619,8 +4818,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1863122575e1519d861de944becbd35a131fdce6a69f49caf41216aede928e"
 dependencies = [
  "derive_more",
  "fnv",
@@ -4637,26 +4837,27 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-database",
- "sp-externalities",
- "sp-inherents",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-keyring",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-storage",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-storage 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
- "sp-trie",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b688ff7096b471f54880ef89de3398deaac60960d694f35d9c4c8b454149951e"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -4674,29 +4875,31 @@ dependencies = [
  "sc-state-db",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-database",
- "sp-runtime",
- "sp-state-machine",
- "sp-trie",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3fdb9e2b5fe1abcb594e1738b522da265e0fcf109cf85865315e100ee1b462f"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
  "sp-consensus",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a7911b98afba10b0c81dfddfa6eee592251626f6770d489487ab0761ba571b"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -4710,24 +4913,25 @@ dependencies = [
  "sc-keystore",
  "sc-telemetry",
  "sp-api",
- "sp-application-crypto",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-timestamp",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c24e5308ac7b5adce1eef22e482d7b0fba4c24cdd40f65cfc3b85caa46dbd1b"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4737,19 +4941,20 @@ dependencies = [
  "sc-client-api",
  "sc-telemetry",
  "sp-api",
- "sp-application-crypto",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f69419f3edc4f0401e3af0b9cf36f7949ece95aadad52d809fb2a42d0d05c4c"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -4761,54 +4966,57 @@ dependencies = [
  "sc-executor-common",
  "sc-executor-wasmi",
  "sp-api",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-panic-handler",
- "sp-runtime-interface",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-panic-handler 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-serializer",
- "sp-trie",
- "sp-version",
- "sp-wasm-interface",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8efb61e051bea21f62c1ffadcb0ee9f645b151a9a29b60a03ad8a520afeefe8b"
 dependencies = [
  "derive_more",
  "log",
  "parity-scale-codec",
  "parity-wasm",
  "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-serializer",
- "sp-wasm-interface",
+ "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c79960b158e0733ff403b1750f4393812a483d41b1f812e7d60d248a2ffc4d2"
 dependencies = [
  "log",
  "parity-scale-codec",
  "sc-executor-common",
  "sp-allocator",
- "sp-core",
- "sp-runtime-interface",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi",
 ]
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f97158df1e9a97d3437f07c25c09bf0dabc6b486b85e6463fb9b5af2adaede"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -4830,32 +5038,34 @@ dependencies = [
  "sc-telemetry",
  "serde_json",
  "sp-api",
- "sp-application-crypto",
- "sp-arithmetic",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-finality-grandpa",
  "sp-finality-tracker",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7fd8683b28f2b6c685a6a3ff04e3ac963b6f777dadf222d0a61aa2cda5f50d"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
  "log",
  "parity-util-mem",
+ "parking_lot 0.10.2",
  "sc-client-api",
  "sc-network",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -4863,23 +5073,26 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893933b7486f25a7333fa8f71840bbe93e5e281324cdf7883dd057f952f24419"
 dependencies = [
  "derive_more",
  "hex",
+ "merlin",
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "serde_json",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3",
 ]
 
 [[package]]
 name = "sc-light"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a25cca4bb1720428c16d6e05ecfc05282c8ee9c7e5cbf7b7bb233a01397c97"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -4889,16 +5102,17 @@ dependencies = [
  "sc-executor",
  "sp-api",
  "sp-blockchain",
- "sp-core",
- "sp-externalities",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-network"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b4947b8a224c6721a190735c313b6a706947ac53eafe97e34349ee5f5d598d"
 dependencies = [
  "bitflags",
  "bs58",
@@ -4933,11 +5147,11 @@ dependencies = [
  "slog",
  "slog_derive",
  "smallvec 0.6.13",
- "sp-arithmetic",
+ "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -4949,8 +5163,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8709913fd5f301e2ad0abdc386a3fcc9a813e0be362e7fcdbc44a0adda6c85a0"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4958,14 +5173,15 @@ dependencies = [
  "log",
  "lru",
  "sc-network",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4e4fd65d9c055228f96e5ea8f685934cd2074a4e8c47725dda8c0e54726dbc"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
@@ -4982,17 +5198,18 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "sp-api",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
  "threadpool",
 ]
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5edf178c5aff9e6050df1dd6f8709fd79422f5adb1fbb7353d8ff067afad119"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -5004,8 +5221,9 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4b517979cfcd7d2cfdafa12927b5cb37f5103c52517e7b6184a1140c83aba3"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5013,8 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1a72a924cd11606a2c77b2c899bc10f1462f69823eb3df12d3ac752580d560"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5032,21 +5251,22 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-chain-spec",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-offchain",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15757eb8b18b19688e61b2f43c5e5fb5c71bceeec7fa4eefad25e4ad4a5b7e16"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5060,32 +5280,35 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-chain-spec",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aca3dd802f39c96fdf0a4962ea1859b599f47387dd707ed64e0c6145a5df623"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
+ "jsonrpc-ipc-server",
  "jsonrpc-pubsub",
  "jsonrpc-ws-server",
  "log",
  "serde",
  "serde_json",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-service"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c43b52b33be16215d84cdedf4b5917321e8fef39b6b12aa62a7ab073c08041"
 dependencies = [
  "derive_more",
  "directories",
@@ -5124,20 +5347,20 @@ dependencies = [
  "serde_json",
  "slog",
  "sp-api",
- "sp-application-crypto",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-session",
- "sp-state-machine",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
- "sp-trie",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-prometheus-endpoint",
  "sysinfo",
  "tempfile",
@@ -5147,8 +5370,9 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8273468d5572371be2cc2a8abd5ee647bc94a8f71ef7fe5d621b782005aeef41"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5156,13 +5380,14 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "sc-client-api",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef09ae7be2780eebb2e014800d972b56a96c2e5cee3227f90822ef4ba34c3ca"
 dependencies = [
  "bytes 0.5.5",
  "futures 0.3.5",
@@ -5183,23 +5408,27 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f1ba4cf38bbcd52734413b03000ee310ee541bc22dad261dbd63b87dbb6dca"
 dependencies = [
  "erased-serde",
  "log",
  "parking_lot 0.10.2",
+ "rustc-hash",
  "sc-telemetry",
  "serde",
  "serde_json",
  "slog",
+ "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-core",
 ]
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e66f8e7aabcfaf6a2df0c5039856f8e2b00184bd710ac1ee8ea44fef3254cb9"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5209,8 +5438,8 @@ dependencies = [
  "parking_lot 0.10.2",
  "serde",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
  "sp-utils",
  "wasm-timer",
@@ -5218,8 +5447,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4dfad2dba9181e8f33e5c025bdfc5b1daca0ca22a7a1c0da2a54e9323a01ea"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5233,9 +5463,9 @@ dependencies = [
  "sc-transaction-graph",
  "sp-api",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
- "sp-tracing",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
  "sp-utils",
  "substrate-prometheus-endpoint",
@@ -5322,6 +5552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -5600,35 +5839,38 @@ dependencies = [
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91eb63d9e57670a15da379c1ffcd79c52deb436c138e48b238d61f6ae24e1643"
 dependencies = [
  "derive_more",
  "log",
- "sp-core",
- "sp-std",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-api"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f9cb8186cb9aedce1af1f2c91a6f3691f35c20559c1225af513b73193f079"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
- "sp-version",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85294ff73aaca3db43c1ecd73356a907cfd98cba7e7cb021d88d55983c7f067"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -5639,45 +5881,74 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "parity-scale-codec",
  "serde",
- "sp-core",
- "sp-io",
- "sp-std",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b302e550cba49331d6e7baac7456381c139e63d95e6d3848f2d2b473c7ee709"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
  "parity-scale-codec",
  "serde",
- "sp-debug-derive",
- "sp-std",
+ "sp-debug-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94d0aa7b308e6107cf7855c8a316385554cf89ddded868c1bf2b2829dc8d2d7"
+dependencies = [
+ "integer-sqrt",
+ "num-traits 0.2.12",
+ "parity-scale-codec",
+ "serde",
+ "sp-debug-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31bac479d30cfd3107966b4509763261b8f373f4098aae11591286b06cd349e3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59492dc00329b03efca65988453e9e725585535f6994079f0da71f9760b8b181"
 dependencies = [
  "derive_more",
  "log",
@@ -5686,8 +5957,8 @@ dependencies = [
  "parking_lot 0.10.2",
  "sp-block-builder",
  "sp-consensus",
- "sp-runtime",
- "sp-state-machine",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5709,16 +5980,17 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sp-api",
- "sp-io",
- "sp-runtime",
- "sp-std",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "triehash",
 ]
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ca9cd7b1958d67560c14bae83d65c4b1bb9dcd95edae26c35fc691bd9dc355"
 dependencies = [
  "serde",
  "serde_json",
@@ -5726,8 +5998,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb43e2ed60cd2c77583940442e4de03417adf5070903ed552a3c439c5dd8f891"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5737,34 +6010,80 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
- "sp-std",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
- "sp-version",
+ "sp-version 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-prometheus-endpoint",
+ "wasm-timer",
 ]
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03035f5ca5813e6db3f6ced9ab61177b1d2111ec4b8fe5c89668e583c8c0a329"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-application-crypto",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+dependencies = [
+ "base58",
+ "blake2-rfc",
+ "byteorder",
+ "derive_more",
+ "ed25519-dalek",
+ "futures 0.3.5",
+ "hash-db",
+ "hash256-std-hasher",
+ "hex",
+ "impl-serde 0.3.1",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "num-traits 0.2.12",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "parking_lot 0.10.2",
+ "primitive-types",
+ "rand 0.7.3",
+ "regex",
+ "schnorrkel",
+ "secrecy",
+ "serde",
+ "sha2",
+ "sp-debug-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-runtime-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-storage 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "substrate-bip39",
+ "tiny-bip39",
+ "tiny-keccak 2.0.2",
+ "twox-hash",
+ "wasmi",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cae177006e7515a1d3566433f4bcd350bf21825de33609055714347dc4eddbb"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -5790,11 +6109,11 @@ dependencies = [
  "schnorrkel",
  "serde",
  "sha2",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
+ "sp-debug-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-storage 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-bip39",
  "tiny-bip39",
  "tiny-keccak 2.0.2",
@@ -5807,15 +6126,16 @@ dependencies = [
 name = "sp-currency-exchange"
 version = "0.1.0"
 dependencies = [
- "frame-support",
+ "frame-support 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-database"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaea1668145b00ee2b2ab23087aed36baa8b81da427332b097c902a31521d823"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -5823,8 +6143,19 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "sp-debug-derive"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e8df3be2c0c4e2b3868ca3e285a71d837b4b19eeb216c6fe760723d452b9560"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -5833,57 +6164,84 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std",
- "sp-storage",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-storage 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dadf74f2b30b407987c848bba8bf674bd304699c76f87a8c0b9941df58223ac8"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-storage 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a1023816558d2c3320b67f6e98a128e23497bcc9506cb2e6322d08267af28db"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
  "serde",
  "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
- "sp-std",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f058c07feb2be45d4ec5ad8c77a5b81ca692302860f54fe37b2bc2c079816d2d"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents",
- "sp-std",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core",
- "sp-std",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1406b4225985188709f26db1eec810881832ad3e7ea3b54441e00f33a948c0"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5891,40 +6249,75 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "sp-core",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-state-machine",
- "sp-std",
- "sp-trie",
- "sp-wasm-interface",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-runtime-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-state-machine 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-tracing 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-trie 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-wasm-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-io"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae9654c2f10db24569e7457dc087195e99a4b6766834f19201946ed4c9446a7"
+dependencies = [
+ "futures 0.3.5",
+ "hash-db",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-state-machine 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c789ab5b744d99acd4b2a76ed863e27e7b7f67cc7dba8908d3738508cf4cd53d"
 dependencies = [
  "lazy_static",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum",
 ]
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7c2a18d1bf01468ee731de5da5e144e6a86e7128766d586597e93aa3f83502"
 dependencies = [
  "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+dependencies = [
+ "backtrace",
+ "log",
+]
+
+[[package]]
+name = "sp-panic-handler"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2028196ab3a4e0de791f23972be8ca121e706d72ea26c97f4da836381d4ecfe3"
 dependencies = [
  "backtrace",
  "log",
@@ -5932,17 +6325,18 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b1b325e27962e491e0cde2f7dc925a87e6cb9bc26935e621ab66cb7ad80506"
 dependencies = [
  "serde",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -5953,33 +6347,85 @@ dependencies = [
  "paste",
  "rand 0.7.3",
  "serde",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-std",
+ "sp-application-crypto 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-arithmetic 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-inherents 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-io 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5175aa1bd3f233220233ee5e260e4662143a9b4256b6769c293458b1aaff22"
+dependencies = [
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "paste",
+ "rand 0.7.3",
+ "serde",
+ "sp-application-crypto 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-io 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
- "sp-std",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-runtime-interface-proc-macro 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-tracing 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-wasm-interface 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d3a46adc3e01acbf3be58eeb2c456707eb00d6f9ab56ef1b6c0a64d4064a36"
+dependencies = [
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface-proc-macro 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-tracing 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-wasm-interface 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+dependencies = [
+ "Inflector",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21067e20e08be0584593958edd9935cf8e4702bda24480b667a620e92326d753"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -5990,8 +6436,9 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860ea7fec3f31507b0795c3945bf50f093ce015d6266717bc34a59661ebd77b9"
 dependencies = [
  "serde",
  "serde_json",
@@ -5999,89 +6446,149 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35d8160fd1643704d2b90f4b3025159d4c297185de310efdf556602b5c9217fa"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-staking",
- "sp-std",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc534846aa8a124b28bf43846b2f5e53bfc510732cb6ed420de9eff943681542"
 dependencies = [
  "parity-scale-codec",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "hash-db",
+ "itertools 0.9.0",
  "log",
  "num-traits 0.2.12",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
- "sp-trie",
+ "smallvec 1.4.0",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-externalities 0.8.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-panic-handler 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-trie 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "trie-db",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c49f96c8737bf8971338a0e000ce8ac55843aedc74f5a73c121b65335489ec6"
+dependencies = [
+ "hash-db",
+ "itertools 0.9.0",
+ "log",
+ "num-traits 0.2.12",
+ "parity-scale-codec",
+ "parking_lot 0.10.2",
+ "rand 0.7.3",
+ "smallvec 1.4.0",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.8.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-panic-handler 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db",
  "trie-root",
 ]
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
+
+[[package]]
+name = "sp-std"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9a60b2db0140169c0bada42bc4045be9902495f44b9f0be62499aafc0ff160"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
  "serde",
- "sp-debug-derive",
- "sp-std",
+ "sp-debug-derive 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-storage"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8396ad6814b515c19bcb18f9c2d8591ad4872def41cdc00dd78894b01398bf8d"
+dependencies = [
+ "impl-serde 0.2.3",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305d1fcb74c5519f47671f65eac6d7197e8b281d6bef001d6f424bd78e6c8385"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "sp-api",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
+ "sp-inherents 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-timer",
 ]
 
 [[package]]
 name = "sp-tracing"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
+ "log",
+ "rental",
+ "tracing",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c35237552c9435311e59fd3e00422fb6b7128e0d2fe50c34d121a4c02001b7e"
+dependencies = [
+ "log",
+ "rental",
  "tracing",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a921555b9eb2957ff2c4ffe3b599d27b7de016e851772a5f30465f6cbf0147"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6090,55 +6597,97 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
- "sp-runtime",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-utils",
 ]
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
- "sp-core",
- "sp-std",
+ "sp-core 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "trie-db",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65fc2f5a2551e2e90d71f23bea3f5c936e3b71a6ab9cf36de37668d99312c93b"
+dependencies = [
+ "hash-db",
+ "memory-db",
+ "parity-scale-codec",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db",
  "trie-root",
 ]
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6e06988a1e5bcd1b30dec3984c628390f0906d74c69bdabe14e6b159f2ff94"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
+ "futures-timer 3.0.2",
  "lazy_static",
  "prometheus",
 ]
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
  "serde",
- "sp-runtime",
- "sp-std",
+ "sp-runtime 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+]
+
+[[package]]
+name = "sp-version"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4c1963ac753da53cd781ef651d6e2993c08bb3f43150a8255d02e1bde2490b"
+dependencies = [
+ "impl-serde 0.2.3",
+ "parity-scale-codec",
+ "serde",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git#0ab1c4f945c8cfb8687c34c926ffd1761d124eba"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 2.0.0-rc4 (git+https://github.com/paritytech/substrate.git)",
+ "wasmi",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8676d1750df36bfedb098bb54131aaf4a5d973738b8a5fe645635ad29d9337"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "sp-std 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi",
 ]
 
@@ -6322,23 +6871,25 @@ dependencies = [
  "log",
  "node-primitives",
  "serde_json",
- "sp-core",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-rpc",
  "url 2.1.1",
 ]
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11136f36b24d56c5a9a7597a0fb4f8176f4408df50795777f0da2623e6c2f52"
 dependencies = [
  "platforms",
 ]
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "2.0.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ce6efc4b793887c53458c3512c8dc13b1f3b4a290c6d3304791e1ecc325ce5"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -6348,18 +6899,21 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "sc-client-api",
+ "sc-rpc-api",
  "serde",
  "sp-api",
+ "sp-block-builder",
  "sp-blockchain",
- "sp-core",
- "sp-runtime",
+ "sp-core 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 2.0.0-rc4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-transaction-pool",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.0-rc3"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "0.8.0-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f3115e72723df26f5b39887f0a43b27d6996e78e79836c2e706134ca9736e7"
 dependencies = [
  "async-std",
  "derive_more",
@@ -6373,7 +6927,8 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate.git?rev=606c56d2e2f69f68f3947551224be6a3515dff60#606c56d2e2f69f68f3947551224be6a3515dff60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
 name = "subtle"
@@ -6742,6 +7297,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-named-pipes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d282d483052288b2308ba5ee795f5673b159c9bdf63c385a05609da782a5eae"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.29",
+ "mio",
+ "mio-named-pipes",
+ "tokio 0.1.22",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6770,6 +7338,15 @@ dependencies = [
  "rustls",
  "tokio 0.2.21",
  "webpki",
+]
+
+[[package]]
+name = "tokio-service"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
+dependencies = [
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -6931,9 +7508,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc309f34008563989045a4c4dbcc5770467f3a3785ee80a9b5cc0d83362475f"
+checksum = "cb230c24c741993b04cfccbabb45acff6f6480c5f00d3ed8794ea43db3a9d727"
 dependencies = [
  "hash-db",
  "hashbrown 0.6.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,7 +1308,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1316,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1333,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1351,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1377,7 +1377,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3176,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3460,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3511,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4601,7 +4601,7 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4625,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4641,7 +4641,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -4657,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "fnv",
@@ -4744,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "log",
@@ -4881,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -4934,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -4953,7 +4953,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "hex",
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -4988,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bitflags",
  "bs58",
@@ -5040,7 +5040,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5055,7 +5055,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
@@ -5082,7 +5082,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -5095,7 +5095,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5104,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5176,7 +5176,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "directories",
@@ -5239,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5253,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "bytes 0.5.5",
  "futures 0.3.5",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "erased-serde",
  "log",
@@ -5292,7 +5292,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5312,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5694,7 +5694,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "log",
@@ -5706,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -5745,7 +5745,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -5758,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5770,7 +5770,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "log",
@@ -5811,7 +5811,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
  "serde_json",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5844,7 +5844,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5858,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -5909,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -5918,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -5965,7 +5965,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5998,7 +5998,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6009,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6019,7 +6019,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "backtrace",
  "log",
@@ -6028,7 +6028,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
  "sp-core",
@@ -6037,7 +6037,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6059,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6074,7 +6074,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6086,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6095,7 +6095,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -6139,12 +6139,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6156,7 +6156,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "log",
  "rental",
@@ -6180,7 +6180,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6210,7 +6210,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -6222,7 +6222,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -6234,7 +6234,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6430,7 +6430,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "platforms",
 ]
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -6461,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc4"
-source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+source = "git+https://github.com/paritytech/substrate.git?tag=v2.0.0-rc4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 dependencies = [
  "async-std",
  "derive_more",

--- a/bin/node/node/Cargo.toml
+++ b/bin/node/node/Cargo.toml
@@ -20,125 +20,79 @@ bridge-node-runtime = { version = "0.1.0", path = "../runtime" }
 sp-bridge-eth-poa = { version = "0.1.0", path = "../../../primitives/ethereum-poa" }
 
 [dependencies.sc-cli]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.sc-rpc]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sp-core]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sc-executor]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.sc-service]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.sp-inherents]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sc-transaction-pool]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sp-transaction-pool]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sc-network]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.sc-consensus-aura]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.sp-consensus-aura]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.sp-consensus]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.grandpa]
 package = "sc-finality-grandpa"
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.grandpa-primitives]
 package = "sp-finality-grandpa"
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sc-consensus]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.sc-client-api]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sc-basic-authorship]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "0.8.0-rc4"
 
 [dependencies.substrate-frame-rpc-system]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.frame-benchmarking]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.frame-benchmarking-cli]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [build-dependencies]
 vergen = "3.1.0"
 
 [build-dependencies.build-script-utils]
 package = "substrate-build-script-utils"
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [build-dependencies.frame-benchmarking-cli]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [features]
 default = []

--- a/bin/node/node/Cargo.toml
+++ b/bin/node/node/Cargo.toml
@@ -21,68 +21,110 @@ sp-bridge-eth-poa = { version = "0.1.0", path = "../../../primitives/ethereum-po
 
 [dependencies.sc-cli]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-rpc]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-executor]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-service]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-inherents]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-transaction-pool]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-transaction-pool]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-network]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus-aura]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus-aura]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa]
 package = "sc-finality-grandpa"
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa-primitives]
 package = "sp-finality-grandpa"
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-client-api]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-basic-authorship]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.substrate-frame-rpc-system]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-benchmarking]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-benchmarking-cli]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [build-dependencies]
 vergen = "3.1.0"
@@ -90,9 +132,13 @@ vergen = "3.1.0"
 [build-dependencies.build-script-utils]
 package = "substrate-build-script-utils"
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [build-dependencies.frame-benchmarking-cli]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [features]
 default = []

--- a/bin/node/node/Cargo.toml
+++ b/bin/node/node/Cargo.toml
@@ -21,109 +21,109 @@ sp-bridge-eth-poa = { version = "0.1.0", path = "../../../primitives/ethereum-po
 
 [dependencies.sc-cli]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-rpc]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-executor]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-service]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-inherents]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-transaction-pool]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-transaction-pool]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-network]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus-aura]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus-aura]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-consensus]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa]
 package = "sc-finality-grandpa"
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.grandpa-primitives]
 package = "sp-finality-grandpa"
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-consensus]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-client-api]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sc-basic-authorship]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.substrate-frame-rpc-system]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-benchmarking]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-benchmarking-cli]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [build-dependencies]
@@ -132,12 +132,12 @@ vergen = "3.1.0"
 [build-dependencies.build-script-utils]
 package = "substrate-build-script-utils"
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [build-dependencies.frame-benchmarking-cli]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [features]

--- a/bin/node/node/src/service.rs
+++ b/bin/node/node/src/service.rs
@@ -92,12 +92,14 @@ macro_rules! new_full_start {
 			},
 			)?
 		.with_rpc_extensions(|builder| -> Result<jsonrpc_core::IoHandler<sc_rpc::Metadata>, _> {
+			use sc_rpc::DenyUnsafe;
 			use substrate_frame_rpc_system::{FullSystem, SystemApi};
 
 			let mut io = jsonrpc_core::IoHandler::default();
 			io.extend_with(SystemApi::to_delegate(FullSystem::new(
 				builder.client().clone(),
 				builder.pool(),
+				DenyUnsafe::No,
 			)));
 			Ok(io)
 		})?;

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -24,13 +24,13 @@ features = ["derive"]
 # Substrate Dependencies
 [dependencies.pallet-aura]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-balances]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
@@ -46,74 +46,74 @@ path = "../../../modules/currency-exchange"
 
 [dependencies.frame-support]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-grandpa]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-randomness-collective-flip]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-sudo]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system-rpc-runtime-api]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-timestamp]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-executive]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 # Substrate Primitives
 [dependencies.sp-api]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-block-builder]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
@@ -129,74 +129,74 @@ path = "../../../primitives/currency-exchange"
 
 [dependencies.sp-consensus-aura]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-inherents]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-offchain]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-session]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-staking]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-transaction-pool]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-version]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -24,11 +24,15 @@ features = ["derive"]
 # Substrate Dependencies
 [dependencies.pallet-aura]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-balances]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-bridge-eth-poa]
 version = "0.1.0"
@@ -42,52 +46,76 @@ path = "../../../modules/currency-exchange"
 
 [dependencies.frame-support]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-grandpa]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-randomness-collective-flip]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-sudo]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system-rpc-runtime-api]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-timestamp]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-executive]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 # Substrate Primitives
 [dependencies.sp-api]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-block-builder]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-bridge-eth-poa]
 version = "0.1.0"
@@ -101,52 +129,76 @@ path = "../../../primitives/currency-exchange"
 
 [dependencies.sp-consensus-aura]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-inherents]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-offchain]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-session]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-staking]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-transaction-pool]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-version]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-bridge-eth-poa]
 version = "0.1.0"
@@ -155,8 +207,9 @@ features = ["test-helpers"]
 path = "../../../primitives/ethereum-poa"
 
 [build-dependencies.wasm-builder-runner]
-version = "1.0.6"
+version = "1.0.5"
 package = "substrate-wasm-builder-runner"
+git = "https://github.com/paritytech/substrate/"
 
 [features]
 default = ["std"]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -23,16 +23,12 @@ features = ["derive"]
 
 # Substrate Dependencies
 [dependencies.pallet-aura]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-balances]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-bridge-eth-poa]
 version = "0.1.0"
@@ -45,77 +41,53 @@ default-features = false
 path = "../../../modules/currency-exchange"
 
 [dependencies.frame-support]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-grandpa]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-randomness-collective-flip]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-sudo]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system-rpc-runtime-api]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-timestamp]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-executive]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 # Substrate Primitives
 [dependencies.sp-api]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-block-builder]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-bridge-eth-poa]
 version = "0.1.0"
@@ -128,77 +100,53 @@ default-features = false
 path = "../../../primitives/currency-exchange"
 
 [dependencies.sp-consensus-aura]
-version = "0.8.0-rc3"
+version = "0.8.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-inherents]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-offchain]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-session]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-staking]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-transaction-pool]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-version]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-bridge-eth-poa]
 version = "0.1.0"
@@ -207,10 +155,8 @@ features = ["test-helpers"]
 path = "../../../primitives/ethereum-poa"
 
 [build-dependencies.wasm-builder-runner]
-version = "1.0.5"
+version = "1.0.6"
 package = "substrate-wasm-builder-runner"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [features]
 default = ["std"]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -157,6 +157,8 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Runtime {
+	/// The basic call filter to use in dispatchable.
+	type BaseCallFilter = ();
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
 	/// The aggregated dispatch type that is available for extrinsics.

--- a/modules/currency-exchange/Cargo.toml
+++ b/modules/currency-exchange/Cargo.toml
@@ -13,45 +13,31 @@ sp-currency-exchange = { path = "../../primitives/currency-exchange", default-fe
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-core]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [dev-dependencies.sp-io]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [features]
 default = ["std"]

--- a/modules/currency-exchange/Cargo.toml
+++ b/modules/currency-exchange/Cargo.toml
@@ -14,43 +14,43 @@ sp-currency-exchange = { path = "../../primitives/currency-exchange", default-fe
 # Substrate Based Dependencies
 [dependencies.frame-support]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-core]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-io]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [features]

--- a/modules/currency-exchange/Cargo.toml
+++ b/modules/currency-exchange/Cargo.toml
@@ -14,30 +14,44 @@ sp-currency-exchange = { path = "../../primitives/currency-exchange", default-fe
 # Substrate Based Dependencies
 [dependencies.frame-support]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-core]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-io]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [features]
 default = ["std"]

--- a/modules/currency-exchange/src/lib.rs
+++ b/modules/currency-exchange/src/lib.rs
@@ -312,6 +312,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type BaseCallFilter = ();
 	}
 
 	impl Trait for TestRuntime {

--- a/modules/ethereum-contract/builtin/Cargo.toml
+++ b/modules/ethereum-contract/builtin/Cargo.toml
@@ -20,18 +20,28 @@ bridge-node-runtime = { path = "../../../bin/node/runtime" }
 
 [dependencies.sp-blockchain]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sc-finality-grandpa]
-version = "0.8.0-dev"
+version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies]
 hex = "0.4"
 
 [dev-dependencies.sp-core]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"

--- a/modules/ethereum-contract/builtin/Cargo.toml
+++ b/modules/ethereum-contract/builtin/Cargo.toml
@@ -20,22 +20,22 @@ bridge-node-runtime = { path = "../../../bin/node/runtime" }
 
 [dependencies.sp-blockchain]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sc-finality-grandpa]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies]
@@ -43,5 +43,5 @@ hex = "0.4"
 
 [dev-dependencies.sp-core]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"

--- a/modules/ethereum-contract/builtin/Cargo.toml
+++ b/modules/ethereum-contract/builtin/Cargo.toml
@@ -19,29 +19,19 @@ finality-grandpa = "0.12.3"
 bridge-node-runtime = { path = "../../../bin/node/runtime" }
 
 [dependencies.sp-blockchain]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [dependencies.sp-finality-grandpa]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [dependencies.sc-finality-grandpa]
 version = "0.8.0-dev"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies]
 hex = "0.4"
 
 [dev-dependencies.sp-core]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"

--- a/modules/ethereum/Cargo.toml
+++ b/modules/ethereum/Cargo.toml
@@ -14,41 +14,29 @@ primitives = { package = "sp-bridge-eth-poa", path = "../../primitives/ethereum-
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.libsecp256k1]
 optional = true

--- a/modules/ethereum/Cargo.toml
+++ b/modules/ethereum/Cargo.toml
@@ -15,28 +15,40 @@ primitives = { package = "sp-bridge-eth-poa", path = "../../primitives/ethereum-
 # Substrate Based Dependencies
 [dependencies.frame-support]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.libsecp256k1]
 optional = true

--- a/modules/ethereum/Cargo.toml
+++ b/modules/ethereum/Cargo.toml
@@ -15,38 +15,38 @@ primitives = { package = "sp-bridge-eth-poa", path = "../../primitives/ethereum-
 # Substrate Based Dependencies
 [dependencies.frame-support]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-io]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-benchmarking]
 optional = true
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 

--- a/modules/ethereum/src/mock.rs
+++ b/modules/ethereum/src/mock.rs
@@ -69,6 +69,7 @@ impl frame_system::Trait for TestRuntime {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type BaseCallFilter = ();
 }
 
 parameter_types! {

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -15,56 +15,56 @@ hash-db = { version = "0.15.2", default-features = false }
 # Substrate Based Dependencies
 [dependencies.frame-support]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-trie]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies
 [dev-dependencies.sp-io]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-state-machine]
 version = "0.8.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [features]

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -15,39 +15,57 @@ hash-db = { version = "0.15.2", default-features = false }
 # Substrate Based Dependencies
 [dependencies.frame-support]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-trie]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies
 [dev-dependencies.sp-io]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-state-machine]
 version = "0.8.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [features]
 default = ["std"]

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -14,58 +14,40 @@ hash-db = { version = "0.15.2", default-features = false }
 
 # Substrate Based Dependencies
 [dependencies.frame-support]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.frame-system]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-session]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-core]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-finality-grandpa]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-trie]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 # Dev Dependencies
 [dev-dependencies.sp-io]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
 
 [dev-dependencies.sp-state-machine]
-version = "0.8.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "0.8.0-rc4"
 
 [features]
 default = ["std"]

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -273,6 +273,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type BaseCallFilter = ();
 	}
 
 	impl Trait for Test {}

--- a/primitives/currency-exchange/Cargo.toml
+++ b/primitives/currency-exchange/Cargo.toml
@@ -13,11 +13,15 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-support]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate.git"
 
 [features]
 default = ["std"]

--- a/primitives/currency-exchange/Cargo.toml
+++ b/primitives/currency-exchange/Cargo.toml
@@ -13,13 +13,13 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-support]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate.git"
 

--- a/primitives/currency-exchange/Cargo.toml
+++ b/primitives/currency-exchange/Cargo.toml
@@ -12,16 +12,12 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 # Substrate Based Dependencies
 
 [dependencies.sp-std]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.frame-support]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
 
 [features]
 default = ["std"]

--- a/primitives/ethereum-poa/Cargo.toml
+++ b/primitives/ethereum-poa/Cargo.toml
@@ -23,28 +23,20 @@ plain_hasher = { version = "0.2.2", default-features = false }
 
 # Substrate Based Dependencies
 [dependencies.sp-api]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-std]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-io]
-version = "2.0.0-rc3"
+version = "2.0.0-rc4"
 default-features = false
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.libsecp256k1]
 optional = true

--- a/primitives/ethereum-poa/Cargo.toml
+++ b/primitives/ethereum-poa/Cargo.toml
@@ -24,25 +24,25 @@ plain_hasher = { version = "0.2.2", default-features = false }
 # Substrate Based Dependencies
 [dependencies.sp-api]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-io]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 default-features = false
 git = "https://github.com/paritytech/substrate.git"
 

--- a/primitives/ethereum-poa/Cargo.toml
+++ b/primitives/ethereum-poa/Cargo.toml
@@ -24,19 +24,27 @@ plain_hasher = { version = "0.2.2", default-features = false }
 # Substrate Based Dependencies
 [dependencies.sp-api]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-std]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-io]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 default-features = false
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.libsecp256k1]
 optional = true

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -44,13 +44,10 @@ version = "2.0.0-rc4"
 [dependencies.pallet-transaction-payment]
 version = "2.0.0-rc4"
 
-# I think this is used for sr-io and stuff
 [dependencies.node-primitives]
 version = "2.0.0-rc4"
 git = "https://github.com/paritytech/substrate.git"
 
-# Branch used for keccack256 hasher code
-# Could probably move the keccack hasher stuff to our own primitives
 [dependencies.sp-core]
 version = "2.0.0-rc4"
 
@@ -60,8 +57,6 @@ version = "2.0.0-rc4"
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
 
-# This should get moved to our `bin` folder
 [dependencies.bridge-node-runtime]
 version = "0.1.0"
 path = "../../bin/node/runtime"
-# node-runtime = { git = "https://github.com/svyatonik/substrate.git", branch = "bridge_runtime" }

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -40,22 +40,33 @@ features = ["http"]
 # Substrate Based Dependencies
 [dependencies.frame-system]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.node-primitives]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-keyring]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.bridge-node-runtime]
 version = "0.1.0"

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -39,37 +39,26 @@ features = ["http"]
 
 # Substrate Based Dependencies
 [dependencies.frame-system]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [dependencies.pallet-transaction-payment]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 # I think this is used for sr-io and stuff
 [dependencies.node-primitives]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
+version = "2.0.0-rc4"
 git = "https://github.com/paritytech/substrate.git"
 
 # Branch used for keccack256 hasher code
 # Could probably move the keccack hasher stuff to our own primitives
 [dependencies.sp-core]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sp-keyring]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 [dependencies.sp-runtime]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate.git"
+version = "2.0.0-rc4"
 
 # This should get moved to our `bin` folder
 [dependencies.bridge-node-runtime]

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -40,32 +40,32 @@ features = ["http"]
 # Substrate Based Dependencies
 [dependencies.frame-system]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.pallet-transaction-payment]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.node-primitives]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-keyring]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.sp-runtime]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate.git"
 
 [dependencies.bridge-node-runtime]

--- a/relays/substrate/Cargo.toml
+++ b/relays/substrate/Cargo.toml
@@ -18,16 +18,11 @@ serde_json = "1.0.56"
 url = "2.1.0"
 
 [dependencies.sp-core]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [dependencies.sp-rpc]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
 
 [dependencies.node-primitives]
-version = "2.0.0-rc3"
-rev = "606c56d2e2f69f68f3947551224be6a3515dff60"
-git = "https://github.com/paritytech/substrate/"
+version = "2.0.0-rc4"
+git = "https://github.com/paritytech/substrate.git"

--- a/relays/substrate/Cargo.toml
+++ b/relays/substrate/Cargo.toml
@@ -19,10 +19,15 @@ url = "2.1.0"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-rpc]
 version = "2.0.0-rc4"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"
 
 [dependencies.node-primitives]
 version = "2.0.0-rc4"
-git = "https://github.com/paritytech/substrate.git"
+rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+git = "https://github.com/paritytech/substrate/"

--- a/relays/substrate/Cargo.toml
+++ b/relays/substrate/Cargo.toml
@@ -19,15 +19,15 @@ url = "2.1.0"
 
 [dependencies.sp-core]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.sp-rpc]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"
 
 [dependencies.node-primitives]
 version = "2.0.0-rc4"
-rev = "00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+tag = 'v2.0.0-rc4'
 git = "https://github.com/paritytech/substrate/"

--- a/scripts/update_rc.sh
+++ b/scripts/update_rc.sh
@@ -2,6 +2,7 @@
 
 # One-liner to update between Substrate `rc` releases
 # Usage: ./update_rc.sh rc4 rc5
+set -xeu
 
 OLD_RC_VERSION=$1
 NEW_RC_VERSION=$2

--- a/scripts/update_rc.sh
+++ b/scripts/update_rc.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# One-liner to update between Substrate `rc` releases
+# Usage: ./update_rc.sh rc4 rc5
+
+OLD_RC_VERSION=$1
+NEW_RC_VERSION=$2
+
+find . -type f -name 'Cargo.toml' -exec sed -i '' -e "s/$OLD_RC_VERSION/$NEW_RC_VERSION/g" {} \;


### PR DESCRIPTION
Since all crates, with the exception of `node-primitives`, are on crates.io I've removed the `rev` and `git` fields from the imports.