### PR TITLE
Faster re-build of docker images.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/target/
+**/.env
 
 **/*.rs.bk
 

--- a/deployments/rialto/Bridge.Dockerfile
+++ b/deployments/rialto/Bridge.Dockerfile
@@ -34,14 +34,19 @@ RUN rustc -vV && \
 WORKDIR /parity-bridges-common
 
 ### Build from the repo
+# Start with master build first.
 ARG BRIDGE_REPO=https://github.com/paritytech/parity-bridges-common
+RUN git clone $BRIDGE_REPO /parity-bridges-common && git checkout master
+
+ARG PROJECT=ethereum-poa-relay
+RUN cargo build --release --verbose -p ${PROJECT}
+
+# Then switch to expected branch and re-build only the stuff that changed.
 ARG BRIDGE_HASH=master
-RUN git clone $BRIDGE_REPO /parity-bridges-common && git checkout $BRIDGE_HASH
+RUN git checkout $BRIDGE_HASH
 
 ### Build locally
 # ADD .
-
-ARG PROJECT=ethereum-poa-relay
 
 RUN cargo build --release --verbose -p ${PROJECT}
 RUN strip ./target/release/${PROJECT}

--- a/deployments/rialto/Bridge.Dockerfile
+++ b/deployments/rialto/Bridge.Dockerfile
@@ -19,7 +19,7 @@ RUN update-ca-certificates && \
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV LAST_RUST_UPDATE 2020-06-22
+ENV LAST_RUST_UPDATE 2020-07-22
 
 RUN rustup update stable && \
 	rustup install nightly && \

--- a/deployments/rialto/Bridge.Dockerfile
+++ b/deployments/rialto/Bridge.Dockerfile
@@ -43,7 +43,7 @@ RUN cargo build --release --verbose -p ${PROJECT}
 
 # Then switch to expected branch and re-build only the stuff that changed.
 ARG BRIDGE_HASH=master
-RUN git checkout $BRIDGE_HASH
+RUN git fetch && git checkout $BRIDGE_HASH
 
 ### Build locally
 # ADD .

--- a/deployments/rialto/OpenEthereum.Dockerfile
+++ b/deployments/rialto/OpenEthereum.Dockerfile
@@ -52,7 +52,7 @@ RUN cargo build --release --verbose || true
 # build the changes.
 WORKDIR /parity-bridges-common
 ARG BRIDGE_HASH=master
-RUN git checkout $BRIDGE_HASH
+RUN git fetch && git checkout $BRIDGE_HASH
 ### Build locally. Make sure to set the CONTEXT to main directory of the repo.
 # ADD . /parity-bridges-common
 

--- a/deployments/rialto/OpenEthereum.Dockerfile
+++ b/deployments/rialto/OpenEthereum.Dockerfile
@@ -34,21 +34,29 @@ WORKDIR /openethereum
 ARG ETHEREUM_REPO=https://github.com/svyatonik/parity.git
 ARG ETHEREUM_HASH=9838f59b6536e7482e145fa55acf07ac4e824ed0
 RUN git clone $ETHEREUM_REPO /openethereum && git checkout $ETHEREUM_HASH
+
 ### Build locally. Make sure to set the CONTEXT to main directory of the repo.
 # ADD openethereum /openethereum
 
 WORKDIR /parity-bridges-common
 
 ### Build from the repo
+# Build using `master` initially.
 ARG BRIDGE_REPO=https://github.com/paritytech/parity-bridges-common
-ARG BRIDGE_HASH=master
+RUN git clone $BRIDGE_REPO /parity-bridges-common && git checkout master
 
-RUN git clone $BRIDGE_REPO /parity-bridges-common && git checkout $BRIDGE_HASH
+WORKDIR /openethereum
+RUN cargo build --release --verbose || true
+
+# Then rebuild by switching to a different branch to only incrementally
+# build the changes.
+WORKDIR /parity-bridges-common
+ARG BRIDGE_HASH=master
+RUN git checkout $BRIDGE_HASH
 ### Build locally. Make sure to set the CONTEXT to main directory of the repo.
 # ADD . /parity-bridges-common
 
 WORKDIR /openethereum
-
 RUN cargo build --release --verbose
 RUN strip ./target/release/openethereum
 

--- a/deployments/rialto/OpenEthereum.Dockerfile
+++ b/deployments/rialto/OpenEthereum.Dockerfile
@@ -17,7 +17,7 @@ RUN update-ca-certificates && \
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV LAST_RUST_UPDATE="2020-06-19"
+ENV LAST_RUST_UPDATE="2020-07-22"
 RUN rustup update stable && \
 	rustup install nightly && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly

--- a/deployments/rialto/docker-compose.yml
+++ b/deployments/rialto/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./OpenEthereum.Dockerfile
       args:
         ETHEREUM_HASH: 9838f59b6536e7482e145fa55acf07ac4e824ed0
-        BRIDGE_HASH: master
+        BRIDGE_HASH: ${BRIDGE_HASH:-master}
     entrypoint:
       - /home/openethereum/openethereum
       - --config=/config/poa-node-config
@@ -50,7 +50,7 @@ services:
       context: .
       dockerfile: ./Bridge.Dockerfile
       args:
-        BRIDGE_HASH: master
+        BRIDGE_HASH: ${BRIDGE_HASH:-master}
         PROJECT: ethereum-poa-relay
     entrypoint: /config/relay-eth2sub-entrypoint.sh
     volumes:
@@ -86,7 +86,7 @@ services:
       context: .
       dockerfile: ./Bridge.Dockerfile
       args:
-        BRIDGE_HASH: master
+        BRIDGE_HASH: ${BRIDGE_HASH:-master}
         PROJECT: bridge-node
     entrypoint:
       - /home/user/bridge-node

--- a/deployments/rialto/update.sh
+++ b/deployments/rialto/update.sh
@@ -5,6 +5,8 @@
 set -xeu
 
 git pull
+sed -i '/BRIDGE_HASH/d' .env || true
+echo "BRIDGE_HASH=$(git rev-parse HEAD)" >> .env
 docker-compose build
 # Stop the proxy cause otherwise the network can't be stopped
 cd ./proxy


### PR DESCRIPTION
This PR adds two-step compilatiion of each project:
1. We first compile against `master` version of `parity-bridges-common` repo
2. Then we switch to `BRIDGE_HASH` and compile again.

The first step should (hopefully) be retrieved from docker cache, so the second step will only incrementally compile changes between `master..BRIDGE_HASH`, which should result in much faster compilation.

Also updates `update.sh` script used on our test deployment, to force rebuild on every pull.