### PR TITLE
Exchange transactions relay dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,33 +2385,6 @@ dependencies = [
 [[package]]
 name = "jsonrpsee"
 version = "1.0.0"
-source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#aed5c25a1850196f86e046228d2439b42c84ce6a"
-dependencies = [
- "async-std",
- "bs58",
- "fnv",
- "futures 0.3.5",
- "futures-timer 3.0.2",
- "globset",
- "hashbrown 0.7.2",
- "hyper 0.13.6",
- "jsonrpsee-proc-macros 1.0.0 (git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api)",
- "lazy_static",
- "log",
- "parking_lot 0.10.2",
- "pin-project",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "smallvec 1.4.1",
- "thiserror",
- "tokio 0.2.21",
- "unicase",
-]
-
-[[package]]
-name = "jsonrpsee"
-version = "1.0.0"
 source = "git+https://github.com/paritytech/jsonrpsee#ccae2c3b05207093e85c4e4c8704c8f8a65ed1e8"
 dependencies = [
  "async-std",
@@ -2442,9 +2415,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-proc-macros"
+name = "jsonrpsee"
 version = "1.0.0"
 source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#aed5c25a1850196f86e046228d2439b42c84ce6a"
+dependencies = [
+ "async-std",
+ "bs58",
+ "fnv",
+ "futures 0.3.5",
+ "futures-timer 3.0.2",
+ "globset",
+ "hashbrown 0.7.2",
+ "hyper 0.13.6",
+ "jsonrpsee-proc-macros 1.0.0 (git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api)",
+ "lazy_static",
+ "log",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "smallvec 1.4.1",
+ "thiserror",
+ "tokio 0.2.21",
+ "unicase",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "1.0.0"
+source = "git+https://github.com/paritytech/jsonrpsee#ccae2c3b05207093e85c4e4c8704c8f8a65ed1e8"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -2455,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-proc-macros"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/jsonrpsee#ccae2c3b05207093e85c4e4c8704c8f8a65ed1e8"
+source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#aed5c25a1850196f86e046228d2439b42c84ce6a"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/grafana-dashboard.yaml
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/grafana-dashboard.yaml
@@ -3,4 +3,4 @@
   folder: ''
   type: file
   options:
-    path: '/etc/grafana/provisioning/dashboards/grafana-dashboard.json'
+    path: '/etc/grafana/provisioning/dashboards'

--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-exchange-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-exchange-dashboard.json
@@ -1,0 +1,477 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "expr": "Ethereum_to_Substrate_Exchange_best_block_numbers",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Best {{type}} block",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Best finalized blocks",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 7,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "expr": "Ethereum_to_Substrate_Exchange_processed_blocks",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Number of processed blocks since last restart",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "Ethereum_to_Substrate_Exchange_system_average_load",
+          "interval": "",
+          "legendFormat": "Average system load in last {{over}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": null
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "System load average",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "expr": "Ethereum_to_Substrate_Exchange_process_cpu_usage_percentage",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Relay process CPU usage (1 CPU = 100)",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "expr": "Ethereum_to_Substrate_Exchange_processed_transactions",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{type}} transactions",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Number of processed transactions since last restart",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "7.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "Ethereum_to_Substrate_Exchange_process_memory_usage_bytes / 1024 / 1024",
+          "interval": "",
+          "legendFormat": "Process memory, MB",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory used by relay process",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Ethereum to Substrate exchange dashboard",
+  "uid": "relay-eth2sub-exchange",
+  "version": 6
+}

--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
@@ -99,7 +99,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(best_block_numbers{node=\"source\"}) - max(best_block_numbers{node=\"target\"})",
+          "expr": "max(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"}) - max(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"target\"})",
           "format": "table",
           "instant": false,
           "interval": "",
@@ -202,7 +202,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "system_average_load",
+          "expr": "Ethereum_to_Substrate_Sync_system_average_load",
           "interval": "",
           "legendFormat": "Average system load in last {{over}}",
           "refId": "A"
@@ -301,7 +301,7 @@
       "pluginVersion": "7.1.0",
       "targets": [
         {
-          "expr": "process_cpu_usage_percentage",
+          "expr": "Ethereum_to_Substrate_Sync_process_cpu_usage_percentage",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -361,7 +361,7 @@
       "pluginVersion": "7.1.0",
       "targets": [
         {
-          "expr": "best_block_numbers",
+          "expr": "Ethereum_to_Substrate_Sync_best_block_numbers",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -421,7 +421,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_memory_usage_bytes / 1024 / 1024",
+          "expr": "Ethereum_to_Substrate_Sync_process_memory_usage_bytes / 1024 / 1024",
           "interval": "",
           "legendFormat": "Process memory, MB",
           "refId": "A"
@@ -512,7 +512,7 @@
       "pluginVersion": "7.1.0",
       "targets": [
         {
-          "expr": "blocks_in_state",
+          "expr": "Ethereum_to_Substrate_Sync_blocks_in_state",
           "instant": true,
           "interval": "",
           "legendFormat": "{{state}}",
@@ -604,7 +604,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(best_block_numbers{node=\"source\"})",
+          "expr": "max(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -685,7 +685,7 @@
     ]
   },
   "timezone": "",
-  "title": "RelayDashboard",
-  "uid": "relay-eth2sub",
+  "title": "Ethereum to Substrate headers sync dashboard",
+  "uid": "relay-eth2sub-sync",
   "version": 1
 }

--- a/deployments/rialto/dashboard/prometheus/prometheus.yml
+++ b/deployments/rialto/dashboard/prometheus/prometheus.yml
@@ -11,7 +11,7 @@ scrape_configs:
   - job_name: 'eth_exchange_sub_relay_node'
 
     # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
+    scrape_interval: 15s
 
     static_configs:
       - targets: ['relay-eth-exchange-sub:9616']

--- a/deployments/rialto/dashboard/prometheus/prometheus.yml
+++ b/deployments/rialto/dashboard/prometheus/prometheus.yml
@@ -10,7 +10,7 @@ scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'eth_exchange_sub_relay_node'
 
-    # Override the global default and scrape targets from this job every 5 seconds.
+    # Override the global default and scrape targets from this job every 15 seconds.
     scrape_interval: 15s
 
     static_configs:

--- a/relays/ethereum/src/exchange_loop.rs
+++ b/relays/ethereum/src/exchange_loop.rs
@@ -98,7 +98,12 @@ pub fn run<P: TransactionProofPipeline>(
 		let mut metrics_global = GlobalMetrics::new();
 		let mut metrics_exch = ExchangeLoopMetrics::new();
 		let metrics_enabled = metrics_params.is_some();
-		metrics_start(metrics_params, &metrics_global, &metrics_exch);
+		metrics_start(
+			format!("{}_to_{}_Exchange", P::SOURCE_NAME, P::TARGET_NAME),
+			metrics_params,
+			&metrics_global,
+			&metrics_exch,
+		);
 
 		let exit_signal = exit_signal.fuse();
 

--- a/relays/ethereum/src/metrics.rs
+++ b/relays/ethereum/src/metrics.rs
@@ -66,8 +66,8 @@ pub fn start(
 				.map_err(|err| format!("Invalid Prometheus host {}: {}", params.host, err))?,
 			params.port,
 		);
-		let metrics_registry = Registry::new_custom(Some(prefix), None)
-			.expect("only fails if prefix is empty; prefix is not empty; qed");
+		let metrics_registry =
+			Registry::new_custom(Some(prefix), None).expect("only fails if prefix is empty; prefix is not empty; qed");
 		global_metrics.register(&metrics_registry)?;
 		extra_metrics.register(&metrics_registry)?;
 		async_std::task::spawn(async move {

--- a/relays/ethereum/src/metrics.rs
+++ b/relays/ethereum/src/metrics.rs
@@ -45,11 +45,18 @@ pub struct GlobalMetrics {
 }
 
 /// Start Prometheus endpoint with given metrics registry.
-pub fn start(params: Option<MetricsParams>, global_metrics: &GlobalMetrics, extra_metrics: &impl Metrics) {
+pub fn start(
+	prefix: String,
+	params: Option<MetricsParams>,
+	global_metrics: &GlobalMetrics,
+	extra_metrics: &impl Metrics,
+) {
 	let params = match params {
 		Some(params) => params,
 		None => return,
 	};
+
+	assert!(!prefix.is_empty(), "Metrics prefix can not be empty");
 
 	let do_start = move || {
 		let prometheus_socket_addr = SocketAddr::new(
@@ -59,7 +66,8 @@ pub fn start(params: Option<MetricsParams>, global_metrics: &GlobalMetrics, extr
 				.map_err(|err| format!("Invalid Prometheus host {}: {}", params.host, err))?,
 			params.port,
 		);
-		let metrics_registry = Registry::new();
+		let metrics_registry = Registry::new_custom(Some(prefix), None)
+			.expect("only fails if prefix is empty; prefix is not empty; qed");
 		global_metrics.register(&metrics_registry)?;
 		extra_metrics.register(&metrics_registry)?;
 		async_std::task::spawn(async move {

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -124,7 +124,12 @@ pub fn run<P: HeadersSyncPipeline, TC: TargetClient<P>>(
 		let mut metrics_global = GlobalMetrics::new();
 		let mut metrics_sync = SyncLoopMetrics::new();
 		let metrics_enabled = metrics_params.is_some();
-		metrics_start(metrics_params, &metrics_global, &metrics_sync);
+		metrics_start(
+			format!("{}_to_{}_Sync", P::SOURCE_NAME, P::TARGET_NAME),
+			metrics_params,
+			&metrics_global,
+			&metrics_sync,
+		);
 
 		let mut source_retry_backoff = retry_backoff();
 		let mut source_client_is_online = false;


### PR DESCRIPTION
This PR adds prefix for metrics that relay exposes - now in `eth-to-sub` mode it'll be exposing metrics that are starting with "Ethereum_to_Substrate_Sync_" prefix. In `eth-exchange-sub` mode, prefix would be "Ethereum_to_Substrate_Exchange_". There's now 2nd dashboard for `eth-exchange-sub` relay.

I was unable to test it in docker env (mostly because of #240), so it is only tested using retrograde [bash scripts](https://github.com/svyatonik/parity-bridges-common.test) :)