### PR TITLE
Don't start proxy by default.

### DIFF
--- a/deployments/rialto/update.sh
+++ b/deployments/rialto/update.sh
@@ -23,5 +23,7 @@ docker-compose down
 docker-compose up -d
 
 # Restart the proxy
-cd ./proxy
-docker-compose up -d
+if [ ! -z ${WITH_PROXY+x} ]; then
+	cd ./proxy
+	docker-compose up -d
+fi


### PR DESCRIPTION
The proxy only needs to be started on the server, so best to avoid doing that in case the script is run locally.