### PR TITLE
Add server domain to grafana.

### DIFF
--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
@@ -531,7 +531,7 @@
           {
             "evaluator": {
               "params": [
-                10
+                5
               ],
               "type": "lt"
             },

--- a/deployments/rialto/docker-compose.yml
+++ b/deployments/rialto/docker-compose.yml
@@ -176,6 +176,7 @@ services:
       LETSENCRYPT_EMAIL: admin@parity.io
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASS:-admin}
       GF_SERVER_ROOT_URL: ${GRAFANA_SERVER_ROOT_URL}
+      GF_SERVER_DOMAIN: ${GRAFANA_SERVER_DOMAIN}
     volumes:
       - ./dashboard/grafana/provisioning/:/etc/grafana/provisioning/
     ports:


### PR DESCRIPTION
I messed up configuration when `ROOT_URL` was added and turns out this is required as well. That was the reason why alerts were not working and the server was down for the last two days.