### PR TITLE
Fix env issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/target/
 **/.env
+**/.env2
 
 **/*.rs.bk
 

--- a/deployments/rialto/update.sh
+++ b/deployments/rialto/update.sh
@@ -11,7 +11,7 @@ sed -i '/BRIDGE_HASH/d' .env || true
 echo "BRIDGE_HASH=$(git rev-parse HEAD)" >> .env
 
 # Update Matrix access token
-(grep MATRIX_ACCESS_TOKEN .env > .env2 && . ./.env2 && rm .env2) || true
+(grep -e MATRIX_ACCESS_TOKEN -e WITH_PROXY .env > .env2 && . ./.env2 && rm .env2) || true
 if [ ! -z ${MATRIX_ACCESS_TOKEN+x} ]; then
 	sed -i "s/access_token.*/access_token: \"$MATRIX_ACCESS_TOKEN\"/" ./dashboard/grafana-matrix/config.yml
 fi

--- a/deployments/rialto/update.sh
+++ b/deployments/rialto/update.sh
@@ -5,19 +5,25 @@
 set -xeu
 
 git pull
+
 # Update BRIDGE_HASH in .env
 sed -i '/BRIDGE_HASH/d' .env || true
 echo "BRIDGE_HASH=$(git rev-parse HEAD)" >> .env
-# Update Matrix access token
-. ./.env
-MATRIX_ACCESS_TOKEN=${MATRIX_ACCESS_TOKEN:-<access_token>}
-sed -i "s/access_token.*/access_token: \"$MATRIX_ACCESS_TOKEN\"/" ./dashboard/grafana-matrix/config.yml
 
+# Update Matrix access token
+(grep MATRIX_ACCESS_TOKEN .env > .env2 && . ./.env2 && rm .env2) || true
+if [ ! -z ${MATRIX_ACCESS_TOKEN+x} ]; then
+	sed -i "s/access_token.*/access_token: \"$MATRIX_ACCESS_TOKEN\"/" ./dashboard/grafana-matrix/config.yml
+fi
+
+# Rebuild images with latest `BRIDGE_HASH`
 docker-compose build
+
 # Stop the proxy cause otherwise the network can't be stopped
 cd ./proxy
 docker-compose down
 cd -
+
 # Restart the network
 docker-compose down
 docker-compose up -d


### PR DESCRIPTION
Bash `.` import expects the variables to be quoted if they contain special characters (i.e. `SOME_VAR="asdf:"`), while `docker-compose` doesn't like the quotes at all.
Since we only need `MATRIX_ACCESS_TOKEN` in the script, I've added a grep here to extract it from `.env` to a temporary file and import that.