### PR TITLE
Update no new blocks alert in eth2sub dashboard

### DIFF
--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
@@ -541,13 +541,13 @@
             "query": {
               "params": [
                 "A",
-                "1m",
+                "2m",
                 "now"
               ]
             },
             "reducer": {
               "params": [],
-              "type": "diff_abs"
+              "type": "min"
             },
             "type": "query"
           }
@@ -604,7 +604,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"})",
+          "expr": "max_over_time(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"}[2m])-min_over_time(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"}[2m])",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -616,13 +616,13 @@
           "fill": true,
           "line": true,
           "op": "lt",
-          "value": 10
+          "value": 5
         }
       ],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Source blocks",
+      "title": "Source blocks difference (last 2m)",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
(as discussed externally - it now uses `max_over_time(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"}[2m])-min_over_time(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"}[2m])` query)

(corresponding fix for sub2eth is in #255)