### PR TITLE
Fix generator in case tty is not available.

### DIFF
--- a/deployments/rialto/bridge-config/poa-exchange-tx-generator-entrypoint.sh
+++ b/deployments/rialto/bridge-config/poa-exchange-tx-generator-entrypoint.sh
@@ -6,7 +6,7 @@
 # exchange transaction from hardcoded PoA senders (assuming they have
 # enough funds) to hardcoded Substrate recipients.
 
-set -e
+set -eu
 
 # Path to relay binary
 RELAY_BINARY_PATH=${RELAY_BINARY_PATH:-./ethereum-poa-relay}
@@ -76,6 +76,7 @@ do
 
 	# submit transaction
 	echo "Sending $EXCHANGE_AMOUNT_ETH from PoA:$ETH_SIGNER to Substrate:$SUB_RECIPIENT. Nonce: $ETH_SIGNER_NONCE"
+	set -x
 	SUBMIT_OUTPUT=`$RELAY_BINARY_PATH 2>&1 eth-submit-exchange-tx \
 		--sub-recipient=$SUB_RECIPIENT \
 		--eth-host=$ETH_HOST \
@@ -83,7 +84,8 @@ do
 		--eth-chain-id=$ETH_CHAIN_ID \
 		--eth-signer=$ETH_SIGNER \
 		--eth-amount=$EXCHANGE_AMOUNT_ETH \
-		$ETH_SIGNER_NONCE_ARG | tee /dev/tty`
+		$ETH_SIGNER_NONCE_ARG`
+	set +x
 
 	# update sender nonce
 	SUBMIT_OUTPUT_RE='nonce: ([0-9]+)'


### PR DESCRIPTION
It seems it still doesn't work because of insufficient funds though:
```
2020-07-30 12:56:52 +0000 ERROR bridge Error submitting exchange transaction to Ethereum node: error submitting transaction: Request(Request(Error { code: ServerError(-32010), message: "Insufficient funds. The account you tried to send transaction from does not have enough funds. Required 185410166640640 and got: 0.", data: None }))
```