### PR TITLE
Retry Connections on Relay Startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,10 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721c249ab59cbc483ad4294c9ee2671835c1e43e9ffc277e6b4ecfef733cfdc5"
 dependencies = [
+ "async-std",
+ "futures-core",
  "instant",
+ "pin-project",
  "rand 0.7.3",
 ]
 
@@ -7406,7 +7409,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.3.23",
 ]
 
 [[package]]

--- a/deployments/rialto/docker-compose.yml
+++ b/deployments/rialto/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       EXCHANGE_GEN_MIN_AMOUNT_FINNEY: ${EXCHANGE_GEN_MIN_AMOUNT_FINNEY:-1}
       EXCHANGE_GEN_MAX_AMOUNT_FINNEY: ${EXCHANGE_GEN_MAX_AMOUNT_FINNEY:-100000}
       EXCHANGE_GEN_MAX_SUBMIT_DELAY_S: ${EXCHANGE_GEN_MAX_SUBMIT_DELAY_S:-60}
+    healthcheck:
+       disable: true
     depends_on: *all-nodes
 
   relay-eth-exchange-sub:

--- a/relays/ethereum/Cargo.toml
+++ b/relays/ethereum/Cargo.toml
@@ -10,7 +10,7 @@ ansi_term = "0.12"
 async-std = "1.6.2"
 async-stream = "0.3.0"
 async-trait = "0.1.36"
-backoff = "0.2"
+backoff = { version = "0.2.1", features = ["async-std"] }
 bp-currency-exchange = { path = "../../primitives/currency-exchange" }
 bp-eth-poa = { path = "../../primitives/ethereum-poa" }
 clap = { version = "2.33.2", features = ["yaml"] }

--- a/relays/ethereum/src/ethereum_client.rs
+++ b/relays/ethereum/src/ethereum_client.rs
@@ -57,6 +57,12 @@ impl Default for EthereumConnectionParams {
 	}
 }
 
+impl std::fmt::Display for EthereumConnectionParams {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "{}:{}", self.host, self.port)
+	}
+}
+
 /// Ethereum signing params.
 #[derive(Clone, Debug)]
 pub struct EthereumSigningParams {

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -22,7 +22,7 @@ use crate::rpc::SubstrateRpc;
 use crate::substrate_client::{SubstrateConnectionParams, SubstrateRpcClient};
 use crate::substrate_types::{Hash as SubstrateHash, Header as SubstrateHeader, SubstrateHeaderId};
 use crate::sync_types::HeaderId;
-use crate::utils::try_connect_to_sub_client;
+use crate::utils::{try_connect_to_eth_client, try_connect_to_sub_client};
 
 use codec::{Decode, Encode};
 use num_traits::Zero;
@@ -64,8 +64,8 @@ pub fn run(params: EthereumDeployContractParams) {
 	} = params;
 
 	let result = local_pool.run_until(async move {
-		let eth_client = EthereumRpcClient::new(eth_params);
 		let sub_client = try_connect_to_sub_client(sub_params, instance).await?;
+		let eth_client = try_connect_to_eth_client(eth_params).await?;
 
 		let (initial_header_id, initial_header) = prepare_initial_header(&sub_client, sub_initial_header).await?;
 		let initial_set_id = sub_initial_authorities_set_id.unwrap_or(0);

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -89,7 +89,6 @@ pub fn run(params: EthereumDeployContractParams) {
 	let result = local_pool.run_until(async move {
 		let eth_client = EthereumRpcClient::new(eth_params);
 		let sub_client = try_connect_to_sub_client(sub_params, instance).await?;
-		// let sub_client = SubstrateRpcClient::new(sub_params, instance).await?;
 
 		let (initial_header_id, initial_header) = prepare_initial_header(&sub_client, sub_initial_header).await?;
 		let initial_set_id = sub_initial_authorities_set_id.unwrap_or(0);

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -45,8 +45,7 @@ pub struct EthereumDeployContractParams {
 	/// Initial header.
 	pub sub_initial_header: Option<Vec<u8>>,
 	/// Instance of the bridge pallet being synchronized.
-	// No instance info is used here, maybe make optional
-	pub instance: SupportedInstance, // Box<dyn BridgeInstance>,
+	pub instance: SupportedInstance,
 }
 
 /// Deploy Bridge contract on Ethereum chain.

--- a/relays/ethereum/src/ethereum_exchange.rs
+++ b/relays/ethereum/src/ethereum_exchange.rs
@@ -38,7 +38,6 @@ use crate::sync_types::HeaderId;
 use crate::utils::try_connect_to_sub_client;
 
 use async_trait::async_trait;
-use backoff::{future::FutureOperation, ExponentialBackoff};
 use bp_currency_exchange::MaybeLockFundsTransaction;
 use bridge_node_runtime::exchange::EthereumTransactionInclusionProof;
 use std::time::Duration;

--- a/relays/ethereum/src/ethereum_exchange_submit.rs
+++ b/relays/ethereum/src/ethereum_exchange_submit.rs
@@ -20,11 +20,14 @@ use crate::ethereum_client::{EthereumConnectionParams, EthereumRpcClient, Ethere
 use crate::ethereum_types::{CallRequest, U256};
 use crate::rpc::EthereumRpc;
 
+use backoff::{future::FutureOperation, ExponentialBackoff};
 use bp_eth_poa::{
 	signatures::{SecretKey, SignTransaction},
 	UnsignedTransaction,
 };
 use bridge_node_runtime::exchange::LOCK_FUNDS_ADDRESS;
+
+use std::time::Duration;
 
 /// Ethereum exchange transaction params.
 #[derive(Debug)]
@@ -54,16 +57,29 @@ pub fn run(params: EthereumExchangeSubmitParams) {
 	} = params;
 
 	let result: Result<_, String> = local_pool.run_until(async move {
-		let eth_client = EthereumRpcClient::new(eth_params);
-
+		let eth_client = EthereumRpcClient::new(eth_params.clone());
 		let eth_signer_address = eth_sign.signer.address();
+
+		// We take this chance to ensure that we have a connection with an Ethereum node, even
+		// if we don't actually end up using this nonce (because of a user override).
+		let current_nonce = (|| async {
+			let wait = Duration::from_secs(1);
+			let eth_client_fut = eth_client.account_nonce(eth_signer_address);
+			async_std::future::timeout(wait, eth_client_fut)
+				.await
+				.map_err(backoff::Error::Transient)
+		})
+		.retry_notify(
+			ExponentialBackoff::default(),
+			|_, _| log::warn!(target: "bridge", "Failed to connect to Ethereum client at {}, trying again...", &eth_params),
+		)
+		.await
+		.map_err(|err| format!("error fetching acount nonce: {:?}", err))??;
+
 		let sub_recipient_encoded = sub_recipient;
 		let nonce = match eth_nonce {
 			Some(eth_nonce) => eth_nonce,
-			None => eth_client
-				.account_nonce(eth_signer_address)
-				.await
-				.map_err(|err| format!("error fetching acount nonce: {:?}", err))?,
+			None => current_nonce,
 		};
 		let gas = eth_client
 			.estimate_gas(CallRequest {

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -193,7 +193,7 @@ pub fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
 
 	let mut local_pool = futures::executor::LocalPool::new();
 	let sub_client =
-		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await.expect("TODO") });
+		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await })?;
 
 	let sign_sub_transactions = match sync_params.target_tx_mode {
 		TargetTransactionMode::Signed | TargetTransactionMode::Backup => true,

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -192,8 +192,7 @@ pub fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
 	let eth_client = EthereumRpcClient::new(eth_params);
 
 	let mut local_pool = futures::executor::LocalPool::new();
-	let sub_client =
-		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await })?;
+	let sub_client = local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await })?;
 
 	let sign_sub_transactions = match sync_params.target_tx_mode {
 		TargetTransactionMode::Signed | TargetTransactionMode::Backup => true,

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -72,7 +72,7 @@ pub struct EthereumSyncParams {
 	/// Metrics parameters.
 	pub metrics_params: Option<MetricsParams>,
 	/// Instance of the bridge pallet being synchronized.
-	pub instance: SupportedInstance, // Box<dyn BridgeInstance>,
+	pub instance: SupportedInstance,
 }
 
 /// Ethereum client as headers source.

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -209,8 +209,10 @@ pub fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
 	} = params;
 
 	let eth_client = EthereumRpcClient::new(eth_params);
-	let client_fut = try_connect_to_sub_client(sub_params, instance);
-	let sub_client = async_std::task::block_on(client_fut).unwrap();
+
+	let mut local_pool = futures::executor::LocalPool::new();
+	let sub_client =
+		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await.expect("TODO") });
 
 	let sign_sub_transactions = match sync_params.target_tx_mode {
 		TargetTransactionMode::Signed | TargetTransactionMode::Backup => true,

--- a/relays/ethereum/src/instances.rs
+++ b/relays/ethereum/src/instances.rs
@@ -42,7 +42,7 @@ pub trait BridgeInstance: Send + Sync + std::fmt::Debug {
 	fn build_currency_exchange_call(&self, proof: Proof) -> Call;
 }
 
-/// TODO
+/// Different instances supported by the relay.
 #[derive(Debug, Clone)]
 pub enum SupportedInstance {
 	Rialto,

--- a/relays/ethereum/src/instances.rs
+++ b/relays/ethereum/src/instances.rs
@@ -42,6 +42,22 @@ pub trait BridgeInstance: Send + Sync + std::fmt::Debug {
 	fn build_currency_exchange_call(&self, proof: Proof) -> Call;
 }
 
+/// TODO
+#[derive(Debug, Clone)]
+pub enum SupportedInstance {
+	Rialto,
+	Kovan,
+}
+
+impl From<&SupportedInstance> for Box<dyn BridgeInstance> {
+	fn from(i: &SupportedInstance) -> Self {
+		match i {
+			SupportedInstance::Rialto => Box::new(Rialto),
+			SupportedInstance::Kovan => Box::new(Kovan),
+		}
+	}
+}
+
 /// Corresponds to the Rialto instance used in the bridge runtime.
 #[derive(Default, Clone, Debug)]
 pub struct Rialto;

--- a/relays/ethereum/src/main.rs
+++ b/relays/ethereum/src/main.rs
@@ -46,7 +46,7 @@ use ethereum_exchange::EthereumExchangeParams;
 use ethereum_exchange_submit::EthereumExchangeSubmitParams;
 use ethereum_sync_loop::EthereumSyncParams;
 use hex_literal::hex;
-use instances::{BridgeInstance, Kovan, Rialto};
+use instances::SupportedInstance;
 use parity_crypto::publickey::{KeyPair, Secret};
 use sp_core::crypto::Pair;
 use substrate_client::{SubstrateConnectionParams, SubstrateSigningParams};
@@ -398,11 +398,11 @@ fn metrics_params(matches: &clap::ArgMatches) -> Result<Option<metrics::MetricsP
 	Ok(Some(metrics_params))
 }
 
-fn instance_params(matches: &clap::ArgMatches) -> Result<Box<dyn BridgeInstance>, String> {
-	let instance: Box<dyn BridgeInstance> = if let Some(instance) = matches.value_of("sub-pallet-instance") {
+fn instance_params(matches: &clap::ArgMatches) -> Result<SupportedInstance, String> {
+	let instance: SupportedInstance = if let Some(instance) = matches.value_of("sub-pallet-instance") {
 		match instance.to_lowercase().as_str() {
-			"rialto" => Box::new(Rialto::default()),
-			"kovan" => Box::new(Kovan::default()),
+			"rialto" => SupportedInstance::Rialto,
+			"kovan" => SupportedInstance::Kovan,
 			_ => return Err("Unsupported bridge pallet instance".to_string()),
 		}
 	} else {

--- a/relays/ethereum/src/main.rs
+++ b/relays/ethereum/src/main.rs
@@ -351,14 +351,18 @@ fn ethereum_exchange_params(matches: &clap::ArgMatches) -> Result<EthereumExchan
 				.parse()
 				.map_err(|e| format!("Failed to parse eth-tx-hash: {}", e))?,
 		),
-		None => ethereum_exchange::ExchangeRelayMode::Auto(match matches.value_of("eth-start-with-block") {
-			Some(eth_start_with_block) => Some(
-				eth_start_with_block
-					.parse()
-					.map_err(|e| format!("Failed to parse eth-start-with-block: {}", e))?,
-			),
-			None => None,
-		}),
+		None => {
+			let start_block = match matches.value_of("eth-start-with-block") {
+				Some(eth_start_with_block) => Some(
+					eth_start_with_block
+						.parse()
+						.map_err(|e| format!("Failed to parse eth-start-with-block: {}", e))?,
+				),
+				None => None,
+			};
+
+			ethereum_exchange::ExchangeRelayMode::Auto(start_block)
+		}
 	};
 
 	let params = EthereumExchangeParams {

--- a/relays/ethereum/src/main.rs
+++ b/relays/ethereum/src/main.rs
@@ -106,7 +106,7 @@ fn main() {
 			ethereum_exchange_submit::run(match ethereum_exchange_submit_params(&eth_exchange_submit_matches) {
 				Ok(eth_exchange_submit_params) => eth_exchange_submit_params,
 				Err(err) => {
-					log::error!(target: "bridge", "Error submitting Eethereum exchange transaction: {}", err);
+					log::error!(target: "bridge", "Error submitting Ethereum exchange transaction: {}", err);
 					return;
 				}
 			});

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -60,6 +60,12 @@ impl Default for SubstrateConnectionParams {
 	}
 }
 
+impl std::fmt::Display for SubstrateConnectionParams {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "{}:{}", self.host, self.port)
+	}
+}
+
 /// Substrate signing params.
 #[derive(Clone)]
 pub struct SubstrateSigningParams {

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -196,7 +196,7 @@ pub fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
 
 	let mut local_pool = futures::executor::LocalPool::new();
 	let sub_client =
-		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await.expect("TODO") });
+		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await })?;
 
 	let target = EthereumHeadersTarget::new(eth_client, eth_contract_address, eth_sign);
 	let source = SubstrateHeadersSource::new(sub_client);

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -212,8 +212,10 @@ pub fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
 	} = params;
 
 	let eth_client = EthereumRpcClient::new(eth_params);
-	// let sub_client = async_std::task::block_on(async { SubstrateRpcClient::new(sub_params, instance).await })?;
-	let sub_client = async_std::task::block_on(try_connect_to_sub_client(sub_params, instance)).unwrap();
+
+	let mut local_pool = futures::executor::LocalPool::new();
+	let sub_client =
+		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await.expect("TODO") });
 
 	let target = EthereumHeadersTarget::new(eth_client, eth_contract_address, eth_sign);
 	let source = SubstrateHeadersSource::new(sub_client);

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -69,7 +69,7 @@ pub struct SubstrateSyncParams {
 	/// Metrics parameters.
 	pub metrics_params: Option<MetricsParams>,
 	/// Instance of the bridge pallet being synchronized.
-	pub instance: SupportedInstance, //Box<dyn BridgeInstance>,
+	pub instance: SupportedInstance,
 }
 
 /// Substrate client as headers source.

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -195,8 +195,7 @@ pub fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
 	let eth_client = EthereumRpcClient::new(eth_params);
 
 	let mut local_pool = futures::executor::LocalPool::new();
-	let sub_client =
-		local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await })?;
+	let sub_client = local_pool.run_until(async move { try_connect_to_sub_client(sub_params, instance).await })?;
 
 	let target = EthereumHeadersTarget::new(eth_client, eth_contract_address, eth_sign);
 	let source = SubstrateHeadersSource::new(sub_client);

--- a/relays/ethereum/src/utils.rs
+++ b/relays/ethereum/src/utils.rs
@@ -21,28 +21,6 @@ use std::time::Duration;
 /// same request again.
 const MAX_BACKOFF_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Macro that returns (client, Err(error)) tuple from function if result is Err(error).
-#[macro_export]
-macro_rules! bail_on_error {
-	($result: expr) => {
-		match $result {
-			(client, Ok(result)) => (client, result),
-			(client, Err(error)) => return (client, Err(error)),
-			}
-	};
-}
-
-/// Macro that returns (client, Err(error)) tuple from function if result is Err(error).
-#[macro_export]
-macro_rules! bail_on_arg_error {
-	($result: expr, $client: ident) => {
-		match $result {
-			Ok(result) => result,
-			Err(error) => return ($client, Err(error)),
-			}
-	};
-}
-
 /// Error type that can signal connection errors.
 pub trait MaybeConnectionError {
 	/// Returns true if error (maybe) represents connection error.

--- a/relays/ethereum/src/utils.rs
+++ b/relays/ethereum/src/utils.rs
@@ -115,6 +115,5 @@ pub async fn try_connect_to_sub_client(
 		ExponentialBackoff::default(),
 		|_, _| log::warn!(target: "bridge", "Failed to connect to Substrate client at {}, trying again...", &params),
 	)
-	.await
-	.expect("TODO")
+	.await?
 }


### PR DESCRIPTION
At the moment if we start the relayer without a Substrate or Ethereum node running it will block the current thread forever. Even if a node is brought up afterwards it isn't able to connect to it since it never retries the connection. This PR aims to implement some sort of re-try mechanism for the relayer so we don't end up stuck forever.

I've been seeing this with our Rialto deployment when running the relayer in various configurations. This is because while `docker-compose` spins up nodes in the "correct" order the relayers may occasionally be brought up too early.