### PR TITLE
Introduce Minimal Header Chain: Proving Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 name = "bp-header-chain"
 version = "0.1.0"
 dependencies = [
- "frame-support",
+ "parity-scale-codec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-header-chain"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+]
+
+[[package]]
 name = "bridge-node"
 version = "0.1.0"
 dependencies = [
@@ -667,6 +674,7 @@ version = "0.1.0"
 dependencies = [
  "bp-currency-exchange",
  "bp-eth-poa",
+ "bp-header-chain",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,6 +3644,7 @@ name = "pallet-bridge-currency-exchange"
 version = "0.1.0"
 dependencies = [
  "bp-currency-exchange",
+ "bp-header-chain",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -206,6 +206,11 @@ version = "0.1.0"
 default-features = false
 path = "../../../primitives/ethereum-poa"
 
+[dependencies.bp-header-chain]
+version = "0.1.0"
+default-features = false
+path = "../../../primitives/header-chain"
+
 # Dev Dependencies
 
 [dev-dependencies.libsecp256k1]

--- a/bin/node/runtime/src/kovan.rs
+++ b/bin/node/runtime/src/kovan.rs
@@ -17,7 +17,7 @@
 use crate::exchange::EthereumTransactionInclusionProof;
 
 use bp_eth_poa::{Address, Header, RawTransaction, U256};
-use bp_header_chain::MinimalHeaderChain;
+use bp_header_chain::BaseHeaderChain;
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
 use pallet_bridge_eth_poa::{
@@ -137,7 +137,7 @@ impl BridgePruningStrategy for PruningStrategy {
 /// The Kovan Blockchain as seen by the runtime.
 pub struct KovanBlockchain;
 
-impl MinimalHeaderChain for KovanBlockchain {
+impl BaseHeaderChain for KovanBlockchain {
 	type Transaction = RawTransaction;
 	type TransactionInclusionProof = EthereumTransactionInclusionProof;
 

--- a/bin/node/runtime/src/kovan.rs
+++ b/bin/node/runtime/src/kovan.rs
@@ -17,9 +17,9 @@
 use crate::exchange::EthereumTransactionInclusionProof;
 
 use bp_eth_poa::{Address, Header, RawTransaction, U256};
+use bp_header_chain::MinimalHeaderChain;
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
-use pallet_bridge_currency_exchange::PeerBlockchain;
 use pallet_bridge_eth_poa::{
 	AuraConfiguration, PruningStrategy as BridgePruningStrategy, ValidatorsConfiguration, ValidatorsSource,
 };
@@ -137,7 +137,7 @@ impl BridgePruningStrategy for PruningStrategy {
 /// The Kovan Blockchain as seen by the runtime.
 pub struct KovanBlockchain;
 
-impl PeerBlockchain for KovanBlockchain {
+impl MinimalHeaderChain for KovanBlockchain {
 	type Transaction = RawTransaction;
 	type TransactionInclusionProof = EthereumTransactionInclusionProof;
 

--- a/bin/node/runtime/src/rialto.rs
+++ b/bin/node/runtime/src/rialto.rs
@@ -17,9 +17,9 @@
 use crate::exchange::EthereumTransactionInclusionProof;
 
 use bp_eth_poa::{Address, Header, RawTransaction, U256};
+use bp_header_chain::MinimalHeaderChain;
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
-use pallet_bridge_currency_exchange::PeerBlockchain;
 use pallet_bridge_eth_poa::{
 	AuraConfiguration, PruningStrategy as TPruningStrategy, ValidatorsConfiguration, ValidatorsSource,
 };
@@ -110,7 +110,7 @@ impl TPruningStrategy for PruningStrategy {
 /// The Rialto Blockchain as seen by the runtime.
 pub struct RialtoBlockchain;
 
-impl PeerBlockchain for RialtoBlockchain {
+impl MinimalHeaderChain for RialtoBlockchain {
 	type Transaction = RawTransaction;
 	type TransactionInclusionProof = EthereumTransactionInclusionProof;
 

--- a/bin/node/runtime/src/rialto.rs
+++ b/bin/node/runtime/src/rialto.rs
@@ -17,7 +17,7 @@
 use crate::exchange::EthereumTransactionInclusionProof;
 
 use bp_eth_poa::{Address, Header, RawTransaction, U256};
-use bp_header_chain::MinimalHeaderChain;
+use bp_header_chain::BaseHeaderChain;
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
 use pallet_bridge_eth_poa::{
@@ -110,7 +110,7 @@ impl TPruningStrategy for PruningStrategy {
 /// The Rialto Blockchain as seen by the runtime.
 pub struct RialtoBlockchain;
 
-impl MinimalHeaderChain for RialtoBlockchain {
+impl BaseHeaderChain for RialtoBlockchain {
 	type Transaction = RawTransaction;
 	type TransactionInclusionProof = EthereumTransactionInclusionProof;
 

--- a/modules/currency-exchange/Cargo.toml
+++ b/modules/currency-exchange/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 bp-currency-exchange = { path = "../../primitives/currency-exchange", default-features = false }
+bp-header-chain = { path = "../../primitives/header-chain", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 serde = { version = "1.0", optional = true }
 

--- a/modules/currency-exchange/src/benchmarking.rs
+++ b/modules/currency-exchange/src/benchmarking.rs
@@ -18,7 +18,7 @@
 //! So we are giving runtime opportunity to prepare environment and construct proof
 //! before invoking module calls.
 
-use super::{Call, Instance, Module as CurrencyExchangeModule, MinimalHeaderChain, Trait as CurrencyExchangeTrait};
+use super::{Call, Instance, MinimalHeaderChain, Module as CurrencyExchangeModule, Trait as CurrencyExchangeTrait};
 use sp_std::prelude::*;
 
 use frame_benchmarking::{account, benchmarks_instance};

--- a/modules/currency-exchange/src/benchmarking.rs
+++ b/modules/currency-exchange/src/benchmarking.rs
@@ -18,7 +18,7 @@
 //! So we are giving runtime opportunity to prepare environment and construct proof
 //! before invoking module calls.
 
-use super::{Call, Instance, MinimalHeaderChain, Module as CurrencyExchangeModule, Trait as CurrencyExchangeTrait};
+use super::{BaseHeaderChain, Call, Instance, Module as CurrencyExchangeModule, Trait as CurrencyExchangeTrait};
 use sp_std::prelude::*;
 
 use frame_benchmarking::{account, benchmarks_instance};
@@ -50,7 +50,7 @@ pub trait Trait<I: Instance>: CurrencyExchangeTrait<I> {
 	/// Prepare proof for importing exchange transaction.
 	fn make_proof(
 		proof_params: ProofParams<Self::AccountId>,
-	) -> <<Self as CurrencyExchangeTrait<I>>::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof;
+	) -> <<Self as CurrencyExchangeTrait<I>>::PeerBlockchain as BaseHeaderChain>::TransactionInclusionProof;
 }
 
 benchmarks_instance! {

--- a/modules/currency-exchange/src/benchmarking.rs
+++ b/modules/currency-exchange/src/benchmarking.rs
@@ -18,7 +18,7 @@
 //! So we are giving runtime opportunity to prepare environment and construct proof
 //! before invoking module calls.
 
-use super::{Call, Instance, Module as CurrencyExchangeModule, PeerBlockchain, Trait as CurrencyExchangeTrait};
+use super::{Call, Instance, Module as CurrencyExchangeModule, MinimalHeaderChain, Trait as CurrencyExchangeTrait};
 use sp_std::prelude::*;
 
 use frame_benchmarking::{account, benchmarks_instance};
@@ -50,7 +50,7 @@ pub trait Trait<I: Instance>: CurrencyExchangeTrait<I> {
 	/// Prepare proof for importing exchange transaction.
 	fn make_proof(
 		proof_params: ProofParams<Self::AccountId>,
-	) -> <<Self as CurrencyExchangeTrait<I>>::PeerBlockchain as PeerBlockchain>::TransactionInclusionProof;
+	) -> <<Self as CurrencyExchangeTrait<I>>::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof;
 }
 
 benchmarks_instance! {

--- a/modules/currency-exchange/src/lib.rs
+++ b/modules/currency-exchange/src/lib.rs
@@ -21,7 +21,7 @@
 use bp_currency_exchange::{
 	CurrencyConverter, DepositInto, Error as ExchangeError, MaybeLockFundsTransaction, RecipientsMap,
 };
-use bp_header_chain::MinimalHeaderChain;
+use bp_header_chain::BaseHeaderChain;
 use frame_support::{decl_error, decl_module, decl_storage, ensure};
 use sp_runtime::DispatchResult;
 
@@ -39,10 +39,10 @@ pub trait Trait<I = DefaultInstance>: frame_system::Trait {
 	/// Handler for transaction submission result.
 	type OnTransactionSubmitted: OnTransactionSubmitted<Self::AccountId>;
 	/// Represents the blockchain that we'll be exchanging currency with.
-	type PeerBlockchain: MinimalHeaderChain;
+	type PeerBlockchain: BaseHeaderChain;
 	/// Peer blockchain transaction parser.
 	type PeerMaybeLockFundsTransaction: MaybeLockFundsTransaction<
-		Transaction = <Self::PeerBlockchain as MinimalHeaderChain>::Transaction,
+		Transaction = <Self::PeerBlockchain as BaseHeaderChain>::Transaction,
 	>;
 	/// Map between blockchains recipients.
 	type RecipientsMap: RecipientsMap<
@@ -89,7 +89,7 @@ decl_module! {
 		#[weight = 0] // TODO: update me (https://github.com/paritytech/parity-bridges-common/issues/78)
 		pub fn import_peer_transaction(
 			origin,
-			proof: <<T as Trait<I>>::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof,
+			proof: <<T as Trait<I>>::PeerBlockchain as BaseHeaderChain>::TransactionInclusionProof,
 		) -> DispatchResult {
 			let submitter = frame_system::ensure_signed(origin)?;
 
@@ -134,9 +134,7 @@ decl_storage! {
 impl<T: Trait<I>, I: Instance> Module<T, I> {
 	/// Returns true if currency exchange module is able to import given transaction proof in
 	/// its current state.
-	pub fn filter_transaction_proof(
-		proof: &<T::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof,
-	) -> bool {
+	pub fn filter_transaction_proof(proof: &<T::PeerBlockchain as BaseHeaderChain>::TransactionInclusionProof) -> bool {
 		if let Err(err) = prepare_deposit_details::<T, I>(proof) {
 			frame_support::debug::trace!(
 				target: "runtime",
@@ -182,7 +180,7 @@ struct DepositDetails<T: Trait<I>, I: Instance> {
 /// Verify and parse transaction proof, preparing everything required for importing
 /// this transaction proof.
 fn prepare_deposit_details<T: Trait<I>, I: Instance>(
-	proof: &<<T as Trait<I>>::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof,
+	proof: &<<T as Trait<I>>::PeerBlockchain as BaseHeaderChain>::TransactionInclusionProof,
 ) -> Result<DepositDetails<T, I>, Error<T, I>> {
 	// ensure that transaction is included in finalized block that we know of
 	let transaction = <T as Trait<I>>::PeerBlockchain::verify_transaction_inclusion_proof(proof)
@@ -241,7 +239,7 @@ mod tests {
 
 	pub struct DummyBlockchain;
 
-	impl MinimalHeaderChain for DummyBlockchain {
+	impl BaseHeaderChain for DummyBlockchain {
 		type Transaction = RawTransaction;
 		type TransactionInclusionProof = (bool, RawTransaction);
 

--- a/modules/currency-exchange/src/lib.rs
+++ b/modules/currency-exchange/src/lib.rs
@@ -21,7 +21,8 @@
 use bp_currency_exchange::{
 	CurrencyConverter, DepositInto, Error as ExchangeError, MaybeLockFundsTransaction, RecipientsMap,
 };
-use frame_support::{decl_error, decl_module, decl_storage, ensure, Parameter};
+use bp_header_chain::MinimalHeaderChain;
+use frame_support::{decl_error, decl_module, decl_storage, ensure};
 use sp_runtime::DispatchResult;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -33,28 +34,15 @@ pub trait OnTransactionSubmitted<AccountId> {
 	fn on_valid_transaction_submitted(submitter: AccountId);
 }
 
-/// Peer blockchain interface.
-pub trait PeerBlockchain {
-	/// Transaction type.
-	type Transaction: Parameter;
-	/// Transaction inclusion proof type.
-	type TransactionInclusionProof: Parameter;
-
-	/// Verify that transaction is a part of given block.
-	///
-	/// Returns Some(transaction) if proof is valid and None otherwise.
-	fn verify_transaction_inclusion_proof(proof: &Self::TransactionInclusionProof) -> Option<Self::Transaction>;
-}
-
 /// The module configuration trait
 pub trait Trait<I = DefaultInstance>: frame_system::Trait {
 	/// Handler for transaction submission result.
 	type OnTransactionSubmitted: OnTransactionSubmitted<Self::AccountId>;
 	/// Represents the blockchain that we'll be exchanging currency with.
-	type PeerBlockchain: PeerBlockchain;
+	type PeerBlockchain: MinimalHeaderChain;
 	/// Peer blockchain transaction parser.
 	type PeerMaybeLockFundsTransaction: MaybeLockFundsTransaction<
-		Transaction = <Self::PeerBlockchain as PeerBlockchain>::Transaction,
+		Transaction = <Self::PeerBlockchain as MinimalHeaderChain>::Transaction,
 	>;
 	/// Map between blockchains recipients.
 	type RecipientsMap: RecipientsMap<
@@ -101,7 +89,7 @@ decl_module! {
 		#[weight = 0] // TODO: update me (https://github.com/paritytech/parity-bridges-common/issues/78)
 		pub fn import_peer_transaction(
 			origin,
-			proof: <<T as Trait<I>>::PeerBlockchain as PeerBlockchain>::TransactionInclusionProof,
+			proof: <<T as Trait<I>>::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof,
 		) -> DispatchResult {
 			let submitter = frame_system::ensure_signed(origin)?;
 
@@ -146,7 +134,9 @@ decl_storage! {
 impl<T: Trait<I>, I: Instance> Module<T, I> {
 	/// Returns true if currency exchange module is able to import given transaction proof in
 	/// its current state.
-	pub fn filter_transaction_proof(proof: &<T::PeerBlockchain as PeerBlockchain>::TransactionInclusionProof) -> bool {
+	pub fn filter_transaction_proof(
+		proof: &<T::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof,
+	) -> bool {
 		if let Err(err) = prepare_deposit_details::<T, I>(proof) {
 			frame_support::debug::trace!(
 				target: "runtime",
@@ -192,7 +182,7 @@ struct DepositDetails<T: Trait<I>, I: Instance> {
 /// Verify and parse transaction proof, preparing everything required for importing
 /// this transaction proof.
 fn prepare_deposit_details<T: Trait<I>, I: Instance>(
-	proof: &<<T as Trait<I>>::PeerBlockchain as PeerBlockchain>::TransactionInclusionProof,
+	proof: &<<T as Trait<I>>::PeerBlockchain as MinimalHeaderChain>::TransactionInclusionProof,
 ) -> Result<DepositDetails<T, I>, Error<T, I>> {
 	// ensure that transaction is included in finalized block that we know of
 	let transaction = <T as Trait<I>>::PeerBlockchain::verify_transaction_inclusion_proof(proof)
@@ -251,7 +241,7 @@ mod tests {
 
 	pub struct DummyBlockchain;
 
-	impl PeerBlockchain for DummyBlockchain {
+	impl MinimalHeaderChain for DummyBlockchain {
 		type Transaction = RawTransaction;
 		type TransactionInclusionProof = (bool, RawTransaction);
 

--- a/primitives/header-chain/Cargo.toml
+++ b/primitives/header-chain/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bp-header-chain"
+description = "A common interface for describing what a bridge pallet should be able to do."
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies.frame-support]
+version = "2.0.0-rc5"
+tag = 'v2.0.0-rc5'
+default-features = false
+git = "https://github.com/paritytech/substrate/"
+
+[features]
+default = ["std"]
+std = [
+	"frame-support/std",
+]

--- a/primitives/header-chain/Cargo.toml
+++ b/primitives/header-chain/Cargo.toml
@@ -6,14 +6,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
-[dependencies.frame-support]
-version = "2.0.0-rc5"
-tag = 'v2.0.0-rc5'
+[dependencies.parity-scale-codec]
+version = "1.3.1"
 default-features = false
-git = "https://github.com/paritytech/substrate/"
+features = ["derive"]
 
 [features]
 default = ["std"]
 std = [
-	"frame-support/std",
+	"parity-scale-codec/std",
 ]

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -33,5 +33,3 @@ pub trait MinimalHeaderChain {
 	/// Returns Some(transaction) if proof is valid and None otherwise.
 	fn verify_transaction_inclusion_proof(proof: &Self::TransactionInclusionProof) -> Option<Self::Transaction>;
 }
-
-

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -19,10 +19,19 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::Parameter;
+use core::clone::Clone;
+use core::cmp::Eq;
+use core::fmt::Debug;
+use parity_scale_codec::{Codec, EncodeLike};
+
+/// A type that can be used as a parameter in a dispatchable function.
+///
+/// When using `decl_module` all arguments for call functions must implement this trait.
+pub trait Parameter: Codec + EncodeLike + Clone + Eq + Debug {}
+impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + Debug {}
 
 /// A base trait for pallets which want to keep track of a full set of headers from a bridged chain.
-pub trait MinimalHeaderChain {
+pub trait BaseHeaderChain {
 	/// Transaction type.
 	type Transaction: Parameter;
 	/// Transaction inclusion proof type.

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -21,7 +21,7 @@
 
 use frame_support::Parameter;
 
-/// Beep boop
+/// A base trait for pallets which want to keep track of a full set of headers from a bridged chain.
 pub trait MinimalHeaderChain {
 	/// Transaction type.
 	type Transaction: Parameter;

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Defines traits which represent a common interface for Substrate pallets which want to
+//! incorporate bridge functionality.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::Parameter;
+
+/// Beep boop
+pub trait MinimalHeaderChain {
+	/// Transaction type.
+	type Transaction: Parameter;
+	/// Transaction inclusion proof type.
+	type TransactionInclusionProof: Parameter;
+
+	/// Verify that transaction is a part of given block.
+	///
+	/// Returns Some(transaction) if proof is valid and None otherwise.
+	fn verify_transaction_inclusion_proof(proof: &Self::TransactionInclusionProof) -> Option<Self::Transaction>;
+}
+
+


### PR DESCRIPTION
Supersedes #265. 

This takes another approach at the minimal headerchain trait. The current trait is just a proving interface for transaction proofs (previously known as `PeerBlockchain`), but it will grow in the future as we implement the Substrate bridge pallet. Maybe `MinimalHeaderChain` isn't the right name for the trait at the moment, but I'm being a bit forward thinking here.