### PR TITLE
Update jsonrpsee reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee"
 version = "1.0.0"
-source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#aed5c25a1850196f86e046228d2439b42c84ce6a"
+source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#99fb015dd9d678392dab8e90efdbd9b4a6b82fd9"
 dependencies = [
  "async-std",
  "bs58",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-proc-macros"
 version = "1.0.0"
-source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#aed5c25a1850196f86e046228d2439b42c84ce6a"
+source = "git+https://github.com/svyatonik/jsonrpsee.git?branch=shared-client-in-rpc-api#99fb015dd9d678392dab8e90efdbd9b4a6b82fd9"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
@@ -301,7 +301,8 @@
       "pluginVersion": "7.1.0",
       "targets": [
         {
-          "expr": "Ethereum_to_Substrate_Sync_process_cpu_usage_percentage",
+          "expr": "avg_over_time(Ethereum_to_Substrate_Exchange_process_cpu_usage_percentage[1m])",
+          "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-sub2eth-sync-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-sub2eth-sync-dashboard.json
@@ -301,7 +301,8 @@
       "pluginVersion": "7.1.0",
       "targets": [
         {
-          "expr": "Substrate_to_Ethereum_Sync_process_cpu_usage_percentage",
+          "expr": "avg_over_time(Substrate_to_Ethereum_Sync_process_cpu_usage_percentage[1m])",
+          "instant": true,
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
This PR brings updated `jsonrpsee` with fixed 100% CPU usage + adds transport errors propagation. All changes are in [this PR](https://github.com/svyatonik/jsonrpsee/pull/1).

I've also updated our CPU-related widgets a bit - they were showing average CPU usage over last 5m (iiuc). If everything would have worked perfectly, I'd prefer them to show CPU usage at this moment (which is just `"instant": true`). But this leads to issues with Grafana UI - sometimes it stops showing widget with error like ".toFixed() is not defined". So the solution is to show average CPU load for last 1m (instant=true + range=1m). For ranges less than 10s it sometimes shows "No Data" => I've left 1m