### PR TITLE
Remove errors from log

### DIFF
--- a/bin/node/runtime/src/exchange.rs
+++ b/bin/node/runtime/src/exchange.rs
@@ -81,7 +81,7 @@ impl MaybeLockFundsTransaction for EthTransaction {
 
 		// we only accept transactions sending funds directly to the pre-configured address
 		if tx.unsigned.to != Some(LOCK_FUNDS_ADDRESS.into()) {
-			frame_support::debug::error!(
+			frame_support::debug::trace!(
 				target: "runtime",
 				"Failed to parse fund locks transaction. Invalid peer recipient: {:?}",
 				tx.unsigned.to,
@@ -94,7 +94,7 @@ impl MaybeLockFundsTransaction for EthTransaction {
 		match tx.unsigned.payload.len() {
 			32 => recipient_raw.as_fixed_bytes_mut().copy_from_slice(&tx.unsigned.payload),
 			len => {
-				frame_support::debug::error!(
+				frame_support::debug::trace!(
 					target: "runtime",
 					"Failed to parse fund locks transaction. Invalid recipient length: {}",
 					len,
@@ -106,7 +106,7 @@ impl MaybeLockFundsTransaction for EthTransaction {
 		let amount = tx.unsigned.value.low_u128();
 
 		if tx.unsigned.value != amount.into() {
-			frame_support::debug::error!(
+			frame_support::debug::trace!(
 				target: "runtime",
 				"Failed to parse fund locks transaction. Invalid amount: {}",
 				tx.unsigned.value,

--- a/relays/ethereum/src/sync_loop.rs
+++ b/relays/ethereum/src/sync_loop.rs
@@ -334,7 +334,7 @@ pub fn run<P: HeadersSyncPipeline, TC: TargetClient<P>>(
 					log::debug!(target: "bridge", "Header submit result: {}", submitted_headers_str);
 
 					sync.headers_mut().headers_submitted(submitted_headers.submitted);
-					sync.headers_mut().add_incomplete_headers(submitted_headers.incomplete);
+					sync.headers_mut().add_incomplete_headers(false, submitted_headers.incomplete);
 
 					// when there's no fatal error, but node has rejected all our headers we may
 					// want to pause until our submitted headers will be accepted


### PR DESCRIPTION
There were two kinds of errors:
1) "Failed to parse fund locks transaction" from transactions relay - I've changed level from error to trace, because they're not errors - we're trying to parse every eth transaction;
2) errors caused by fact that I've been marking header incomplete (and thus synced) before it has been actually synced.