### PR TITLE
Fix stalled sync alert condition

### DIFF
--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-eth2sub-sync-dashboard.json
@@ -40,7 +40,7 @@
             },
             "reducer": {
               "params": [],
-              "type": "max"
+              "type": "min"
             },
             "type": "query"
           }

--- a/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-sub2eth-sync-dashboard.json
+++ b/deployments/rialto/dashboard/grafana/provisioning/dashboards/relay-sub2eth-sync-dashboard.json
@@ -40,7 +40,7 @@
             },
             "reducer": {
               "params": [],
-              "type": "max"
+              "type": "min"
             },
             "type": "query"
           }


### PR DESCRIPTION
Previous (`max`) reducer worked as follows:
1) at time T1 it has been selecting maximal difference in last 5 minutes. If there has been a moment in last 5 minutes where difference was larger than 5, alert switched to signaling mode;
2) at time T2 = T1+5m it has been doing the same. And if in `[T1; T2]` there has been a moment where difference was larger than 5, then alert started alerting.

But actually difference > 5-6 blocks is ok for sub2eth, because we're waiting for justification. So it is better to use `min` here - i.e. if there'll be at least 1 moment when diff is <=5, then we should consider sync as not stalled.