### PR TITLE
Fix (workaround) for "cannot read property 'toFixed' of null"

### DIFF
--- a/relays/ethereum/src/metrics.rs
+++ b/relays/ethereum/src/metrics.rs
@@ -150,7 +150,8 @@ impl GlobalMetrics {
 					memory_usage,
 				);
 
-				self.process_cpu_usage_percentage.set(if cpu_usage.is_finite() { cpu_usage } else { 0f64 });
+				self.process_cpu_usage_percentage
+					.set(if cpu_usage.is_finite() { cpu_usage } else { 0f64 });
 				self.process_memory_usage_bytes.set(memory_usage);
 			}
 			_ => {

--- a/relays/ethereum/src/metrics.rs
+++ b/relays/ethereum/src/metrics.rs
@@ -18,7 +18,7 @@ pub use substrate_prometheus_endpoint::{register, Counter, CounterVec, Gauge, Ga
 
 use std::net::SocketAddr;
 use substrate_prometheus_endpoint::init_prometheus;
-use sysinfo::{ProcessExt, System, SystemExt};
+use sysinfo::{ProcessExt, RefreshKind, System, SystemExt};
 
 /// Prometheus endpoint MetricsParams.
 #[derive(Debug, Clone)]
@@ -111,7 +111,7 @@ impl GlobalMetrics {
 	/// Creates global metrics.
 	pub fn new() -> Self {
 		GlobalMetrics {
-			system: System::new(),
+			system: System::new_with_specifics(RefreshKind::everything()),
 			system_average_load: GaugeVec::new(Opts::new("system_average_load", "System load average"), &["over"])
 				.expect("metric is static and thus valid; qed"),
 			process_cpu_usage_percentage: Gauge::new("process_cpu_usage_percentage", "Process CPU usage")
@@ -141,8 +141,17 @@ impl GlobalMetrics {
 		let is_process_refreshed = self.system.refresh_process(pid);
 		match (is_process_refreshed, self.system.get_process(pid)) {
 			(true, Some(process_info)) => {
-				self.process_cpu_usage_percentage.set(process_info.cpu_usage() as f64);
-				self.process_memory_usage_bytes.set(process_info.memory() * 1024);
+				let cpu_usage = process_info.cpu_usage() as f64;
+				let memory_usage = process_info.memory() * 1024;
+				log::trace!(
+					target: "bridge-metrics",
+					"Refreshed process metrics: CPU={}, memory={}",
+					cpu_usage,
+					memory_usage,
+				);
+
+				self.process_cpu_usage_percentage.set(if cpu_usage.is_finite() { cpu_usage } else { 0f64 });
+				self.process_memory_usage_bytes.set(memory_usage);
 			}
 			_ => {
 				log::warn!(


### PR DESCRIPTION
On our deployments, CPU widget still shows error from title. I've found that sometimes `sysinfo::Process::cpu_usage()` returns NaN. Haven't found anything in the `sysinfo` crate repo => used workaround:
```rust
if cpu_usage.is_finite() { cpu_usage } else { 0f64 }
```

The other change:
```rust
System::new_with_specifics(RefreshKind::everything())
```
fixes warning in logs on relay startup ("Failed to refresh process information. Metrics may show obsolete values").

I've also added a trace, but now it isn't that critical => under separate (`bridge-metrics`) target.