### PR TITLE
Dependabot ignore substrate updates.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,6 +7,12 @@ update_configs:
       - match:
           dependency_name: "sp-*"
       - match:
+          dependency_name: "sc-*"
+      - match:
+          dependency_name: "node-*"
+      - match:
+          dependency_name: "substrate-*"
+      - match:
           dependency_name: "frame-*"
       - match:
           dependency_name: "pallet-*"


### PR DESCRIPTION
Since we upgrade substrate manually anyway, we'd rather avoid dependabot spamming us with PRs.