### PR TITLE
Unpin Nightly Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,12 +44,6 @@ jobs:
         with:
           fetch-depth:             5
           submodules:              recursive
-      - name:                      Adding toolchain
-        if:                        matrix.toolchain == 'nightly'
-        run:                       rustup toolchain add ${{ matrix.toolchain }}
-      - name:                      Adding WASM
-        if:                        matrix.toolchain == 'nightly'
-        run:                       rustup target add wasm32-unknown-unknown --toolchain ${{ matrix.toolchain }}
       - name:                      Configure CARGO_HOME & CARGO_TARGET_DIR
         run:                       ./scripts/ci-cache.sh "${{ github.head_ref }}" "${{ matrix.toolchain }}"
       - name:                      Cache checking

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
         toolchain:
           - stable
           #- beta
-          - nightly-2020-07-27
+          - nightly
     runs-on:                       self-hosted
     container:
       image:                       paritytech/ci-linux:production
@@ -45,10 +45,10 @@ jobs:
           fetch-depth:             5
           submodules:              recursive
       - name:                      Adding toolchain
-        if:                        matrix.toolchain == 'nightly-2020-07-27'
+        if:                        matrix.toolchain == 'nightly'
         run:                       rustup toolchain add ${{ matrix.toolchain }}
       - name:                      Adding WASM
-        if:                        matrix.toolchain == 'nightly-2020-07-27'
+        if:                        matrix.toolchain == 'nightly'
         run:                       rustup target add wasm32-unknown-unknown --toolchain ${{ matrix.toolchain }}
       - name:                      Configure CARGO_HOME & CARGO_TARGET_DIR
         run:                       ./scripts/ci-cache.sh "${{ github.head_ref }}" "${{ matrix.toolchain }}"
@@ -78,11 +78,11 @@ jobs:
           toolchain:               ${{ matrix.toolchain }}
           args:                    --all  --verbose
       - name:                      Add clippy
-        if:                        matrix.toolchain == 'nightly-2020-07-27'
+        if:                        matrix.toolchain == 'nightly'
         run:                       rustup component add clippy --toolchain ${{ matrix.toolchain }}
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
-        if:                        matrix.toolchain == 'nightly-2020-07-27'
+        if:                        matrix.toolchain == 'nightly'
         with:
           command:                 clippy
           toolchain:               ${{ matrix.toolchain }}


### PR DESCRIPTION
While #321 has succeeded && fixed compilation, #299 has failed with:
```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
##[error]  --> /cache/dummy-ordered-pallet/nightly-2020-07-27/git/checkouts/substrate-7e08433d4c370a21/e00d78c/primitives/runtime-interface/src/impls.rs:44:1
   |
44 | assert_eq_size!(usize, u32);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: source type: `usize` (64 bits)
   = note: target type: `u32` (32 bits)
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
```

Probably that's because of old nightly? But why the #321 has succeeded then? Opening this PR to check if we still need to pin nightly