### PR TITLE
Whitelist extensions in CORS settings for PoA nodes

### DIFF
--- a/deployments/dev/poa-config/poa-node-config
+++ b/deployments/dev/poa-config/poa-node-config
@@ -8,6 +8,7 @@ password = ["./deployments/dev/poa-config/pass"]
 
 [rpc]
 apis = ["all"]
+cors = ["moz-extension://*", "chrome-extension://*"]
 
 [mining]
 force_sealing = true

--- a/deployments/rialto/poa-config/poa-node-config
+++ b/deployments/rialto/poa-config/poa-node-config
@@ -11,7 +11,7 @@ reserved_peers = "/config/reserved"
 
 [rpc]
 apis = ["all"]
-cors = ["all"]
+cors = ["moz-extension://*", "chrome-extension://*"]
 
 [mining]
 force_sealing = true

--- a/deployments/rialto/poa-config/poa-node-config
+++ b/deployments/rialto/poa-config/poa-node-config
@@ -11,6 +11,7 @@ reserved_peers = "/config/reserved"
 
 [rpc]
 apis = ["all"]
+cors = ["all"]
 
 [mining]
 force_sealing = true


### PR DESCRIPTION
That's to allow Metamask connecting to the node.
CC @Tbaut 