### PR TITLE
Bump default OpenEthereum commit for Docker images

### DIFF
--- a/deployments/rialto/OpenEthereum.Dockerfile
+++ b/deployments/rialto/OpenEthereum.Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /openethereum
 
 ### Build from the repo
 ARG ETHEREUM_REPO=https://github.com/paritytech/openethereum.git
-ARG ETHEREUM_HASH=4fecaa56da067e4c62aee76a6afb6be52754c1cf
+ARG ETHEREUM_HASH=344991dbba2bc8657b00916f0e4b029c66f159e8
 RUN git clone $ETHEREUM_REPO /openethereum && git checkout $ETHEREUM_HASH
 
 ### Build locally. Make sure to set the CONTEXT to main directory of the repo.

--- a/deployments/rialto/docker-compose.git.yml
+++ b/deployments/rialto/docker-compose.git.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: ./OpenEthereum.Dockerfile
       args:
-        ETHEREUM_HASH: ${ETHEREUM_HASH:-4fecaa56da067e4c62aee76a6afb6be52754c1cf}
+        ETHEREUM_HASH: ${ETHEREUM_HASH:-344991dbba2bc8657b00916f0e4b029c66f159e8}
         BRIDGE_HASH: ${ETH_BRIDGE_HASH:-master}
 
   poa-node-bertha:


### PR DESCRIPTION
The new OpenEthereum commit is a dependency bump, but without it OpenEthereum fails to build.