### PR TITLE
Rename Ethereum Headers to AuraHeader

### DIFF
--- a/bin/rialto-runtime/src/kovan.rs
+++ b/bin/rialto-runtime/src/kovan.rs
@@ -16,7 +16,7 @@
 
 use crate::exchange::EthereumTransactionInclusionProof;
 
-use bp_eth_poa::{Address, Header, RawTransaction, U256};
+use bp_eth_poa::{Address, AuraHeader, RawTransaction, U256};
 use bp_header_chain::BaseHeaderChain;
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
@@ -95,8 +95,8 @@ pub fn genesis_validators() -> Vec<Address> {
 }
 
 /// Genesis header of the Kovan chain.
-pub fn genesis_header() -> Header {
-	Header {
+pub fn genesis_header() -> AuraHeader {
+	AuraHeader {
 		parent_hash: Default::default(),
 		timestamp: 0,
 		number: 0,

--- a/bin/rialto-runtime/src/lib.rs
+++ b/bin/rialto-runtime/src/lib.rs
@@ -526,7 +526,7 @@ impl_runtime_apis! {
 			(finalized_block.number, finalized_block.hash)
 		}
 
-		fn is_import_requires_receipts(header: bp_eth_poa::Header) -> bool {
+		fn is_import_requires_receipts(header: bp_eth_poa::AuraHeader) -> bool {
 			BridgeRialto::is_import_requires_receipts(header)
 		}
 
@@ -546,7 +546,7 @@ impl_runtime_apis! {
 			(finalized_block.number, finalized_block.hash)
 		}
 
-		fn is_import_requires_receipts(header: bp_eth_poa::Header) -> bool {
+		fn is_import_requires_receipts(header: bp_eth_poa::AuraHeader) -> bool {
 			BridgeKovan::is_import_requires_receipts(header)
 		}
 

--- a/bin/rialto-runtime/src/rialto.rs
+++ b/bin/rialto-runtime/src/rialto.rs
@@ -16,7 +16,7 @@
 
 use crate::exchange::EthereumTransactionInclusionProof;
 
-use bp_eth_poa::{Address, Header, RawTransaction, U256};
+use bp_eth_poa::{Address, AuraHeader, RawTransaction, U256};
 use bp_header_chain::BaseHeaderChain;
 use frame_support::RuntimeDebug;
 use hex_literal::hex;
@@ -70,8 +70,8 @@ pub fn genesis_validators() -> Vec<Address> {
 /// ```bash
 /// $ http localhost:8545 jsonrpc=2.0 id=1 method=eth_getBlockByNumber params:='["earliest", false]' -v
 /// ```
-pub fn genesis_header() -> Header {
-	Header {
+pub fn genesis_header() -> AuraHeader {
+	AuraHeader {
 		parent_hash: Default::default(),
 		timestamp: 0,
 		number: 0,

--- a/deployments/types.json
+++ b/deployments/types.json
@@ -18,7 +18,7 @@
   },
   "StoredHeader": {
 	"submitter": "Option<Address>",
-	"header": "Header",
+	"header": "AuraHeader",
 	"total_difficulty": "U256",
 	"next_validator_set_id": "u64",
 	"last_signal_block": "Option<HeaderId>"

--- a/deployments/types.json
+++ b/deployments/types.json
@@ -23,7 +23,7 @@
 	"next_validator_set_id": "u64",
 	"last_signal_block": "Option<HeaderId>"
   },
-  "Header": {
+  "AuraHeader": {
 	"parent_hash": "Hash",
 	"timestamp": "u64",
 	"number": "u64",

--- a/modules/ethereum/src/benchmarking.rs
+++ b/modules/ethereum/src/benchmarking.rs
@@ -218,7 +218,7 @@ benchmarks_instance! {
 	}
 }
 
-fn initialize_bench<T: Trait<I>, I: Instance>(num_validators: usize) -> Header {
+fn initialize_bench<T: Trait<I>, I: Instance>(num_validators: usize) -> AuraHeader {
 	// Initialize storage with some initial header
 	let initial_header = build_genesis_header(&validator(0));
 	let initial_difficulty = initial_header.difficulty;

--- a/modules/ethereum/src/finality.rs
+++ b/modules/ethereum/src/finality.rs
@@ -16,7 +16,7 @@
 
 use crate::error::Error;
 use crate::Storage;
-use bp_eth_poa::{public_to_address, Address, Header, HeaderId, SealedEmptyStep, H256};
+use bp_eth_poa::{public_to_address, Address, AuraHeader, HeaderId, SealedEmptyStep, H256};
 use codec::{Decode, Encode};
 use sp_io::crypto::secp256k1_ecdsa_recover;
 use sp_runtime::RuntimeDebug;
@@ -37,7 +37,7 @@ pub struct CachedFinalityVotes<Submitter> {
 	pub stopped_at_finalized_sibling: bool,
 	/// Header ancestors that were read while we have been searching for
 	/// cached votes entry. Newest header has index 0.
-	pub unaccounted_ancestry: VecDeque<(HeaderId, Option<Submitter>, Header)>,
+	pub unaccounted_ancestry: VecDeque<(HeaderId, Option<Submitter>, AuraHeader)>,
 	/// Cached finality votes, if they have been found. The associated
 	/// header is not included into `unaccounted_ancestry`.
 	pub votes: Option<FinalityVotes<Submitter>>,
@@ -86,7 +86,7 @@ pub fn finalize_blocks<S: Storage>(
 	header_validators: (HeaderId, &[Address]),
 	id: HeaderId,
 	submitter: Option<&S::Submitter>,
-	header: &Header,
+	header: &AuraHeader,
 	two_thirds_majority_transition: u64,
 ) -> Result<FinalityEffects<S::Submitter>, Error> {
 	// compute count of voters for every unfinalized block in ancestry
@@ -145,7 +145,7 @@ fn prepare_votes<Submitter>(
 	best_finalized: HeaderId,
 	validators: &BTreeSet<&Address>,
 	id: HeaderId,
-	header: &Header,
+	header: &AuraHeader,
 	submitter: Option<Submitter>,
 ) -> Result<FinalityVotes<Submitter>, Error> {
 	// if we have reached finalized block sibling, then we're trying
@@ -243,7 +243,7 @@ fn remove_signers_votes(signers_to_remove: &BTreeSet<Address>, votes: &mut BTree
 }
 
 /// Returns unique set of empty steps signers.
-fn empty_steps_signers(header: &Header) -> BTreeSet<Address> {
+fn empty_steps_signers(header: &AuraHeader) -> BTreeSet<Address> {
 	header
 		.empty_steps()
 		.into_iter()
@@ -298,7 +298,7 @@ mod tests {
 					(Default::default(), &[]),
 					Default::default(),
 					None,
-					&Header::default(),
+					&AuraHeader::default(),
 					0,
 				),
 				Err(Error::NotValidator),

--- a/modules/ethereum/src/import.rs
+++ b/modules/ethereum/src/import.rs
@@ -19,7 +19,7 @@ use crate::finality::finalize_blocks;
 use crate::validators::{Validators, ValidatorsConfiguration};
 use crate::verification::{is_importable_header, verify_aura_header};
 use crate::{AuraConfiguration, ChangeToEnact, PruningStrategy, Storage};
-use bp_eth_poa::{Header, HeaderId, Receipt};
+use bp_eth_poa::{AuraHeader, HeaderId, Receipt};
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 /// Imports bunch of headers and updates blocks finality.
@@ -37,7 +37,7 @@ pub fn import_headers<S: Storage, PS: PruningStrategy>(
 	aura_config: &AuraConfiguration,
 	validators_config: &ValidatorsConfiguration,
 	submitter: Option<S::Submitter>,
-	headers: Vec<(Header, Option<Vec<Receipt>>)>,
+	headers: Vec<(AuraHeader, Option<Vec<Receipt>>)>,
 	finalized_headers: &mut BTreeMap<S::Submitter, u64>,
 ) -> Result<(u64, u64), Error> {
 	let mut useful = 0;
@@ -85,7 +85,7 @@ pub fn import_header<S: Storage, PS: PruningStrategy>(
 	aura_config: &AuraConfiguration,
 	validators_config: &ValidatorsConfiguration,
 	submitter: Option<S::Submitter>,
-	header: Header,
+	header: AuraHeader,
 	receipts: Option<Vec<Receipt>>,
 ) -> Result<(HeaderId, FinalizedHeaders<S>), Error> {
 	// first check that we are able to import this header at all
@@ -153,7 +153,7 @@ pub fn import_header<S: Storage, PS: PruningStrategy>(
 pub fn header_import_requires_receipts<S: Storage>(
 	storage: &S,
 	validators_config: &ValidatorsConfiguration,
-	header: &Header,
+	header: &AuraHeader,
 ) -> bool {
 	is_importable_header(storage, header)
 		.map(|_| Validators::new(validators_config))
@@ -391,7 +391,7 @@ mod tests {
 	fn import_custom_block<S: Storage>(
 		storage: &mut S,
 		validators: &[SecretKey],
-		header: Header,
+		header: AuraHeader,
 	) -> Result<HeaderId, Error> {
 		let id = header.compute_id();
 		import_header(

--- a/modules/ethereum/src/mock.rs
+++ b/modules/ethereum/src/mock.rs
@@ -19,7 +19,7 @@ pub use bp_eth_poa::signatures::secret_to_address;
 
 use crate::validators::{ValidatorsConfiguration, ValidatorsSource};
 use crate::{AuraConfiguration, GenesisConfig, PruningStrategy, Trait};
-use bp_eth_poa::{Address, Header, H256, U256};
+use bp_eth_poa::{Address, AuraHeader, H256, U256};
 use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
 use secp256k1::SecretKey;
 use sp_runtime::{
@@ -89,7 +89,7 @@ impl Trait for TestRuntime {
 /// Test context.
 pub struct TestContext {
 	/// Initial (genesis) header.
-	pub genesis: Header,
+	pub genesis: AuraHeader,
 	/// Number of initial validators.
 	pub total_validators: usize,
 	/// Secret keys of validators, ordered by validator index.
@@ -118,7 +118,7 @@ pub fn test_validators_config() -> ValidatorsConfiguration {
 }
 
 /// Genesis header that is used in tests by default.
-pub fn genesis() -> Header {
+pub fn genesis() -> AuraHeader {
 	HeaderBuilder::genesis().sign_by(&validator(0))
 }
 
@@ -128,7 +128,11 @@ pub fn run_test<T>(total_validators: usize, test: impl FnOnce(TestContext) -> T)
 }
 
 /// Run test with default genesis header.
-pub fn run_test_with_genesis<T>(genesis: Header, total_validators: usize, test: impl FnOnce(TestContext) -> T) -> T {
+pub fn run_test_with_genesis<T>(
+	genesis: AuraHeader,
+	total_validators: usize,
+	test: impl FnOnce(TestContext) -> T,
+) -> T {
 	let validators = validators(total_validators);
 	let addresses = validators_addresses(total_validators);
 	sp_io::TestExternalities::new(

--- a/modules/ethereum/src/validators.rs
+++ b/modules/ethereum/src/validators.rs
@@ -16,7 +16,7 @@
 
 use crate::error::Error;
 use crate::{ChangeToEnact, Storage};
-use bp_eth_poa::{Address, Header, HeaderId, LogEntry, Receipt, U256};
+use bp_eth_poa::{Address, AuraHeader, HeaderId, LogEntry, Receipt, U256};
 use sp_std::prelude::*;
 
 /// The hash of InitiateChange event of the validators set contract.
@@ -65,7 +65,7 @@ impl<'a> Validators<'a> {
 
 	/// Returns true if header (probabilistically) signals validators change and
 	/// the caller needs to provide transactions receipts to import the header.
-	pub fn maybe_signals_validators_change(&self, header: &Header) -> bool {
+	pub fn maybe_signals_validators_change(&self, header: &AuraHeader) -> bool {
 		let (_, _, source) = self.source_at(header.number);
 
 		// if we are taking validators set from the fixed list, there's always
@@ -95,7 +95,7 @@ impl<'a> Validators<'a> {
 	/// current block). The second element is the immediately applied change.
 	pub fn extract_validators_change(
 		&self,
-		header: &Header,
+		header: &AuraHeader,
 		receipts: Option<Vec<Receipt>>,
 	) -> Result<(ValidatorsChange, ValidatorsChange), Error> {
 		// let's first check if new source is starting from this header
@@ -325,7 +325,7 @@ pub(crate) mod tests {
 		// when contract is active, but bloom has no required bits set
 		let config = ValidatorsConfiguration::Single(ValidatorsSource::Contract(Default::default(), Vec::new()));
 		let validators = Validators::new(&config);
-		let mut header = Header::default();
+		let mut header = AuraHeader::default();
 		header.number = u64::max_value();
 		assert!(!validators.maybe_signals_validators_change(&header));
 
@@ -347,7 +347,7 @@ pub(crate) mod tests {
 			(200, ValidatorsSource::Contract([3; 20].into(), vec![[3; 20].into()])),
 		]);
 		let validators = Validators::new(&config);
-		let mut header = Header::default();
+		let mut header = AuraHeader::default();
 
 		// when we're at the block that switches to list source
 		header.number = 100;
@@ -420,7 +420,7 @@ pub(crate) mod tests {
 			let finalized_blocks = vec![(id10, None), (id100, None)];
 			let header100 = StoredHeader::<u64> {
 				submitter: None,
-				header: Header {
+				header: AuraHeader {
 					number: 100,
 					..Default::default()
 				},

--- a/primitives/ethereum-poa/src/lib.rs
+++ b/primitives/ethereum-poa/src/lib.rs
@@ -68,7 +68,7 @@ pub struct HeaderId {
 /// An Aura header.
 #[derive(Clone, Default, Encode, Decode, PartialEq, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct Header {
+pub struct AuraHeader {
 	/// Parent block hash.
 	pub parent_hash: H256,
 	/// Block timestamp.
@@ -182,7 +182,7 @@ pub struct SealedEmptyStep {
 	pub step: u64,
 }
 
-impl Header {
+impl AuraHeader {
 	/// Compute id of this header.
 	pub fn compute_id(&self) -> HeaderId {
 		HeaderId {
@@ -558,7 +558,7 @@ sp_api::decl_runtime_apis! {
 		/// Returns number and hash of the best finalized block known to the bridge module.
 		fn finalized_block() -> (u64, H256);
 		/// Returns true if the import of given block requires transactions receipts.
-		fn is_import_requires_receipts(header: Header) -> bool;
+		fn is_import_requires_receipts(header: AuraHeader) -> bool;
 		/// Returns true if header is known to the runtime.
 		fn is_known_block(hash: H256) -> bool;
 	}
@@ -573,7 +573,7 @@ sp_api::decl_runtime_apis! {
 		/// Returns number and hash of the best finalized block known to the bridge module.
 		fn finalized_block() -> (u64, H256);
 		/// Returns true if the import of given block requires transactions receipts.
-		fn is_import_requires_receipts(header: Header) -> bool;
+		fn is_import_requires_receipts(header: AuraHeader) -> bool;
 		/// Returns true if header is known to the runtime.
 		fn is_known_block(hash: H256) -> bool;
 	}

--- a/primitives/ethereum-poa/src/signatures.rs
+++ b/primitives/ethereum-poa/src/signatures.rs
@@ -23,8 +23,8 @@
 pub use secp256k1::SecretKey;
 
 use crate::{
-	public_to_address, rlp_encode, step_validator, Address, Header, RawTransaction, UnsignedTransaction, H256, H520,
-	U256,
+	public_to_address, rlp_encode, step_validator, Address, AuraHeader, RawTransaction, UnsignedTransaction, H256,
+	H520, U256,
 };
 
 use secp256k1::{Message, PublicKey};
@@ -32,9 +32,9 @@ use secp256k1::{Message, PublicKey};
 /// Utilities for signing headers.
 pub trait SignHeader {
 	/// Signs header by given author.
-	fn sign_by(self, author: &SecretKey) -> Header;
+	fn sign_by(self, author: &SecretKey) -> AuraHeader;
 	/// Signs header by given authors set.
-	fn sign_by_set(self, authors: &[SecretKey]) -> Header;
+	fn sign_by_set(self, authors: &[SecretKey]) -> AuraHeader;
 }
 
 /// Utilities for signing transactions.
@@ -43,7 +43,7 @@ pub trait SignTransaction {
 	fn sign_by(self, author: &SecretKey, chain_id: Option<u64>) -> RawTransaction;
 }
 
-impl SignHeader for Header {
+impl SignHeader for AuraHeader {
 	fn sign_by(mut self, author: &SecretKey) -> Self {
 		self.author = secret_to_address(author);
 

--- a/relays/ethereum/src/rpc.rs
+++ b/relays/ethereum/src/rpc.rs
@@ -17,7 +17,6 @@
 //! RPC Module
 
 #![warn(missing_docs)]
-
 // The compiler doesn't think we're using the
 // code from rpc_api!
 #![allow(dead_code)]
@@ -35,7 +34,7 @@ use crate::substrate_types::{
 };
 
 use async_trait::async_trait;
-use bp_eth_poa::Header as SubstrateEthereumHeader;
+use bp_eth_poa::AuraHeader as SubstrateEthereumHeader;
 
 type Result<T> = result::Result<T, RpcError>;
 type GrandpaAuthorityList = Vec<u8>;

--- a/relays/ethereum/src/substrate_client.rs
+++ b/relays/ethereum/src/substrate_client.rs
@@ -23,7 +23,7 @@ use crate::sync_types::SubmittedHeaders;
 use crate::utils::HeaderId;
 
 use async_trait::async_trait;
-use bp_eth_poa::Header as SubstrateEthereumHeader;
+use bp_eth_poa::AuraHeader as SubstrateEthereumHeader;
 use codec::{Decode, Encode};
 use jsonrpsee::raw::RawClient;
 use jsonrpsee::transport::http::HttpTransportClient;

--- a/relays/ethereum/src/substrate_types.rs
+++ b/relays/ethereum/src/substrate_types.rs
@@ -23,7 +23,7 @@ use crate::utils::HeaderId;
 use codec::Encode;
 
 pub use bp_eth_poa::{
-	Address, Bloom, Bytes, Header as SubstrateEthereumHeader, LogEntry as SubstrateEthereumLogEntry,
+	Address, AuraHeader as SubstrateEthereumHeader, Bloom, Bytes, LogEntry as SubstrateEthereumLogEntry,
 	Receipt as SubstrateEthereumReceipt, TransactionOutcome as SubstrateEthereumTransactionOutcome, H256, U256,
 };
 


### PR DESCRIPTION
While doing some other work I realized that our node couldn't do some basic things in Polkadot JS Apps (like a balance transfer between Alice and Bob) due to some strange issues. I believe it has to do with the type definitions we have. To work around this I've renamed the `Header` defined in the Ethereum PoA primitives to `AuraHeader`. This will prevent clashes with PolkadotJS Apps.

Right now this doesn't work, as I'm getting the following error when doing a transfer:

```
DRR: Error: 1002: Verification Error: Execution: Could not convert parameter `tx` between node and runtime: No such variant in enum MultiSignature: RuntimeApi("Execution: Could not convert parameter `tx` between node and runtime: No such variant in
```
I _think_ the new `types.json` file looks fine, but maybe it's not?

cc @Tbaut 

Closes #336. 