### PR TITLE
Remove Cargo Check with Nightly Toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,7 @@ jobs:
         - /cache:/cache
     env:
       RUST_BACKTRACE:              full
+      SKIP_WASM_BUILD:             1
       SCCACHE_REDIS:               redis://172.17.0.1/0
       SCCACHE_IDLE_TIMEOUT:        0
       CMAKE_C_COMPILER_LAUNCHER:   sccache
@@ -70,8 +71,6 @@ jobs:
         if:                        matrix.toolchain == 'nightly'
         run:                       rustup component add clippy --toolchain ${{ matrix.toolchain }}
       - name:                      Clippy
-        env:
-          SKIP_WASM_BUILD:         1
         uses:                      actions-rs/cargo@master
         if:                        matrix.toolchain == 'nightly'
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,6 +70,8 @@ jobs:
         if:                        matrix.toolchain == 'nightly'
         run:                       rustup component add clippy --toolchain ${{ matrix.toolchain }}
       - name:                      Clippy
+        env:
+          SKIP_WASM_BUILD:         1
         uses:                      actions-rs/cargo@master
         if:                        matrix.toolchain == 'nightly'
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,6 @@ jobs:
         - /cache:/cache
     env:
       RUST_BACKTRACE:              full
-      SKIP_WASM_BUILD:             1
       SCCACHE_REDIS:               redis://172.17.0.1/0
       SCCACHE_IDLE_TIMEOUT:        0
       CMAKE_C_COMPILER_LAUNCHER:   sccache
@@ -67,16 +66,6 @@ jobs:
           command:                 check
           toolchain:               ${{ matrix.toolchain }}
           args:                    --all  --verbose
-      - name:                      Add clippy
-        if:                        matrix.toolchain == 'nightly'
-        run:                       rustup component add clippy --toolchain ${{ matrix.toolchain }}
-      - name:                      Clippy
-        uses:                      actions-rs/cargo@master
-        if:                        matrix.toolchain == 'nightly'
-        with:
-          command:                 clippy
-          toolchain:               ${{ matrix.toolchain }}
-          args:                    --all-targets -- -D warnings
 
 ## Test stage
       - name:                      Testing rust-${{ matrix.toolchain }}
@@ -91,6 +80,18 @@ jobs:
           command:                 check
           toolchain:               ${{ matrix.toolchain }}
           args:                    --manifest-path ./bin/rialto-node/Cargo.toml --no-default-features --features runtime-benchmarks --verbose
+
+## Run Clippy Linter
+      - name:                      Add clippy
+        if:                        matrix.toolchain == 'nightly'
+        run:                       rustup component add clippy --toolchain ${{ matrix.toolchain }}
+      - name:                      Clippy
+        uses:                      actions-rs/cargo@master
+        if:                        matrix.toolchain == 'nightly'
+        with:
+          command:                 clippy
+          toolchain:               ${{ matrix.toolchain }}
+          args:                    --all-targets -- -D warnings
 
 ## Build stage
       - name:                      Building rust-${{ matrix.toolchain }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,15 +60,10 @@ jobs:
         shell:                     bash
       - name:                      Checking rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
+        # Clippy runs `cargo check` so don't run it on nightly
+        if:                        matrix.toolchain == 'stable'
         with:
           command:                 check
-          toolchain:               ${{ matrix.toolchain }}
-          args:                    --all  --verbose
-## Test stage
-      - name:                      Testing rust-${{ matrix.toolchain }}
-        uses:                      actions-rs/cargo@master
-        with:
-          command:                 test
           toolchain:               ${{ matrix.toolchain }}
           args:                    --all  --verbose
       - name:                      Add clippy
@@ -81,6 +76,14 @@ jobs:
           command:                 clippy
           toolchain:               ${{ matrix.toolchain }}
           args:                    --all-targets -- -D warnings
+
+## Test stage
+      - name:                      Testing rust-${{ matrix.toolchain }}
+        uses:                      actions-rs/cargo@master
+        with:
+          command:                 test
+          toolchain:               ${{ matrix.toolchain }}
+          args:                    --all  --verbose
       - name:                      Check Rialto benchmarks runtime ${{ matrix.platform }} rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
         with:


### PR DESCRIPTION
I recently learned that [Clippy runs `cargo check` explicitly](https://stackoverflow.com/questions/57449356/is-cargo-clippy-a-superset-of-cargo-check) as part of its execution. This means we can get rid of our own `cargo check` runs. Well, actually only the one on `+nightly` since we can't run Clippy on stable in our repo.

Also, since it's not totally clear from the diff I moved the Clippy CI stage right after our `cargo check` stage, I didn't move the test stage at all.