### PR TITLE
Integrate Rialto <-> Millau message lanes into Millau/Rialto runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bridge-runtime-common"
+version = "0.1.0"
+dependencies = [
+ "bp-message-dispatch",
+ "bp-message-lane",
+ "bp-runtime",
+ "frame-support",
+ "pallet-bridge-call-dispatch",
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+]
+
+[[package]]
 name = "bs58"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5332,6 +5347,7 @@ dependencies = [
  "bp-millau",
  "bp-rialto",
  "bp-runtime",
+ "bridge-runtime-common",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,6 +3586,8 @@ dependencies = [
  "bp-message-lane",
  "bp-millau",
  "bp-rialto",
+ "bp-runtime",
+ "bridge-runtime-common",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -3616,6 +3618,7 @@ dependencies = [
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
+ "sp-trie",
  "sp-version",
  "substrate-wasm-builder-runner",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4141,6 +4141,7 @@ name = "pallet-message-lane"
 version = "0.1.0"
 dependencies = [
  "bp-message-lane",
+ "bp-runtime",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -5326,9 +5327,11 @@ dependencies = [
  "bp-currency-exchange",
  "bp-eth-poa",
  "bp-header-chain",
+ "bp-message-dispatch",
  "bp-message-lane",
  "bp-millau",
  "bp-rialto",
+ "bp-runtime",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
@@ -5364,6 +5367,7 @@ dependencies = [
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
+ "sp-trie",
  "sp-version",
  "substrate-wasm-builder-runner",
 ]

--- a/bin/millau/runtime/Cargo.toml
+++ b/bin/millau/runtime/Cargo.toml
@@ -17,6 +17,8 @@ serde = { version = "1.0.117", optional = true, features = ["derive"] }
 bp-message-lane = { path = "../../../primitives/message-lane", default-features = false }
 bp-millau = { path = "../../../primitives/millau", default-features = false }
 bp-rialto = { path = "../../../primitives/rialto", default-features = false }
+bp-runtime = { path = "../../../primitives/runtime", default-features = false }
+bridge-runtime-common = { path = "../../runtime-common", default-features = false }
 pallet-bridge-call-dispatch = { path = "../../../modules/call-dispatch", default-features = false }
 pallet-message-lane = { path = "../../../modules/message-lane", default-features = false }
 pallet-shift-session-manager = { path = "../../../modules/shift-session-manager", default-features = false }
@@ -47,6 +49,7 @@ sp-runtime = { version = "2.0", default-features = false }
 sp-session = { version = "2.0", default-features = false }
 sp-std = { version = "2.0", default-features = false }
 sp-transaction-pool = { version = "2.0", default-features = false }
+sp-trie = { version = "2.0", default-features = false }
 sp-version = { version = "2.0", default-features = false }
 
 [build-dependencies]
@@ -58,6 +61,8 @@ std = [
 	"bp-message-lane/std",
 	"bp-millau/std",
 	"bp-rialto/std",
+	"bp-runtime/std",
+	"bridge-runtime-common/std",
 	"codec/std",
 	"frame-executive/std",
 	"frame-support/std",
@@ -87,5 +92,6 @@ std = [
 	"sp-session/std",
 	"sp-std/std",
 	"sp-transaction-pool/std",
+	"sp-trie/std",
 	"sp-version/std",
 ]

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -146,10 +146,9 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
+	pub const MaximumBlockWeight: Weight = bp_millau::MAXIMUM_BLOCK_WEIGHT;
 	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
-	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-	/// Assume 10% of weight for average on_initialize calls.
+	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(bp_millau::AVAILABLE_BLOCK_RATIO);
 	pub MaximumExtrinsicWeight: Weight = bp_millau::MAXIMUM_EXTRINSIC_WEIGHT;
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -34,7 +34,7 @@ use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as G
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::traits::{Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify};
+use sp_runtime::traits::{Block as BlockT, IdentityLookup, NumberFor, OpaqueKeys, Saturating};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionSource, TransactionValidity},
@@ -65,18 +65,18 @@ pub use sp_runtime::{Perbill, Permill};
 pub type BlockNumber = bp_millau::BlockNumber;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
-pub type Signature = MultiSignature;
+pub type Signature = bp_millau::Signature;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
-pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+pub type AccountId = bp_millau::AccountId;
 
 /// The type for looking up accounts. We don't expect more than 4 billion of them, but you
 /// never know...
 pub type AccountIndex = u32;
 
 /// Balance of an account.
-pub type Balance = u128;
+pub type Balance = bp_millau::Balance;
 
 /// Index of a transaction in the chain.
 pub type Index = u32;

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -34,7 +34,7 @@ use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as G
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::traits::{Block as BlockT, IdentityLookup, NumberFor, OpaqueKeys, Saturating};
+use sp_runtime::traits::{Block as BlockT, IdentityLookup, NumberFor, OpaqueKeys};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionSource, TransactionValidity},
@@ -149,8 +149,7 @@ parameter_types! {
 	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	/// Assume 10% of weight for average on_initialize calls.
-	pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
-		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
+	pub MaximumExtrinsicWeight: Weight = bp_millau::MAXIMUM_EXTRINSIC_WEIGHT;
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -54,7 +54,7 @@ pub struct WithRialtoMessageBridge;
 impl MessageBridge for WithRialtoMessageBridge {
 	const INSTANCE: InstanceId = *b"rlto";
 
-	const RELAYER_INTEREST_PERCENT: u32 = 10;
+	const RELAYER_FEE_PERCENT: u32 = 10;
 
 	type ThisChain = Millau;
 	type BridgedChain = Rialto;

--- a/bin/rialto/runtime/Cargo.toml
+++ b/bin/rialto/runtime/Cargo.toml
@@ -18,9 +18,11 @@ serde = { version = "1.0.117", optional = true, features = ["derive"] }
 bp-currency-exchange = { path = "../../../primitives/currency-exchange", default-features = false }
 bp-eth-poa = { path = "../../../primitives/ethereum-poa", default-features = false }
 bp-header-chain = { path = "../../../primitives/header-chain", default-features = false }
+bp-message-dispatch = { path = "../../../primitives/message-dispatch", default-features = false }
 bp-message-lane = { path = "../../../primitives/message-lane", default-features = false }
 bp-millau = { path = "../../../primitives/millau", default-features = false }
 bp-rialto = { path = "../../../primitives/rialto", default-features = false }
+bp-runtime = { path = "../../../primitives/runtime", default-features = false }
 pallet-bridge-eth-poa = { path = "../../../modules/ethereum", default-features = false }
 pallet-bridge-call-dispatch = { path = "../../../modules/call-dispatch", default-features = false }
 pallet-bridge-currency-exchange = { path = "../../../modules/currency-exchange", default-features = false }
@@ -55,6 +57,7 @@ sp-runtime = { version = "2.0", default-features = false }
 sp-session = { version = "2.0", default-features = false }
 sp-std = { version = "2.0", default-features = false }
 sp-transaction-pool = { version = "2.0", default-features = false }
+sp-trie = { version = "2.0", default-features = false }
 sp-version = { version = "2.0", default-features = false }
 
 [dev-dependencies]
@@ -69,9 +72,11 @@ std = [
 	"bp-currency-exchange/std",
 	"bp-eth-poa/std",
 	"bp-header-chain/std",
+	"bp-message-dispatch/std",
 	"bp-message-lane/std",
-	"bp-rialto/std",
 	"bp-millau/std",
+	"bp-rialto/std",
+	"bp-runtime/std",
 	"codec/std",
 	"frame-benchmarking/std",
 	"frame-executive/std",
@@ -104,6 +109,7 @@ std = [
 	"sp-session/std",
 	"sp-std/std",
 	"sp-transaction-pool/std",
+	"sp-trie/std",
 	"sp-version/std",
 ]
 runtime-benchmarks = [

--- a/bin/rialto/runtime/Cargo.toml
+++ b/bin/rialto/runtime/Cargo.toml
@@ -23,6 +23,7 @@ bp-message-lane = { path = "../../../primitives/message-lane", default-features 
 bp-millau = { path = "../../../primitives/millau", default-features = false }
 bp-rialto = { path = "../../../primitives/rialto", default-features = false }
 bp-runtime = { path = "../../../primitives/runtime", default-features = false }
+bridge-runtime-common = { path = "../../runtime-common", default-features = false }
 pallet-bridge-eth-poa = { path = "../../../modules/ethereum", default-features = false }
 pallet-bridge-call-dispatch = { path = "../../../modules/call-dispatch", default-features = false }
 pallet-bridge-currency-exchange = { path = "../../../modules/currency-exchange", default-features = false }
@@ -77,6 +78,7 @@ std = [
 	"bp-millau/std",
 	"bp-rialto/std",
 	"bp-runtime/std",
+	"bridge-runtime-common/std",
 	"codec/std",
 	"frame-benchmarking/std",
 	"frame-executive/std",

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -426,7 +426,7 @@ impl pallet_shift_session_manager::Trait for Runtime {}
 
 parameter_types! {
 	pub const MaxMessagesToPruneAtOnce: bp_message_lane::MessageNonce = 8;
-	pub const MaxUnconfirmedMessagesAtInboundLane: bp_message_lane::MessageNonce = 0;
+	pub const MaxUnconfirmedMessagesAtInboundLane: bp_message_lane::MessageNonce = 128;
 }
 
 impl pallet_message_lane::Trait for Runtime {
@@ -442,7 +442,7 @@ impl pallet_message_lane::Trait for Runtime {
 	type InboundRelayer = bp_millau::AccountId;
 
 	type TargetHeaderChain = crate::millau_messages::Millau;
-	type LaneMessageVerifier = crate::millau_messages::Millau;
+	type LaneMessageVerifier = crate::millau_messages::ToMillauMessageVerifier;
 	type MessageDeliveryAndDispatchPayment =
 		pallet_message_lane::instant_payments::InstantCurrencyPayments<AccountId, pallet_balances::Module<Runtime>>;
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -154,9 +154,9 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
+	pub const MaximumBlockWeight: Weight = bp_rialto::MAXIMUM_BLOCK_WEIGHT;
 	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
-	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(bp_rialto::AVAILABLE_BLOCK_RATIO);
 	pub MaximumExtrinsicWeight: Weight = bp_rialto::MAXIMUM_EXTRINSIC_WEIGHT;
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -41,7 +41,7 @@ use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as G
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::traits::{Block as BlockT, IdentityLookup, NumberFor, OpaqueKeys, Saturating};
+use sp_runtime::traits::{Block as BlockT, IdentityLookup, NumberFor, OpaqueKeys};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionSource, TransactionValidity},
@@ -157,9 +157,7 @@ parameter_types! {
 	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
 	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-	/// Assume 10% of weight for average on_initialize calls.
-	pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
-		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
+	pub MaximumExtrinsicWeight: Weight = bp_rialto::MAXIMUM_EXTRINSIC_WEIGHT;
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
@@ -428,7 +426,7 @@ impl pallet_shift_session_manager::Trait for Runtime {}
 
 parameter_types! {
 	pub const MaxMessagesToPruneAtOnce: bp_message_lane::MessageNonce = 8;
-	pub const MaxUnconfirmedMessagesAtInboundLane: bp_message_lane::MessageNonce = 16;
+	pub const MaxUnconfirmedMessagesAtInboundLane: bp_message_lane::MessageNonce = 0;
 }
 
 impl pallet_message_lane::Trait for Runtime {

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -34,13 +34,14 @@ pub mod exchange;
 pub mod benches;
 pub mod kovan;
 pub mod millau;
+pub mod millau_messages;
 pub mod rialto_poa;
 
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::traits::{Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify};
+use sp_runtime::traits::{Block as BlockT, IdentityLookup, NumberFor, OpaqueKeys, Saturating};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionSource, TransactionValidity},
@@ -73,18 +74,18 @@ pub use sp_runtime::{Perbill, Permill};
 pub type BlockNumber = bp_rialto::BlockNumber;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
-pub type Signature = MultiSignature;
+pub type Signature = bp_rialto::Signature;
 
 /// Some way of identifying an account on the chain. We intentionally make it equivalent
 /// to the public key of our transaction signing scheme.
-pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+pub type AccountId = bp_rialto::AccountId;
 
 /// The type for looking up accounts. We don't expect more than 4 billion of them, but you
 /// never know...
 pub type AccountIndex = u32;
 
 /// Balance of an account.
-pub type Balance = u128;
+pub type Balance = bp_rialto::Balance;
 
 /// Index of a transaction in the chain.
 pub type Index = u32;
@@ -425,6 +426,32 @@ impl pallet_substrate_bridge::Trait for Runtime {
 
 impl pallet_shift_session_manager::Trait for Runtime {}
 
+parameter_types! {
+	pub const MaxMessagesToPruneAtOnce: bp_message_lane::MessageNonce = 8;
+	pub const MaxUnconfirmedMessagesAtInboundLane: bp_message_lane::MessageNonce = 16;
+}
+
+impl pallet_message_lane::Trait for Runtime {
+	type Event = Event;
+	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
+	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
+
+	type OutboundPayload = crate::millau_messages::ToMillauMessagePayload;
+	type OutboundMessageFee = Balance;
+
+	type InboundPayload = crate::millau_messages::FromMillauMessagePayload;
+	type InboundMessageFee = bp_millau::Balance;
+	type InboundRelayer = bp_millau::AccountId;
+
+	type TargetHeaderChain = crate::millau_messages::Millau;
+	type LaneMessageVerifier = crate::millau_messages::Millau;
+	type MessageDeliveryAndDispatchPayment =
+		pallet_message_lane::instant_payments::InstantCurrencyPayments<AccountId, pallet_balances::Module<Runtime>>;
+
+	type SourceHeaderChain = crate::millau_messages::Millau;
+	type MessageDispatch = crate::millau_messages::FromMillauMessageDispatch;
+}
+
 construct_runtime!(
 	pub enum Runtime where
 		Block = Block,
@@ -437,6 +464,7 @@ construct_runtime!(
 		BridgeKovanCurrencyExchange: pallet_bridge_currency_exchange::<Instance2>::{Module, Call},
 		BridgeMillau: pallet_substrate_bridge::{Module, Call, Storage, Config<T>},
 		BridgeCallDispatch: pallet_bridge_call_dispatch::{Module, Event<T>},
+		BridgeMillauMessageLane: pallet_message_lane::{Module, Call, Event<T>},
 		System: frame_system::{Module, Call, Config, Storage, Event<T>},
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -1,0 +1,211 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Everything required to serve Millau <-> Rialto message lanes.
+
+use bp_message_dispatch::MessageDispatch as _;
+use bp_message_lane::{
+	source_chain::{LaneMessageVerifier, TargetHeaderChain},
+	target_chain::{DispatchMessage, MessageDispatch, ProvedMessages, SourceHeaderChain},
+	InboundLaneData, LaneId, Message, MessageNonce,
+};
+use codec::{Compact, Decode, Input};
+use frame_support::{
+	weights::{Weight, WeightToFeePolynomial},
+	RuntimeDebug,
+};
+use sp_std::vec::Vec;
+use sp_trie::StorageProof;
+
+/// Millau bridge instance id.
+pub const INSTANCE: bp_runtime::InstanceId = *b"mllu";
+
+/// Encoded Call of Millau chain.
+pub type OpaqueMillauCall = Vec<u8>;
+
+/// Message payload for Rialto -> Millau messages.
+pub type ToMillauMessagePayload = pallet_bridge_call_dispatch::MessagePayload<
+	bp_rialto::AccountSigner,
+	bp_millau::AccountSigner,
+	bp_millau::Signature,
+	OpaqueMillauCall,
+>;
+
+/// Call origin for Millau -> Rialto messages.
+pub type FromMillauMessageCallOrigin =
+	pallet_bridge_call_dispatch::CallOrigin<bp_millau::AccountSigner, bp_rialto::AccountSigner, bp_rialto::Signature>;
+
+/// Message payload for Millau -> Rialto messages.
+pub struct FromMillauMessagePayload(
+	pallet_bridge_call_dispatch::MessagePayload<
+		bp_millau::AccountSigner,
+		bp_rialto::AccountSigner,
+		bp_rialto::Signature,
+		crate::Call,
+	>,
+);
+
+impl Decode for FromMillauMessagePayload {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+		// for bridged chain our Calls are opaque - they're encoded to Vec<u8> by submitter
+		// => skip encoded vec length here before decoding Call
+		let spec_version = pallet_bridge_call_dispatch::SpecVersion::decode(input)?;
+		let weight = Weight::decode(input)?;
+		let origin = FromMillauMessageCallOrigin::decode(input)?;
+		let _skipped_length = Compact::<u32>::decode(input)?;
+		let call = crate::Call::decode(input)?;
+
+		Ok(FromMillauMessagePayload(pallet_bridge_call_dispatch::MessagePayload {
+			spec_version,
+			weight,
+			origin,
+			call,
+		}))
+	}
+}
+
+/// Millau chain from message lane point of view.
+#[derive(RuntimeDebug, Clone, Copy)]
+pub struct Millau;
+
+impl TargetHeaderChain<ToMillauMessagePayload, bp_rialto::AccountId> for Millau {
+	type Error = &'static str;
+	// The proof is:
+	// - hash of the header this proof has been created with;
+	// - the storage proof or one or several keys;
+	// - id of the lane we prove state of.
+	type MessagesDeliveryProof = (bp_millau::Hash, StorageProof, LaneId);
+
+	fn verify_message(payload: &ToMillauMessagePayload) -> Result<(), Self::Error> {
+		if payload.weight > dynamic::maximal_dispatch_weight_of_millau_message() {
+			return Err("Too large weight declared");
+		}
+
+		Ok(())
+	}
+
+	fn verify_messages_delivery_proof(
+		_proof: Self::MessagesDeliveryProof,
+	) -> Result<(LaneId, InboundLaneData<bp_millau::AccountId>), Self::Error> {
+		unimplemented!("https://github.com/paritytech/parity-bridges-common/issues/397")
+	}
+}
+
+impl LaneMessageVerifier<bp_rialto::AccountId, ToMillauMessagePayload, bp_rialto::Balance> for Millau {
+	type Error = &'static str;
+
+	fn verify_message(
+		_submitter: &bp_rialto::AccountId,
+		delivery_and_dispatch_fee: &bp_rialto::Balance,
+		_lane: &LaneId,
+		payload: &ToMillauMessagePayload,
+	) -> Result<(), Self::Error> {
+		// compute all components of total fee in Millau tokens
+		let millau_delivery_base_fee = dynamic::millau_weight_to_fee(dynamic::millau_delivery_base_weight());
+		let millau_dispatch_fee = dynamic::millau_weight_to_fee(payload.weight);
+		let millau_confirmation_fee = dynamic::rialto_balance_into_millau_balance(
+			<crate::Runtime as pallet_transaction_payment::Trait>::WeightToFee::calc(
+				&dynamic::rialto_confirmation_weight(),
+			),
+		);
+
+		// compute total expected fee and add relayers interest (10%)
+		let millau_minimal_fee = millau_delivery_base_fee + millau_dispatch_fee + millau_confirmation_fee;
+		let millau_minimal_expected_fee = millau_minimal_fee + millau_minimal_fee / 10;
+
+		// compare with actual fee paid
+		let millau_actual_fee = dynamic::rialto_balance_into_millau_balance(*delivery_and_dispatch_fee);
+		if millau_actual_fee < millau_minimal_expected_fee {
+			return Err("Too low fee paid");
+		}
+
+		Ok(())
+	}
+}
+
+impl SourceHeaderChain<bp_millau::Balance> for Millau {
+	type Error = &'static str;
+	// The proof is:
+	// - hash of the header this proof has been created with;
+	// - the storage proof or one or several keys;
+	// - id of the lane we prove messages for;
+	// - inclusive range of messages nonces that are proved.
+	type MessagesProof = (bp_millau::Hash, StorageProof, LaneId, MessageNonce, MessageNonce);
+
+	fn verify_messages_proof(
+		_proof: Self::MessagesProof,
+	) -> Result<ProvedMessages<Message<bp_millau::Balance>>, Self::Error> {
+		unimplemented!("https://github.com/paritytech/parity-bridges-common/issues/397")
+	}
+}
+
+/// Call-dispatch based message dispatch for Millau -> Rialto messages.
+#[derive(RuntimeDebug, Clone, Copy)]
+pub struct FromMillauMessageDispatch;
+
+impl MessageDispatch<bp_millau::Balance> for FromMillauMessageDispatch {
+	type DispatchPayload = FromMillauMessagePayload;
+
+	fn dispatch_weight(message: &DispatchMessage<Self::DispatchPayload, bp_millau::Balance>) -> Weight {
+		message
+			.data
+			.payload
+			.as_ref()
+			.map(|payload| payload.0.weight)
+			.unwrap_or(0)
+	}
+
+	fn dispatch(message: DispatchMessage<Self::DispatchPayload, bp_millau::Balance>) {
+		if let Ok(payload) = message.data.payload {
+			pallet_bridge_call_dispatch::Module::<crate::Runtime>::dispatch(
+				INSTANCE,
+				(message.key.lane_id, message.key.nonce),
+				payload.0,
+			);
+		}
+	}
+}
+
+mod dynamic {
+	use frame_support::weights::{Weight, WeightToFeePolynomial};
+
+	/// Maximal dispatch weight of the call we are able to dispatch.
+	pub fn maximal_dispatch_weight_of_millau_message() -> Weight {
+		// this should be maximal weight on Millau minus millau_delivery_base_weight()
+		// or even less to support future upgrardes
+		1_000_000_000_000 - millau_delivery_base_weight()
+	}
+
+	/// Return maximal weight of delivery confirmation transaction on Rialto chain.
+	pub fn rialto_confirmation_weight() -> Weight {
+		1_000_000
+	}
+
+	/// Return maximal base weight of delivery transaction on Millau chain.
+	pub fn millau_delivery_base_weight() -> Weight {
+		1_000_000
+	}
+
+	/// Estimate cost (in Millau tokens) of dispatching call with given weight on Millau chain.
+	pub fn millau_weight_to_fee(weight: Weight) -> bp_millau::Balance {
+		<crate::Runtime as pallet_transaction_payment::Trait>::WeightToFee::calc(&weight)
+	}
+
+	/// Convert from Rialto to Millau fee tokens.
+	pub fn rialto_balance_into_millau_balance(balance: bp_rialto::Balance) -> bp_millau::Balance {
+		balance * 10
+	}
+}

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -54,7 +54,7 @@ pub struct WithMillauMessageBridge;
 impl MessageBridge for WithMillauMessageBridge {
 	const INSTANCE: InstanceId = *b"mllu";
 
-	const RELAYER_INTEREST_PERCENT: u32 = 10;
+	const RELAYER_FEE_PERCENT: u32 = 10;
 
 	type ThisChain = Rialto;
 	type BridgedChain = Millau;

--- a/bin/runtime-common/Cargo.toml
+++ b/bin/runtime-common/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "bridge-runtime-common"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/parity-bridges-common/"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
+
+# Bridge dependencies
+
+bp-message-dispatch = { path = "../../primitives/message-dispatch", default-features = false }
+bp-message-lane = { path = "../../primitives/message-lane", default-features = false }
+bp-runtime = { path = "../../primitives/runtime", default-features = false }
+pallet-bridge-call-dispatch = { path = "../../modules/call-dispatch", default-features = false }
+
+# Substrate dependencies
+
+frame-support = { version = "2.0", default-features = false }
+sp-runtime = { version = "2.0", default-features = false }
+sp-std = { version = "2.0", default-features = false }
+sp-trie = { version = "2.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"bp-message-dispatch/std",
+	"bp-message-lane/std",
+	"bp-runtime/std",
+	"codec/std",
+	"frame-support/std",
+	"pallet-bridge-call-dispatch/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"sp-trie/std",
+]

--- a/bin/runtime-common/src/lib.rs
+++ b/bin/runtime-common/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Common types/functions that may be used by runtimes of all bridged chains.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod messages;

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -17,7 +17,8 @@
 //! Types that allow runtime to act as a source/target endpoint of message lanes.
 //!
 //! Messages are assumed to be encoded `Call`s of the target chain. Call-dispatch
-//! pallet is used to dispatch incoming messages.
+//! pallet is used to dispatch incoming messages. Message identified by a tuple
+//! of to elements - message lane id and message nonce.
 
 use bp_message_dispatch::MessageDispatch as _;
 use bp_message_lane::{
@@ -29,7 +30,7 @@ use bp_runtime::InstanceId;
 use codec::{Compact, Decode, Input};
 use frame_support::RuntimeDebug;
 use sp_runtime::traits::{CheckedAdd, CheckedDiv, CheckedMul};
-use sp_std::{cmp::PartialOrd, vec::Vec};
+use sp_std::{cmp::PartialOrd, marker::PhantomData, vec::Vec};
 
 /// Bidirectional message bridge.
 pub trait MessageBridge {
@@ -80,7 +81,10 @@ pub trait ChainWithMessageLanes {
 	type Signature: Decode;
 	/// Call type on the chain.
 	type Call: Decode;
-	/// Type of weight that is used on the chain.
+	/// Type of weight that is used on the chain. This would almost always be a regular
+	/// `frame_support::weight::Weight`. But since meaining of weight on different chains
+	/// may be different, the `WeightOf<>` construct is used to avoid confusion between
+	/// different weights.
 	type Weight: From<frame_support::weights::Weight>;
 	/// Type of balances that is used on the chain.
 	type Balance: CheckedAdd + CheckedDiv + CheckedMul + PartialOrd + From<u32> + Copy;
@@ -89,6 +93,8 @@ pub trait ChainWithMessageLanes {
 pub(crate) type ThisChain<B> = <B as MessageBridge>::ThisChain;
 pub(crate) type BridgedChain<B> = <B as MessageBridge>::BridgedChain;
 pub(crate) type AccountIdOf<C> = <C as ChainWithMessageLanes>::AccountId;
+pub(crate) type SignerOf<C> = <C as ChainWithMessageLanes>::Signer;
+pub(crate) type SignatureOf<C> = <C as ChainWithMessageLanes>::Signature;
 pub(crate) type WeightOf<C> = <C as ChainWithMessageLanes>::Weight;
 pub(crate) type BalanceOf<C> = <C as ChainWithMessageLanes>::Balance;
 pub(crate) type CallOf<C> = <C as ChainWithMessageLanes>::Call;
@@ -102,21 +108,20 @@ pub mod source {
 
 	/// Message payload for This -> Bridged chain messages.
 	pub type FromThisChainMessagePayload<B> = pallet_bridge_call_dispatch::MessagePayload<
-		<ThisChain<B> as ChainWithMessageLanes>::Signer,
-		<BridgedChain<B> as ChainWithMessageLanes>::Signer,
-		<BridgedChain<B> as ChainWithMessageLanes>::Signature,
+		SignerOf<ThisChain<B>>,
+		SignerOf<BridgedChain<B>>,
+		SignatureOf<BridgedChain<B>>,
 		BridgedChainOpaqueCall,
 	>;
 
 	/// Message verifier that requires submitter to pay minimal delivery and dispatch fee.
 	#[derive(RuntimeDebug)]
-	pub struct FromThisChainMessageVerifier<B>(sp_std::marker::PhantomData<B>);
+	pub struct FromThisChainMessageVerifier<B>(PhantomData<B>);
 
-	impl<B: MessageBridge> LaneMessageVerifier<
-		AccountIdOf<ThisChain<B>>,
-		FromThisChainMessagePayload<B>,
-		BalanceOf<ThisChain<B>>,
-	> for FromThisChainMessageVerifier<B> {
+	impl<B: MessageBridge>
+		LaneMessageVerifier<AccountIdOf<ThisChain<B>>, FromThisChainMessagePayload<B>, BalanceOf<ThisChain<B>>>
+		for FromThisChainMessageVerifier<B>
+	{
 		type Error = &'static str;
 
 		fn verify_message(
@@ -125,15 +130,13 @@ pub mod source {
 			_lane: &LaneId,
 			payload: &FromThisChainMessagePayload<B>,
 		) -> Result<(), Self::Error> {
-			let minimal_fee_in_bridged_tokens = estimate_message_dispatch_and_delivery_fee::<B>(
-				payload,
-				B::RELAYER_INTEREST_PERCENT,
-			).ok_or("Overflow when computing minimal required message delivery and dispatch fee")?;
+			let minimal_fee_in_bridged_tokens =
+				estimate_message_dispatch_and_delivery_fee::<B>(payload, B::RELAYER_INTEREST_PERCENT)
+					.ok_or("Overflow when computing minimal required message delivery and dispatch fee")?;
 
 			// compare with actual fee paid
-			let actual_fee_in_bridged_tokens = B::this_chain_balance_to_bridged_chain_balance(
-				*delivery_and_dispatch_fee,
-			);
+			let actual_fee_in_bridged_tokens =
+				B::this_chain_balance_to_bridged_chain_balance(*delivery_and_dispatch_fee);
 			if actual_fee_in_bridged_tokens < minimal_fee_in_bridged_tokens {
 				return Err("Too low fee paid");
 			}
@@ -185,21 +188,21 @@ pub mod target {
 
 	/// Call origin for Bridged -> This chain messages.
 	pub type FromBridgedChainMessageCallOrigin<B> = pallet_bridge_call_dispatch::CallOrigin<
-		<BridgedChain<B> as ChainWithMessageLanes>::Signer,
-		<ThisChain<B> as ChainWithMessageLanes>::Signer,
-		<ThisChain<B> as ChainWithMessageLanes>::Signature,
+		SignerOf<BridgedChain<B>>,
+		SignerOf<ThisChain<B>>,
+		SignatureOf<ThisChain<B>>,
 	>;
 
 	/// Decoded Bridged -> This message payload.
 	pub type FromBridgedChainDecodedMessagePayload<B> = pallet_bridge_call_dispatch::MessagePayload<
-		<BridgedChain<B> as ChainWithMessageLanes>::Signer,
-		<ThisChain<B> as ChainWithMessageLanes>::Signer,
-		<ThisChain<B> as ChainWithMessageLanes>::Signature,
-		<ThisChain<B> as ChainWithMessageLanes>::Call,
+		SignerOf<BridgedChain<B>>,
+		SignerOf<ThisChain<B>>,
+		SignatureOf<ThisChain<B>>,
+		CallOf<ThisChain<B>>,
 	>;
 
 	/// Message payload for Bridged -> This messages.
-	pub struct FromBridgedChainMessagePayload<B: MessageBridge>(FromBridgedChainDecodedMessagePayload<B>);
+	pub struct FromBridgedChainMessagePayload<B: MessageBridge>(pub(crate) FromBridgedChainDecodedMessagePayload<B>);
 
 	impl<B: MessageBridge> Decode for FromBridgedChainMessagePayload<B> {
 		fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
@@ -225,7 +228,7 @@ pub mod target {
 	/// Dispatching Bridged -> This chain messages.
 	#[derive(RuntimeDebug, Clone, Copy)]
 	pub struct FromBridgedChainMessageDispatch<B, ThisRuntime, ThisCallDispatchInstance> {
-		_marker: sp_std::marker::PhantomData<(B, ThisRuntime, ThisCallDispatchInstance)>,
+		_marker: PhantomData<(B, ThisRuntime, ThisCallDispatchInstance)>,
 	}
 
 	impl<B: MessageBridge, ThisRuntime, ThisCallDispatchInstance>
@@ -262,5 +265,274 @@ pub mod target {
 				);
 			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use codec::{Decode, Encode};
+	use frame_support::weights::Weight;
+
+	const DELIVERY_TRANSACTION_WEIGHT: Weight = 100;
+	const DELIVERY_CONFIRMATION_TRANSACTION_WEIGHT: Weight = 100;
+	const REWARD_CONFIRMATION_TRANSACTION_WEIGHT: Weight = 100;
+	const THIS_CHAIN_WEIGHT_TO_BALANCE_RATE: Weight = 2;
+	const BRIDGED_CHAIN_WEIGHT_TO_BALANCE_RATE: Weight = 4;
+	const THIS_CHAIN_TO_BRIDGED_CHAIN_BALANCE_RATE: u32 = 6;
+
+	/// Bridge that is deployed on ThisChain and allows sending/receiving messages to/from BridgedChain;
+	struct OnThisChainBridge;
+
+	impl MessageBridge for OnThisChainBridge {
+		const INSTANCE: InstanceId = *b"this";
+		const RELAYER_INTEREST_PERCENT: u32 = 10;
+
+		type ThisChain = ThisChain;
+		type BridgedChain = BridgedChain;
+
+		fn maximal_dispatch_weight_of_message_on_bridged_chain() -> Weight {
+			unreachable!()
+		}
+
+		fn weight_of_delivery_transaction() -> Weight {
+			DELIVERY_TRANSACTION_WEIGHT
+		}
+
+		fn weight_of_delivery_confirmation_transaction_on_this_chain() -> Weight {
+			DELIVERY_CONFIRMATION_TRANSACTION_WEIGHT
+		}
+
+		fn weight_of_reward_confirmation_transaction_on_target_chain() -> Weight {
+			REWARD_CONFIRMATION_TRANSACTION_WEIGHT
+		}
+
+		fn this_weight_to_balance(weight: Weight) -> ThisChainBalance {
+			ThisChainBalance(weight as u32 * THIS_CHAIN_WEIGHT_TO_BALANCE_RATE as u32)
+		}
+
+		fn bridged_weight_to_balance(weight: Weight) -> BridgedChainBalance {
+			BridgedChainBalance(weight as u32 * BRIDGED_CHAIN_WEIGHT_TO_BALANCE_RATE as u32)
+		}
+
+		fn this_chain_balance_to_bridged_chain_balance(this_balance: ThisChainBalance) -> BridgedChainBalance {
+			BridgedChainBalance(this_balance.0 * THIS_CHAIN_TO_BRIDGED_CHAIN_BALANCE_RATE as u32)
+		}
+	}
+
+	/// Bridge that is deployed on BridgedChain and allows sending/receiving messages to/from ThisChain;
+	struct OnBridgedChainBridge;
+
+	impl MessageBridge for OnBridgedChainBridge {
+		const INSTANCE: InstanceId = *b"brdg";
+		const RELAYER_INTEREST_PERCENT: u32 = 20;
+
+		type ThisChain = BridgedChain;
+		type BridgedChain = ThisChain;
+
+		fn maximal_dispatch_weight_of_message_on_bridged_chain() -> Weight {
+			unreachable!()
+		}
+
+		fn weight_of_delivery_transaction() -> Weight {
+			unreachable!()
+		}
+
+		fn weight_of_delivery_confirmation_transaction_on_this_chain() -> Weight {
+			unreachable!()
+		}
+
+		fn weight_of_reward_confirmation_transaction_on_target_chain() -> Weight {
+			unreachable!()
+		}
+
+		fn this_weight_to_balance(_weight: Weight) -> BridgedChainBalance {
+			unreachable!()
+		}
+
+		fn bridged_weight_to_balance(_weight: Weight) -> ThisChainBalance {
+			unreachable!()
+		}
+
+		fn this_chain_balance_to_bridged_chain_balance(_this_balance: BridgedChainBalance) -> ThisChainBalance {
+			unreachable!()
+		}
+	}
+
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	struct ThisChainAccountId(u32);
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	struct ThisChainSigner(u32);
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	struct ThisChainSignature(u32);
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	enum ThisChainCall {
+		#[codec(index = 42)]
+		Transfer,
+		#[codec(index = 84)]
+		Mint,
+	}
+
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	struct BridgedChainAccountId(u32);
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	struct BridgedChainSigner(u32);
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	struct BridgedChainSignature(u32);
+	#[derive(Debug, PartialEq, Decode, Encode)]
+	enum BridgedChainCall {}
+
+	macro_rules! impl_wrapped_balance {
+		($name:ident) => {
+			#[derive(Debug, PartialEq, Decode, Encode, Clone, Copy)]
+			struct $name(u32);
+
+			impl From<u32> for $name {
+				fn from(balance: u32) -> Self {
+					Self(balance)
+				}
+			}
+
+			impl sp_std::ops::Add for $name {
+				type Output = $name;
+
+				fn add(self, other: Self) -> Self {
+					Self(self.0 + other.0)
+				}
+			}
+
+			impl sp_std::ops::Div for $name {
+				type Output = $name;
+
+				fn div(self, other: Self) -> Self {
+					Self(self.0 / other.0)
+				}
+			}
+
+			impl sp_std::ops::Mul for $name {
+				type Output = $name;
+
+				fn mul(self, other: Self) -> Self {
+					Self(self.0 * other.0)
+				}
+			}
+
+			impl sp_std::cmp::PartialOrd for $name {
+				fn partial_cmp(&self, other: &Self) -> Option<sp_std::cmp::Ordering> {
+					self.0.partial_cmp(&other.0)
+				}
+			}
+
+			impl CheckedAdd for $name {
+				fn checked_add(&self, other: &Self) -> Option<Self> {
+					self.0.checked_add(other.0).map(Self)
+				}
+			}
+
+			impl CheckedDiv for $name {
+				fn checked_div(&self, other: &Self) -> Option<Self> {
+					self.0.checked_div(other.0).map(Self)
+				}
+			}
+
+			impl CheckedMul for $name {
+				fn checked_mul(&self, other: &Self) -> Option<Self> {
+					self.0.checked_mul(other.0).map(Self)
+				}
+			}
+		};
+	}
+
+	impl_wrapped_balance!(ThisChainBalance);
+	impl_wrapped_balance!(BridgedChainBalance);
+
+	struct ThisChain;
+
+	impl ChainWithMessageLanes for ThisChain {
+		type AccountId = ThisChainAccountId;
+		type Signer = ThisChainSigner;
+		type Signature = ThisChainSignature;
+		type Call = ThisChainCall;
+		type Weight = frame_support::weights::Weight;
+		type Balance = ThisChainBalance;
+	}
+
+	struct BridgedChain;
+
+	impl ChainWithMessageLanes for BridgedChain {
+		type AccountId = BridgedChainAccountId;
+		type Signer = BridgedChainSigner;
+		type Signature = BridgedChainSignature;
+		type Call = BridgedChainCall;
+		type Weight = frame_support::weights::Weight;
+		type Balance = BridgedChainBalance;
+	}
+
+	#[test]
+	fn message_from_bridged_chain_is_decoded() {
+		// the message is encoded on the bridged chain
+		let message_on_bridged_chain = source::FromThisChainMessagePayload::<OnBridgedChainBridge> {
+			spec_version: 1,
+			weight: 100,
+			origin: pallet_bridge_call_dispatch::CallOrigin::BridgeAccount,
+			call: ThisChainCall::Transfer.encode(),
+		}
+		.encode();
+
+		// and sent to this chain where it is decoded
+		let message_on_this_chain =
+			target::FromBridgedChainMessagePayload::<OnThisChainBridge>::decode(&mut &message_on_bridged_chain[..])
+				.unwrap();
+		assert_eq!(
+			message_on_this_chain.0,
+			target::FromBridgedChainDecodedMessagePayload::<OnThisChainBridge> {
+				spec_version: 1,
+				weight: 100,
+				origin: pallet_bridge_call_dispatch::CallOrigin::BridgeAccount,
+				call: ThisChainCall::Transfer,
+			}
+		);
+	}
+
+	#[test]
+	fn message_fee_is_checked_by_verifier() {
+		const EXPECTED_MINIMAL_FEE: u32 = 2640;
+
+		// payload of the This -> Bridged chain message
+		let payload = source::FromThisChainMessagePayload::<OnThisChainBridge> {
+			spec_version: 1,
+			weight: 100,
+			origin: pallet_bridge_call_dispatch::CallOrigin::BridgeAccount,
+			call: vec![42],
+		};
+
+		// let's check if estimation matching hardcoded value
+		assert_eq!(
+			source::estimate_message_dispatch_and_delivery_fee::<OnThisChainBridge>(
+				&payload,
+				OnThisChainBridge::RELAYER_INTEREST_PERCENT,
+			),
+			Some(BridgedChainBalance(EXPECTED_MINIMAL_FEE)),
+		);
+
+		// and now check that the verifier checks the fee
+		assert!(
+			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
+				&ThisChainAccountId(0),
+				&ThisChainBalance(1),
+				&*b"test",
+				&payload,
+			)
+			.is_err(),
+		);
+		assert!(
+			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
+				&ThisChainAccountId(0),
+				&ThisChainBalance(1_000_000),
+				&*b"test",
+				&payload,
+			)
+			.is_ok(),
+		);
 	}
 }

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -1,0 +1,225 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Types that allow runtime to act as a source/target endpoint of message lanes.
+//!
+//! Messages are assumed to be encoded `Call`s of the target chain. Call-dispatch
+//! pallet is used to dispatch incoming messages.
+
+use bp_message_dispatch::MessageDispatch as _;
+use bp_message_lane::{
+	target_chain::{DispatchMessage, MessageDispatch},
+	LaneId, MessageNonce,
+};
+use bp_runtime::InstanceId;
+use codec::{Compact, Decode, Input};
+use frame_support::RuntimeDebug;
+use sp_runtime::traits::{CheckedAdd, CheckedDiv, CheckedMul};
+use sp_std::vec::Vec;
+
+/// Bidirectional message bridge.
+pub trait MessageBridge {
+	/// Instance id of this bridge.
+	const INSTANCE: InstanceId;
+
+	/// This chain in context of message bridge.
+	type ThisChain: ChainWithMessageLanes;
+	/// Bridged chain in context of message bridge.
+	type BridgedChain: ChainWithMessageLanes;
+
+	/// Maximal (dispatch) weight of the message that we are able to send to Bridged chain.
+	fn maximal_dispatch_weight_of_message_on_bridged_chain() -> WeightOf<BridgedChain<Self>>;
+
+	/// Maximal weight of single message delivery transaction on Bridged chain.
+	fn weight_of_delivery_transaction() -> WeightOf<BridgedChain<Self>>;
+
+	/// Maximal weight of single message delivery confirmation transaction on This chain.
+	fn weight_of_delivery_confirmation_transaction_on_this_chain() -> WeightOf<ThisChain<Self>>;
+
+	/// Weight of single message reward confirmation on the Bridged chain. This confirmation
+	/// is a part of delivery transaction, so this weight is added to the delivery
+	/// transaction weight.
+	fn weight_of_reward_confirmation_transaction_on_target_chain() -> WeightOf<BridgedChain<Self>>;
+
+	/// Convert weight of This chain to the fee (paid in Balance) of This chain.
+	fn this_weight_to_balance(weight: WeightOf<ThisChain<Self>>) -> BalanceOf<ThisChain<Self>>;
+
+	/// Convert weight of the Bridged chain to the fee (paid in Balance) of the Bridged chain.
+	fn bridged_weight_to_balance(weight: WeightOf<BridgedChain<Self>>) -> BalanceOf<BridgedChain<Self>>;
+
+	/// Convert This chain Balance into Bridged chain Balance.
+	fn this_chain_balance_to_bridged_chain_balance(
+		this_balance: BalanceOf<ThisChain<Self>>,
+	) -> BalanceOf<BridgedChain<Self>>;
+}
+
+/// Chain that has `message-lane` and `call-dispatch` modules.
+pub trait ChainWithMessageLanes {
+	/// Public key of the chain account that may be used to verify signatures.
+	type Signer: Decode;
+	/// Signature type used on the chain.
+	type Signature: Decode;
+	/// Call type on the chain.
+	type Call: Decode;
+	/// Type of weight that is used on the chain.
+	type Weight: From<frame_support::weights::Weight>;
+	/// Type of balances that is used on the chain.
+	type Balance: CheckedAdd + CheckedDiv + CheckedMul + From<u32>;
+}
+
+pub(crate) type ThisChain<B> = <B as MessageBridge>::ThisChain;
+pub(crate) type BridgedChain<B> = <B as MessageBridge>::BridgedChain;
+pub(crate) type WeightOf<C> = <C as ChainWithMessageLanes>::Weight;
+pub(crate) type BalanceOf<C> = <C as ChainWithMessageLanes>::Balance;
+pub(crate) type CallOf<C> = <C as ChainWithMessageLanes>::Call;
+
+/// Sub-module that is declaring types required for processing This -> Bridged chain messages.
+pub mod source {
+	use super::*;
+
+	/// Encoded Call of the Bridged chain. We never try to decode it on This chain.
+	pub type BridgedChainOpaqueCall = Vec<u8>;
+
+	/// Message payload for This -> Bridged chain messages.
+	pub type FromThisChainMessagePayload<B> = pallet_bridge_call_dispatch::MessagePayload<
+		<ThisChain<B> as ChainWithMessageLanes>::Signer,
+		<BridgedChain<B> as ChainWithMessageLanes>::Signer,
+		<BridgedChain<B> as ChainWithMessageLanes>::Signature,
+		BridgedChainOpaqueCall,
+	>;
+
+	/// Estimate delivery and dispatch fee that must be paid for delivering a message to the Bridged chain.
+	///
+	/// The fee is paid in This chain Balance, but we use Bridged chain balance to avoid additional conversions.
+	/// Returns `None` if overflow has happened.
+	pub fn estimate_message_dispatch_and_delivery_fee<B: MessageBridge>(
+		payload: &FromThisChainMessagePayload<B>,
+		relayer_interest_percent: u32,
+	) -> Option<BalanceOf<BridgedChain<B>>> {
+		// the fee (in Bridged tokens) of all transactions that are made on the Bridged chain
+		let delivery_fee = B::bridged_weight_to_balance(B::weight_of_delivery_transaction());
+		let dispatch_fee = B::bridged_weight_to_balance(payload.weight.into());
+		let reward_confirmation_fee =
+			B::bridged_weight_to_balance(B::weight_of_reward_confirmation_transaction_on_target_chain());
+
+		// the fee (in Bridged tokens) of all transactions that are made on This chain
+		let delivery_confirmation_fee = B::this_chain_balance_to_bridged_chain_balance(B::this_weight_to_balance(
+			B::weight_of_delivery_confirmation_transaction_on_this_chain(),
+		));
+
+		// minimal fee (in Bridged tokens) is a sum of all required fees
+		let minimal_fee = delivery_fee
+			.checked_add(&dispatch_fee)
+			.and_then(|fee| fee.checked_add(&reward_confirmation_fee))
+			.and_then(|fee| fee.checked_add(&delivery_confirmation_fee));
+
+		// before returning, add extra fee that is paid to the relayer (relayer interest)
+		minimal_fee.and_then(|fee|
+			// having message with fee that is near the `Balance::MAX_VALUE` of the chain is
+			// unlikely and should be treated as an error
+			// => let's do multiplication first
+			fee
+				.checked_mul(&relayer_interest_percent.into())
+				.and_then(|interest| interest.checked_div(&100u32.into()))
+				.and_then(|interest| fee.checked_add(&interest)))
+	}
+}
+
+/// Sub-module that is declaring types required for processing Bridged -> This chain messages.
+pub mod target {
+	use super::*;
+
+	/// Call origin for Bridged -> This chain messages.
+	pub type FromBridgedChainMessageCallOrigin<B> = pallet_bridge_call_dispatch::CallOrigin<
+		<BridgedChain<B> as ChainWithMessageLanes>::Signer,
+		<ThisChain<B> as ChainWithMessageLanes>::Signer,
+		<ThisChain<B> as ChainWithMessageLanes>::Signature,
+	>;
+
+	/// Decoded Bridged -> This message payload.
+	pub type FromBridgedChainDecodedMessagePayload<B> = pallet_bridge_call_dispatch::MessagePayload<
+		<BridgedChain<B> as ChainWithMessageLanes>::Signer,
+		<ThisChain<B> as ChainWithMessageLanes>::Signer,
+		<ThisChain<B> as ChainWithMessageLanes>::Signature,
+		<ThisChain<B> as ChainWithMessageLanes>::Call,
+	>;
+
+	/// Message payload for Bridged -> This messages.
+	pub struct FromBridgedChainMessagePayload<B: MessageBridge>(FromBridgedChainDecodedMessagePayload<B>);
+
+	impl<B: MessageBridge> Decode for FromBridgedChainMessagePayload<B> {
+		fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
+			// for bridged chain our Calls are opaque - they're encoded to Vec<u8> by submitter
+			// => skip encoded vec length here before decoding Call
+			let spec_version = pallet_bridge_call_dispatch::SpecVersion::decode(input)?;
+			let weight = frame_support::weights::Weight::decode(input)?;
+			let origin = FromBridgedChainMessageCallOrigin::<B>::decode(input)?;
+			let _skipped_length = Compact::<u32>::decode(input)?;
+			let call = CallOf::<ThisChain<B>>::decode(input)?;
+
+			Ok(FromBridgedChainMessagePayload(
+				pallet_bridge_call_dispatch::MessagePayload {
+					spec_version,
+					weight,
+					origin,
+					call,
+				},
+			))
+		}
+	}
+
+	/// Dispatching Bridged -> This chain messages.
+	#[derive(RuntimeDebug, Clone, Copy)]
+	pub struct FromBridgedChainMessageDispatch<B, ThisRuntime, ThisCallDispatchInstance> {
+		_marker: sp_std::marker::PhantomData<(B, ThisRuntime, ThisCallDispatchInstance)>,
+	}
+
+	impl<B: MessageBridge, ThisRuntime, ThisCallDispatchInstance>
+		MessageDispatch<<BridgedChain<B> as ChainWithMessageLanes>::Balance>
+		for FromBridgedChainMessageDispatch<B, ThisRuntime, ThisCallDispatchInstance>
+	where
+		ThisCallDispatchInstance: frame_support::traits::Instance,
+		ThisRuntime: pallet_bridge_call_dispatch::Trait<ThisCallDispatchInstance>,
+		pallet_bridge_call_dispatch::Module<ThisRuntime, ThisCallDispatchInstance>:
+			bp_message_dispatch::MessageDispatch<
+				(LaneId, MessageNonce),
+				Message = FromBridgedChainDecodedMessagePayload<B>,
+			>,
+	{
+		type DispatchPayload = FromBridgedChainMessagePayload<B>;
+
+		fn dispatch_weight(
+			message: &DispatchMessage<Self::DispatchPayload, BalanceOf<BridgedChain<B>>>,
+		) -> frame_support::weights::Weight {
+			message
+				.data
+				.payload
+				.as_ref()
+				.map(|payload| payload.0.weight)
+				.unwrap_or(0)
+		}
+
+		fn dispatch(message: DispatchMessage<Self::DispatchPayload, BalanceOf<BridgedChain<B>>>) {
+			if let Ok(payload) = message.data.payload {
+				pallet_bridge_call_dispatch::Module::<ThisRuntime, ThisCallDispatchInstance>::dispatch(
+					B::INSTANCE,
+					(message.key.lane_id, message.key.nonce),
+					payload.0,
+				);
+			}
+		}
+	}
+}

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -170,15 +170,16 @@ pub mod source {
 			.and_then(|fee| fee.checked_add(&delivery_confirmation_fee));
 
 		// before returning, add extra fee that is paid to the relayer (relayer interest)
-		minimal_fee.and_then(|fee|
+		minimal_fee
+			.and_then(|fee|
 			// having message with fee that is near the `Balance::MAX_VALUE` of the chain is
 			// unlikely and should be treated as an error
 			// => let's do multiplication first
 			fee
 				.checked_mul(&relayer_fee_percent.into())
 				.and_then(|interest| interest.checked_div(&100u32.into()))
-				.and_then(|interest| fee.checked_add(&interest))
-		).ok_or("Overflow when computing minimal required message delivery and dispatch fee")
+				.and_then(|interest| fee.checked_add(&interest)))
+			.ok_or("Overflow when computing minimal required message delivery and dispatch fee")
 	}
 }
 

--- a/modules/call-dispatch/src/lib.rs
+++ b/modules/call-dispatch/src/lib.rs
@@ -47,7 +47,7 @@ use sp_std::{marker::PhantomData, prelude::*};
 pub type SpecVersion = u32;
 
 /// Origin of the call on the target chain.
-#[derive(RuntimeDebug, Encode, Decode, Clone)]
+#[derive(RuntimeDebug, Encode, Decode, Clone, PartialEq, Eq)]
 pub enum CallOrigin<SourceChainAccountPublic, TargetChainAccountPublic, TargetChainSignature> {
 	/// Call is originated from bridge account, which is (designed to be) specific to
 	/// the single deployed instance of the messages bridge (message-lane, ...) module.
@@ -67,7 +67,7 @@ pub enum CallOrigin<SourceChainAccountPublic, TargetChainAccountPublic, TargetCh
 }
 
 /// Message payload type used by call-dispatch module.
-#[derive(RuntimeDebug, Encode, Decode, Clone)]
+#[derive(RuntimeDebug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct MessagePayload<SourceChainAccountPublic, TargetChainAccountPublic, TargetChainSignature, Call> {
 	/// Runtime specification version. We only dispatch messages that have the same
 	/// runtime version. Otherwise we risk to misinterpret encoded calls.

--- a/modules/message-lane/Cargo.toml
+++ b/modules/message-lane/Cargo.toml
@@ -12,6 +12,7 @@ codec = { package = "parity-scale-codec", version = "1.3.1", default-features = 
 # Bridge dependencies
 
 bp-message-lane = { path = "../../primitives/message-lane", default-features = false }
+bp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 # Substrate Dependencies
 
@@ -28,6 +29,7 @@ sp-io = "2.0"
 default = ["std"]
 std = [
 	"bp-message-lane/std",
+	"bp-runtime/std",
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/modules/message-lane/src/instant_payments.rs
+++ b/modules/message-lane/src/instant_payments.rs
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Implementation of `MessageDeliveryAndDispatchPayment` trait on top of `Currency` trait.
+//! All payments are instant.
+
+use bp_message_lane::source_chain::MessageDeliveryAndDispatchPayment;
+use bp_runtime::{bridge_account_id, MESSAGE_LANE_MODULE_PREFIX, NO_INSTANCE_ID};
+use codec::Decode;
+use frame_support::traits::{Currency as CurrencyT, ExistenceRequirement};
+use sp_std::fmt::Debug;
+
+/// Instant message payments made in given currency. Until claimed, fee is stored in special
+/// 'relayers-fund' account.
+pub struct InstantCurrencyPayments<AccountId, Currency> {
+	_phantom: sp_std::marker::PhantomData<(AccountId, Currency)>,
+}
+
+impl<AccountId, Currency> MessageDeliveryAndDispatchPayment<AccountId, Currency::Balance>
+	for InstantCurrencyPayments<AccountId, Currency>
+where
+	Currency: CurrencyT<AccountId>,
+	AccountId: Debug + Default + Decode,
+{
+	type Error = &'static str;
+
+	fn pay_delivery_and_dispatch_fee(submitter: &AccountId, fee: &Currency::Balance) -> Result<(), Self::Error> {
+		Currency::transfer(
+			submitter,
+			&relayers_fund_account(),
+			*fee,
+			ExistenceRequirement::AllowDeath,
+		)
+		.map_err(Into::into)
+	}
+
+	fn pay_relayer_reward(_confirmation_relayer: &AccountId, relayer: &AccountId, reward: &Currency::Balance) {
+		let pay_result = Currency::transfer(
+			&relayers_fund_account(),
+			relayer,
+			*reward,
+			ExistenceRequirement::AllowDeath,
+		);
+
+		// we can't actually do anything here, because rewards are paid as a part of unrelated transaction
+		if let Err(error) = pay_result {
+			frame_support::debug::trace!(
+				target: "runtime",
+				"Failed to pay relayer {:?} reward {:?}: {:?}",
+				relayer,
+				reward,
+				error,
+			);
+		}
+	}
+}
+
+/// Return account id of shared relayers-fund account that is storing all fees
+/// paid by submitters, until they're claimed by relayers.
+fn relayers_fund_account<AccountId: Default + Decode>() -> AccountId {
+	bridge_account_id(NO_INSTANCE_ID, MESSAGE_LANE_MODULE_PREFIX)
+}

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -48,6 +48,8 @@ use sp_std::{cell::RefCell, marker::PhantomData, prelude::*};
 mod inbound_lane;
 mod outbound_lane;
 
+pub mod instant_payments;
+
 #[cfg(test)]
 mod mock;
 

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -21,13 +21,16 @@
 #![allow(clippy::unnecessary_mut_passed)]
 
 use bp_runtime::Chain;
-use frame_support::RuntimeDebug;
+use frame_support::{weights::Weight, RuntimeDebug};
 use sp_core::Hasher as HasherT;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, Verify},
 	MultiSignature, MultiSigner,
 };
 use sp_std::prelude::*;
+
+/// Maximal weight of single Millau extrinsic.
+pub const MAXIMUM_EXTRINSIC_WEIGHT: Weight = 1_300_000_000_000;
 
 /// Block number type used in Millau.
 pub type BlockNumber = u32;

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -23,7 +23,10 @@
 use bp_runtime::Chain;
 use frame_support::RuntimeDebug;
 use sp_core::Hasher as HasherT;
-use sp_runtime::traits::BlakeTwo256;
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentifyAccount, Verify},
+	MultiSignature, MultiSigner,
+};
 use sp_std::prelude::*;
 
 /// Block number type used in Millau.
@@ -55,6 +58,19 @@ pub const BEST_MILLAU_BLOCK_METHOD: &str = "MillauHeaderApi_best_block";
 pub const IS_KNOWN_MILLAU_BLOCK_METHOD: &str = "MillauHeaderApi_is_known_block";
 /// Name of the `MillauHeaderApi::incomplete_headers` runtime method.
 pub const INCOMPLETE_MILLAU_HEADERS_METHOD: &str = "MillauHeaderApi_incomplete_headers";
+
+/// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
+pub type Signature = MultiSignature;
+
+/// Some way of identifying an account on the chain. We intentionally make it equivalent
+/// to the public key of our transaction signing scheme.
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+/// Public key of the chain account that may be used to verify signatures.
+pub type AccountSigner = MultiSigner;
+
+/// Balance of an account.
+pub type Balance = u128;
 
 sp_api::decl_runtime_apis! {
 	/// API for querying information about Millau headers from the Bridge Pallet instance.

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -29,8 +29,13 @@ use sp_runtime::{
 };
 use sp_std::prelude::*;
 
-/// Maximal weight of single Millau extrinsic.
-pub const MAXIMUM_EXTRINSIC_WEIGHT: Weight = 1_300_000_000_000;
+/// Maximal weight of single Millau block.
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = 2_000_000_000_000;
+/// Portion of block reserved for regular transactions.
+pub const AVAILABLE_BLOCK_RATIO: u32 = 75;
+/// Maximal weight of single Millau extrinsic (65% of maximum block weight = 75% for regular
+/// transactions minus 10% for initialization).
+pub const MAXIMUM_EXTRINSIC_WEIGHT: Weight = MAXIMUM_BLOCK_WEIGHT / 100 * (AVAILABLE_BLOCK_RATIO as Weight - 10);
 
 /// Block number type used in Millau.
 pub type BlockNumber = u32;

--- a/primitives/rialto/Cargo.toml
+++ b/primitives/rialto/Cargo.toml
@@ -13,6 +13,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
+
 frame-support = { version = "2.0", default-features = false }
 sp-api = { version = "2.0", default-features = false }
 sp-core = { version = "2.0", default-features = false }

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -21,13 +21,16 @@
 #![allow(clippy::unnecessary_mut_passed)]
 
 use bp_runtime::Chain;
-use frame_support::RuntimeDebug;
+use frame_support::{weights::Weight, RuntimeDebug};
 use sp_core::Hasher as HasherT;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, Verify},
 	MultiSignature, MultiSigner,
 };
 use sp_std::prelude::*;
+
+/// Maximal weight of single Rialto extrinsic.
+pub const MAXIMUM_EXTRINSIC_WEIGHT: Weight = 1_300_000_000_000;
 
 /// Block number type used in Rialto.
 pub type BlockNumber = u32;

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -23,7 +23,10 @@
 use bp_runtime::Chain;
 use frame_support::RuntimeDebug;
 use sp_core::Hasher as HasherT;
-use sp_runtime::traits::BlakeTwo256;
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentifyAccount, Verify},
+	MultiSignature, MultiSigner,
+};
 use sp_std::prelude::*;
 
 /// Block number type used in Rialto.
@@ -48,6 +51,19 @@ impl Chain for Rialto {
 	type Hasher = Hasher;
 	type Header = Header;
 }
+
+/// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
+pub type Signature = MultiSignature;
+
+/// Some way of identifying an account on the chain. We intentionally make it equivalent
+/// to the public key of our transaction signing scheme.
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+/// Public key of the chain account that may be used to verify signatures.
+pub type AccountSigner = MultiSigner;
+
+/// Balance of an account.
+pub type Balance = u128;
 
 sp_api::decl_runtime_apis! {
 	/// API for querying information about Rialto headers from the Bridge Pallet instance.

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -29,8 +29,13 @@ use sp_runtime::{
 };
 use sp_std::prelude::*;
 
-/// Maximal weight of single Rialto extrinsic.
-pub const MAXIMUM_EXTRINSIC_WEIGHT: Weight = 1_300_000_000_000;
+/// Maximal weight of single Millau block.
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = 2_000_000_000_000;
+/// Portion of block reserved for regular transactions.
+pub const AVAILABLE_BLOCK_RATIO: u32 = 75;
+/// Maximal weight of single Millau extrinsic (65% of maximum block weight = 75% for regular
+/// transactions minus 10% for initialization).
+pub const MAXIMUM_EXTRINSIC_WEIGHT: Weight = MAXIMUM_BLOCK_WEIGHT / 100 * (AVAILABLE_BLOCK_RATIO as Weight - 10);
 
 /// Block number type used in Rialto.
 pub type BlockNumber = u32;

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -25,8 +25,14 @@ pub use chain::{BlockNumberOf, Chain, HashOf, HasherOf, HeaderOf};
 
 mod chain;
 
+/// Use this when something must be shared among all instances.
+pub const NO_INSTANCE_ID: InstanceId = [0, 0, 0, 0];
+
 /// Call-dispatch module prefix.
 pub const CALL_DISPATCH_MODULE_PREFIX: &[u8] = b"pallet-bridge/call-dispatch";
+
+/// Message-lane module prefix.
+pub const MESSAGE_LANE_MODULE_PREFIX: &[u8] = b"pallet-bridge/message-lane";
 
 /// Id of deployed module instance. We have a bunch of pallets that may be used in
 /// different bridges. E.g. message-lane pallet may be deployed twice in the same


### PR DESCRIPTION
The integration code is mostly in `bin/runtime-common/src/messages.rs` with runtime-specific type aliases in `bin/millau/runtime/src/rialto_messages.rs` and `bin/rialto/runtime/src/millau_messages.rs`.