### PR TITLE
Move Chain trait to runtime primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,8 +733,12 @@ dependencies = [
 name = "bp-runtime"
 version = "0.1.0"
 dependencies = [
+ "frame-support",
+ "num-traits",
  "parity-scale-codec",
  "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -4164,6 +4168,7 @@ dependencies = [
 name = "pallet-substrate-bridge"
 version = "0.1.0"
 dependencies = [
+ "bp-runtime",
  "finality-grandpa",
  "frame-support",
  "frame-system",
@@ -5186,6 +5191,7 @@ name = "relay-substrate-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bp-runtime",
  "frame-support",
  "frame-system",
  "headers-relay",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,8 @@ dependencies = [
 name = "bp-millau"
 version = "0.1.0"
 dependencies = [
+ "bp-runtime",
+ "frame-support",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -723,6 +725,8 @@ dependencies = [
 name = "bp-rialto"
 version = "0.1.0"
 dependencies = [
+ "bp-runtime",
+ "frame-support",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -4173,7 +4177,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hash-db",
- "num-traits",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -32,9 +32,7 @@ use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as G
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::traits::{
-	Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify,
-};
+use sp_runtime::traits::{Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionSource, TransactionValidity},

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -84,6 +84,9 @@ pub type Index = u32;
 /// A hash of some data used by the chain.
 pub type Hash = bp_millau::Hash;
 
+/// Hashing algorithm used by the chain.
+pub type Hashing = BlakeTwo256;
+
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
 
@@ -97,7 +100,7 @@ pub mod opaque {
 	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
 
 	/// Opaque block header type.
-	pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	pub type Header = generic::Header<BlockNumber, Hashing>;
 	/// Opaque block type.
 	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 	/// Opaque block identifier type.
@@ -172,9 +175,9 @@ impl frame_system::Trait for Runtime {
 	/// The type for hashing blocks and tries.
 	type Hash = Hash;
 	/// The hashing algorithm used.
-	type Hashing = BlakeTwo256;
+	type Hashing = Hashing;
 	/// The header type.
-	type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	type Header = generic::Header<BlockNumber, Hashing>;
 	/// The ubiquitous event type.
 	type Event = Event;
 	/// The ubiquitous origin type.
@@ -341,7 +344,7 @@ construct_runtime!(
 /// The address format for describing accounts.
 pub type Address = AccountId;
 /// Block header type as expected by this runtime.
-pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Header = generic::Header<BlockNumber, Hashing>;
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 /// A Block signed with a Justification

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -33,7 +33,7 @@ use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify,
+	Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
@@ -85,7 +85,7 @@ pub type Index = u32;
 pub type Hash = bp_millau::Hash;
 
 /// Hashing algorithm used by the chain.
-pub type Hashing = BlakeTwo256;
+pub type Hashing = bp_millau::Hasher;
 
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
@@ -312,10 +312,7 @@ impl pallet_session::Trait for Runtime {
 }
 
 impl pallet_substrate_bridge::Trait for Runtime {
-	type BridgedHeader = bp_rialto::Header;
-	type BridgedBlockNumber = bp_rialto::BlockNumber;
-	type BridgedBlockHash = bp_rialto::Hash;
-	type BridgedBlockHasher = bp_rialto::Hasher;
+	type BridgedChain = bp_rialto::Rialto;
 }
 
 impl pallet_shift_session_manager::Trait for Runtime {}

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -40,7 +40,7 @@ use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify,
+	Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
@@ -93,7 +93,7 @@ pub type Index = u32;
 pub type Hash = bp_rialto::Hash;
 
 /// Hashing algorithm used by the chain.
-pub type Hashing = BlakeTwo256;
+pub type Hashing = bp_rialto::Hasher;
 
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
@@ -418,10 +418,7 @@ impl pallet_session::Trait for Runtime {
 }
 
 impl pallet_substrate_bridge::Trait for Runtime {
-	type BridgedHeader = bp_millau::Header;
-	type BridgedBlockNumber = bp_millau::BlockNumber;
-	type BridgedBlockHash = bp_millau::Hash;
-	type BridgedBlockHasher = bp_millau::Hasher;
+	type BridgedChain = bp_millau::Millau;
 }
 
 impl pallet_shift_session_manager::Trait for Runtime {}

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -92,6 +92,9 @@ pub type Index = u32;
 /// A hash of some data used by the chain.
 pub type Hash = bp_rialto::Hash;
 
+/// Hashing algorithm used by the chain.
+pub type Hashing = BlakeTwo256;
+
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
 
@@ -105,7 +108,7 @@ pub mod opaque {
 	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
 
 	/// Opaque block header type.
-	pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	pub type Header = generic::Header<BlockNumber, Hashing>;
 	/// Opaque block type.
 	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 	/// Opaque block identifier type.
@@ -180,9 +183,9 @@ impl frame_system::Trait for Runtime {
 	/// The type for hashing blocks and tries.
 	type Hash = Hash;
 	/// The hashing algorithm used.
-	type Hashing = BlakeTwo256;
+	type Hashing = Hashing;
 	/// The header type.
-	type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	type Header = generic::Header<BlockNumber, Hashing>;
 	/// The ubiquitous event type.
 	type Event = Event;
 	/// The ubiquitous origin type.
@@ -451,7 +454,7 @@ construct_runtime!(
 /// The address format for describing accounts.
 pub type Address = AccountId;
 /// Block header type as expected by this runtime.
-pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Header = generic::Header<BlockNumber, Hashing>;
 /// Block type as expected by this runtime.
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 /// A Block signed with a Justification

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -39,9 +39,7 @@ use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as G
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_runtime::traits::{
-	Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify,
-};
+use sp_runtime::traits::{Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, OpaqueKeys, Saturating, Verify};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionSource, TransactionValidity},

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -14,6 +14,10 @@ hash-db = { version = "0.15.2", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", optional = true }
 
+# Bridge Dependencies
+
+bp-runtime = { path = "../../primitives/runtime" }
+
 # Substrate Dependencies
 
 frame-support = { version = "2.0", default-features = false }

--- a/modules/substrate/Cargo.toml
+++ b/modules/substrate/Cargo.toml
@@ -11,12 +11,11 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 finality-grandpa = { version = "0.12.3", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
-num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", optional = true }
 
 # Bridge Dependencies
 
-bp-runtime = { path = "../../primitives/runtime" }
+bp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 # Substrate Dependencies
 
@@ -36,12 +35,12 @@ sp-state-machine = "0.8"
 [features]
 default = ["std"]
 std = [
+	"bp-runtime/std",
 	"codec/std",
 	"finality-grandpa/std",
 	"frame-support/std",
 	"frame-system/std",
 	"hash-db/std",
-	"num-traits/std",
 	"serde",
 	"sp-finality-grandpa/std",
 	"sp-runtime/std",

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -61,7 +61,7 @@ pub(crate) type BridgedHeader<T> = HeaderOf<<T as Trait>::BridgedChain>;
 decl_storage! {
 	trait Store for Module<T: Trait> as SubstrateBridge {
 		/// Hash of the header at the highest known height.
-		BestHeader: T::BridgedBlockHash;
+		BestHeader: BridgedBlockHash<T>;
 		/// Hash of the best finalized header.
 		BestFinalized: BridgedBlockHash<T>;
 		/// A header which enacts an authority set change and therefore
@@ -186,7 +186,7 @@ impl<T: Trait> Module<T> {
 	/// Get the highest header that the pallet knows of.
 	// In a future where we support forks this could be a Vec of headers
 	// since we may have multiple headers at the same height.
-	pub fn best_header() -> T::BridgedHeader {
+	pub fn best_header() -> BridgedHeader<T> {
 		PalletStorage::<T>::new().best_header().header
 	}
 
@@ -195,12 +195,12 @@ impl<T: Trait> Module<T> {
 	/// Since this has been finalized correctly a user of the bridge
 	/// pallet should be confident that any transactions that were
 	/// included in this or any previous header will not be reverted.
-	pub fn best_finalized() -> T::BridgedHeader {
+	pub fn best_finalized() -> BridgedHeader<T> {
 		PalletStorage::<T>::new().best_finalized_header().header
 	}
 
 	/// Check if a particular header is known to the bridge pallet.
-	pub fn is_known_header(hash: T::BridgedBlockHash) -> bool {
+	pub fn is_known_header(hash: BridgedBlockHash<T>) -> bool {
 		PalletStorage::<T>::new().header_exists(hash)
 	}
 
@@ -210,7 +210,7 @@ impl<T: Trait> Module<T> {
 	// One thing worth noting here is that this approach won't work well
 	// once we track forks since there could be an older header on a
 	// different fork which isn't an ancestor of our best finalized header.
-	pub fn is_finalized_header(hash: T::BridgedBlockHash) -> bool {
+	pub fn is_finalized_header(hash: BridgedBlockHash<T>) -> bool {
 		let storage = PalletStorage::<T>::new();
 		if let Some(header) = storage.header_by_hash(hash) {
 			header.number() <= storage.best_finalized_header().number()
@@ -223,7 +223,7 @@ impl<T: Trait> Module<T> {
 	/// and still needs a finality proof.
 	///
 	/// Will return None if there are no headers which are missing finality proofs.
-	pub fn requires_justification() -> Option<T::BridgedHeader> {
+	pub fn requires_justification() -> Option<BridgedHeader<T>> {
 		let storage = PalletStorage::<T>::new();
 		let hash = storage.unfinalized_header()?;
 		let imported_header = storage.header_by_hash(hash).expect(
@@ -338,7 +338,7 @@ impl<T: Trait> BridgeStorage for PalletStorage<T> {
 		<ImportedHeaders<T>>::get(hash)
 	}
 
-	fn unfinalized_header(&self) -> Option<T::BridgedBlockHash> {
+	fn unfinalized_header(&self) -> Option<BridgedBlockHash<T>> {
 		<RequiresJustification<T>>::get()
 	}
 

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -32,11 +32,8 @@
 #![allow(clippy::large_enum_variant)]
 
 use crate::storage::{AuthoritySet, ImportedHeader, ScheduledChange};
-use bp_runtime::{Chain, BlockNumberOf, HashOf, HeaderOf};
-use frame_support::{
-	decl_error, decl_module, decl_storage,
-	dispatch::DispatchResult,
-};
+use bp_runtime::{BlockNumberOf, Chain, HashOf, HeaderOf};
+use frame_support::{decl_error, decl_module, decl_storage, dispatch::DispatchResult};
 use frame_system::ensure_signed;
 use sp_runtime::traits::Header as HeaderT;
 use sp_std::{marker::PhantomData, prelude::*};

--- a/modules/substrate/src/mock.rs
+++ b/modules/substrate/src/mock.rs
@@ -92,8 +92,8 @@ pub fn run_test<T>(test: impl FnOnce() -> T) -> T {
 }
 
 pub mod helpers {
-	use crate::{BridgedBlockNumber, BridgedBlockHash, BridgedHeader};
 	use super::*;
+	use crate::{BridgedBlockHash, BridgedBlockNumber, BridgedHeader};
 	use finality_grandpa::voter_set::VoterSet;
 	use sp_finality_grandpa::{AuthorityId, AuthorityList};
 	use sp_keyring::Ed25519Keyring;

--- a/modules/substrate/src/mock.rs
+++ b/modules/substrate/src/mock.rs
@@ -21,6 +21,7 @@
 #![cfg(test)]
 
 use crate::Trait;
+use bp_runtime::Chain;
 use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
 use sp_runtime::{
 	testing::{Header, H256},
@@ -73,10 +74,17 @@ impl frame_system::Trait for TestRuntime {
 }
 
 impl Trait for TestRuntime {
-	type BridgedHeader = <Self as frame_system::Trait>::Header;
-	type BridgedBlockNumber = <Self as frame_system::Trait>::BlockNumber;
-	type BridgedBlockHash = <Self as frame_system::Trait>::Hash;
-	type BridgedBlockHasher = <Self as frame_system::Trait>::Hashing;
+	type BridgedChain = TestBridgedChain;
+}
+
+#[derive(Debug)]
+pub struct TestBridgedChain;
+
+impl Chain for TestBridgedChain {
+	type BlockNumber = <TestRuntime as frame_system::Trait>::BlockNumber;
+	type Hash = <TestRuntime as frame_system::Trait>::Hash;
+	type Hasher = <TestRuntime as frame_system::Trait>::Hashing;
+	type Header = <TestRuntime as frame_system::Trait>::Header;
 }
 
 pub fn run_test<T>(test: impl FnOnce() -> T) -> T {
@@ -84,14 +92,15 @@ pub fn run_test<T>(test: impl FnOnce() -> T) -> T {
 }
 
 pub mod helpers {
+	use crate::{BridgedBlockNumber, BridgedBlockHash, BridgedHeader};
 	use super::*;
 	use finality_grandpa::voter_set::VoterSet;
 	use sp_finality_grandpa::{AuthorityId, AuthorityList};
 	use sp_keyring::Ed25519Keyring;
 
-	pub type TestHeader = <TestRuntime as Trait>::BridgedHeader;
-	pub type TestNumber = <TestRuntime as Trait>::BridgedBlockNumber;
-	pub type TestHash = <TestRuntime as Trait>::BridgedBlockHash;
+	pub type TestHeader = BridgedHeader<TestRuntime>;
+	pub type TestNumber = BridgedBlockNumber<TestRuntime>;
+	pub type TestHash = BridgedBlockHash<TestRuntime>;
 	pub type HeaderId = (TestHash, TestNumber);
 
 	pub fn test_header(num: TestNumber) -> TestHeader {

--- a/primitives/millau/Cargo.toml
+++ b/primitives/millau/Cargo.toml
@@ -8,7 +8,13 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 
+# Bridge Dependencies
+
+bp-runtime = { path = "../runtime", default-features = false }
+
 # Substrate Based Dependencies
+
+frame-support = { version = "2.0", default-features = false }
 sp-api = { version = "2.0", default-features = false }
 sp-core = { version = "2.0", default-features = false }
 sp-runtime = { version = "2.0", default-features = false }
@@ -17,6 +23,8 @@ sp-std = { version = "2.0", default-features = false }
 [features]
 default = ["std"]
 std = [
+	"bp-runtime/std",
+	"frame-support/std",
 	"sp-api/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -20,6 +20,8 @@
 // Runtime-generated DecodeLimit::decode_all_With_depth_limit
 #![allow(clippy::unnecessary_mut_passed)]
 
+use bp_runtime::Chain;
+use frame_support::RuntimeDebug;
 use sp_core::Hasher as HasherT;
 use sp_runtime::traits::BlakeTwo256;
 use sp_std::prelude::*;
@@ -35,6 +37,17 @@ pub type Hasher = BlakeTwo256;
 
 /// The header type used by Millau.
 pub type Header = sp_runtime::generic::Header<BlockNumber, Hasher>;
+
+/// Millau chain.
+#[derive(RuntimeDebug)]
+pub struct Millau;
+
+impl Chain for Millau {
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+}
 
 sp_api::decl_runtime_apis! {
 	/// API for querying information about Millau headers from the Bridge Pallet instance.

--- a/primitives/rialto/Cargo.toml
+++ b/primitives/rialto/Cargo.toml
@@ -8,15 +8,23 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 
+# Bridge Dependencies
+
+bp-runtime = { path = "../runtime", default-features = false }
+
 # Substrate Based Dependencies
-sp-api = { version = "2.0.0", default-features = false }
-sp-core = { version = "2.0.0", default-features = false }
-sp-runtime = { version = "2.0.0", default-features = false }
-sp-std = { version = "2.0.0", default-features = false }
+
+frame-support = { version = "2.0", default-features = false }
+sp-api = { version = "2.0", default-features = false }
+sp-core = { version = "2.0", default-features = false }
+sp-runtime = { version = "2.0", default-features = false }
+sp-std = { version = "2.0", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"bp-runtime/std",
+	"frame-support/std",
 	"sp-api/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -20,6 +20,8 @@
 // Runtime-generated DecodeLimit::decode_all_With_depth_limit
 #![allow(clippy::unnecessary_mut_passed)]
 
+use bp_runtime::Chain;
+use frame_support::RuntimeDebug;
 use sp_core::Hasher as HasherT;
 use sp_runtime::traits::BlakeTwo256;
 use sp_std::prelude::*;
@@ -35,6 +37,17 @@ pub type Hasher = BlakeTwo256;
 
 /// The header type used by Rialto.
 pub type Header = sp_runtime::generic::Header<BlockNumber, Hasher>;
+
+/// Rialto chain.
+#[derive(RuntimeDebug)]
+pub struct Rialto;
+
+impl Chain for Rialto {
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+}
 
 sp_api::decl_runtime_apis! {
 	/// API for querying information about Rialto headers from the Bridge Pallet instance.

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -8,14 +8,22 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 
 # Substrate Dependencies
 
+frame-support = { version = "2.0", default-features = false }
 sp-io = { version = "2.0", default-features = false }
+sp-runtime = { version = "2.0", default-features = false }
+sp-std = { version = "2.0", default-features = false }
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
+	"frame-support/std",
+	"num-traits/std",
 	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std",
 ]

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -1,0 +1,85 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+use frame_support::Parameter;
+use num_traits::AsPrimitive;
+use sp_runtime::traits::{
+	AtLeast32BitUnsigned, Hash as HashT, Header as HeaderT, MaybeDisplay, MaybeMallocSizeOf, MaybeSerializeDeserialize,
+	Member, SimpleBitOps,
+};
+use sp_std::str::FromStr;
+
+/// Minimal Substrate-based chain representation that may be used from no_std environment.
+pub trait Chain {
+	/// A type that fulfills the abstract idea of what a Substrate block number is.
+	// Constraits come from the associated Number type of `sp_runtime::traits::Header`
+	// See here for more info:
+	// https://crates.parity.io/sp_runtime/traits/trait.Header.html#associatedtype.Number
+	//
+	// Note that the `AsPrimitive<usize>` trait is required by the Grandpa justification
+	// verifier, and is not usually part of a Substrate Header's Number type.
+	type BlockNumber: Parameter
+		+ Member
+		+ MaybeSerializeDeserialize
+		+ sp_std::hash::Hash
+		+ Copy
+		+ MaybeDisplay
+		+ AtLeast32BitUnsigned
+		+ FromStr
+		+ MaybeMallocSizeOf
+		+ AsPrimitive<usize>;
+
+	/// A type that fulfills the abstract idea of what a Substrate hash is.
+	// Constraits come from the associated Hash type of `sp_runtime::traits::Header`
+	// See here for more info:
+	// https://crates.parity.io/sp_runtime/traits/trait.Header.html#associatedtype.Hash
+	type Hash: Parameter
+		+ Member
+		+ MaybeSerializeDeserialize
+		+ sp_std::hash::Hash
+		+ Ord
+		+ Copy
+		+ MaybeDisplay
+		+ Default
+		+ SimpleBitOps
+		+ AsRef<[u8]>
+		+ AsMut<[u8]>
+		+ MaybeMallocSizeOf;
+
+	/// A type that fulfills the abstract idea of what a Substrate hasher (a type
+	/// that produces hashes) is.
+	// Constraits come from the associated Hashing type of `sp_runtime::traits::Header`
+	// See here for more info:
+	// https://crates.parity.io/sp_runtime/traits/trait.Header.html#associatedtype.Hashing
+	type Hasher: HashT<Output = Self::Hash>;
+
+	/// A type that fulfills the abstract idea of what a Substrate header is.
+	// See here for more info:
+	// https://crates.parity.io/sp_runtime/traits/trait.Header.html
+	type Header: Parameter + HeaderT<Number = Self::BlockNumber, Hash = Self::Hash>;
+}
+
+/// Block number used by the chain.
+pub type BlockNumberOf<C> = <C as Chain>::BlockNumber;
+
+/// Hash type used by the chain.
+pub type HashOf<C> = <C as Chain>::Hash;
+
+/// Hasher type used by the chain.
+pub type HasherOf<C> = <C as Chain>::Header;
+
+/// Header type used by the chain.
+pub type HeaderOf<C> = <C as Chain>::Header;

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -21,7 +21,7 @@
 use codec::{Decode, Encode};
 use sp_io::hashing::blake2_256;
 
-pub use chain::{Chain, BlockNumberOf, HashOf, HasherOf, HeaderOf};
+pub use chain::{BlockNumberOf, Chain, HashOf, HasherOf, HeaderOf};
 
 mod chain;
 

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -21,6 +21,10 @@
 use codec::{Decode, Encode};
 use sp_io::hashing::blake2_256;
 
+pub use chain::{Chain, BlockNumberOf, HashOf, HasherOf, HeaderOf};
+
+mod chain;
+
 /// Call-dispatch module prefix.
 pub const CALL_DISPATCH_MODULE_PREFIX: &[u8] = b"pallet-bridge/call-dispatch";
 

--- a/relays/millau-client/src/lib.rs
+++ b/relays/millau-client/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Types used to connect to the Millau-Substrate chain.
 
-use relay_substrate_client::Chain;
+use relay_substrate_client::{Chain, ChainBase};
 
 use headers_relay::sync_types::SourceHeader;
 use sp_runtime::traits::Header as HeaderT;
@@ -28,10 +28,14 @@ pub type HeaderId = relay_utils::HeaderId<millau_runtime::Hash, millau_runtime::
 #[derive(Debug, Clone, Copy)]
 pub struct Millau;
 
-impl Chain for Millau {
+impl ChainBase for Millau {
 	type BlockNumber = millau_runtime::BlockNumber;
 	type Hash = millau_runtime::Hash;
+	type Hasher = millau_runtime::Hashing;
 	type Header = millau_runtime::Header;
+}
+
+impl Chain for Millau {
 	type AccountId = millau_runtime::AccountId;
 	type Index = millau_runtime::Index;
 	type SignedBlock = millau_runtime::SignedBlock;

--- a/relays/rialto-client/src/lib.rs
+++ b/relays/rialto-client/src/lib.rs
@@ -18,7 +18,7 @@
 
 use codec::Encode;
 use headers_relay::sync_types::SourceHeader;
-use relay_substrate_client::{Chain, Client, TransactionSignScheme};
+use relay_substrate_client::{Chain, ChainBase, Client, TransactionSignScheme};
 use sp_core::Pair;
 use sp_runtime::{
 	generic::SignedPayload,
@@ -32,10 +32,14 @@ pub type HeaderId = relay_utils::HeaderId<rialto_runtime::Hash, rialto_runtime::
 #[derive(Debug, Clone, Copy)]
 pub struct Rialto;
 
-impl Chain for Rialto {
+impl ChainBase for Rialto {
 	type BlockNumber = rialto_runtime::BlockNumber;
 	type Hash = rialto_runtime::Hash;
+	type Hasher = rialto_runtime::Hashing;
 	type Header = rialto_runtime::Header;
+}
+
+impl Chain for Rialto {
 	type AccountId = rialto_runtime::AccountId;
 	type Index = rialto_runtime::Index;
 	type SignedBlock = rialto_runtime::SignedBlock;

--- a/relays/substrate-client/Cargo.toml
+++ b/relays/substrate-client/Cargo.toml
@@ -14,6 +14,7 @@ num-traits = "0.2"
 
 # Bridge dependencies
 
+bp-runtime = { path = "../../primitives/runtime" }
 headers-relay = { path = "../headers-relay" }
 relay-utils = { path = "../utils" }
 

--- a/relays/substrate-client/src/chain.rs
+++ b/relays/substrate-client/src/chain.rs
@@ -22,10 +22,7 @@ use jsonrpsee::common::{DeserializeOwned, Serialize};
 use sp_core::Pair;
 use sp_runtime::{
 	generic::SignedBlock,
-	traits::{
-		AtLeast32Bit, Dispatchable, MaybeDisplay,
-		MaybeSerialize, MaybeSerializeDeserialize, Member,
-	},
+	traits::{AtLeast32Bit, Dispatchable, MaybeDisplay, MaybeSerialize, MaybeSerializeDeserialize, Member},
 	Justification,
 };
 use sp_std::fmt::Debug;

--- a/relays/substrate-client/src/chain.rs
+++ b/relays/substrate-client/src/chain.rs
@@ -64,15 +64,6 @@ pub trait TransactionSignScheme {
 	) -> Self::SignedTransaction;
 }
 
-/// Header type used by the chain.
-pub type HeaderOf<C> = bp_runtime::HeaderOf<C>;
-
-/// Hash type used by the chain.
-pub type HashOf<C> = bp_runtime::HashOf<C>;
-
-/// Block number used by the chain.
-pub type BlockNumberOf<C> = bp_runtime::BlockNumberOf<C>;
-
 impl<Block> BlockWithJustification for SignedBlock<Block> {
 	fn justification(&self) -> Option<&Justification> {
 		self.justification.as_ref()

--- a/relays/substrate-client/src/chain.rs
+++ b/relays/substrate-client/src/chain.rs
@@ -16,51 +16,22 @@
 
 use crate::client::Client;
 
+use bp_runtime::Chain as ChainBase;
 use frame_support::Parameter;
 use jsonrpsee::common::{DeserializeOwned, Serialize};
 use sp_core::Pair;
 use sp_runtime::{
 	generic::SignedBlock,
 	traits::{
-		AtLeast32Bit, AtLeast32BitUnsigned, Bounded, CheckEqual, Dispatchable, Header as HeaderT, MaybeDisplay,
-		MaybeMallocSizeOf, MaybeSerialize, MaybeSerializeDeserialize, Member, SimpleBitOps,
+		AtLeast32Bit, Dispatchable, MaybeDisplay,
+		MaybeSerialize, MaybeSerializeDeserialize, Member,
 	},
 	Justification,
 };
 use sp_std::fmt::Debug;
 
 /// Substrate-based chain from minimal relay-client point of view.
-pub trait Chain {
-	/// The block number type used by the runtime.
-	type BlockNumber: Parameter
-		+ Member
-		+ MaybeSerializeDeserialize
-		+ Debug
-		+ MaybeDisplay
-		+ AtLeast32BitUnsigned
-		+ Default
-		+ Bounded
-		+ Copy
-		+ sp_std::hash::Hash
-		+ sp_std::str::FromStr
-		+ MaybeMallocSizeOf;
-	/// The output of the `Hashing` function.
-	type Hash: Parameter
-		+ Member
-		+ MaybeSerializeDeserialize
-		+ Debug
-		+ MaybeDisplay
-		+ SimpleBitOps
-		+ Ord
-		+ Default
-		+ Copy
-		+ CheckEqual
-		+ sp_std::hash::Hash
-		+ AsRef<[u8]>
-		+ AsMut<[u8]>
-		+ MaybeMallocSizeOf;
-	/// The block header.
-	type Header: Parameter + HeaderT<Number = Self::BlockNumber, Hash = Self::Hash>;
+pub trait Chain: ChainBase {
 	/// The user account identifier type for the runtime.
 	type AccountId: Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + Ord + Default;
 	/// Account index (aka nonce) type. This stores the number of previous transactions associated
@@ -97,13 +68,13 @@ pub trait TransactionSignScheme {
 }
 
 /// Header type used by the chain.
-pub type HeaderOf<C> = <C as Chain>::Header;
+pub type HeaderOf<C> = bp_runtime::HeaderOf<C>;
 
 /// Hash type used by the chain.
-pub type HashOf<C> = <C as Chain>::Hash;
+pub type HashOf<C> = bp_runtime::HashOf<C>;
 
 /// Block number used by the chain.
-pub type BlockNumberOf<C> = <C as Chain>::BlockNumber;
+pub type BlockNumberOf<C> = bp_runtime::BlockNumberOf<C>;
 
 impl<Block> BlockWithJustification for SignedBlock<Block> {
 	fn justification(&self) -> Option<&Justification> {

--- a/relays/substrate-client/src/lib.rs
+++ b/relays/substrate-client/src/lib.rs
@@ -25,10 +25,10 @@ mod rpc;
 
 pub mod headers_source;
 
-pub use crate::chain::{BlockNumberOf, BlockWithJustification, Chain, HashOf, HeaderOf, TransactionSignScheme};
+pub use crate::chain::{BlockWithJustification, Chain, TransactionSignScheme};
 pub use crate::client::{Client, OpaqueGrandpaAuthoritiesSet};
 pub use crate::error::{Error, Result};
-pub use bp_runtime::Chain as ChainBase;
+pub use bp_runtime::{BlockNumberOf, Chain as ChainBase, HashOf, HeaderOf};
 
 /// Substrate connection params.
 #[derive(Debug, Clone)]

--- a/relays/substrate-client/src/lib.rs
+++ b/relays/substrate-client/src/lib.rs
@@ -25,10 +25,10 @@ mod rpc;
 
 pub mod headers_source;
 
-pub use bp_runtime::Chain as ChainBase;
 pub use crate::chain::{BlockNumberOf, BlockWithJustification, Chain, HashOf, HeaderOf, TransactionSignScheme};
 pub use crate::client::{Client, OpaqueGrandpaAuthoritiesSet};
 pub use crate::error::{Error, Result};
+pub use bp_runtime::Chain as ChainBase;
 
 /// Substrate connection params.
 #[derive(Debug, Clone)]

--- a/relays/substrate-client/src/lib.rs
+++ b/relays/substrate-client/src/lib.rs
@@ -25,6 +25,7 @@ mod rpc;
 
 pub mod headers_source;
 
+pub use bp_runtime::Chain as ChainBase;
 pub use crate::chain::{BlockNumberOf, BlockWithJustification, Chain, HashOf, HeaderOf, TransactionSignScheme};
 pub use crate::client::{Client, OpaqueGrandpaAuthoritiesSet};
 pub use crate::error::{Error, Result};


### PR DESCRIPTION
We've discussed this some time ago with @HCastano . This is to have one place for definitions like this (now it is duplicated):
```rust
	/// A type that fulfills the abstract idea of what a Substrate block number is.	
	// Constraits come from the associated Number type of `sp_runtime::traits::Header`	
	// See here for more info:	
	// https://crates.parity.io/sp_runtime/traits/trait.Header.html#associatedtype.Number	
	//	
	// Note that the `AsPrimitive<usize>` trait is required by the Grandpa justification	
	// verifier, and is not usually part of a Substrate Header's Number type.	
	type BridgedBlockNumber: Parameter	
		+ Member	
		+ MaybeSerializeDeserialize	
		+ Debug	
		+ sp_std::hash::Hash	
		+ Copy	
		+ MaybeDisplay	
		+ AtLeast32BitUnsigned	
		+ Codec	
		+ FromStr	
		+ MaybeMallocSizeOf	
		+ AsPrimitive<usize>;	

	/// A type that fulfills the abstract idea of what a Substrate hash is.	
	// Constraits come from the associated Hash type of `sp_runtime::traits::Header`	
	// See here for more info:	
	// https://crates.parity.io/sp_runtime/traits/trait.Header.html#associatedtype.Hash	
	type BridgedBlockHash: Parameter	
		+ Member	
		+ MaybeSerializeDeserialize	
		+ Debug	
		+ sp_std::hash::Hash	
		+ Ord	
		+ Copy	
		+ MaybeDisplay	
		+ Default	
		+ SimpleBitOps	
		+ Codec	
		+ AsRef<[u8]>	
		+ AsMut<[u8]>	
		+ MaybeMallocSizeOf	
		+ EncodeLike;	

	/// A type that fulfills the abstract idea of what a Substrate hasher (a type	
	/// that produces hashes) is.	
	// Constraits come from the associated Hashing type of `sp_runtime::traits::Header`	
	// See here for more info:	
	// https://crates.parity.io/sp_runtime/traits/trait.Header.html#associatedtype.Hashing	
	type BridgedBlockHasher: HashT<Output = Self::BridgedBlockHash>;
```