### PR TITLE
Publish substrate relay && millau bridge node images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,11 +17,17 @@ jobs:
       matrix:
         project:
           - rialto-bridge-node
+          - millau-bridge-node
           - ethereum-poa-relay
+          - substrate-relay
         include:
           - project: rialto-bridge-node
             healthcheck: http://localhost:9933/health
+          - project: millau-bridge-node
+            healthcheck: http://localhost:9933/health
           - project: ethereum-poa-relay
+            healthcheck: http://localhost:9616/metrics
+          - project: substrate-relay
             healthcheck: http://localhost:9616/metrics
     runs-on:                                        self-hosted
     container:


### PR DESCRIPTION
We'll need these for `docker-compose.yml` of Millau chain.