### PR TITLE
Pin Rust Nightly Version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           fetch-depth:             5
           submodules:              recursive
+      - name:                      Install Toolchain
+        if:                        matrix.toolchain == 'nightly-2020-10-04'
+        run:                       rustup toolchain add ${{ matrix.toolchain }}
+      - name:                      Add WASM Utilities
+        if:                        matrix.toolchain == 'nightly-2020-10-04'
+        run:                       rustup target add wasm32-unknown-unknown --toolchain ${{ matrix.toolchain }}
       - name:                      Configure CARGO_HOME & CARGO_TARGET_DIR
         run:                       ./scripts/ci-cache.sh "${{ github.head_ref }}" "${{ matrix.toolchain }}"
       - name:                      Cache checking

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
         toolchain:
           - stable
           #- beta
-          - nightly
+          - nightly-2020-10-04
     runs-on:                       self-hosted
     container:
       image:                       paritytech/ci-linux:production
@@ -75,11 +75,11 @@ jobs:
 
 ## Linting Stage
       - name:                      Add clippy
-        if:                        matrix.toolchain == 'nightly'
+        if:                        matrix.toolchain == 'nightly-2020-10-04'
         run:                       rustup component add clippy --toolchain ${{ matrix.toolchain }}
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
-        if:                        matrix.toolchain == 'nightly'
+        if:                        matrix.toolchain == 'nightly-2020-10-04'
         with:
           command:                 clippy
           toolchain:               ${{ matrix.toolchain }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,11 @@ RUN update-ca-certificates && \
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV LAST_RUST_UPDATE 2020-09-09
+ENV LAST_RUST_UPDATE 2020-10-15
 
 RUN rustup update stable && \
-	rustup install nightly && \
-	rustup target add wasm32-unknown-unknown --toolchain nightly
+	rustup install nightly-2020-10-04 && \
+	rustup target add wasm32-unknown-unknown --toolchain nightly-2020-10-04
 
 RUN rustc -vV && \
     cargo -V && \

--- a/deployments/rialto/Bridge.Dockerfile
+++ b/deployments/rialto/Bridge.Dockerfile
@@ -19,11 +19,11 @@ RUN update-ca-certificates && \
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV LAST_RUST_UPDATE 2020-09-09
+ENV LAST_RUST_UPDATE 2020-10-15
 
 RUN rustup update stable && \
-	rustup install nightly && \
-	rustup target add wasm32-unknown-unknown --toolchain nightly
+	rustup install nightly-2020-10-04 && \
+	rustup target add wasm32-unknown-unknown --toolchain nightly-2020-10-04
 
 RUN rustc -vV && \
     cargo -V && \


### PR DESCRIPTION
We're currently running into problems building Substrate due to the latest Rust 1.49 nightly releases. I've pinned the nightly compiler version to the one used by Polkadot for the `v0.8.25` release from ~a week ago.