### PR TITLE
InboundLaneApi::latest_confirmed_nonce

### DIFF
--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -71,8 +71,8 @@ pub trait Trait<I = DefaultInstance>: frame_system::Trait {
 	/// dispatched. Its delivery confirmation is still pending. This limit is introduced to bound
 	/// maximal number of relayers-ids in the inbound lane state.
 	///
-	/// "Message" in this context does not necessarily mean individual message, but instead
-	/// continuous range of indivdual messages, that are delivered by single relayer. So if relayer#1
+	/// "Message" in this context does not necessarily mean an individual message, but instead
+	/// continuous range of individual messages, that are delivered by single relayer. So if relayer#1
 	/// has submitted delivery transaction#1 with individual messages [1; 2] and then delivery
 	/// transaction#2 with individual messages [3; 4], this would be treated as single "Message" and
 	/// would occupy single unit of `MaxUnconfirmedMessagesAtInboundLane` limit.

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -66,10 +66,16 @@ pub trait Trait<I = DefaultInstance>: frame_system::Trait {
 	/// confirmed. The reason is that if you want to use lane, you should be ready to pay
 	/// for it.
 	type MaxMessagesToPruneAtOnce: Get<MessageNonce>;
-	/// Maximal number of messages in the 'unconfirmed' state at inbound lane. Unconfirmed
-	/// message at inbound lane is the message that has been: sent, delivered and dispatched.
-	/// Its delivery confirmation is still pending. This limit is introduced to bound maximal
-	/// number of relayers-ids in the inbound lane state.
+	/// Maximal number of "messages" (see note below) in the 'unconfirmed' state at inbound lane.
+	/// Unconfirmed message at inbound lane is the message that has been: sent, delivered and
+	/// dispatched. Its delivery confirmation is still pending. This limit is introduced to bound
+	/// maximal number of relayers-ids in the inbound lane state.
+	///
+	/// "Message" in this context does not necessarily mean individual message, but instead
+	/// continuous range of indivdual messages, that are delivered by single relayer. So if relayer#1
+	/// has submitted delivery transaction#1 with individual messages [1; 2] and then delivery
+	/// transaction#2 with individual messages [3; 4], this would be treated as single "Message" and
+	/// would occupy single unit of `MaxUnconfirmedMessagesAtInboundLane` limit.
 	type MaxUnconfirmedMessagesAtInboundLane: Get<MessageNonce>;
 
 	/// Payload type of outbound messages. This payload is dispatched on the bridged chain.

--- a/primitives/message-lane/src/lib.rs
+++ b/primitives/message-lane/src/lib.rs
@@ -136,5 +136,7 @@ decl_runtime_apis! {
 	pub trait InboundLaneApi {
 		/// Returns nonce of the latest message, received by given lane.
 		fn latest_received_nonce(lane: LaneId) -> MessageNonce;
+		/// Nonce of latest message that has been confirmed to the bridged chain.
+		fn latest_confirmed_nonce(lane: LaneId) -> MessageNonce;
 	}
 }


### PR DESCRIPTION
follow-up of #385 