### PR TITLE
Test that actual Millau state root is used in Rialto runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ version = "0.1.0"
 dependencies = [
  "bp-runtime",
  "frame-support",
+ "hex-literal 0.3.1",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -3552,6 +3553,7 @@ name = "millau-bridge-node"
 version = "0.1.0"
 dependencies = [
  "bp-message-lane",
+ "bp-millau",
  "bp-rialto",
  "bp-runtime",
  "frame-benchmarking",
@@ -3576,6 +3578,7 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-inherents",
  "sp-runtime",
+ "sp-state-machine",
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",

--- a/bin/millau/node/Cargo.toml
+++ b/bin/millau/node/Cargo.toml
@@ -44,6 +44,10 @@ sp-finality-grandpa = "2.0"
 sp-runtime = "2.0"
 substrate-frame-rpc-system = "2.0"
 
+[dev-dependencies]
+bp-millau = { path = "../../../primitives/millau" }
+sp-state-machine = "0.8.0"
+
 [build-dependencies]
 build-script-utils = { package = "substrate-build-script-utils", version = "2.0" }
 frame-benchmarking-cli = "2.0"

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -177,10 +177,10 @@ fn load_rialto_bridge_config() -> Option<BridgeRialtoConfig> {
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use millau_runtime::BuildStorage;
 	use sp_core::traits::Externalities;
 	use sp_state_machine::BasicExternalities;
-	use super::*;
 
 	#[test]
 	fn local_testnet_genesis_match() {

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -174,3 +174,22 @@ fn load_rialto_bridge_config() -> Option<BridgeRialtoConfig> {
 		first_scheduled_change: None,
 	})
 }
+
+#[cfg(test)]
+mod tests {
+	use millau_runtime::BuildStorage;
+	use sp_core::traits::Externalities;
+	use sp_state_machine::BasicExternalities;
+	use super::*;
+
+	#[test]
+	fn local_testnet_genesis_match() {
+		let chain_spec = Alternative::LocalTestnet.load().unwrap();
+		let genesis_storage = chain_spec.build_storage().unwrap();
+		let mut ext = BasicExternalities::new(genesis_storage);
+		let mut storage_root = millau_runtime::Hash::default();
+		storage_root.as_mut().copy_from_slice(&ext.storage_root());
+
+		assert_eq!(storage_root, bp_millau::local_testnet_genesis_state_root());
+	}
+}

--- a/bin/rialto/runtime/src/millau.rs
+++ b/bin/rialto/runtime/src/millau.rs
@@ -36,7 +36,7 @@ pub fn initial_header() -> Header {
 	Header {
 		parent_hash: Default::default(),
 		number: Default::default(),
-		state_root: hex!("dc7567715330c666eca349a4612e82ec3b3c4f306ef941dce192a37fb3131cfa").into(),
+		state_root: bp_millau::local_testnet_genesis_state_root(),
 		extrinsics_root: hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into(),
 		digest: Default::default(),
 	}

--- a/primitives/millau/Cargo.toml
+++ b/primitives/millau/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+hex-literal = "0.3"
 
 # Bridge Dependencies
 

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -22,6 +22,7 @@
 
 use bp_runtime::Chain;
 use frame_support::{weights::Weight, RuntimeDebug};
+use hex_literal::hex;
 use sp_core::Hasher as HasherT;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, Verify},
@@ -107,4 +108,13 @@ sp_api::decl_runtime_apis! {
 		/// Returns true if the header is considered finalized by the runtime.
 		fn is_finalized_block(hash: Hash) -> bool;
 	}
+}
+
+/// Returns state root of genesis block of Millau local testnet.
+///
+/// This function shall never be used from Millau runtime. Otherwise it won't be removed
+/// by compiler and will change runtime code. Changing runtime code would lead to
+/// `state_root` change.
+pub fn local_testnet_genesis_state_root() -> Hash {
+	hex!("64d2f3e667e15e84fc71631d8baa9dcc5637fd9e1a5ad85470191f53c6940df3").into()
 }


### PR DESCRIPTION
Right now almost any PR that is touching runtime modules, primitives or dependencies may change state root of Millau genesis block (because it affects Millau runtime code and genesis storage includes that code). This PR adds test to avoid cases when Millau code has been updated, but its state root isn't updated.