### PR TITLE
Use is_finalized in is_finalized_header

### DIFF
--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -251,7 +251,7 @@ impl<T: Trait> Module<T> {
 	pub fn is_finalized_header(hash: BridgedBlockHash<T>) -> bool {
 		let storage = PalletStorage::<T>::new();
 		if let Some(header) = storage.header_by_hash(hash) {
-			header.number() <= storage.best_finalized_header().number()
+			header.is_finalized
 		} else {
 			false
 		}


### PR DESCRIPTION
Iiuc there's no pruning now && even if it'll be, most probably it'll be non-instant => we can't rely on `header.number() <= storage.best_finalized_header().number()`