### PR TITLE
Allow Substrate Pallet to be Halted

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -159,7 +159,6 @@ fn testnet_genesis(
 			// We'll initialize the pallet with a dispatchable instead.
 			init_data: None,
 			owner: None,
-			is_halted: true,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key }),
 		pallet_session: Some(SessionConfig {

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -158,6 +158,8 @@ fn testnet_genesis(
 		pallet_substrate_bridge: Some(BridgeRialtoConfig {
 			// We'll initialize the pallet with a dispatchable instead.
 			init_data: None,
+			owner: None,
+			is_halted: true,
 		}),
 		pallet_sudo: Some(SudoConfig { key: root_key }),
 		pallet_session: Some(SessionConfig {

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -188,6 +188,5 @@ fn load_millau_bridge_config() -> Option<BridgeMillauConfig> {
 	Some(BridgeMillauConfig {
 		init_data: Some(rialto_runtime::millau::init_data()),
 		owner: Some([0; 32].into()),
-		is_halted: false,
 	})
 }

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -187,5 +187,7 @@ fn load_kovan_bridge_config() -> Option<BridgeKovanConfig> {
 fn load_millau_bridge_config() -> Option<BridgeMillauConfig> {
 	Some(BridgeMillauConfig {
 		init_data: Some(rialto_runtime::millau::init_data()),
+		owner: Some([0; 32].into()),
+		is_halted: false,
 	})
 }

--- a/bin/rialto/runtime/src/millau.rs
+++ b/bin/rialto/runtime/src/millau.rs
@@ -32,6 +32,7 @@ pub fn init_data() -> InitializationData<Header> {
 		authority_list: authority_set.authorities,
 		set_id: authority_set.set_id,
 		scheduled_change: None,
+		is_halted: false,
 	}
 }
 

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -148,7 +148,7 @@ decl_storage! {
 		/// `None`, then there are no direct ways to halt/resume pallet operations, but other
 		/// runtime methods may still be used to do that (i.e. democracy::referendum to update halt
 		/// flag directly or call the `halt_operations`).
-		pub ModuleOwner get(fn module_owner) config(): Option<T::AccountId>;
+		pub ModuleOwner get(fn module_owner): Option<T::AccountId>;
 		/// If true, all pallet transactions are failed immediately.
 		pub IsHalted get(fn is_halted) config(): bool;
 		/// Map of lane id => inbound lane data.
@@ -160,6 +160,12 @@ decl_storage! {
 	}
 	add_extra_genesis {
 		config(phantom): sp_std::marker::PhantomData<I>;
+		config(owner): Option<T::AccountId>;
+		build(|config| {
+			if let Some(ref owner) = config.owner {
+				<ModuleOwner<T, I>>::put(owner);
+			}
+		})
 	}
 }
 

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -196,11 +196,11 @@ decl_module! {
 			match new_owner {
 				Some(new_owner) => {
 					ModuleOwner::<T, I>::put(&new_owner);
-					frame_support::debug::info!(target: "runtime", "Setting pallet Owner to: {:?}", new_owner);
+					frame_support::debug::info!("Setting pallet Owner to: {:?}", new_owner);
 				},
 				None => {
 					ModuleOwner::<T, I>::kill();
-					frame_support::debug::info!(target: "runtime", "Removed Owner of pallet.");
+					frame_support::debug::info!("Removed Owner of pallet.");
 				},
 			}
 		}
@@ -212,7 +212,7 @@ decl_module! {
 		pub fn halt_operations(origin) {
 			ensure_owner_or_root::<T, I>(origin)?;
 			IsHalted::<I>::put(true);
-			frame_support::debug::warn!(target: "runtime", "Stopping pallet operations.");
+			frame_support::debug::warn!("Stopping pallet operations.");
 		}
 
 		/// Resume all pallet operations. May be called even if pallet is halted.
@@ -222,7 +222,7 @@ decl_module! {
 		pub fn resume_operations(origin) {
 			ensure_owner_or_root::<T, I>(origin)?;
 			IsHalted::<I>::put(false);
-			frame_support::debug::info!(target: "runtime", "Resuming pallet operations.");
+			frame_support::debug::info!("Resuming pallet operations.");
 		}
 
 		/// Send message over lane.
@@ -239,7 +239,6 @@ decl_module! {
 			// let's first check if message can be delivered to target chain
 			T::TargetHeaderChain::verify_message(&payload).map_err(|err| {
 				frame_support::debug::trace!(
-					target: "runtime",
 					"Message to lane {:?} is rejected by target chain: {:?}",
 					lane_id,
 					err,
@@ -256,7 +255,6 @@ decl_module! {
 				&payload,
 			).map_err(|err| {
 				frame_support::debug::trace!(
-					target: "runtime",
 					"Message to lane {:?} is rejected by lane verifier: {:?}",
 					lane_id,
 					err,
@@ -271,7 +269,6 @@ decl_module! {
 				&delivery_and_dispatch_fee,
 			).map_err(|err| {
 				frame_support::debug::trace!(
-					target: "runtime",
 					"Message to lane {:?} is rejected because submitter {:?} is unable to pay fee {:?}: {:?}",
 					lane_id,
 					submitter,
@@ -291,7 +288,6 @@ decl_module! {
 			lane.prune_messages(T::MaxMessagesToPruneAtOnce::get());
 
 			frame_support::debug::trace!(
-				target: "runtime",
 				"Accepted message {} to lane {:?}",
 				nonce,
 				lane_id,
@@ -317,7 +313,6 @@ decl_module! {
 			let messages = verify_and_decode_messages_proof::<T::SourceHeaderChain, T::InboundMessageFee, T::InboundPayload>(proof)
 				.map_err(|err| {
 					frame_support::debug::trace!(
-						target: "runtime",
 						"Rejecting invalid messages proof: {:?}",
 						err,
 					);
@@ -337,7 +332,6 @@ decl_module! {
 				.sum();
 			if dispatch_weight < actual_dispatch_weight {
 				frame_support::debug::trace!(
-					target: "runtime",
 					"Rejecting messages proof because of dispatch weight mismatch: declared={}, expected={}",
 					dispatch_weight,
 					actual_dispatch_weight,
@@ -356,7 +350,6 @@ decl_module! {
 					let updated_latest_confirmed_nonce = lane.receive_state_update(lane_state);
 					if let Some(updated_latest_confirmed_nonce) = updated_latest_confirmed_nonce {
 						frame_support::debug::trace!(
-							target: "runtime",
 							"Received lane {:?} state update: latest_confirmed_nonce={}",
 							lane_id,
 							updated_latest_confirmed_nonce,
@@ -375,7 +368,6 @@ decl_module! {
 			}
 
 			frame_support::debug::trace!(
-				target: "runtime",
 				"Received messages: total={}, valid={}",
 				total_messages,
 				valid_messages,
@@ -392,7 +384,6 @@ decl_module! {
 			let confirmation_relayer = ensure_signed(origin)?;
 			let (lane_id, lane_data) = T::TargetHeaderChain::verify_messages_delivery_proof(proof).map_err(|err| {
 				frame_support::debug::trace!(
-					target: "runtime",
 					"Rejecting invalid messages delivery proof: {:?}",
 					err,
 				);
@@ -428,7 +419,6 @@ decl_module! {
 			}
 
 			frame_support::debug::trace!(
-				target: "runtime",
 				"Received messages delivery proof up to (and including) {} at lane {:?}",
 				lane_data.latest_received_nonce,
 				lane_id,

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -194,8 +194,14 @@ decl_module! {
 		pub fn set_owner(origin, new_owner: Option<T::AccountId>) {
 			ensure_owner_or_root::<T, I>(origin)?;
 			match new_owner {
-				Some(new_owner) => ModuleOwner::<T, I>::put(new_owner),
-				None => ModuleOwner::<T, I>::kill(),
+				Some(new_owner) => {
+					ModuleOwner::<T, I>::put(&new_owner);
+					frame_support::debug::info!(target: "runtime", "Setting pallet Owner to: {:?}", new_owner);
+				},
+				None => {
+					ModuleOwner::<T, I>::kill();
+					frame_support::debug::info!(target: "runtime", "Removed Owner of pallet.");
+				},
 			}
 		}
 
@@ -206,6 +212,7 @@ decl_module! {
 		pub fn halt_operations(origin) {
 			ensure_owner_or_root::<T, I>(origin)?;
 			IsHalted::<I>::put(true);
+			frame_support::debug::warn!(target: "runtime", "Stopping pallet operations.");
 		}
 
 		/// Resume all pallet operations. May be called even if pallet is halted.
@@ -215,6 +222,7 @@ decl_module! {
 		pub fn resume_operations(origin) {
 			ensure_owner_or_root::<T, I>(origin)?;
 			IsHalted::<I>::put(false);
+			frame_support::debug::info!(target: "runtime", "Resuming pallet operations.");
 		}
 
 		/// Send message over lane.

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -579,6 +579,7 @@ mod tests {
 				authority_list: authority_list(),
 				set_id: 1,
 				scheduled_change: None,
+				is_halted: false,
 			};
 
 			assert_noop!(
@@ -601,6 +602,7 @@ mod tests {
 				authority_list: authority_list(),
 				set_id: 1,
 				scheduled_change: None,
+				is_halted: false,
 			};
 
 			assert_ok!(Module::<TestRuntime>::initialize(Origin::root(), init_data.clone()));
@@ -616,6 +618,7 @@ mod tests {
 			);
 			assert_eq!(storage.best_finalized_header().hash(), init_data.header.hash());
 			assert_eq!(storage.current_authority_set().authorities, init_data.authority_list);
+			assert_eq!(IsHalted::get(), false);
 		})
 	}
 

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -172,7 +172,7 @@ decl_module! {
 		) -> DispatchResult {
 			ensure_operational::<T>()?;
 			let _ = ensure_signed(origin)?;
-			frame_support::debug::trace!(target: "sub-bridge", "Got header {:?}", header);
+			frame_support::debug::trace!("Got header {:?}", header);
 
 			let mut verifier = verifier::Verifier {
 				storage: PalletStorage::<T>::new(),
@@ -199,7 +199,7 @@ decl_module! {
 		) -> DispatchResult {
 			ensure_operational::<T>()?;
 			let _ = ensure_signed(origin)?;
-			frame_support::debug::trace!(target: "sub-bridge", "Got header hash {:?}", hash);
+			frame_support::debug::trace!("Got header hash {:?}", hash);
 
 			let mut verifier = verifier::Verifier {
 				storage: PalletStorage::<T>::new(),
@@ -233,7 +233,6 @@ decl_module! {
 			initialize_bridge::<T>(init_data.clone());
 
 			frame_support::debug::info!(
-				target: "sub-bridge",
 				"Pallet has been initialized with the following parameters: {:?}", init_data
 			);
 		}
@@ -247,11 +246,11 @@ decl_module! {
 			match new_owner {
 				Some(new_owner) => {
 					ModuleOwner::<T>::put(&new_owner);
-					frame_support::debug::info!(target: "sub-bridge", "Setting pallet Owner to: {:?}", new_owner);
+					frame_support::debug::info!("Setting pallet Owner to: {:?}", new_owner);
 				},
 				None => {
 					ModuleOwner::<T>::kill();
-					frame_support::debug::info!(target: "sub-bridge", "Removed Owner of pallet.");
+					frame_support::debug::info!("Removed Owner of pallet.");
 				},
 			}
 		}
@@ -263,7 +262,7 @@ decl_module! {
 		pub fn halt_operations(origin) {
 			ensure_owner_or_root::<T>(origin)?;
 			IsHalted::put(true);
-			frame_support::debug::warn!(target: "sub-bridge", "Stopping pallet operations.");
+			frame_support::debug::warn!("Stopping pallet operations.");
 		}
 
 		/// Resume all pallet operations. May be called even if pallet is halted.
@@ -273,7 +272,7 @@ decl_module! {
 		pub fn resume_operations(origin) {
 			ensure_owner_or_root::<T>(origin)?;
 			IsHalted::put(false);
-			frame_support::debug::info!(target: "sub-bridge", "Resuming pallet operations.");
+			frame_support::debug::info!("Resuming pallet operations.");
 		}
 	}
 }

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -115,14 +115,12 @@ decl_storage! {
 		/// flag directly or call the `halt_operations`).
 		ModuleOwner get(fn module_owner): Option<T::AccountId>;
 		/// If true, all pallet transactions are failed immediately.
-		IsHalted get(fn is_halted) config(): bool;
+		IsHalted get(fn is_halted): bool;
 	}
 	add_extra_genesis {
 		config(owner): Option<T::AccountId>;
 		config(init_data): Option<InitializationData<BridgedHeader<T>>>;
 		build(|config| {
-			IsHalted::put(config.is_halted);
-
 			if let Some(ref owner) = config.owner {
 				<ModuleOwner<T>>::put(owner);
 			}
@@ -364,6 +362,7 @@ fn initialize_bridge<T: Trait>(init_params: InitializationData<BridgedHeader<T>>
 		authority_list,
 		set_id,
 		scheduled_change,
+		is_halted,
 	} = init_params;
 
 	let initial_hash = header.hash();
@@ -395,6 +394,8 @@ fn initialize_bridge<T: Trait>(init_params: InitializationData<BridgedHeader<T>>
 			signal_hash,
 		},
 	);
+
+	IsHalted::put(is_halted);
 }
 
 /// Expected interface for interacting with bridge pallet storage.

--- a/modules/substrate/src/storage.rs
+++ b/modules/substrate/src/storage.rs
@@ -38,6 +38,8 @@ pub struct InitializationData<H: HeaderT> {
 	pub set_id: SetId,
 	/// The first scheduled authority set change of the pallet.
 	pub scheduled_change: Option<ScheduledChange<H::Number>>,
+	/// Should the pallet block transaction immediately after initialization.
+	pub is_halted: bool,
 }
 
 /// A Grandpa Authority List and ID.


### PR DESCRIPTION
Basically a copy-paste of the `message-lane` code from #472.

I did add some stuff surrounding the initialization of the pallet though. I removed the `IsInitialized` storage entry, and instead have decided to enforce (at least when initializing with `GenesisConfig`) that if we didn't get any data for initialization the pallet is halted.

If you decide to initialize via a dipatchable, we have stopped checking if the pallet has already been initialized. As Root/Owner you should be doing this check (by, for example, seeing if there are any finalized headers) before calling `initialize()`. If you don't, sucks to suck 🤷. Another note on initializing via `initialize()`. If you're doing this (for the first time) it means that you didn't go through the genesis config, which means that the pallet must be halted. The pallet should be unblocked manually with `resume_operations()` afterwards.