### PR TITLE
Use the correct folder name for entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ WORKDIR /home/user
 ARG PROJECT=ethereum-poa-relay
 
 COPY --chown=user:user --from=builder /parity-bridges-common/target/release/${PROJECT} ./
-COPY --chown=user:user --from=builder /parity-bridges-common/deployments/scripts/bridge-entrypoint.sh ./
+COPY --chown=user:user --from=builder /parity-bridges-common/deployments/local-scripts/bridge-entrypoint.sh ./
 
 # check if executable works in this container
 RUN ./${PROJECT} --version


### PR DESCRIPTION
I missed this change in #464. This should fix our failing publishing step.