### PR TITLE
Remove Millau Genesis Config in Rialto Node

### DIFF
--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -186,7 +186,7 @@ fn load_kovan_bridge_config() -> Option<BridgeKovanConfig> {
 
 fn load_millau_bridge_config() -> Option<BridgeMillauConfig> {
 	Some(BridgeMillauConfig {
-		init_data: Some(rialto_runtime::millau::init_data()),
+		init_data: None,
 		owner: Some([0; 32].into()),
 	})
 }


### PR DESCRIPTION
The initial Millau data isn't exactly accurate, and now that we have #483 we don't need to have it anymore.

I'm submitting this as an individual fix instead of as part of #493 so that I can have a published Docker image to work with. 