### PR TITLE
Fix Grafana Dashboards for PoA-Rialto Deployment

### DIFF
--- a/deployments/bridges/poa-rialto/dashboard/prometheus/prometheus.yml
+++ b/deployments/bridges/poa-rialto/dashboard/prometheus/prometheus.yml
@@ -1,26 +1,24 @@
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'eth2sub_relay_node'
+  - job_name: 'poa_to_rialto_relay_node'
 
     # Override the global default and scrape targets from this job every 15 seconds.
     scrape_interval: 15s
-
     static_configs:
       - targets: ['relay-headers-poa-to-rialto:9616']
+
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'eth_exchange_sub_relay_node'
+  - job_name: 'poa_exchange_rialto_relay_node'
 
     # Override the global default and scrape targets from this job every 15 seconds.
     scrape_interval: 15s
-
     static_configs:
       - targets: ['relay-poa-exchange-rialto:9616']
 
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'sub2eth_relay_node'
+  - job_name: 'rialto_to_poa_relay_node'
 
     # Override the global default and scrape targets from this job every 15 seconds.
     scrape_interval: 15s
-
     static_configs:
       - targets: ['relay-headers-rialto-to-poa:9616']

--- a/deployments/bridges/poa-rialto/dashboard/prometheus/prometheus.yml
+++ b/deployments/bridges/poa-rialto/dashboard/prometheus/prometheus.yml
@@ -6,7 +6,7 @@ scrape_configs:
     scrape_interval: 15s
 
     static_configs:
-      - targets: ['relay-eth2sub:9616']
+      - targets: ['relay-headers-poa-to-rialto:9616']
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'eth_exchange_sub_relay_node'
 
@@ -14,7 +14,7 @@ scrape_configs:
     scrape_interval: 15s
 
     static_configs:
-      - targets: ['relay-eth-exchange-sub:9616']
+      - targets: ['relay-poa-exchange-rialto:9616']
 
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'sub2eth_relay_node'
@@ -23,4 +23,4 @@ scrape_configs:
     scrape_interval: 15s
 
     static_configs:
-      - targets: ['relay-sub2eth:9616']
+      - targets: ['relay-headers-rialto-to-poa:9616']


### PR DESCRIPTION
In #464 I renamed some of the Compose services and forgot to update the `targets` in the Prometheus configuration file. This PR updates the config to point to the correct services.