### PR TITLE
Use (some) different chain primitives in Millau

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,11 +736,19 @@ version = "0.1.0"
 dependencies = [
  "bp-message-lane",
  "bp-runtime",
+ "fixed-hash 0.6.1",
  "frame-support",
+ "hash256-std-hasher",
+ "impl-codec",
+ "impl-serde 0.3.1",
+ "parity-util-mem",
+ "serde",
  "sp-api",
  "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-trie",
 ]
 
 [[package]]
@@ -5345,6 +5353,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.7",
  "log",
+ "num-traits",
  "substrate-prometheus-endpoint",
  "sysinfo",
  "time 0.2.22",

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -256,7 +256,7 @@ impl pallet_timestamp::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = 500;
+	pub const ExistentialDeposit: bp_millau::Balance = 500;
 	// For weight estimation, we assume that the most locks on an individual account will be 50.
 	// This number may need to be adjusted in the future if this assumption no longer holds true.
 	pub const MaxLocks: u32 = 50;

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -110,12 +110,12 @@ impl MessageBridge for WithRialtoMessageBridge {
 
 	fn bridged_weight_to_bridged_balance(weight: Weight) -> bp_rialto::Balance {
 		// we're using the same weights in both chains now
-		<crate::Runtime as pallet_transaction_payment::Trait>::WeightToFee::calc(&weight)
+		<crate::Runtime as pallet_transaction_payment::Trait>::WeightToFee::calc(&weight) as _
 	}
 
 	fn this_balance_to_bridged_balance(this_balance: bp_millau::Balance) -> bp_rialto::Balance {
 		// 1:1 conversion that will probably change in the future
-		this_balance
+		this_balance as _
 	}
 }
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -365,7 +365,7 @@ impl pallet_timestamp::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = 500;
+	pub const ExistentialDeposit: bp_rialto::Balance = 500;
 	// For weight estimation, we assume that the most locks on an individual account will be 50.
 	// This number may need to be adjusted in the future if this assumption no longer holds true.
 	pub const MaxLocks: u32 = 50;

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -110,12 +110,12 @@ impl MessageBridge for WithMillauMessageBridge {
 
 	fn bridged_weight_to_bridged_balance(weight: Weight) -> bp_millau::Balance {
 		// we're using the same weights in both chains now
-		<crate::Runtime as pallet_transaction_payment::Trait>::WeightToFee::calc(&weight)
+		<crate::Runtime as pallet_transaction_payment::Trait>::WeightToFee::calc(&weight) as _
 	}
 
 	fn this_balance_to_bridged_balance(this_balance: bp_rialto::Balance) -> bp_millau::Balance {
 		// 1:1 conversion that will probably change in the future
-		this_balance
+		this_balance as _
 	}
 }
 

--- a/primitives/millau/Cargo.toml
+++ b/primitives/millau/Cargo.toml
@@ -12,23 +12,39 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 bp-message-lane = { path = "../message-lane", default-features = false }
 bp-runtime = { path = "../runtime", default-features = false }
+fixed-hash = { version = "0.6.1", default-features = false }
+hash256-std-hasher = { version = "0.15.2", default-features = false }
+impl-codec = { version = "0.4.2", default-features = false }
+impl-serde = { version = "0.3.1", optional = true }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
+serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 # Substrate Based Dependencies
 
 frame-support = { version = "2.0", default-features = false }
 sp-api = { version = "2.0", default-features = false }
 sp-core = { version = "2.0", default-features = false }
+sp-io = { version = "2.0", default-features = false }
 sp-runtime = { version = "2.0", default-features = false }
 sp-std = { version = "2.0", default-features = false }
+sp-trie = { version = "2.0", default-features = false }
 
 [features]
 default = ["std"]
 std = [
 	"bp-message-lane/std",
 	"bp-runtime/std",
+	"fixed-hash/std",
 	"frame-support/std",
+	"hash256-std-hasher/std",
+	"impl-codec/std",
+	"impl-serde",
+	"parity-util-mem/std",
+	"serde",
 	"sp-api/std",
 	"sp-core/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"sp-trie/std",
 ]

--- a/primitives/millau/src/millau_hash.rs
+++ b/primitives/millau/src/millau_hash.rs
@@ -1,0 +1,57 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+use parity_util_mem::MallocSizeOf;
+use sp_runtime::traits::CheckEqual;
+
+// `sp_core::H512` can't be used, because it doesn't implement `CheckEqual`, which is required
+// by `frame_system::Trait::Hash`.
+
+fixed_hash::construct_fixed_hash! {
+	/// Hash type used in Millau chain.
+	#[derive(MallocSizeOf)]
+	pub struct MillauHash(64);
+}
+
+#[cfg(feature = "std")]
+impl_serde::impl_fixed_hash_serde!(MillauHash, 64);
+
+impl_codec::impl_fixed_hash_codec!(MillauHash, 64);
+
+impl CheckEqual for MillauHash {
+	#[cfg(feature = "std")]
+	fn check_equal(&self, other: &Self) {
+		use sp_core::hexdisplay::HexDisplay;
+		if self != other {
+			println!(
+				"Hash: given={}, expected={}",
+				HexDisplay::from(self.as_fixed_bytes()),
+				HexDisplay::from(other.as_fixed_bytes()),
+			);
+		}
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn check_equal(&self, other: &Self) {
+		use frame_support::Printable;
+
+		if self != other {
+			"Hash not equal".print();
+			self.as_bytes().print();
+			other.as_bytes().print();
+		}
+	}
+}

--- a/relays/headers-relay/src/sync_types.rs
+++ b/relays/headers-relay/src/sync_types.rs
@@ -52,21 +52,7 @@ pub trait HeadersSyncPipeline: Clone + Send + Sync {
 	/// Headers we're syncing are identified by this hash.
 	type Hash: Eq + Clone + Copy + Send + Sync + std::fmt::Debug + std::fmt::Display + std::hash::Hash;
 	/// Headers we're syncing are identified by this number.
-	type Number: From<u32>
-		+ Ord
-		+ Clone
-		+ Copy
-		+ Send
-		+ Sync
-		+ std::fmt::Debug
-		+ std::fmt::Display
-		+ std::hash::Hash
-		+ std::ops::Add<Output = Self::Number>
-		+ std::ops::Sub<Output = Self::Number>
-		+ num_traits::Saturating
-		+ num_traits::Zero
-		+ num_traits::One
-		+ Into<u64>;
+	type Number: relay_utils::BlockNumberBase;
 	/// Type of header that we're syncing.
 	type Header: SourceHeader<Self::Hash, Self::Number>;
 	/// Type of extra data for the header that we're receiving from the source node:

--- a/relays/messages-relay/src/message_lane.rs
+++ b/relays/messages-relay/src/message_lane.rs
@@ -19,8 +19,7 @@
 //! 1) relay new messages from source to target node;
 //! 2) relay proof-of-delivery from target to source node.
 
-use relay_utils::HeaderId;
-
+use relay_utils::{BlockNumberBase, HeaderId};
 use std::fmt::Debug;
 
 /// One-way message lane.
@@ -36,12 +35,12 @@ pub trait MessageLane: Clone + Send + Sync {
 	type MessagesReceivingProof: Clone + Send + Sync;
 
 	/// Number of the source header.
-	type SourceHeaderNumber: Clone + Debug + Ord + PartialEq + Into<u64> + Send + Sync;
+	type SourceHeaderNumber: BlockNumberBase;
 	/// Hash of the source header.
 	type SourceHeaderHash: Clone + Debug + Default + PartialEq + Send + Sync;
 
 	/// Number of the target header.
-	type TargetHeaderNumber: Clone + Debug + Ord + PartialEq + Into<u64> + Send + Sync;
+	type TargetHeaderNumber: BlockNumberBase;
 	/// Hash of the target header.
 	type TargetHeaderHash: Clone + Debug + Default + PartialEq + Send + Sync;
 }

--- a/relays/substrate-client/src/headers_source.rs
+++ b/relays/substrate-client/src/headers_source.rs
@@ -25,7 +25,6 @@ use headers_relay::{
 	sync_loop::SourceClient,
 	sync_types::{HeaderIdOf, HeadersSyncPipeline, QueuedHeader, SourceHeader},
 };
-use num_traits::Saturating;
 use sp_runtime::{traits::Header as HeaderT, Justification};
 use std::marker::PhantomData;
 
@@ -49,7 +48,7 @@ impl<C: Chain, P> HeadersSource<C, P> {
 impl<C, P> SourceClient<P> for HeadersSource<C, P>
 where
 	C: Chain,
-	C::BlockNumber: Into<u64> + Saturating,
+	C::BlockNumber: relay_utils::BlockNumberBase,
 	C::Header: Into<P::Header>,
 	P: HeadersSyncPipeline<Extra = (), Completion = Justification, Hash = C::Hash, Number = C::BlockNumber>,
 	P::Header: SourceHeader<C::Hash, C::BlockNumber>,

--- a/relays/substrate/src/headers_pipeline.rs
+++ b/relays/substrate/src/headers_pipeline.rs
@@ -26,8 +26,8 @@ use headers_relay::{
 	sync::{HeadersSyncParams, TargetTransactionMode},
 	sync_types::{HeadersSyncPipeline, QueuedHeader, SourceHeader},
 };
-use num_traits::Saturating;
 use relay_substrate_client::{headers_source::HeadersSource, BlockNumberOf, Chain, Client, HashOf};
+use relay_utils::BlockNumberBase;
 use sp_runtime::Justification;
 use std::marker::PhantomData;
 
@@ -59,7 +59,7 @@ impl<SourceChain, SourceSyncHeader, TargetChain, TargetSign> HeadersSyncPipeline
 	for SubstrateHeadersToSubstrate<SourceChain, SourceSyncHeader, TargetChain, TargetSign>
 where
 	SourceChain: Clone + Chain,
-	BlockNumberOf<SourceChain>: Saturating + Into<u64>,
+	BlockNumberOf<SourceChain>: BlockNumberBase,
 	SourceSyncHeader:
 		SourceHeader<HashOf<SourceChain>, BlockNumberOf<SourceChain>> + std::ops::Deref<Target = SourceChain::Header>,
 	TargetChain: Clone + Chain,
@@ -107,7 +107,7 @@ pub async fn run<SourceChain, TargetChain, P>(
 	P::Header: SourceHeader<HashOf<SourceChain>, BlockNumberOf<SourceChain>>,
 	SourceChain: Clone + Chain,
 	SourceChain::Header: Into<P::Header>,
-	BlockNumberOf<SourceChain>: Into<u64> + Saturating,
+	BlockNumberOf<SourceChain>: BlockNumberBase,
 	TargetChain: Clone + Chain,
 {
 	let source_justifications = match source_client.clone().subscribe_justifications().await {

--- a/relays/substrate/src/messages_source.rs
+++ b/relays/substrate/src/messages_source.rs
@@ -28,7 +28,7 @@ use messages_relay::{
 	message_lane_loop::{ClientState, MessageProofParameters, MessageWeightsMap, SourceClient, SourceClientState},
 };
 use relay_substrate_client::{Chain, Client, Error as SubstrateError, HashOf, HeaderIdOf};
-use relay_utils::HeaderId;
+use relay_utils::{BlockNumberBase, HeaderId};
 use sp_core::Bytes;
 use sp_runtime::{traits::Header as HeaderT, DeserializeOwned};
 use sp_trie::StorageProof;
@@ -93,7 +93,7 @@ where
 	C: Chain,
 	C::Header: DeserializeOwned,
 	C::Index: DeserializeOwned,
-	<C::Header as HeaderT>::Number: Into<u64>,
+	C::BlockNumber: BlockNumberBase,
 	P: MessageLane<
 		MessagesProof = SubstrateMessagesProof<C>,
 		SourceHeaderNumber = <C::Header as HeaderT>::Number,

--- a/relays/substrate/src/messages_target.rs
+++ b/relays/substrate/src/messages_target.rs
@@ -29,6 +29,7 @@ use messages_relay::{
 	message_lane_loop::{TargetClient, TargetClientState},
 };
 use relay_substrate_client::{Chain, Client, Error as SubstrateError, HashOf};
+use relay_utils::BlockNumberBase;
 use sp_core::Bytes;
 use sp_runtime::{traits::Header as HeaderT, DeserializeOwned};
 use sp_trie::StorageProof;
@@ -89,7 +90,7 @@ where
 	C: Chain,
 	C::Header: DeserializeOwned,
 	C::Index: DeserializeOwned,
-	<C::Header as HeaderT>::Number: Into<u64>,
+	<C::Header as HeaderT>::Number: BlockNumberBase,
 	P: MessageLane<
 		MessagesReceivingProof = (HashOf<C>, StorageProof, LaneId),
 		TargetHeaderNumber = <C::Header as HeaderT>::Number,

--- a/relays/utils/Cargo.toml
+++ b/relays/utils/Cargo.toml
@@ -12,6 +12,7 @@ backoff = "0.2"
 env_logger = "0.7.0"
 futures = "0.3.5"
 log = "0.4.11"
+num-traits = "0.2"
 sysinfo = "0.15"
 time = "0.2"
 

--- a/relays/utils/src/lib.rs
+++ b/relays/utils/src/lib.rs
@@ -30,6 +30,51 @@ pub const CONNECTION_ERROR_DELAY: Duration = Duration::from_secs(10);
 pub mod initialize;
 pub mod metrics;
 
+/// Block number traits shared by all chains that relay is able to serve.
+pub trait BlockNumberBase:
+	'static
+	+ From<u32>
+	+ Into<u64>
+	+ Ord
+	+ Clone
+	+ Copy
+	+ Default
+	+ Send
+	+ Sync
+	+ std::fmt::Debug
+	+ std::fmt::Display
+	+ std::hash::Hash
+	+ std::ops::Add<Output = Self>
+	+ std::ops::Sub<Output = Self>
+	+ num_traits::CheckedSub
+	+ num_traits::Saturating
+	+ num_traits::Zero
+	+ num_traits::One
+{
+}
+
+impl<T> BlockNumberBase for T where
+	T: 'static
+		+ From<u32>
+		+ Into<u64>
+		+ Ord
+		+ Clone
+		+ Copy
+		+ Default
+		+ Send
+		+ Sync
+		+ std::fmt::Debug
+		+ std::fmt::Display
+		+ std::hash::Hash
+		+ std::ops::Add<Output = Self>
+		+ std::ops::Sub<Output = Self>
+		+ num_traits::CheckedSub
+		+ num_traits::Saturating
+		+ num_traits::Zero
+		+ num_traits::One
+{
+}
+
 /// Macro that returns (client, Err(error)) tuple from function if result is Err(error).
 #[macro_export]
 macro_rules! bail_on_error {


### PR DESCRIPTION
The point of this PR is to prove that relay + pallets are able to bridge heterogeneous chains. Millau will be using separate hash, hasher and block number. More (mostly account id, signature and Millau<-> Rialto conversion rate) are to come in next PRs.
