### PR TITLE
Add more substrate accounts + use one account in one relay

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -111,12 +111,16 @@ impl Alternative {
 							get_account_id_from_seed::<sr25519::Public>("Dave"),
 							get_account_id_from_seed::<sr25519::Public>("Eve"),
 							get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+							get_account_id_from_seed::<sr25519::Public>("George"),
+							get_account_id_from_seed::<sr25519::Public>("Harry"),
 							get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+							get_account_id_from_seed::<sr25519::Public>("George//stash"),
+							get_account_id_from_seed::<sr25519::Public>("Harry//stash"),
 						],
 						true,
 					)
@@ -147,7 +151,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		}),
 		pallet_balances: Some(BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 50)).collect(),
 		}),
 		pallet_aura: Some(AuraConfig {
 			authorities: Vec::new(),

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -111,12 +111,16 @@ impl Alternative {
 							get_account_id_from_seed::<sr25519::Public>("Dave"),
 							get_account_id_from_seed::<sr25519::Public>("Eve"),
 							get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+							get_account_id_from_seed::<sr25519::Public>("George"),
+							get_account_id_from_seed::<sr25519::Public>("Harry"),
 							get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+							get_account_id_from_seed::<sr25519::Public>("George//stash"),
+							get_account_id_from_seed::<sr25519::Public>("Harry//stash"),
 						],
 						true,
 					)
@@ -147,7 +151,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		}),
 		pallet_balances: Some(BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 50)).collect(),
 		}),
 		pallet_aura: Some(AuraConfig {
 			authorities: Vec::new(),

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -83,13 +83,13 @@ Rialto authorities are named: `Alice`, `Bob`, `Charlie`, `Dave`, `Eve`.
 Rialto-PoA authorities are named: `Arthur`, `Bertha`, `Carlos`.
 Millau authorities are named: `Alice`, `Bob`, `Charlie`, `Dave`, `Eve`.
 
-Both authorities and following accounts have enough funds on corresponding Substrate chains:
+Both authorities and following accounts have enough funds (for test purposes) on corresponding Substrate chains:
 
 - on Rialto: `Ferdie`, `George`, `Harry`.
 - on Millau: `Ferdie`, `George`, `Harry`.
 
 Names of accounts on Substrate (Rialto and Millau) chains may be prefixed with `//` and used as
-seeds for the `sr25519` keys. This seed may also be used in the signer argument in substrate
+seeds for the `sr25519` keys. This seed may also be used in the signer argument in Substrate
 and PoA relays. Example:
 
 ```bash

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -116,8 +116,8 @@ Following accounts are used when `rialto-millau` bridge is running:
 
 - Millau's `Charlie` signs relay transactions with new Rialto headers;
 - Rialto's `Charlie` signs relay transactions with new Millau headers;
-- Millau's `Dave` signs Millau transactions with messages to Rialto;
-- Rialto's `Dave` signs Rialto transactions with messages to Millau;
+- Millau's `Dave` signs Millau transactions which contain messages for Rialto;
+- Rialto's `Dave` signs Rialto transactions which contain messages for Millau;
 - Millau's `Eve` signs relay transactions with message delivery confirmations from Rialto to Millau;
 - Rialto's `Eve` signs relay transactions with messages from Millau to Rialto;
 - Millau's `Ferdie` signs relay transactions with messages from Rialto to Millau;

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -50,7 +50,7 @@ We currently support two bridge deployments
 These networks can be deployed using our [`./run.sh`](./run.sh) script.
 
 The first argument it takes is the name of the bridge you want to run. Right now we only support two
-networks: `poa-rialto` and `rialto-millau`.
+bridges: `poa-rialto` and `rialto-millau`.
 
 ```bash
 ./run.sh poa-rialto
@@ -79,8 +79,49 @@ not strictly required.
 
 ## General Notes
 
-Substrate authorities are named: `Alice`, `Bob`, `Charlie`, `Dave`, `Eve`, `Ferdie`.
-Ethereum authorities are named: `Arthur`, `Bertha`, `Carlos`.
+Rialto authorities are named: `Alice`, `Bob`, `Charlie`, `Dave`, `Eve`.
+Rialto-PoA authorities are named: `Arthur`, `Bertha`, `Carlos`.
+Millau authorities are named: `Alice`, `Bob`, `Charlie`, `Dave`, `Eve`.
+
+Both authorities and following accounts have enough funds on corresponding Substrate chains:
+
+- on Rialto: `Ferdie`, `George`, `Harry`.
+- on Millau: `Ferdie`, `George`, `Harry`.
+
+Names of accounts on Substrate (Rialto and Millau) chains may be prefixed with `//` and used as
+seeds for the `sr25519` keys. This seed may also be used in the signer argument in substrate
+and PoA relays. Example:
+
+```bash
+./substrate-relay rialto-headers-to-millau \
+	--rialto-host rialto-node-alice \
+	--rialto-port 9944 \
+	--millau-host millau-node-alexander \
+	--millau-port 9944 \
+	--rialto-signer //Harry \
+	--prometheus-host=0.0.0.0
+```
+
+Some accounts are used by bridge components. Using these accounts to sign other transactions
+is not recommended, because this may lead to nonces conflict.
+
+Following accounts are used when `poa-rialto` bridge is running:
+
+- Rialto' `Alice` signs relay transactions with new Rialto-PoA headers;
+- Rialto' `Bob` signs relay transactions with Rialto-PoA -> Rialto currency exchange proofs.
+- Rialto-PoA' `Arthur`: signs relay transactions with new Rialto headers;
+- Rialto-PoA' `Bertha`: signs currency exchange transactions.
+
+Following accounts are used when `rialto-millau` bridge is running:
+
+- Millau' `Charlie` signs relay transactions with new Rialto headers;
+- Rialto' `Charlie` signs relay transactions with new Millau headers;
+- Millau' `Dave` signs Millau transactions with messages to Rialto;
+- Rialto' `Dave` signs Rialto transactions with messages to Millau;
+- Millau' `Eve` signs relay transactions with message delivery confirmations from Rialto to Millau;
+- Rialto' `Eve` signs relay transactions with messages from Millau to Rialto;
+- Millau' `Ferdie` signs relay transactions with messages from Rialto to Millau;
+- Rialto' `Ferdie` signs relay transactions with message delivery confirmations from Millau to Rialto.
 
 ### Docker Usage
 When the network is running you can query logs from individual nodes using:

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -107,21 +107,21 @@ is not recommended, because this may lead to nonces conflict.
 
 Following accounts are used when `poa-rialto` bridge is running:
 
-- Rialto' `Alice` signs relay transactions with new Rialto-PoA headers;
-- Rialto' `Bob` signs relay transactions with Rialto-PoA -> Rialto currency exchange proofs.
-- Rialto-PoA' `Arthur`: signs relay transactions with new Rialto headers;
-- Rialto-PoA' `Bertha`: signs currency exchange transactions.
+- Rialto's `Alice` signs relay transactions with new Rialto-PoA headers;
+- Rialto's `Bob` signs relay transactions with Rialto-PoA -> Rialto currency exchange proofs.
+- Rialto-PoA's `Arthur`: signs relay transactions with new Rialto headers;
+- Rialto-PoA's `Bertha`: signs currency exchange transactions.
 
 Following accounts are used when `rialto-millau` bridge is running:
 
-- Millau' `Charlie` signs relay transactions with new Rialto headers;
-- Rialto' `Charlie` signs relay transactions with new Millau headers;
-- Millau' `Dave` signs Millau transactions with messages to Rialto;
-- Rialto' `Dave` signs Rialto transactions with messages to Millau;
-- Millau' `Eve` signs relay transactions with message delivery confirmations from Rialto to Millau;
-- Rialto' `Eve` signs relay transactions with messages from Millau to Rialto;
-- Millau' `Ferdie` signs relay transactions with messages from Rialto to Millau;
-- Rialto' `Ferdie` signs relay transactions with message delivery confirmations from Millau to Rialto.
+- Millau's `Charlie` signs relay transactions with new Rialto headers;
+- Rialto's `Charlie` signs relay transactions with new Millau headers;
+- Millau's `Dave` signs Millau transactions with messages to Rialto;
+- Rialto's `Dave` signs Rialto transactions with messages to Millau;
+- Millau's `Eve` signs relay transactions with message delivery confirmations from Rialto to Millau;
+- Rialto's `Eve` signs relay transactions with messages from Millau to Rialto;
+- Millau's `Ferdie` signs relay transactions with messages from Rialto to Millau;
+- Rialto's `Ferdie` signs relay transactions with message delivery confirmations from Millau to Rialto.
 
 ### Docker Usage
 When the network is running you can query logs from individual nodes using:

--- a/deployments/bridges/poa-rialto/entrypoints/relay-poa-exchange-rialto-entrypoint.sh
+++ b/deployments/bridges/poa-rialto/entrypoints/relay-poa-exchange-rialto-entrypoint.sh
@@ -11,5 +11,6 @@ curl -v http://rialto-node-charlie:9933/health
 
 /home/user/ethereum-poa-relay eth-exchange-sub \
 	--sub-host rialto-node-alice \
+	--sub-signer //Bob \
 	--eth-host poa-node-arthur \
 	--prometheus-host=0.0.0.0

--- a/deployments/bridges/rialto-millau/entrypoints/relay-headers-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-headers-millau-to-rialto-entrypoint.sh
@@ -10,7 +10,7 @@ curl -v http://rialto-node-alice:9933/health
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \
 	--rialto-port 9944 \
-	--rialto-signer //Alice \
+	--rialto-signer //Alice
 
 # Give chain a little bit of time to process initialization transaction
 sleep 6
@@ -19,5 +19,5 @@ sleep 6
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \
 	--rialto-port 9944 \
-	--rialto-signer //Alice \
+	--rialto-signer //Charlie \
 	--prometheus-host=0.0.0.0

--- a/deployments/bridges/rialto-millau/entrypoints/relay-headers-rialto-to-millau-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-headers-rialto-to-millau-entrypoint.sh
@@ -10,7 +10,7 @@ curl -v http://rialto-node-alice:9933/health
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \
 	--rialto-port 9944 \
-	--millau-signer //Alice \
+	--millau-signer //Alice
 
 # Give chain a little bit of time to process initialization transaction
 sleep 6
@@ -19,5 +19,5 @@ sleep 6
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \
 	--rialto-port 9944 \
-	--millau-signer //Alice \
+	--millau-signer //Charlie \
 	--prometheus-host=0.0.0.0

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-generator-entrypoint.sh
@@ -23,8 +23,8 @@ do
 	/home/user/substrate-relay submit-millau-to-rialto-message \
 		--millau-host millau-node-bob \
 		--millau-port 9944 \
-		--millau-signer //Bob \
-		--rialto-signer //Bob \
+		--millau-signer //Dave \
+		--rialto-signer //Dave \
 		--lane $MESSAGE_LANE \
 		--message $MESSAGE \
 		--fee 100000000

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
@@ -11,8 +11,8 @@ MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 	--lane $MESSAGE_LANE \
 	--millau-host millau-node-bob \
 	--millau-port 9944 \
-	--millau-signer //Bob \
+	--millau-signer //Eve \
 	--rialto-host rialto-node-bob \
 	--rialto-port 9944 \
-	--rialto-signer //Bob \
+	--rialto-signer //Eve \
 	--prometheus-host=0.0.0.0


### PR DESCRIPTION
Changing names would break Substrate cli options (`--alice`, `--bob`, ...) that we use + we'll be unable to use matching keyring anymore.

This PR reserves `Ferdie` account, but it is yet unused - missing components should be added after this PR and #525