### PR TITLE
Message relay fixes for nightly stuck

### DIFF
--- a/relays/messages-relay/src/message_lane_loop.rs
+++ b/relays/messages-relay/src/message_lane_loop.rs
@@ -103,6 +103,9 @@ pub trait SourceClient<P: MessageLane>: Clone + Send + Sync {
 	) -> Result<(SourceHeaderIdOf<P>, MessageNonce), Self::Error>;
 
 	/// Returns mapping of message nonces, generated on this client, to their weights.
+	///
+	/// Some weights may be missing from returned map, if corresponding messages were pruned at
+	/// the source chain.
 	async fn generated_messages_weights(
 		&self,
 		id: SourceHeaderIdOf<P>,

--- a/relays/messages-relay/src/message_race_delivery.rs
+++ b/relays/messages-relay/src/message_race_delivery.rs
@@ -223,11 +223,11 @@ impl<P: MessageLane> RaceStrategy<SourceHeaderIdOf<P>, TargetHeaderIdOf<P>, P::M
 		self.strategy.is_empty()
 	}
 
-	fn best_at_source(&self) -> MessageNonce {
+	fn best_at_source(&self) -> Option<MessageNonce> {
 		self.strategy.best_at_source()
 	}
 
-	fn best_at_target(&self) -> MessageNonce {
+	fn best_at_target(&self) -> Option<MessageNonce> {
 		self.strategy.best_at_target()
 	}
 

--- a/relays/messages-relay/src/message_race_loop.rs
+++ b/relays/messages-relay/src/message_race_loop.rs
@@ -395,8 +395,7 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>>(
 						.submit_proof(at_block.clone(), nonces_range.clone(), proof.clone())
 						.fuse(),
 				);
-			}
-			if target_nonces_required {
+			} else if target_nonces_required {
 				log::debug!(target: "bridge", "Asking {} about message nonces", P::target_name());
 				let at_block = race_state
 					.best_target_header_id

--- a/relays/messages-relay/src/message_race_loop.rs
+++ b/relays/messages-relay/src/message_race_loop.rs
@@ -334,7 +334,15 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>>(
 					async_std::task::sleep,
 					|| format!("Error submitting proof {}", P::target_name()),
 				).fail_if_connection_error(FailedClient::Target)?;
-			}
+			},
+
+			// when we're ready to retry request
+			_ = source_go_offline_future => {
+				source_client_is_online = true;
+			},
+			_ = target_go_offline_future => {
+				target_client_is_online = true;
+			},
 		}
 
 		progress_context = print_race_progress::<P, _>(progress_context, &strategy);

--- a/relays/messages-relay/src/message_race_loop.rs
+++ b/relays/messages-relay/src/message_race_loop.rs
@@ -144,9 +144,14 @@ pub trait RaceStrategy<SourceHeaderId, TargetHeaderId, Proof> {
 	/// Should return true if nothing has to be synced.
 	fn is_empty(&self) -> bool;
 	/// Return best nonce at source node.
-	fn best_at_source(&self) -> MessageNonce;
+	///
+	/// `Some` is returned only if we are sure that the value is greater or equal
+	/// than the result of `best_at_target`.
+	fn best_at_source(&self) -> Option<MessageNonce>;
 	/// Return best nonce at target node.
-	fn best_at_target(&self) -> MessageNonce;
+	///
+	/// May return `None` if value is yet unknown.
+	fn best_at_target(&self) -> Option<MessageNonce>;
 
 	/// Called when nonces are updated at source node of the race.
 	fn source_nonces_updated(&mut self, at_block: SourceHeaderId, nonces: SourceClientNonces<Self::SourceNoncesRange>);
@@ -358,6 +363,7 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>>(
 			source_client_is_online = false;
 
 			let nonces_to_deliver = select_nonces_to_deliver(&race_state, &mut strategy);
+			let best_at_source = strategy.best_at_source();
 
 			if let Some((at_block, nonces_range, proof_parameters)) = nonces_to_deliver {
 				log::debug!(
@@ -372,7 +378,7 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>>(
 						.generate_proof(at_block, nonces_range, proof_parameters)
 						.fuse(),
 				);
-			} else if source_nonces_required {
+			} else if source_nonces_required && best_at_source.is_some() {
 				log::debug!(target: "bridge", "Asking {} about message nonces", P::source_name());
 				let at_block = race_state
 					.best_finalized_source_header_id_at_source
@@ -382,7 +388,11 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>>(
 						best_finalized_source_header_id_at_source is Some; qed",
 					)
 					.clone();
-				source_nonces.set(race_source.nonces(at_block, strategy.best_at_source()).fuse());
+				source_nonces.set(
+					race_source
+						.nonces(at_block, best_at_source.expect("guaranteed by if condition; qed"))
+						.fuse(),
+				);
 			} else {
 				source_client_is_online = true;
 			}

--- a/relays/substrate/src/messages_source.rs
+++ b/relays/substrate/src/messages_source.rs
@@ -150,23 +150,11 @@ where
 				Some(id.1),
 			)
 			.await?;
-		let weights: Vec<(MessageNonce, Weight)> =
-			Decode::decode(&mut &encoded_response.0[..]).map_err(SubstrateError::ResponseParseFailed)?;
 
-		let mut expected_nonce = *nonces.start();
-		let mut weights_map = MessageWeightsMap::new();
-		for (nonce, weight) in weights {
-			if nonce != expected_nonce {
-				return Err(SubstrateError::Custom(format!(
-					"Unexpected nonce in messages_dispatch_weight call result. Expected {}, got {}",
-					expected_nonce, nonce
-				)));
-			}
-
-			weights_map.insert(nonce, weight);
-			expected_nonce += 1;
-		}
-		Ok(weights_map)
+		make_message_weights_map::<C>(
+			Decode::decode(&mut &encoded_response.0[..]).map_err(SubstrateError::ResponseParseFailed)?,
+			nonces,
+		)
 	}
 
 	async fn prove_messages(
@@ -244,4 +232,109 @@ where
 		best_finalized_self: self_best_finalized_id,
 		best_finalized_peer_at_best_self: peer_on_self_best_finalized_id,
 	})
+}
+
+fn make_message_weights_map<C: Chain>(
+	weights: Vec<(MessageNonce, Weight)>,
+	nonces: RangeInclusive<MessageNonce>,
+) -> Result<MessageWeightsMap, SubstrateError> {
+	let make_missing_nonce_error = |expected_nonce| {
+		Err(SubstrateError::Custom(format!(
+			"Missing nonce {} in messages_dispatch_weight call result. Expected all nonces from {:?}",
+			expected_nonce, nonces,
+		)))
+	};
+
+	let mut weights_map = MessageWeightsMap::new();
+
+	// this is actually prevented by external logic
+	if nonces.is_empty() {
+		return Ok(weights_map);
+	}
+
+	// check if last nonce is missing - loop below is not checking this
+	let last_nonce_is_missing = weights
+		.last()
+		.map(|(last_nonce, _)| last_nonce != nonces.end())
+		.unwrap_or(true);
+	if last_nonce_is_missing {
+		return make_missing_nonce_error(*nonces.end());
+	}
+
+	let mut expected_nonce = *nonces.start();
+	let mut is_at_head = true;
+
+	for (nonce, weight) in weights {
+		match (nonce == expected_nonce, is_at_head) {
+			(true, _) => (),
+			(false, true) => {
+				// this may happen if some messages were already pruned from the source node
+				//
+				// this is not critical error and will be auto-resolved by messages lane (and target node)
+				log::info!(
+					target: "bridge",
+					"Some messages are missing from the {} node: {:?}. Target node may be out of sync?",
+					C::NAME,
+					expected_nonce..nonce,
+				);
+			}
+			(false, false) => {
+				// some nonces are missing from the middle/tail of the range
+				//
+				// this is critical error, because we can't miss any nonces
+				return make_missing_nonce_error(expected_nonce);
+			}
+		}
+
+		weights_map.insert(nonce, weight);
+		expected_nonce = nonce + 1;
+		is_at_head = false;
+	}
+
+	Ok(weights_map)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn make_message_weights_map_succeeds_if_no_messages_are_missing() {
+		assert_eq!(
+			make_message_weights_map::<relay_rialto_client::Rialto>(vec![(1, 0), (2, 0), (3, 0)], 1..=3).unwrap(),
+			vec![(1, 0), (2, 0), (3, 0)].into_iter().collect(),
+		);
+	}
+
+	#[test]
+	fn make_message_weights_map_succeeds_if_head_messages_are_missing() {
+		assert_eq!(
+			make_message_weights_map::<relay_rialto_client::Rialto>(vec![(2, 0), (3, 0)], 1..=3).unwrap(),
+			vec![(2, 0), (3, 0)].into_iter().collect(),
+		);
+	}
+
+	#[test]
+	fn make_message_weights_map_fails_if_mid_messages_are_missing() {
+		assert!(matches!(
+			make_message_weights_map::<relay_rialto_client::Rialto>(vec![(1, 0), (3, 0)], 1..=3),
+			Err(SubstrateError::Custom(_)),
+		));
+	}
+
+	#[test]
+	fn make_message_weights_map_fails_if_tail_messages_are_missing() {
+		assert!(matches!(
+			make_message_weights_map::<relay_rialto_client::Rialto>(vec![(1, 0), (2, 0)], 1..=3),
+			Err(SubstrateError::Custom(_)),
+		));
+	}
+
+	#[test]
+	fn make_message_weights_map_fails_if_all_messages_are_missing() {
+		assert!(matches!(
+			make_message_weights_map::<relay_rialto_client::Rialto>(vec![], 1..=3),
+			Err(SubstrateError::Custom(_)),
+		));
+	}
 }

--- a/relays/substrate/src/messages_source.rs
+++ b/relays/substrate/src/messages_source.rs
@@ -318,7 +318,7 @@ mod tests {
 	fn make_message_weights_map_fails_if_mid_messages_are_missing() {
 		assert!(matches!(
 			make_message_weights_map::<relay_rialto_client::Rialto>(vec![(1, 0), (3, 0)], 1..=3),
-			Err(SubstrateError::Custom(_)),
+			Err(SubstrateError::Custom(_))
 		));
 	}
 
@@ -326,7 +326,7 @@ mod tests {
 	fn make_message_weights_map_fails_if_tail_messages_are_missing() {
 		assert!(matches!(
 			make_message_weights_map::<relay_rialto_client::Rialto>(vec![(1, 0), (2, 0)], 1..=3),
-			Err(SubstrateError::Custom(_)),
+			Err(SubstrateError::Custom(_))
 		));
 	}
 
@@ -334,7 +334,7 @@ mod tests {
 	fn make_message_weights_map_fails_if_all_messages_are_missing() {
 		assert!(matches!(
 			make_message_weights_map::<relay_rialto_client::Rialto>(vec![], 1..=3),
-			Err(SubstrateError::Custom(_)),
+			Err(SubstrateError::Custom(_))
 		));
 	}
 }


### PR DESCRIPTION
Because of [first issue](https://github.com/paritytech/parity-bridges-common/commit/336c0e2372af123dc0269ef9a10056f3f5f85984) relay may have tried to send several (same) transactions simultaneously => this may have lead to errors like `Error submitting proof Rialto::MessagesDelivery: Request(Request(Error { code: MethodError(1014), message: "Priority is too low: (36797852575 vs 36797852575)", data: Some(String("The transaction has too low priority to replace another transaction already in the pool.")) })). Retrying in 0.48135872`.

The attempt was supposed to be retried (as visible from the error message above). But actually, because of [second issue](https://github.com/paritytech/parity-bridges-common/commit/a1cd15b485fea5b9e9c50c9b6df5e40902b58048), target client was never marked as available for retrying.

Since relay has stall-timeout, loop has been restarted after this timeout has passed. But here comes the [third issue](https://github.com/paritytech/parity-bridges-common/commit/6a8c88be111aea46b795e97d5d880eac5f92620c). Basically - on source chain we have already pruned messages 1 and 2, because they were delivered to the target chain. But source nonces were read before target nonces. The code was assuming that the nonce on the target chain is zero in this case. So we were trying to read weights of messages 1 and 2 from the source node. Obviously, this request has failed and the source node was marked as failing (aka offline). But here comes the second issue - source client was never 'returned back'.

Finally, stall-timeout works only if race (delivery or confirmations) has submitted something, but the nonce has not changed at the race target within stall-timeout interval (i.e. transaction is lost). In this case, all messages were delivered and confirmed after restart and since source client was unavailable to check if there are new nonces at the source (because of second issue), relay was (and still is) thinking that there is nothing to do.

I'll add more alerts to the messages-relay dashboard in next PR - for testnets we're sure that there's at least 1 message / minute. So this may be detected.