### PR TITLE
Message lane benchmarks: start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,9 +4099,11 @@ version = "0.1.0"
 dependencies = [
  "bp-message-lane",
  "bp-runtime",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "hex-literal 0.3.1",
+ "num-traits",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/bin/rialto/runtime/Cargo.toml
+++ b/bin/rialto/runtime/Cargo.toml
@@ -121,5 +121,6 @@ runtime-benchmarks = [
 	"libsecp256k1",
 	"pallet-bridge-currency-exchange/runtime-benchmarks",
 	"pallet-bridge-eth-poa/runtime-benchmarks",
+	"pallet-message-lane/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -435,6 +435,7 @@ parameter_types! {
 		bp_rialto::MAX_MESSAGES_IN_DELIVERY_TRANSACTION;
 }
 
+pub(crate) type WithMillauMessageLaneInstance = pallet_message_lane::DefaultInstance;
 impl pallet_message_lane::Trait for Runtime {
 	type Event = Event;
 	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
@@ -807,12 +808,32 @@ impl_runtime_apis! {
 				}
 			}
 
+			use pallet_message_lane::benchmarking::{
+				Module as MessageLaneBench,
+				Trait as MessageLaneTrait,
+				MessageParams as MessageLaneMessageParams,
+			};
+
+			impl MessageLaneTrait<WithMillauMessageLaneInstance> for Runtime {
+				fn prepare_message(
+					_params: MessageLaneMessageParams,
+				) -> (millau_messages::ToMillauMessagePayload, Balance) {
+					unimplemented!("TODO")
+				}
+			}
+
 			add_benchmark!(params, batches, pallet_bridge_eth_poa, BridgeKovan);
 			add_benchmark!(
 				params,
 				batches,
 				pallet_bridge_currency_exchange,
 				BridgeCurrencyExchangeBench::<Runtime, KovanCurrencyExchange>
+			);
+			add_benchmark!(
+				params,
+				batches,
+				pallet_message_lane,
+				MessageLaneBench::<Runtime, WithMillauMessageLaneInstance>
 			);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -143,7 +143,7 @@ impl messages::ChainWithMessageLanes for Rialto {
 	type Weight = Weight;
 	type Balance = bp_rialto::Balance;
 
-	type MessageLaneInstance = pallet_message_lane::DefaultInstance;
+	type MessageLaneInstance = crate::WithMillauMessageLaneInstance;
 }
 
 /// Millau chain from message lane point of view.

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -174,6 +174,11 @@ pub mod source {
 		}
 	}
 
+	/// Return maximal message size of This -> Bridged chain message.
+	pub fn maximal_message_size<B: MessageBridge>() -> u32 {
+		B::maximal_extrinsic_size_on_target_chain() / 3 * 2
+	}
+
 	/// Do basic Bridged-chain specific verification of This -> Bridged chain message.
 	///
 	/// Ok result from this function means that the delivery transaction with this message
@@ -197,7 +202,7 @@ pub mod source {
 		// is enormously large, it should be several dozens/hundreds of bytes. The delivery
 		// transaction also contains signatures and signed extensions. Because of this, we reserve
 		// 1/3 of the the maximal extrinsic weight for this data.
-		if payload.call.len() > B::maximal_extrinsic_size_on_target_chain() as usize * 2 / 3 {
+		if payload.call.len() > maximal_message_size::<B>() as usize {
 			return Err("The message is too large to be sent over the lane");
 		}
 
@@ -856,7 +861,7 @@ mod tests {
 				spec_version: 1,
 				weight: BRIDGED_CHAIN_MAX_EXTRINSIC_WEIGHT,
 				origin: pallet_bridge_call_dispatch::CallOrigin::SourceRoot,
-				call: vec![0; BRIDGED_CHAIN_MAX_EXTRINSIC_SIZE as usize * 2 / 3 + 1],
+				call: vec![0; maximal_message_size::<OnThisChainBridge>() + 1],
 			},)
 			.is_err()
 		);
@@ -871,7 +876,7 @@ mod tests {
 				spec_version: 1,
 				weight: BRIDGED_CHAIN_MAX_EXTRINSIC_WEIGHT,
 				origin: pallet_bridge_call_dispatch::CallOrigin::SourceRoot,
-				call: vec![0; BRIDGED_CHAIN_MAX_EXTRINSIC_SIZE as usize * 2 / 3],
+				call: vec![0; maximal_message_size::<OnThisChainBridge>()],
 			},),
 			Ok(()),
 		);

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -861,7 +861,7 @@ mod tests {
 				spec_version: 1,
 				weight: BRIDGED_CHAIN_MAX_EXTRINSIC_WEIGHT,
 				origin: pallet_bridge_call_dispatch::CallOrigin::SourceRoot,
-				call: vec![0; maximal_message_size::<OnThisChainBridge>() + 1],
+				call: vec![0; source::maximal_message_size::<OnThisChainBridge>() as usize + 1],
 			},)
 			.is_err()
 		);
@@ -876,7 +876,7 @@ mod tests {
 				spec_version: 1,
 				weight: BRIDGED_CHAIN_MAX_EXTRINSIC_WEIGHT,
 				origin: pallet_bridge_call_dispatch::CallOrigin::SourceRoot,
-				call: vec![0; maximal_message_size::<OnThisChainBridge>()],
+				call: vec![0; source::maximal_message_size::<OnThisChainBridge>() as _],
 			},),
 			Ok(()),
 		);

--- a/modules/message-lane/Cargo.toml
+++ b/modules/message-lane/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 # Bridge dependencies
@@ -17,6 +18,7 @@ bp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 # Substrate Dependencies
 
+frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false, optional = true }
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
@@ -35,8 +37,12 @@ std = [
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",
+	"num-traits/std",
 	"serde",
 	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",
+]
+runtime-benchmarks = [
+	"frame-benchmarking",
 ]

--- a/modules/message-lane/src/benchmarking.rs
+++ b/modules/message-lane/src/benchmarking.rs
@@ -1,0 +1,87 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Message lane pallet benchmarking.
+
+use crate::{Call, Instance};
+
+use bp_message_lane::{LaneId, MessageData, MessageNonce};
+use frame_benchmarking::{account, benchmarks_instance};
+use frame_support::traits::Get;
+use frame_system::RawOrigin;
+use num_traits::Zero;
+use sp_std::prelude::*;
+
+/// Message crafted with this size factor should be the largest possible message.
+pub const WORST_MESSAGE_SIZE_FACTOR: u32 = 1000;
+
+const SEED: u32 = 0;
+
+/// Module we're benchmarking here.
+pub struct Module<T: Trait<I>, I: crate::Instance>(crate::Module<T, I>);
+
+/// Benchmark-specific message parameters.
+pub struct MessageParams {
+	/// Size factor of the message payload. Message payload grows with every factor
+	/// increment. Zero is the smallest possible message and the `WORST_MESSAGE_SIZE_FACTOR` is
+	/// largest possible message.
+	pub size_factor: u32,
+}
+
+/// Trait that must be implemented by runtime.
+pub trait Trait<I: Instance>: crate::Trait<I> {
+	/// Prepare message to send over lane.
+	fn prepare_message(params: MessageParams) -> (Self::OutboundPayload, Self::OutboundMessageFee);
+}
+
+benchmarks_instance! {
+	_ { }
+
+	// Benchmark `send_message` extrinsic with the worst possible conditions:
+	// * outbound lane already has state, so it needs to be read and decoded;
+	// * relayers fund account does not exists (in practice it needs to exist in production environment);
+	// * message size is maximal for the target chain;
+	// * maximal number of messages is pruned.
+	send_message_worst_case {
+		let i in 1..100;
+		let n in WORST_MESSAGE_SIZE_FACTOR..WORST_MESSAGE_SIZE_FACTOR+1;
+
+		let lane_id = bench_lane_id();
+		let sender = account("sender", i, SEED);
+
+		// 'send' messages that are to be pruned when our message is sent
+		for _nonce in 1..=T::MaxMessagesToPruneAtOnce::get() {
+			send_regular_message::<T, I>();
+		}
+		confirm_message_delivery::<T, I>(T::MaxMessagesToPruneAtOnce::get());
+
+		let (payload, fee) = T::prepare_message(MessageParams { size_factor: n });
+	}: send_message(RawOrigin::Signed(sender), lane_id, payload, fee)
+}
+
+fn bench_lane_id() -> LaneId {
+	*b"test"
+}
+
+fn send_regular_message<T: Trait<I>, I: Instance>() {
+	let mut outbound_lane = crate::outbound_lane::<T, I>(bench_lane_id());
+	outbound_lane.send_message(MessageData { payload: vec![], fee: Zero::zero() });
+}
+
+fn confirm_message_delivery<T: Trait<I>, I: Instance>(nonce: MessageNonce) {
+	let mut outbound_lane = crate::outbound_lane::<T, I>(bench_lane_id());
+	assert!(outbound_lane.confirm_delivery(nonce).is_some());
+}

--- a/modules/message-lane/src/benchmarking.rs
+++ b/modules/message-lane/src/benchmarking.rs
@@ -59,7 +59,6 @@ benchmarks_instance! {
 	// * message size is maximal for the target chain.
 	send_message_worst_case {
 		let i in 1..100;
-		let n in WORST_MESSAGE_SIZE_FACTOR..WORST_MESSAGE_SIZE_FACTOR+1;
 
 		let lane_id = bench_lane_id();
 		let sender = account("sender", i, SEED);
@@ -71,7 +70,7 @@ benchmarks_instance! {
 		}
 		confirm_message_delivery::<T, I>(T::MaxMessagesToPruneAtOnce::get());
 
-		let (payload, fee) = T::prepare_message(MessageParams { size_factor: n });
+		let (payload, fee) = T::prepare_message(MessageParams { size_factor: WORST_MESSAGE_SIZE_FACTOR });
 	}: send_message(RawOrigin::Signed(sender), lane_id, payload, fee)
 }
 

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -45,6 +45,7 @@ use frame_support::{
 	Parameter, StorageMap,
 };
 use frame_system::{ensure_signed, RawOrigin};
+use num_traits::Zero;
 use sp_runtime::{traits::BadOrigin, DispatchResult};
 use sp_std::{cell::RefCell, marker::PhantomData, prelude::*};
 
@@ -52,6 +53,9 @@ mod inbound_lane;
 mod outbound_lane;
 
 pub mod instant_payments;
+
+#[cfg(feature = "runtime-benchmarks")]
+pub mod benchmarking;
 
 #[cfg(test)]
 mod mock;
@@ -71,9 +75,8 @@ pub trait Trait<I = DefaultInstance>: frame_system::Trait {
 	/// They overarching event type.
 	type Event: From<Event<Self, I>> + Into<<Self as frame_system::Trait>::Event>;
 	/// Maximal number of messages that may be pruned during maintenance. Maintenance occurs
-	/// whenever outbound lane is updated - i.e. when new message is sent, or receival is
-	/// confirmed. The reason is that if you want to use lane, you should be ready to pay
-	/// for it.
+	/// whenever new message is sent. The reason is that if you want to use lane, you should
+	/// be ready to pay for its maintenance.
 	type MaxMessagesToPruneAtOnce: Get<MessageNonce>;
 	/// Maximal number of "messages" (see note below) in the 'unconfirmed' state at inbound lane.
 	/// Unconfirmed message at inbound lane is the message that has been: sent, delivered and
@@ -95,7 +98,7 @@ pub trait Trait<I = DefaultInstance>: frame_system::Trait {
 	/// Payload type of outbound messages. This payload is dispatched on the bridged chain.
 	type OutboundPayload: Parameter;
 	/// Message fee type of outbound messages. This fee is paid on this chain.
-	type OutboundMessageFee: Parameter;
+	type OutboundMessageFee: Parameter + Zero;
 
 	/// Payload type of inbound messages. This payload is dispatched on this chain.
 	type InboundPayload: Decode;


### PR DESCRIPTION
This should be a PR with the only benchmark - `send_message_worst_case`, all other benchmarks will be added in follow-up PRs. Right now #551 is required to continue this work => draft.