### PR TITLE
Add scripts for running local Rialto<->Millau header sync

### DIFF
--- a/deployments/local-scripts/relay-millau-to-rialto.sh
+++ b/deployments/local-scripts/relay-millau-to-rialto.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# A script for relaying Millau headers to the Rialto chain.
+#
+# Will not work unless both the Rialto and Millau are running (see `run-rialto-node.sh`
+# and `run-millau-node.sh).
+
+RUST_LOG=bridge=debug \
+./target/debug/substrate-relay initialize-millau-headers-bridge-in-rialto \
+	--millau-host localhost \
+	--millau-port 9945 \
+	--rialto-host localhost \
+	--rialto-port 9944 \
+	--rialto-signer //Alice \
+
+sleep 5
+RUST_LOG=bridge=debug \
+./target/debug/substrate-relay millau-headers-to-rialto \
+	--millau-host localhost \
+	--millau-port 9945 \
+	--rialto-host localhost \
+	--rialto-port 9944 \
+	--rialto-signer //Alice \
+	--prometheus-host=0.0.0.0

--- a/deployments/local-scripts/relay-rialto-to-millau.sh
+++ b/deployments/local-scripts/relay-rialto-to-millau.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# A script for relaying Rialto headers to the Millau chain.
+#
+# Will not work unless both the Rialto and Millau are running (see `run-rialto-node.sh`
+# and `run-millau-node.sh).
+
+RUST_LOG=bridge=debug \
+./target/debug/substrate-relay initialize-rialto-headers-bridge-in-millau \
+	--millau-host localhost \
+	--millau-port 9945 \
+	--rialto-host localhost \
+	--rialto-port 9944 \
+	--millau-signer //Alice \
+
+sleep 5
+RUST_LOG=bridge=debug \
+./target/debug/substrate-relay rialto-headers-to-millau \
+	--millau-host localhost \
+	--millau-port 9945 \
+	--rialto-host localhost \
+	--rialto-port 9944 \
+	--millau-signer //Alice \
+	--prometheus-host=0.0.0.0

--- a/deployments/local-scripts/run-millau-node.sh
+++ b/deployments/local-scripts/run-millau-node.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run a development instance of the Millau Substrate bridge node.
+
+RUST_LOG=runtime=trace \
+./target/debug/millau-bridge-node --dev --tmp \
+    --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external \
+    --port 33044 --rpc-port 9934 --ws-port 9945 \

--- a/deployments/local-scripts/run-rialto-node.sh
+++ b/deployments/local-scripts/run-rialto-node.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run a development instance of the Rialto Substrate bridge node.
+
+RUST_LOG=runtime=trace \
+    ./target/debug/rialto-bridge-node --dev --tmp \
+    --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external \
+    --port 33033 --rpc-port 9933 --ws-port 9944 \

--- a/scripts/run-rialto-node.sh
+++ b/scripts/run-rialto-node.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Run a development instance of the Substrate bridge node.
-
-RUST_LOG=runtime=trace,rpc=debug \
-    ./target/debug/rialto-bridge-node --dev --tmp \
-    --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external


### PR DESCRIPTION
I've intentionally left out scripts for message lanes since that adds a bit of complexity to the local setup and at that point you might as well use our Compose deployment and swap out individual components with local builds.

If you guys think that's the wrong mindset I can add scripts for message lanes.