### PR TITLE
Add messages count parameter to delivery transaction

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -313,8 +313,6 @@ parameter_types! {
 		bp_millau::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
 	pub const MaxUnconfirmedMessagesAtInboundLane: bp_message_lane::MessageNonce =
 		bp_millau::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
-	pub const MaxMessagesInDeliveryTransaction: bp_message_lane::MessageNonce =
-		bp_millau::MAX_MESSAGES_IN_DELIVERY_TRANSACTION;
 }
 
 impl pallet_message_lane::Config for Runtime {
@@ -322,7 +320,6 @@ impl pallet_message_lane::Config for Runtime {
 	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
-	type MaxMessagesInDeliveryTransaction = MaxMessagesInDeliveryTransaction;
 
 	type OutboundPayload = crate::rialto_messages::ToRialtoMessagePayload;
 	type OutboundMessageFee = Balance;

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -192,8 +192,8 @@ impl SourceHeaderChain<bp_rialto::Balance> for Rialto {
 
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		max_messages: MessageNonce,
+		messages_count: MessageNonce,
 	) -> Result<ProvedMessages<Message<bp_rialto::Balance>>, Self::Error> {
-		messages::target::verify_messages_proof::<WithRialtoMessageBridge, Runtime>(proof, max_messages)
+		messages::target::verify_messages_proof::<WithRialtoMessageBridge, Runtime>(proof, messages_count)
 	}
 }

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -420,8 +420,6 @@ parameter_types! {
 		bp_millau::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE;
 	pub const MaxUnconfirmedMessagesAtInboundLane: bp_message_lane::MessageNonce =
 		bp_rialto::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE;
-	pub const MaxMessagesInDeliveryTransaction: bp_message_lane::MessageNonce =
-		bp_rialto::MAX_MESSAGES_IN_DELIVERY_TRANSACTION;
 }
 
 pub(crate) type WithMillauMessageLaneInstance = pallet_message_lane::DefaultInstance;
@@ -430,7 +428,6 @@ impl pallet_message_lane::Config for Runtime {
 	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
-	type MaxMessagesInDeliveryTransaction = MaxMessagesInDeliveryTransaction;
 
 	type OutboundPayload = crate::millau_messages::ToMillauMessagePayload;
 	type OutboundMessageFee = Balance;

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -192,8 +192,8 @@ impl SourceHeaderChain<bp_millau::Balance> for Millau {
 
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		max_messages: MessageNonce,
+		messages_count: MessageNonce,
 	) -> Result<ProvedMessages<Message<bp_millau::Balance>>, Self::Error> {
-		messages::target::verify_messages_proof::<WithMillauMessageBridge, Runtime>(proof, max_messages)
+		messages::target::verify_messages_proof::<WithMillauMessageBridge, Runtime>(proof, messages_count)
 	}
 }

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -393,7 +393,7 @@ pub mod target {
 	/// Verify proof of Bridged -> This chain messages.
 	pub fn verify_messages_proof<B: MessageBridge, ThisRuntime>(
 		proof: FromBridgedChainMessagesProof<B>,
-		max_messages: MessageNonce,
+		messages_count: MessageNonce,
 	) -> Result<ProvedMessages<Message<BalanceOf<BridgedChain<B>>>>, &'static str>
 	where
 		ThisRuntime: pallet_substrate_bridge::Config,
@@ -403,7 +403,7 @@ pub mod target {
 	{
 		verify_messages_proof_with_parser::<B, _, _>(
 			proof,
-			max_messages,
+			messages_count,
 			|bridged_header_hash, bridged_storage_proof| {
 				pallet_substrate_bridge::Module::<ThisRuntime>::parse_finalized_storage_proof(
 					bridged_header_hash.into(),
@@ -423,7 +423,7 @@ pub mod target {
 	#[derive(Debug, PartialEq)]
 	pub(crate) enum MessageProofError {
 		Empty,
-		TooManyMessages,
+		MessagesCountMismatch,
 		MissingRequiredMessage,
 		FailedToDecodeMessage,
 		FailedToDecodeOutboundLaneState,
@@ -434,7 +434,7 @@ pub mod target {
 		fn from(err: MessageProofError) -> &'static str {
 			match err {
 				MessageProofError::Empty => "Messages proof is empty",
-				MessageProofError::TooManyMessages => "Too many messages in the proof",
+				MessageProofError::MessagesCountMismatch => "Declared messages count doesn't match actual value",
 				MessageProofError::MissingRequiredMessage => "Message is missing from the proof",
 				MessageProofError::FailedToDecodeMessage => "Failed to decode message from the proof",
 				MessageProofError::FailedToDecodeOutboundLaneState => {
@@ -482,7 +482,7 @@ pub mod target {
 	/// Verify proof of Bridged -> This chain messages using given message proof parser.
 	pub(crate) fn verify_messages_proof_with_parser<B: MessageBridge, BuildParser, Parser>(
 		proof: FromBridgedChainMessagesProof<B>,
-		max_messages: MessageNonce,
+		messages_count: MessageNonce,
 		build_parser: BuildParser,
 	) -> Result<ProvedMessages<Message<BalanceOf<BridgedChain<B>>>>, MessageProofError>
 	where
@@ -494,8 +494,8 @@ pub mod target {
 		// receiving proofs where end < begin is ok (if proof includes outbound lane state)
 		// => hence unwrap_or(0)
 		let messages_in_the_proof = end.checked_sub(begin).and_then(|diff| diff.checked_add(1)).unwrap_or(0);
-		if messages_in_the_proof > max_messages {
-			return Err(MessageProofError::TooManyMessages);
+		if messages_in_the_proof != messages_count {
+			return Err(MessageProofError::MessagesCountMismatch);
 		}
 
 		let parser = build_parser(bridged_header_hash, bridged_storage_proof)?;
@@ -1003,14 +1003,26 @@ mod tests {
 	}
 
 	#[test]
-	fn messages_proof_is_rejected_if_there_are_too_many_messages() {
+	fn messages_proof_is_rejected_if_declared_less_than_actual_number_of_messages() {
 		assert_eq!(
 			target::verify_messages_proof_with_parser::<OnThisChainBridge, _, TestMessageProofParser>(
-				(Default::default(), StorageProof::new(vec![]), Default::default(), 1, 11),
-				10,
+				(Default::default(), StorageProof::new(vec![]), Default::default(), 1, 10),
+				5,
 				|_, _| unreachable!(),
 			),
-			Err(target::MessageProofError::TooManyMessages),
+			Err(target::MessageProofError::MessagesCountMismatch),
+		);
+	}
+
+	#[test]
+	fn messages_proof_is_rejected_if_declared_more_than_actual_number_of_messages() {
+		assert_eq!(
+			target::verify_messages_proof_with_parser::<OnThisChainBridge, _, TestMessageProofParser>(
+				(Default::default(), StorageProof::new(vec![]), Default::default(), 1, 10),
+				15,
+				|_, _| unreachable!(),
+			),
+			Err(target::MessageProofError::MessagesCountMismatch),
 		);
 	}
 
@@ -1063,7 +1075,7 @@ mod tests {
 		assert_eq!(
 			target::verify_messages_proof_with_parser::<OnThisChainBridge, _, _>(
 				(Default::default(), StorageProof::new(vec![]), Default::default(), 1, 0),
-				10,
+				0,
 				|_, _| Ok(TestMessageProofParser {
 					failing: true,
 					messages: no_messages_range(),
@@ -1083,7 +1095,7 @@ mod tests {
 		assert_eq!(
 			target::verify_messages_proof_with_parser::<OnThisChainBridge, _, _>(
 				(Default::default(), StorageProof::new(vec![]), Default::default(), 1, 0),
-				10,
+				0,
 				|_, _| Ok(TestMessageProofParser {
 					failing: false,
 					messages: no_messages_range(),
@@ -1099,7 +1111,7 @@ mod tests {
 		assert_eq!(
 			target::verify_messages_proof_with_parser::<OnThisChainBridge, _, _>(
 				(Default::default(), StorageProof::new(vec![]), Default::default(), 1, 0),
-				10,
+				0,
 				|_, _| Ok(TestMessageProofParser {
 					failing: false,
 					messages: no_messages_range(),
@@ -1131,7 +1143,7 @@ mod tests {
 		assert_eq!(
 			target::verify_messages_proof_with_parser::<OnThisChainBridge, _, _>(
 				(Default::default(), StorageProof::new(vec![]), Default::default(), 1, 1),
-				10,
+				1,
 				|_, _| Ok(TestMessageProofParser {
 					failing: false,
 					messages: 1..=1,

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -93,11 +93,6 @@ pub trait Config<I = DefaultInstance>: frame_system::Config {
 	/// This constant limits difference between last message from last entry of the
 	/// `InboundLaneData::relayers` and first message at the first entry.
 	type MaxUnconfirmedMessagesAtInboundLane: Get<MessageNonce>;
-	/// Maximal number of messages in single delivery transaction. This directly affects the base
-	/// weight of the delivery transaction.
-	///
-	/// All transactions that deliver more messages than this number, are rejected.
-	type MaxMessagesInDeliveryTransaction: Get<MessageNonce>;
 
 	/// Payload type of outbound messages. This payload is dispatched on the bridged chain.
 	type OutboundPayload: Parameter;
@@ -322,17 +317,16 @@ decl_module! {
 		}
 
 		/// Receive messages proof from bridged chain.
-		#[weight = DELIVERY_OVERHEAD_WEIGHT
-			.saturating_add(
-				T::MaxMessagesInDeliveryTransaction::get()
-					.saturating_mul(SINGLE_MESSAGE_DELIVERY_WEIGHT)
-			)
+		#[weight = messages_count
+			.saturating_mul(SINGLE_MESSAGE_DELIVERY_WEIGHT)
+			.saturating_add(DELIVERY_OVERHEAD_WEIGHT)
 			.saturating_add(*dispatch_weight)
 		]
 		pub fn receive_messages_proof(
 			origin,
 			relayer_id: T::InboundRelayer,
 			proof: MessagesProofOf<T, I>,
+			messages_count: MessageNonce,
 			dispatch_weight: Weight,
 		) -> DispatchResult {
 			ensure_operational::<T, I>()?;
@@ -343,7 +337,7 @@ decl_module! {
 				T::SourceHeaderChain,
 				T::InboundMessageFee,
 				T::InboundPayload,
-			>(proof, T::MaxMessagesInDeliveryTransaction::get())
+			>(proof, messages_count)
 				.map_err(|err| {
 					frame_support::debug::trace!(
 						"Rejecting invalid messages proof: {:?}",
@@ -669,9 +663,9 @@ impl<T: Config<I>, I: Instance> OutboundLaneStorage for RuntimeOutboundLaneStora
 /// Verify messages proof and return proved messages with decoded payload.
 fn verify_and_decode_messages_proof<Chain: SourceHeaderChain<Fee>, Fee, DispatchPayload: Decode>(
 	proof: Chain::MessagesProof,
-	max_messages: MessageNonce,
+	messages_count: MessageNonce,
 ) -> Result<ProvedMessages<DispatchMessage<DispatchPayload, Fee>>, Chain::Error> {
-	Chain::verify_messages_proof(proof, max_messages).map(|messages_by_lane| {
+	Chain::verify_messages_proof(proof, messages_count).map(|messages_by_lane| {
 		messages_by_lane
 			.into_iter()
 			.map(|(lane, lane_data)| {
@@ -841,6 +835,7 @@ mod tests {
 					Origin::signed(1),
 					TEST_RELAYER_A,
 					Ok(vec![message(2, REGULAR_PAYLOAD)]).into(),
+					1,
 					REGULAR_PAYLOAD.1,
 				),
 				Error::<TestRuntime, DefaultInstance>::Halted,
@@ -919,6 +914,7 @@ mod tests {
 				Origin::signed(1),
 				TEST_RELAYER_A,
 				Ok(vec![message(1, REGULAR_PAYLOAD)]).into(),
+				1,
 				REGULAR_PAYLOAD.1,
 			));
 
@@ -959,6 +955,7 @@ mod tests {
 				Origin::signed(1),
 				TEST_RELAYER_A,
 				message_proof,
+				1,
 				REGULAR_PAYLOAD.1,
 			));
 
@@ -990,6 +987,7 @@ mod tests {
 					Origin::signed(1),
 					TEST_RELAYER_A,
 					Ok(vec![message(1, REGULAR_PAYLOAD)]).into(),
+					1,
 					REGULAR_PAYLOAD.1 - 1,
 				),
 				Error::<TestRuntime, DefaultInstance>::InvalidMessagesDispatchWeight,
@@ -1005,6 +1003,7 @@ mod tests {
 					Origin::signed(1),
 					TEST_RELAYER_A,
 					Err(()).into(),
+					1,
 					0,
 				),
 				Error::<TestRuntime, DefaultInstance>::InvalidMessagesProof,
@@ -1107,6 +1106,7 @@ mod tests {
 				Origin::signed(1),
 				TEST_RELAYER_A,
 				Ok(vec![invalid_message]).into(),
+				1,
 				0, // weight may be zero in this case (all messages are improperly encoded)
 			),);
 
@@ -1129,6 +1129,7 @@ mod tests {
 					message(3, REGULAR_PAYLOAD),
 				])
 				.into(),
+				3,
 				REGULAR_PAYLOAD.1 + REGULAR_PAYLOAD.1,
 			),);
 

--- a/modules/message-lane/src/mock.rs
+++ b/modules/message-lane/src/mock.rs
@@ -97,7 +97,6 @@ parameter_types! {
 	pub const MaxMessagesToPruneAtOnce: u64 = 10;
 	pub const MaxUnrewardedRelayerEntriesAtInboundLane: u64 = 16;
 	pub const MaxUnconfirmedMessagesAtInboundLane: u64 = 32;
-	pub const MaxMessagesInDeliveryTransaction: u64 = 128;
 }
 
 impl Config for TestRuntime {
@@ -105,7 +104,6 @@ impl Config for TestRuntime {
 	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
-	type MaxMessagesInDeliveryTransaction = MaxMessagesInDeliveryTransaction;
 
 	type OutboundPayload = TestPayload;
 	type OutboundMessageFee = TestMessageFee;
@@ -279,7 +277,7 @@ impl SourceHeaderChain<TestMessageFee> for TestSourceHeaderChain {
 
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		_max_messages: MessageNonce,
+		_messages_count: MessageNonce,
 	) -> Result<ProvedMessages<Message<TestMessageFee>>, Self::Error> {
 		proof
 			.result

--- a/primitives/message-lane/src/target_chain.rs
+++ b/primitives/message-lane/src/target_chain.rs
@@ -68,13 +68,13 @@ pub trait SourceHeaderChain<Fee> {
 	/// Verify messages proof and return proved messages.
 	///
 	/// Returns error if either proof is incorrect, or the number of messages in the proof
-	/// is larger than `max_messages`.
+	/// is not matching the `messages_count`.
 	///
 	/// Messages vector is required to be sorted by nonce within each lane. Out-of-order
 	/// messages will be rejected.
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		max_messages: MessageNonce,
+		messages_count: MessageNonce,
 	) -> Result<ProvedMessages<Message<Fee>>, Self::Error>;
 }
 

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -83,10 +83,6 @@ pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// Represents the portion of a block that will be used by Normal extrinsics.
 pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-// TODO: may need to be updated after https://github.com/paritytech/parity-bridges-common/issues/78
-/// Maximal number of messages in single delivery transaction.
-pub const MAX_MESSAGES_IN_DELIVERY_TRANSACTION: MessageNonce = 1024;
-
 /// Maximal number of unrewarded relayer entries at inbound lane.
 pub const MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE: MessageNonce = 1024;
 

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -45,10 +45,6 @@ pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// Represents the portion of a block that will be used by Normal extrinsics.
 pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-// TODO: may need to be updated after https://github.com/paritytech/parity-bridges-common/issues/78
-/// Maximal number of messages in single delivery transaction.
-pub const MAX_MESSAGES_IN_DELIVERY_TRANSACTION: MessageNonce = 128;
-
 /// Maximal number of unrewarded relayer entries at inbound lane.
 pub const MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE: MessageNonce = 128;
 

--- a/relays/substrate/src/rialto_messages_to_millau.rs
+++ b/relays/substrate/src/rialto_messages_to_millau.rs
@@ -73,11 +73,14 @@ impl SubstrateMessageLane for RialtoMessagesToMillau {
 		proof: <Self as MessageLane>::MessagesProof,
 	) -> Result<Self::TargetSignedTransaction, SubstrateError> {
 		let (dispatch_weight, proof) = proof;
+		let (_, _, _, ref nonces_begin, ref nonces_end) = proof;
+		let messages_count = nonces_end - nonces_begin + 1;
 		let account_id = self.target_sign.signer.public().as_array_ref().clone().into();
 		let nonce = self.target_client.next_account_index(account_id).await?;
 		let call = millau_runtime::MessageLaneCall::receive_messages_proof(
 			self.relayer_id_at_source.clone(),
 			proof,
+			messages_count,
 			dispatch_weight,
 		)
 		.into();
@@ -119,6 +122,14 @@ pub fn run(
 		lane.relayer_id_at_source,
 	);
 
+	// TODO: these two parameters need to be updated after https://github.com/paritytech/parity-bridges-common/issues/78
+	// the rough idea is to reserve some portion (1/3?) of max extrinsic weight for delivery tx overhead + messages
+	// overhead
+	// this must be tuned mostly with `max_messages_in_single_batch`, but `max_messages_weight_in_single_batch` also
+	// needs to be updated (subtract tx overhead)
+	let max_messages_in_single_batch = 1024;
+	let max_messages_weight_in_single_batch = bp_rialto::max_extrinsic_weight();
+
 	messages_relay::message_lane_loop::run(
 		messages_relay::message_lane_loop::Params {
 			lane: lane_id,
@@ -129,10 +140,8 @@ pub fn run(
 			delivery_params: messages_relay::message_lane_loop::MessageDeliveryParams {
 				max_unrewarded_relayer_entries_at_target: bp_millau::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
 				max_unconfirmed_nonces_at_target: bp_millau::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE,
-				max_messages_in_single_batch: bp_millau::MAX_MESSAGES_IN_DELIVERY_TRANSACTION,
-				// TODO: subtract base weight of delivery from this when it'll be known
-				// https://github.com/paritytech/parity-bridges-common/issues/78
-				max_messages_weight_in_single_batch: bp_millau::max_extrinsic_weight(),
+				max_messages_in_single_batch,
+				max_messages_weight_in_single_batch,
 				// 2/3 is reserved for proofs and tx overhead
 				max_messages_size_in_single_batch: bp_millau::max_extrinsic_size() as usize / 3,
 			},


### PR DESCRIPTION
first part of #579

One thing I was thinking of is that now anyone could submit tx with some invalid data in `proof` parameter and declaring 0 messages in the tx. So it'll pay minimal fee for the tx. But since we're targeting chains where tx fee includes per-byte fee, I think it is ok. The same may be achieved with the `remark` call, which has declared constant weight e.g. on Polkadot/Kusama.