### PR TITLE
Decrease transfer amount

### DIFF
--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -42,7 +42,7 @@ do
 		--fee 1000000000 \
 		--origin Target \
 		transfer \
-		--amount 1000000000000 \
+		--amount 1000000000 \
 		--recipient $FERDIE_ADDR
 
 	rand_sleep
@@ -60,6 +60,6 @@ do
 		--fee 1000000000 \
 		--origin Source \
 		transfer \
-		--amount 1000000000000 \
+		--amount 1000000000 \
 		--recipient $FERDIE_ADDR
 done

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -42,7 +42,7 @@ do
 		--fee 1000000000 \
 		--origin Target \
 		transfer \
-		--amount 1000000000000 \
+		--amount 1000000000 \
 		--recipient $FERDIE_ADDR
 
 	rand_sleep
@@ -60,6 +60,6 @@ do
 		--fee 1000000000 \
 		--origin Source \
 		transfer \
-		--amount 1000000000000 \
+		--amount 1000000000 \
 		--recipient $FERDIE_ADDR
 done

--- a/modules/ethereum/src/verification.rs
+++ b/modules/ethereum/src/verification.rs
@@ -235,6 +235,7 @@ fn contextual_checks<Submitter>(
 	if header_step == parent_step {
 		return Err(Error::DoubleVote);
 	}
+	#[allow(clippy::suspicious-operation-groupings)]
 	if header.number >= config.validate_step_transition && header_step < parent_step {
 		return Err(Error::DoubleVote);
 	}

--- a/modules/ethereum/src/verification.rs
+++ b/modules/ethereum/src/verification.rs
@@ -232,7 +232,10 @@ fn contextual_checks<Submitter>(
 	let parent_step = context.parent_header().step().ok_or(Error::MissingStep)?;
 
 	// Ensure header is from the step after context.
-	if header_step == parent_step || (header.number >= config.validate_step_transition && header_step <= parent_step) {
+	if header_step == parent_step {
+		return Err(Error::DoubleVote);
+	}
+	if header.number >= config.validate_step_transition && header_step < parent_step {
 		return Err(Error::DoubleVote);
 	}
 

--- a/modules/ethereum/src/verification.rs
+++ b/modules/ethereum/src/verification.rs
@@ -232,10 +232,7 @@ fn contextual_checks<Submitter>(
 	let parent_step = context.parent_header().step().ok_or(Error::MissingStep)?;
 
 	// Ensure header is from the step after context.
-	if header_step == parent_step {
-		return Err(Error::DoubleVote);
-	}
-	if header.number >= config.validate_step_transition && header_step < parent_step {
+	if header_step == parent_step || (header.number >= config.validate_step_transition && header_step <= parent_step) {
 		return Err(Error::DoubleVote);
 	}
 

--- a/modules/ethereum/src/verification.rs
+++ b/modules/ethereum/src/verification.rs
@@ -235,7 +235,6 @@ fn contextual_checks<Submitter>(
 	if header_step == parent_step {
 		return Err(Error::DoubleVote);
 	}
-	#[allow(clippy::suspicious-operation-groupings)]
 	if header.number >= config.validate_step_transition && header_step < parent_step {
 		return Err(Error::DoubleVote);
 	}


### PR DESCRIPTION
Right now Millau/Rialto Dave every `RND(1s; 30s)` pays: `(100_000_000 fee + 1_000_000_000 fee + 1_000_000_000_000 transfer + 100_000_000 fee + 1_000_000_000 fee)` . Balance of Dave is `1 << 50`, which is `1125899906842624`. So this balance is enough for `1123` intervals.

I've decreased transfer amount from `1_000_000_000_000` to `1_000_000_000`. I believe fees may also be decreased (last time I was trying they've been estimated to something less than `1_000_000`), but it'll be fixed in #578, which I prefer to do after finally introducing message lane weights. Even without changing fees, with fixed amount it should be enough for `351_843` intervals, which is ~60 hours even if interval is always 1s.