### PR TITLE
Estimate message fee api

### DIFF
--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -124,9 +124,9 @@ impl MessageBridge for WithRialtoMessageBridge {
 		<crate::Runtime as pallet_transaction_payment::Config>::WeightToFee::calc(&weight) as _
 	}
 
-	fn this_balance_to_bridged_balance(this_balance: bp_millau::Balance) -> bp_rialto::Balance {
+	fn bridged_balance_to_this_balance(bridged_balance: bp_rialto::Balance) -> bp_millau::Balance {
 		// 1:1 conversion that will probably change in the future
-		this_balance as _
+		bridged_balance as _
 	}
 }
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -36,6 +36,9 @@ pub mod kovan;
 pub mod millau_messages;
 pub mod rialto_poa;
 
+use crate::millau_messages::{ToMillauMessagePayload, WithMillauMessageBridge};
+
+use bridge_runtime_common::messages::{source::estimate_message_dispatch_and_delivery_fee, MessageBridge};
 use codec::Decode;
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
@@ -695,7 +698,17 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl bp_millau::ToMillauOutboundLaneApi<Block> for Runtime {
+	impl bp_millau::ToMillauOutboundLaneApi<Block, Balance, ToMillauMessagePayload> for Runtime {
+		fn estimate_message_delivery_and_dispatch_fee(
+			_lane_id: bp_message_lane::LaneId,
+			payload: ToMillauMessagePayload,
+		) -> Option<Balance> {
+			estimate_message_dispatch_and_delivery_fee::<WithMillauMessageBridge>(
+				&payload,
+				WithMillauMessageBridge::RELAYER_FEE_PERCENT,
+			).ok()
+		}
+
 		fn messages_dispatch_weight(
 			lane: bp_message_lane::LaneId,
 			begin: bp_message_lane::MessageNonce,

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -125,9 +125,9 @@ impl MessageBridge for WithMillauMessageBridge {
 		<crate::Runtime as pallet_transaction_payment::Config>::WeightToFee::calc(&weight) as _
 	}
 
-	fn this_balance_to_bridged_balance(this_balance: bp_rialto::Balance) -> bp_millau::Balance {
+	fn bridged_balance_to_this_balance(bridged_balance: bp_millau::Balance) -> bp_rialto::Balance {
 		// 1:1 conversion that will probably change in the future
-		this_balance as _
+		bridged_balance as _
 	}
 }
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -31,7 +31,6 @@ do
 	echo "Sending Remark from Rialto to Millau using Target Origin"
 	$SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 100000000 \
 		--origin Target \
 		remark
 
@@ -39,7 +38,6 @@ do
 	echo "Sending Transfer from Rialto to Millau using Target Origin"
 	 $SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 1000000000 \
 		--origin Target \
 		transfer \
 		--amount 1000000000 \
@@ -49,7 +47,6 @@ do
 	echo "Sending Remark from Rialto to Millau using Source Origin"
 	 $SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 100000000 \
 		--origin Source \
 		remark
 
@@ -57,7 +54,6 @@ do
 	echo "Sending Transfer from Rialto to Millau using Source Origin"
 	 $SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 1000000000 \
 		--origin Source \
 		transfer \
 		--amount 1000000000 \

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -31,7 +31,6 @@ do
 	echo "Sending Remark from Millau to Rialto using Target Origin"
 	$SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 100000000 \
 		--origin Target \
 		remark
 
@@ -39,7 +38,6 @@ do
 	echo "Sending Transfer from Millau to Rialto using Target Origin"
 	 $SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 1000000000 \
 		--origin Target \
 		transfer \
 		--amount 1000000000 \
@@ -49,7 +47,6 @@ do
 	echo "Sending Remark from Millau to Rialto using Source Origin"
 	 $SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 100000000 \
 		--origin Source \
 		remark
 
@@ -57,7 +54,6 @@ do
 	echo "Sending Transfer from Millau to Rialto using Source Origin"
 	 $SEND_MESSAGE \
 		--lane $MESSAGE_LANE \
-		--fee 1000000000 \
 		--origin Source \
 		transfer \
 		--amount 1000000000 \

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -25,7 +25,7 @@ mod millau_hash;
 use bp_message_lane::{LaneId, MessageNonce, UnrewardedRelayersState};
 use bp_runtime::Chain;
 use frame_support::{
-	weights::{constants::WEIGHT_PER_MILLIS, DispatchClass, Weight},
+	weights::{constants::WEIGHT_PER_SECOND, DispatchClass, Weight},
 	Parameter, RuntimeDebug,
 };
 use frame_system::limits;

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -191,6 +191,9 @@ pub const IS_KNOWN_MILLAU_BLOCK_METHOD: &str = "MillauHeaderApi_is_known_block";
 /// Name of the `MillauHeaderApi::incomplete_headers` runtime method.
 pub const INCOMPLETE_MILLAU_HEADERS_METHOD: &str = "MillauHeaderApi_incomplete_headers";
 
+/// Name of the `ToMillauOutboundLaneApi::estimate_message_delivery_and_dispatch_fee` runtime method.
+pub const TO_MILLAU_ESTIMATE_MESSAGE_FEE_METHOD: &str =
+	"ToMillauOutboundLaneApi_estimate_message_delivery_and_dispatch_fee";
 /// Name of the `ToMillauOutboundLaneApi::messages_dispatch_weight` runtime method.
 pub const TO_MILLAU_MESSAGES_DISPATCH_WEIGHT_METHOD: &str = "ToMillauOutboundLaneApi_messages_dispatch_weight";
 /// Name of the `ToMillauOutboundLaneApi::latest_received_nonce` runtime method.

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -26,7 +26,7 @@ use bp_message_lane::{LaneId, MessageNonce, UnrewardedRelayersState};
 use bp_runtime::Chain;
 use frame_support::{
 	weights::{constants::WEIGHT_PER_MILLIS, DispatchClass, Weight},
-	RuntimeDebug,
+	Parameter, RuntimeDebug,
 };
 use frame_system::limits;
 use sp_core::Hasher as HasherT;
@@ -235,7 +235,20 @@ sp_api::decl_runtime_apis! {
 	///
 	/// This API is implemented by runtimes that are sending messages to Millau chain, not the
 	/// Millau runtime itself.
-	pub trait ToMillauOutboundLaneApi {
+	pub trait ToMillauOutboundLaneApi<OutboundMessageFee: Parameter, OutboundPayload: Parameter> {
+		/// Estimate message delivery and dispatch fee that needs to be paid by the sender on
+		/// this chain.
+		///
+		/// Returns `None` if message is too expensive to be sent to Millau from this chain.
+		///
+		/// Please keep in mind that this method returns lowest message fee required for message
+		/// to be accepted to the lane. It may be good idea to pay a bit over this price to account
+		/// future exchange rate changes and guarantee that relayer would deliver your message
+		/// to the target chain.
+		fn estimate_message_delivery_and_dispatch_fee(
+			lane_id: LaneId,
+			payload: OutboundPayload,
+		) -> Option<OutboundMessageFee>;
 		/// Returns total dispatch weight and encoded payload size of all messages in given inclusive range.
 		///
 		/// If some (or all) messages are missing from the storage, they'll also will

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -24,7 +24,7 @@ use bp_message_lane::{LaneId, MessageNonce, UnrewardedRelayersState};
 use bp_runtime::Chain;
 use frame_support::{
 	weights::{constants::WEIGHT_PER_SECOND, DispatchClass, Weight},
-	RuntimeDebug,
+	Parameter, RuntimeDebug,
 };
 use frame_system::limits;
 use sp_core::Hasher as HasherT;
@@ -196,7 +196,20 @@ sp_api::decl_runtime_apis! {
 	///
 	/// This API is implemented by runtimes that are sending messages to Rialto chain, not the
 	/// Rialto runtime itself.
-	pub trait ToRialtoOutboundLaneApi {
+	pub trait ToRialtoOutboundLaneApi<OutboundMessageFee: Parameter, OutboundPayload: Parameter> {
+		/// Estimate message delivery and dispatch fee that needs to be paid by the sender on
+		/// this chain.
+		///
+		/// Returns `None` if message is too expensive to be sent to Rialto from this chain.
+		///
+		/// Please keep in mind that this method returns lowest message fee required for message
+		/// to be accepted to the lane. It may be good idea to pay a bit over this price to account
+		/// future exchange rate changes and guarantee that relayer would deliver your message
+		/// to the target chain.
+		fn estimate_message_delivery_and_dispatch_fee(
+			lane_id: LaneId,
+			payload: OutboundPayload,
+		) -> Option<OutboundMessageFee>;
 		/// Returns total dispatch weight and encoded payload size of all messages in given inclusive range.
 		///
 		/// If some (or all) messages are missing from the storage, they'll also will

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -152,6 +152,9 @@ pub const IS_KNOWN_RIALTO_BLOCK_METHOD: &str = "RialtoHeaderApi_is_known_block";
 /// Name of the `RialtoHeaderApi::incomplete_headers` runtime method.
 pub const INCOMPLETE_RIALTO_HEADERS_METHOD: &str = "RialtoHeaderApi_incomplete_headers";
 
+/// Name of the `ToRialtoOutboundLaneApi::estimate_message_delivery_and_dispatch_fee` runtime method.
+pub const TO_RIALTO_ESTIMATE_MESSAGE_FEE_METHOD: &str =
+	"ToRialtoOutboundLaneApi_estimate_message_delivery_and_dispatch_fee";
 /// Name of the `ToRialtoOutboundLaneApi::messages_dispatch_weight` runtime method.
 pub const TO_RIALTO_MESSAGES_DISPATCH_WEIGHT_METHOD: &str = "ToRialtoOutboundLaneApi_messages_dispatch_weight";
 /// Name of the `ToRialtoOutboundLaneApi::latest_generated_nonce` runtime method.

--- a/relays/substrate/src/cli.rs
+++ b/relays/substrate/src/cli.rs
@@ -101,9 +101,9 @@ pub enum Command {
 		/// Hex-encoded lane id.
 		#[structopt(long)]
 		lane: HexLaneId,
-		/// Delivery and dispatch fee.
+		/// Delivery and dispatch fee. If not passed, determined automatically.
 		#[structopt(long)]
-		fee: bp_millau::Balance,
+		fee: Option<bp_millau::Balance>,
 		/// Message type.
 		#[structopt(subcommand)]
 		message: ToRialtoMessage,
@@ -138,9 +138,9 @@ pub enum Command {
 		/// Hex-encoded lane id.
 		#[structopt(long)]
 		lane: HexLaneId,
-		/// Delivery and dispatch fee.
+		/// Delivery and dispatch fee. If not passed, determined automatically.
 		#[structopt(long)]
-		fee: bp_rialto::Balance,
+		fee: Option<bp_rialto::Balance>,
 		/// Message type.
 		#[structopt(subcommand)]
 		message: ToMillauMessage,

--- a/scripts/send-message.sh
+++ b/scripts/send-message.sh
@@ -15,7 +15,6 @@ case "$1" in
 			--millau-signer //Dave \
 			--rialto-signer //Dave \
 			--lane 00000000 \
-			--fee 100000000 \
 			--origin Target \
 			remark \
 		;;
@@ -27,7 +26,6 @@ case "$1" in
 			--millau-signer //Dave \
 			--rialto-signer //Dave \
 			--lane 00000000 \
-			--fee 1000000000 \
 			--origin Target \
 			transfer \
 			--amount 100000000000000 \


### PR DESCRIPTION
closes #578 

This PR adds: (1) runtime API methods for estimating message fees and (2) mode when relay estimates message fee itself, when sending message over lane. I may also add separate command to relay just to estimate fee, but I have no usage for this command atm.