### PR TITLE
Increase maximal block weight at Millau

### DIFF
--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -25,7 +25,7 @@ mod millau_hash;
 use bp_message_lane::{LaneId, MessageNonce, UnrewardedRelayersState};
 use bp_runtime::Chain;
 use frame_support::{
-	weights::{constants::WEIGHT_PER_MILLIS, DispatchClass, Weight},
+	weights::{constants::WEIGHT_PER_SECOND, DispatchClass, Weight},
 	RuntimeDebug,
 };
 use frame_system::limits;
@@ -45,8 +45,8 @@ pub use millau_hash::MillauHash;
 
 /// Maximum weight of single Millau block.
 ///
-/// This represents 0.1 seconds of compute assuming a target block time of six seconds.
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = 10 * WEIGHT_PER_MILLIS;
+/// This represents 0.5 seconds of compute assuming a target block time of six seconds.
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND / 2;
 
 /// Represents the average portion of a block's weight that will be used by an
 /// `on_initialize()` runtime call.


### PR DESCRIPTION
It was set to `1_000_000_000`, which is lower than weight of `send_message` call (`4_289_189_000` that I got from my laptop). So no messages may have been sent from Millau.

Will merge once CI is green, because it breaks nightly chains.