### PR TITLE
Fix Dependency Image Publishing

### DIFF
--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -26,13 +26,6 @@ jobs:
         with:
           fetch-depth:                              5
           submodules:                               recursive
-      - name:                                       Set vars
-        id:                                         vars
-        run:                                        |
-          if [[ ${GITHUB_REF} = refs/tags/* ]]
-          then
-            echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
-          fi
       - name:                                       Build and push dependencies
         uses:                                       docker/build-push-action@v1
         with:
@@ -40,15 +33,14 @@ jobs:
           password:                                 ${{ secrets.DOCKER_PASSWORD }}
           repository:                               paritytech/parity-bridges-common
           dockerfile:                               deployments/BridgeDeps.Dockerfile
-          tags:                                     ${{ steps.vars.outputs.TAG }}, latest
+          tag_with_ref:                             true
+          tag_with_sha:                             true
           labels:
-            org.opencontainers.image.created=${{ steps.vars.outputs.DATE }},
             org.opencontainers.image.source="https://github.com/paritytech/parity-bridges-common",
             org.opencontainers.image.authors="devops-team@parity.io",
             org.opencontainers.image.vendor="Parity Technologies",
             org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common",
             org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md",
-            org.opencontainers.image.version=${{ steps.vars.outputs.TAG }},
             org.opencontainers.image.title=${{ matrix.project }},
             org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common",
             org.opencontainers.image.licenses="GPL-3.0 License"

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -9,9 +9,6 @@ on:
       - diagrams/
   schedule:                                         # Nightly build
     - cron:                                         '0 0 * * *'
-  pull_request:
-    branches:
-      - master
 jobs:
 ## Publish to Docker hub
   publish:

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           username:                                 ${{ secrets.DOCKER_USER }}
           password:                                 ${{ secrets.DOCKER_PASSWORD }}
-          repository:                               paritytech/parity-bridges-common
+          repository:                               paritytech/bridge-dependencies
           dockerfile:                               deployments/BridgeDeps.Dockerfile
           tag_with_ref:                             true
           tag_with_sha:                             true

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -9,6 +9,9 @@ on:
       - diagrams/
   schedule:                                         # Nightly build
     - cron:                                         '0 0 * * *'
+  pull_request:
+    branches:
+      - master
 jobs:
 ## Publish to Docker hub
   publish:


### PR DESCRIPTION
Publishing is failing because of an empty `tag`. This uses automatic tagging to fix that.

Images are being published [here](https://hub.docker.com/r/paritytech/bridge-dependencies/tags?page=1&ordering=last_updated).