### PR TITLE
Add some disclaimers about security decisions

### DIFF
--- a/deployments/networks/eth-poa.yml
+++ b/deployments/networks/eth-poa.yml
@@ -3,7 +3,8 @@
 # Note that this PoA network is only used for testing, so the configuration settings you see here
 # are *not* recommended for a production environment.
 #
-# For example, you should not keep your account key in version control, or publicly expose RPC ports.
+# For example, do *not* keep your account key in version control, and unless you're _really_ sure
+# you want to provide public access to your nodes do *not* publicly expose RPC methods.
 version: '3.5'
 services:
   poa-node-arthur: &poa-node

--- a/deployments/networks/eth-poa.yml
+++ b/deployments/networks/eth-poa.yml
@@ -1,3 +1,9 @@
+# Compose file for quickly spinning up a local instance of an Ethereum PoA network.
+#
+# Note that this PoA network is only used for testing, so the configuration settings you see here
+# are *not* recommended for a production environment.
+#
+# For example, you should not keep your account key in version control, or publicly expose RPC ports.
 version: '3.5'
 services:
   poa-node-arthur: &poa-node

--- a/deployments/networks/millau.yml
+++ b/deployments/networks/millau.yml
@@ -3,7 +3,8 @@
 # Note that the Millau network is only used for testing, so the configuration settings you see here
 # are *not* recommended for a production environment.
 #
-# For example, you should not keep your `node-key` in version control, or publicly expose RPC ports.
+# For example, do *not* keep your `node-key` in version control, and unless you're _really_ sure you
+# want to provide public access to your nodes do *not* publicly expose RPC methods.
 version: '3.5'
 services:
   millau-node-alice: &millau-bridge-node

--- a/deployments/networks/millau.yml
+++ b/deployments/networks/millau.yml
@@ -1,3 +1,9 @@
+# Compose file for quickly spinning up a local instance of the Millau Substrate network.
+#
+# Note that the Millau network is only used for testing, so the configuration settings you see here
+# are *not* recommended for a production environment.
+#
+# For example, you should not keep your `node-key` in version control, or publicly expose RPC ports.
 version: '3.5'
 services:
   millau-node-alice: &millau-bridge-node

--- a/deployments/networks/rialto.yml
+++ b/deployments/networks/rialto.yml
@@ -1,3 +1,9 @@
+# Compose file for quickly spinning up a local instance of the Rialto Substrate network.
+#
+# Note that the Rialto network is only used for testing, so the configuration settings you see here
+# are *not* recommended for a production environment.
+#
+# For example, you should not keep your `node-key` in version control, or publicly expose RPC ports.
 version: '3.5'
 services:
   rialto-node-alice: &rialto-bridge-node

--- a/deployments/networks/rialto.yml
+++ b/deployments/networks/rialto.yml
@@ -3,7 +3,8 @@
 # Note that the Rialto network is only used for testing, so the configuration settings you see here
 # are *not* recommended for a production environment.
 #
-# For example, you should not keep your `node-key` in version control, or publicly expose RPC ports.
+# For example, do *not* keep your `node-key` in version control, and unless you're _really_ sure you
+# want to provide public access to your nodes do *not* publicly expose RPC methods.
 version: '3.5'
 services:
   rialto-node-alice: &rialto-bridge-node


### PR DESCRIPTION
I got word of a security report today that was concerned with us having leaked private keys in `millau.yml` and `rialto.yml`. Since we only use the Rialto and Millau networks for testing, and we don't intend to deploy production versions of them, this is a non-issue. However, I've added some comments to indicate that what we're doing in our Compose files is *not* recommended for production deployments.