### PR TITLE
Pin Rust Nightly to 2020-12-17

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
         toolchain:
           - stable
           #- beta
-          - nightly
+          - nightly-2020-12-17
     runs-on:                       self-hosted
     container:
       image:                       paritytech/ci-linux:production
@@ -35,6 +35,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER:   sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       CARGO_TARGET_DIR:            "/cache/${{ github.head_ref }}/${{ matrix.toolchain }}/"
+      WASM_BUILD_TOOLCHAIN:        nightly-2020-12-17
     steps:
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
@@ -48,6 +49,10 @@ jobs:
       - name:                      Configure CARGO_TARGET_DIR
         shell:                     bash
         run:                       ./scripts/ci-cache.sh
+      - name:                      Install Toolchain
+        run:                       rustup toolchain add nightly-2020-12-17
+      - name:                      Add WASM Utilities
+        run:                       rustup target add wasm32-unknown-unknown --toolchain nightly-2020-12-17
       - name:                      Cache checking
         if:                        github.event_name == 'pull_request' && github.event.action == 'opened' || github.event.action == 'reopened'
         continue-on-error:         true
@@ -77,11 +82,11 @@ jobs:
 
 ## Linting Stage
       - name:                      Add clippy
-        if:                        matrix.toolchain == 'nightly'
+        if:                        matrix.toolchain == 'nightly-2020-12-17'
         run:                       rustup component add clippy --toolchain ${{ matrix.toolchain }}
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
-        if:                        matrix.toolchain == 'nightly'
+        if:                        matrix.toolchain == 'nightly-2020-12-17'
         with:
           command:                 clippy
           toolchain:               ${{ matrix.toolchain }}


### PR DESCRIPTION
Clippy is panicking with the current nightly version that the CI is using. This rolls back our nightly to one which doesn't have this problem. I've commented about this issue [here](https://github.com/rust-lang/rust-clippy/issues/6592#issuecomment-761054533).

Note that I didn't rollback the compiler version for our Docker builds. I don't really see the point since this fix is mainly just to get the Clippy step of the CI passing.