### PR TITLE
Disallow Duplicate Best Headers

### DIFF
--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -521,7 +521,12 @@ impl<T: Config> BridgeStorage for PalletStorage<T> {
 
 		match current_height.cmp(&best_height) {
 			Ordering::Equal => {
-				<BestHeaders<T>>::append(hash);
+				// Want to avoid duplicates in the case where we're writing a finalized header to
+				// storage which also happens to be at the best height the best height
+				let not_duplicate = !<ImportedHeaders<T>>::contains_key(hash);
+				if not_duplicate {
+					<BestHeaders<T>>::append(hash);
+				}
 			}
 			Ordering::Greater => {
 				<BestHeaders<T>>::kill();

--- a/modules/substrate/src/verifier.rs
+++ b/modules/substrate/src/verifier.rs
@@ -562,7 +562,7 @@ mod tests {
 
 			// It should be fine to import both
 			assert_ok!(verifier.import_header(best_header.hash(), best_header.clone()));
-			assert_ok!(verifier.import_header(also_best_header.hash(), also_best_header.clone()));
+			assert_ok!(verifier.import_header(also_best_header.hash(), also_best_header));
 
 			// The headers we manually imported should have been marked as the best
 			// upon writing to storage. Let's confirm that.


### PR DESCRIPTION
Fixes a bug in which we wrote the same header twice to the `BestHeaders` Vec.

What was happening was that we'd write the header once during import, and a second time if we finalized the header (we go through the same `write_header()` function). Since we're allowed to have multiple headers at the same height (they might be on different forks), we ended up with the same header duplicated in the `BestHeaders`.