### PR TITLE
Fixed messages count check

### DIFF
--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -192,7 +192,7 @@ impl SourceHeaderChain<bp_rialto::Balance> for Rialto {
 
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		messages_count: MessageNonce,
+		messages_count: u32,
 	) -> Result<ProvedMessages<Message<bp_rialto::Balance>>, Self::Error> {
 		messages::target::verify_messages_proof::<WithRialtoMessageBridge, Runtime>(proof, messages_count)
 	}

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -193,7 +193,7 @@ impl SourceHeaderChain<bp_millau::Balance> for Millau {
 
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		messages_count: MessageNonce,
+		messages_count: u32,
 	) -> Result<ProvedMessages<Message<bp_millau::Balance>>, Self::Error> {
 		messages::target::verify_messages_proof::<WithMillauMessageBridge, Runtime>(proof, messages_count)
 	}

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -396,6 +396,10 @@ pub mod target {
 	}
 
 	/// Verify proof of Bridged -> This chain messages.
+	///
+	/// The `messages_count` argument verification (sane limits) is supposed to be made
+	/// outside of this function. This function only verifies that the proof declares exactly
+	/// `messages_count` messages.
 	pub fn verify_messages_proof<B: MessageBridge, ThisRuntime>(
 		proof: FromBridgedChainMessagesProof<B>,
 		messages_count: MessageNonce,
@@ -497,11 +501,18 @@ pub mod target {
 		let (bridged_header_hash, bridged_storage_proof, lane_id, begin, end) = proof;
 
 		// receiving proofs where end < begin is ok (if proof includes outbound lane state)
-		// => hence unwrap_or(0)
-		let messages_in_the_proof = end.checked_sub(begin).and_then(|diff| diff.checked_add(1)).unwrap_or(0);
-		if messages_in_the_proof != messages_count {
-			return Err(MessageProofError::MessagesCountMismatch);
-		}
+		let messages_in_the_proof = if let Some(nonces_difference) = end.checked_sub(begin) {
+			// let's check that the user (relayer) has passed correct `messages_count`
+			// (this bounds maximal capacity of messages vec below)
+			let messages_in_the_proof = nonces_difference.saturating_add(1);
+			if messages_in_the_proof != messages_count {
+				return Err(MessageProofError::MessagesCountMismatch);
+			}
+
+			messages_in_the_proof
+		} else {
+			0
+		};
 
 		let parser = build_parser(bridged_header_hash, bridged_storage_proof)?;
 
@@ -509,7 +520,7 @@ pub mod target {
 		// be in the proof. So any error in `read_value`, or even missing value is fatal.
 		//
 		// Mind that we allow proofs with no messages if outbound lane state is proved.
-		let mut messages = Vec::with_capacity(end.saturating_sub(begin) as _);
+		let mut messages = Vec::with_capacity(messages_in_the_proof as _);
 		for nonce in begin..=end {
 			let message_key = MessageKey { lane_id, nonce };
 			let raw_message_data = parser
@@ -1181,6 +1192,58 @@ mod tests {
 			)]
 			.into_iter()
 			.collect()),
+		);
+	}
+
+	#[test]
+	fn verify_messages_proof_with_parser_does_not_panic_if_messages_count_mismatches() {
+		assert_eq!(
+			target::verify_messages_proof_with_parser::<OnThisChainBridge, _, _>(
+				(
+					Default::default(),
+					StorageProof::new(vec![]),
+					Default::default(),
+					0,
+					u64::MAX
+				),
+				0,
+				|_, _| Ok(TestMessageProofParser {
+					failing: false,
+					messages: 0..=u64::MAX,
+					outbound_lane_data: Some(OutboundLaneData {
+						oldest_unpruned_nonce: 1,
+						latest_received_nonce: 1,
+						latest_generated_nonce: 1,
+					}),
+				}),
+			),
+			Err(target::MessageProofError::MessagesCountMismatch),
+		);
+	}
+
+	#[test]
+	#[should_panic]
+	fn verify_messages_proof_with_parser_panic_if_too_many_messages_declared() {
+		let _ = target::verify_messages_proof_with_parser::<OnThisChainBridge, _, _>(
+			(
+				Default::default(),
+				StorageProof::new(vec![]),
+				Default::default(),
+				0,
+				u64::MAX,
+			),
+			u64::MAX,
+			|_, _| {
+				Ok(TestMessageProofParser {
+					failing: false,
+					messages: 0..=u64::MAX,
+					outbound_lane_data: Some(OutboundLaneData {
+						oldest_unpruned_nonce: 1,
+						latest_received_nonce: 1,
+						latest_generated_nonce: 1,
+					}),
+				})
+			},
 		);
 	}
 }

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -749,7 +749,7 @@ fn verify_and_decode_messages_proof<Chain: SourceHeaderChain<Fee>, Fee, Dispatch
 	messages_count: u32,
 ) -> Result<ProvedMessages<DispatchMessage<DispatchPayload, Fee>>, Chain::Error> {
 	// `receive_messages_proof` weight formula and `MaxUnconfirmedMessagesAtInboundLane` check
-	// guarantees that the `message_count` is sane and Vec<Messagae> may be allocated.
+	// guarantees that the `message_count` is sane and Vec<Message> may be allocated.
 	// (tx with too many messages will either be rejected from the pool, or will fail earlier)
 	Chain::verify_messages_proof(proof, messages_count).map(|messages_by_lane| {
 		messages_by_lane

--- a/modules/message-lane/src/mock.rs
+++ b/modules/message-lane/src/mock.rs
@@ -309,7 +309,7 @@ impl SourceHeaderChain<TestMessageFee> for TestSourceHeaderChain {
 
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		_messages_count: MessageNonce,
+		_messages_count: u32,
 	) -> Result<ProvedMessages<Message<TestMessageFee>>, Self::Error> {
 		proof
 			.result

--- a/primitives/message-lane/src/target_chain.rs
+++ b/primitives/message-lane/src/target_chain.rs
@@ -72,6 +72,10 @@ pub trait SourceHeaderChain<Fee> {
 	///
 	/// Messages vector is required to be sorted by nonce within each lane. Out-of-order
 	/// messages will be rejected.
+	///
+	/// The `messages_count` argument verification (sane limits) is supposed to be made
+	/// outside of this function. This function only verifies that the proof declares exactly
+	/// `messages_count` messages.
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
 		messages_count: MessageNonce,

--- a/primitives/message-lane/src/target_chain.rs
+++ b/primitives/message-lane/src/target_chain.rs
@@ -16,7 +16,7 @@
 
 //! Primitives of message lane module, that are used on the target chain.
 
-use crate::{LaneId, Message, MessageData, MessageKey, MessageNonce, OutboundLaneData};
+use crate::{LaneId, Message, MessageData, MessageKey, OutboundLaneData};
 
 use codec::{Decode, Encode, Error as CodecError};
 use frame_support::{weights::Weight, Parameter, RuntimeDebug};
@@ -78,7 +78,7 @@ pub trait SourceHeaderChain<Fee> {
 	/// `messages_count` messages.
 	fn verify_messages_proof(
 		proof: Self::MessagesProof,
-		messages_count: MessageNonce,
+		messages_count: u32,
 	) -> Result<ProvedMessages<Message<Fee>>, Self::Error>;
 }
 

--- a/relays/substrate/src/millau_messages_to_rialto.rs
+++ b/relays/substrate/src/millau_messages_to_rialto.rs
@@ -81,7 +81,7 @@ impl SubstrateMessageLane for MillauMessagesToRialto {
 		let call = rialto_runtime::MessageLaneCall::receive_messages_proof(
 			self.relayer_id_at_source.clone(),
 			proof,
-			messages_count,
+			messages_count as _,
 			dispatch_weight,
 		)
 		.into();

--- a/relays/substrate/src/rialto_messages_to_millau.rs
+++ b/relays/substrate/src/rialto_messages_to_millau.rs
@@ -81,7 +81,7 @@ impl SubstrateMessageLane for RialtoMessagesToMillau {
 		let call = millau_runtime::MessageLaneCall::receive_messages_proof(
 			self.relayer_id_at_source.clone(),
 			proof,
-			messages_count,
+			messages_count as _,
 			dispatch_weight,
 		)
 		.into();


### PR DESCRIPTION
closes https://github.com/paritytech/srlabs_findings/issues/40 

The guaratee there is not that straightforward as in https://github.com/paritytech/parity-bridges-common/pull/658 - there's no direct link betweeen maximal tx weight and maximal vector capacity. But e.g. on our testnets the max number of messages is roughly 2 * weight_per_1s / single_message_overhead ~ 6900. This doesn't include other factors - like that max extrinsic weight is only 75% of 2s or that extrinsic weight has other components. So it should be fine both for testnets + real chains. In case if you think it is too fragile, I may resurrect parts of https://github.com/paritytech/parity-bridges-common/pull/541 - it had explicit limit of messages in the delivery transaction.
