### PR TITLE
Decode call after spec_version check

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -215,6 +215,7 @@ impl pallet_bridge_call_dispatch::Config for Runtime {
 	type Event = Event;
 	type MessageId = (bp_message_lane::LaneId, bp_message_lane::MessageNonce);
 	type Call = Call;
+	type EncodedCall = crate::rialto_messages::FromRialtoEncodedCall;
 	type SourceChainAccountId = bp_rialto::AccountId;
 	type TargetChainAccountPublic = MultiSigner;
 	type TargetChainSignature = MultiSignature;

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -63,6 +63,9 @@ pub type ToRialtoMessageVerifier = messages::source::FromThisChainMessageVerifie
 /// Message payload for Rialto -> Millau messages.
 pub type FromRialtoMessagePayload = messages::target::FromBridgedChainMessagePayload<WithRialtoMessageBridge>;
 
+/// Encoded Millau Call as it comes from Rialto.
+pub type FromRialtoEncodedCall = messages::target::FromBridgedChainEncodedMessageCall<WithRialtoMessageBridge>;
+
 /// Messages proof for Rialto -> Millau messages.
 type FromRialtoMessagesProof = messages::target::FromBridgedChainMessagesProof<WithRialtoMessageBridge>;
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -266,6 +266,7 @@ impl pallet_bridge_call_dispatch::Config for Runtime {
 	type Event = Event;
 	type MessageId = (bp_message_lane::LaneId, bp_message_lane::MessageNonce);
 	type Call = Call;
+	type EncodedCall = crate::millau_messages::FromMillauEncodedCall;
 	type SourceChainAccountId = bp_millau::AccountId;
 	type TargetChainAccountPublic = MultiSigner;
 	type TargetChainSignature = MultiSignature;

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -63,6 +63,9 @@ pub type ToMillauMessageVerifier = messages::source::FromThisChainMessageVerifie
 /// Message payload for Millau -> Rialto messages.
 pub type FromMillauMessagePayload = messages::target::FromBridgedChainMessagePayload<WithMillauMessageBridge>;
 
+/// Encoded Rialto Call as it comes from Millau.
+pub type FromMillauEncodedCall = messages::target::FromBridgedChainEncodedMessageCall<WithMillauMessageBridge>;
+
 /// Call-dispatch based message dispatch for Millau -> Rialto messages.
 pub type FromMillauMessageDispatch = messages::target::FromBridgedChainMessageDispatch<
 	WithMillauMessageBridge,

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -27,7 +27,7 @@ use bp_message_lane::{
 	InboundLaneData, LaneId, Message, MessageData, MessageKey, MessageNonce, OutboundLaneData,
 };
 use bp_runtime::InstanceId;
-use codec::{Compact, Decode, Encode, Input};
+use codec::{Compact, Decode, Encode};
 use frame_support::{traits::Instance, RuntimeDebug};
 use hash_db::Hasher;
 use pallet_substrate_bridge::StorageProofChecker;
@@ -302,11 +302,11 @@ pub mod target {
 	>;
 
 	/// Decoded Bridged -> This message payload.
-	pub type FromBridgedChainDecodedMessagePayload<B> = pallet_bridge_call_dispatch::MessagePayload<
+	pub type FromBridgedChainMessagePayload<B> = pallet_bridge_call_dispatch::MessagePayload<
 		AccountIdOf<BridgedChain<B>>,
 		SignerOf<ThisChain<B>>,
 		SignatureOf<ThisChain<B>>,
-		CallOf<ThisChain<B>>,
+		FromBridgedChainEncodedMessageCall<B>,
 	>;
 
 	/// Messages proof from bridged chain:
@@ -323,33 +323,21 @@ pub mod target {
 		MessageNonce,
 	);
 
-	/// Message payload for Bridged -> This messages.
-	pub struct FromBridgedChainMessagePayload<B: MessageBridge>(pub(crate) FromBridgedChainDecodedMessagePayload<B>);
-
-	impl<B: MessageBridge> From<FromBridgedChainDecodedMessagePayload<B>> for FromBridgedChainMessagePayload<B> {
-		fn from(decoded_payload: FromBridgedChainDecodedMessagePayload<B>) -> Self {
-			Self(decoded_payload)
-		}
+	/// Encoded Call of This chain as it is transferred over bridge.
+	///
+	/// Our Call is opaque (`Vec<u8>`) for Bridged chain. So it is encoded, prefixed with
+	/// vector length. Custom decode implementation here is exactly to deal with this.
+	#[derive(Decode, Encode, RuntimeDebug, PartialEq)]
+	pub struct FromBridgedChainEncodedMessageCall<B> {
+		pub(crate) encoded_call: Vec<u8>,
+		pub(crate) _marker: PhantomData<B>,
 	}
 
-	impl<B: MessageBridge> Decode for FromBridgedChainMessagePayload<B> {
-		fn decode<I: Input>(input: &mut I) -> Result<Self, codec::Error> {
-			// for bridged chain our Calls are opaque - they're encoded to Vec<u8> by submitter
-			// => skip encoded vec length here before decoding Call
-			let spec_version = pallet_bridge_call_dispatch::SpecVersion::decode(input)?;
-			let weight = frame_support::weights::Weight::decode(input)?;
-			let origin = FromBridgedChainMessageCallOrigin::<B>::decode(input)?;
-			let _skipped_length = Compact::<u32>::decode(input)?;
-			let call = CallOf::<ThisChain<B>>::decode(input)?;
-
-			Ok(FromBridgedChainMessagePayload(
-				pallet_bridge_call_dispatch::MessagePayload {
-					spec_version,
-					weight,
-					origin,
-					call,
-				},
-			))
+	impl<B: MessageBridge> From<FromBridgedChainEncodedMessageCall<B>> for Result<CallOf<ThisChain<B>>, ()> {
+		fn from(encoded_call: FromBridgedChainEncodedMessageCall<B>) -> Self {
+			let mut input = &encoded_call.encoded_call[..];
+			let _skipped_length = Compact::<u32>::decode(&mut input).map_err(drop)?;
+			CallOf::<ThisChain<B>>::decode(&mut input).map_err(drop)
 		}
 	}
 
@@ -366,22 +354,14 @@ pub mod target {
 		ThisCallDispatchInstance: frame_support::traits::Instance,
 		ThisRuntime: pallet_bridge_call_dispatch::Config<ThisCallDispatchInstance>,
 		pallet_bridge_call_dispatch::Module<ThisRuntime, ThisCallDispatchInstance>:
-			bp_message_dispatch::MessageDispatch<
-				(LaneId, MessageNonce),
-				Message = FromBridgedChainDecodedMessagePayload<B>,
-			>,
+			bp_message_dispatch::MessageDispatch<(LaneId, MessageNonce), Message = FromBridgedChainMessagePayload<B>>,
 	{
 		type DispatchPayload = FromBridgedChainMessagePayload<B>;
 
 		fn dispatch_weight(
 			message: &DispatchMessage<Self::DispatchPayload, BalanceOf<BridgedChain<B>>>,
 		) -> frame_support::weights::Weight {
-			message
-				.data
-				.payload
-				.as_ref()
-				.map(|payload| payload.0.weight)
-				.unwrap_or(0)
+			message.data.payload.as_ref().map(|payload| payload.weight).unwrap_or(0)
 		}
 
 		fn dispatch(message: DispatchMessage<Self::DispatchPayload, BalanceOf<BridgedChain<B>>>) {
@@ -389,7 +369,7 @@ pub mod target {
 				pallet_bridge_call_dispatch::Module::<ThisRuntime, ThisCallDispatchInstance>::dispatch(
 					B::INSTANCE,
 					(message.key.lane_id, message.key.nonce),
-					payload.0,
+					payload,
 				);
 			}
 		}
@@ -567,6 +547,7 @@ mod tests {
 	const BRIDGED_CHAIN_MAX_EXTRINSIC_SIZE: u32 = 1024;
 
 	/// Bridge that is deployed on ThisChain and allows sending/receiving messages to/from BridgedChain;
+	#[derive(Debug, PartialEq)]
 	struct OnThisChainBridge;
 
 	impl MessageBridge for OnThisChainBridge {
@@ -611,6 +592,7 @@ mod tests {
 	}
 
 	/// Bridge that is deployed on BridgedChain and allows sending/receiving messages to/from ThisChain;
+	#[derive(Debug, PartialEq)]
 	struct OnBridgedChainBridge;
 
 	impl MessageBridge for OnBridgedChainBridge {
@@ -784,12 +766,15 @@ mod tests {
 			target::FromBridgedChainMessagePayload::<OnThisChainBridge>::decode(&mut &message_on_bridged_chain[..])
 				.unwrap();
 		assert_eq!(
-			message_on_this_chain.0,
-			target::FromBridgedChainDecodedMessagePayload::<OnThisChainBridge> {
+			message_on_this_chain,
+			target::FromBridgedChainMessagePayload::<OnThisChainBridge> {
 				spec_version: 1,
 				weight: 100,
 				origin: pallet_bridge_call_dispatch::CallOrigin::SourceRoot,
-				call: ThisChainCall::Transfer,
+				call: target::FromBridgedChainEncodedMessageCall::<OnThisChainBridge> {
+					encoded_call: ThisChainCall::Transfer.encode(),
+					_marker: PhantomData::default(),
+				},
 			}
 		);
 	}


### PR DESCRIPTION
closes #613

There's a new `type EncodedCall;` in the `pallet_call_dispatch::Config` trait. It needs to be `Encode + Decode` and these implementations must match implementations on the source chain (so that signed message matches original message). At the same time, we shall support conversions from this `EncodedCall` into `Call`. That's why there's that strange `Into<Result<<Self as Config<I>>::Call, ()>>` bound. Initially it was `TryInto<<Self as Config<I>>::Call>`, but I've ran into https://github.com/rust-lang/rust/issues/50133 . If you feel that `Into<Result<_, _>>` is too awkward, I could e.g. introduce new trait for this conversion.