### PR TITLE
Bump Cargo Chef

### DIFF
--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -9,6 +9,10 @@ on:
       - diagrams/
   schedule:                                         # Nightly build
     - cron:                                         '0 0 * * *'
+  pull_request:
+    branches:
+      - master
+
 jobs:
 ## Publish to Docker hub
   publish:

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -9,9 +9,6 @@ on:
       - diagrams/
   schedule:                                         # Nightly build
     - cron:                                         '0 0 * * *'
-  pull_request:
-    branches:
-      - master
 
 jobs:
 ## Publish to Docker hub

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,6 +9,9 @@ on:
       - diagrams/
   schedule:                                         # Nightly build
     - cron:                                         '0 1 * * *'
+  pull_request:
+    branches:
+      - master
 jobs:
 ## Publish to Docker hub
   publish:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,9 +9,7 @@ on:
       - diagrams/
   schedule:                                         # Nightly build
     - cron:                                         '0 1 * * *'
-  pull_request:
-    branches:
-      - master
+
 jobs:
 ## Publish to Docker hub
   publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # This first stage prepares our dependencies to be built by `cargo-chef`.
 FROM rust as planner
 WORKDIR /parity-bridges-common
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --version 0.1.13
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
@@ -20,7 +20,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 # step doesn't blow our cache.
 FROM paritytech/bridge-dependencies AS cacher
 WORKDIR /parity-bridges-common
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --version 0.1.13
 
 COPY --from=planner /parity-bridges-common/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
@@ -30,7 +30,7 @@ RUN cargo chef cook --release --recipe-path recipe.json
 # cached in the previous stage.
 FROM paritytech/bridge-dependencies as builder
 WORKDIR /parity-bridges-common
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --version 0.1.13
 
 COPY . .
 COPY --from=cacher /parity-bridges-common/target target

--- a/deployments/BridgeDeps.Dockerfile
+++ b/deployments/BridgeDeps.Dockerfile
@@ -4,7 +4,7 @@
 # the various components in the bridge repo, such as nodes and relayers.
 FROM ubuntu:xenial
 
-ENV LAST_DEPS_UPDATE 2021-01-20
+ENV LAST_DEPS_UPDATE 2020-12-21
 
 RUN set -eux; \
 	apt-get update && \
@@ -17,7 +17,7 @@ RUN update-ca-certificates && \
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV LAST_RUST_UPDATE 2021-01-20
+ENV LAST_RUST_UPDATE 2020-12-21
 
 RUN rustup update stable && \
 	rustup install nightly && \

--- a/deployments/BridgeDeps.Dockerfile
+++ b/deployments/BridgeDeps.Dockerfile
@@ -4,7 +4,7 @@
 # the various components in the bridge repo, such as nodes and relayers.
 FROM ubuntu:xenial
 
-ENV LAST_DEPS_UPDATE 2020-12-21
+ENV LAST_DEPS_UPDATE 2021-01-20
 
 RUN set -eux; \
 	apt-get update && \
@@ -17,7 +17,7 @@ RUN update-ca-certificates && \
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV LAST_RUST_UPDATE 2020-12-21
+ENV LAST_RUST_UPDATE 2021-01-20
 
 RUN rustup update stable && \
 	rustup install nightly && \


### PR DESCRIPTION
I'm bumping the version of `cargo-chef` used by the CI to see if https://github.com/LukeMathWalker/cargo-chef/issues/45 has been fixed.

I'll change the publishing schedule back to it's regular nightly run if this PR succeeds.