### PR TITLE
Prevent potential signature reuse

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -596,12 +596,12 @@ impl_runtime_apis! {
 	}
 }
 
-/// Proof Rialto account ownership from Millau.
+/// Rialto account ownership digest from Millau.
 ///
 /// The byte vector returned by this function should be signed with a Rialto account private key.
 /// This way, the owner of `millau_account_id` on Millau proves that the Rialto account private key
 /// is also under his control.
-pub fn rialto_account_ownership_proof<Call, AccountId, SpecVersion>(
+pub fn rialto_account_ownership_digest<Call, AccountId, SpecVersion>(
 	rialto_call: Call,
 	millau_account_id: AccountId,
 	rialto_spec_version: SpecVersion,
@@ -611,7 +611,7 @@ where
 	AccountId: codec::Encode,
 	SpecVersion: codec::Encode,
 {
-	pallet_bridge_call_dispatch::account_ownership_proof(
+	pallet_bridge_call_dispatch::account_ownership_digest(
 		rialto_call,
 		millau_account_id,
 		rialto_spec_version,

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -611,14 +611,12 @@ where
 	AccountId: codec::Encode,
 	SpecVersion: codec::Encode,
 {
-	let proof = pallet_bridge_call_dispatch::account_ownership_proof(
+	pallet_bridge_call_dispatch::account_ownership_proof(
 		rialto_call,
 		millau_account_id,
 		rialto_spec_version,
 		bp_runtime::MILLAU_BRIDGE_INSTANCE,
-	);
-
-	proof
+	)
 }
 
 #[cfg(test)]

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -596,6 +596,31 @@ impl_runtime_apis! {
 	}
 }
 
+/// Proof account ownership on 'rialto'.
+///
+/// The byte vector returned by this function will be signed with a 'rialto' account private key.
+/// This way, the owner of `millau_account_id` on 'millau' proves that the 'rialto' account private key
+/// is also under his control.
+pub fn rialto_account_ownership_proof<Call, AccountId, SpecVersion>(
+	rialto_call: Call,
+	millau_account_id: AccountId,
+	rialto_spec_version: SpecVersion,
+) -> sp_std::vec::Vec<u8>
+where
+	Call: codec::Encode,
+	AccountId: codec::Encode,
+	SpecVersion: codec::Encode,
+{
+	let proof = pallet_bridge_call_dispatch::account_ownership_proof(
+		rialto_call,
+		millau_account_id,
+		rialto_spec_version,
+		bp_runtime::MILLAU_BRIDGE_INSTANCE,
+	);
+
+	proof
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -596,10 +596,10 @@ impl_runtime_apis! {
 	}
 }
 
-/// Proof account ownership on 'rialto'.
+/// Proof Rialto account ownership from Millau.
 ///
-/// The byte vector returned by this function will be signed with a 'rialto' account private key.
-/// This way, the owner of `millau_account_id` on 'millau' proves that the 'rialto' account private key
+/// The byte vector returned by this function should be signed with a Rialto account private key.
+/// This way, the owner of `millau_account_id` on Millau proves that the Rialto account private key
 /// is also under his control.
 pub fn rialto_account_ownership_proof<Call, AccountId, SpecVersion>(
 	rialto_call: Call,

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -985,12 +985,12 @@ impl_runtime_apis! {
 	}
 }
 
-/// Proof Millau account ownership from Rialto.
+/// Millau account ownership digest from Rialto.
 ///
 /// The byte vector returned by this function should be signed with a Millau account private key.
 /// This way, the owner of `rialto_account_id` on Rialto proves that the 'millau' account private key
 /// is also under his control.
-pub fn millau_account_ownership_proof<Call, AccountId, SpecVersion>(
+pub fn millau_account_ownership_digest<Call, AccountId, SpecVersion>(
 	millau_call: Call,
 	rialto_account_id: AccountId,
 	millau_spec_version: SpecVersion,
@@ -1000,7 +1000,7 @@ where
 	AccountId: codec::Encode,
 	SpecVersion: codec::Encode,
 {
-	pallet_bridge_call_dispatch::account_ownership_proof(
+	pallet_bridge_call_dispatch::account_ownership_digest(
 		millau_call,
 		rialto_account_id,
 		millau_spec_version,

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -1000,14 +1000,12 @@ where
 	AccountId: codec::Encode,
 	SpecVersion: codec::Encode,
 {
-	let proof = pallet_bridge_call_dispatch::account_ownership_proof(
+	pallet_bridge_call_dispatch::account_ownership_proof(
 		millau_call,
 		rialto_account_id,
 		millau_spec_version,
 		bp_runtime::RIALTO_BRIDGE_INSTANCE,
-	);
-
-	proof
+	)
 }
 
 #[cfg(test)]

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -985,10 +985,10 @@ impl_runtime_apis! {
 	}
 }
 
-/// Proof account ownership on 'millau'.
+/// Proof Millau account ownership from Rialto.
 ///
-/// The byte vector returned by this function will be signed with a 'millau' account private key.
-/// This way, the owner of `rialto_account_id` on 'rialto' proves that the 'millau' account private key
+/// The byte vector returned by this function should be signed with a Millau account private key.
+/// This way, the owner of `rialto_account_id` on Rialto proves that the 'millau' account private key
 /// is also under his control.
 pub fn millau_account_ownership_proof<Call, AccountId, SpecVersion>(
 	millau_call: Call,

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -985,6 +985,31 @@ impl_runtime_apis! {
 	}
 }
 
+/// Proof account ownership on 'millau'.
+///
+/// The byte vector returned by this function will be signed with a 'millau' account private key.
+/// This way, the owner of `rialto_account_id` on 'rialto' proves that the 'millau' account private key
+/// is also under his control.
+pub fn millau_account_ownership_proof<Call, AccountId, SpecVersion>(
+	millau_call: Call,
+	rialto_account_id: AccountId,
+	millau_spec_version: SpecVersion,
+) -> sp_std::vec::Vec<u8>
+where
+	Call: codec::Encode,
+	AccountId: codec::Encode,
+	SpecVersion: codec::Encode,
+{
+	let proof = pallet_bridge_call_dispatch::account_ownership_proof(
+		millau_call,
+		rialto_account_id,
+		millau_spec_version,
+		bp_runtime::RIALTO_BRIDGE_INSTANCE,
+	);
+
+	proof
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/deny.toml
+++ b/deny.toml
@@ -50,12 +50,9 @@ notice = "warn"
 ignore = [
 	# yaml-rust < clap. Not feasible to upgrade and also not possible to trigger in practice.
 	"RUSTSEC-2018-0006",
-<<<<<<< HEAD
-=======
 	# We need to wait until Substrate updates their `wasmtime` dependency to fix this.
 	# TODO: See issue #676: https://github.com/paritytech/parity-bridges-common/issues/676
 	"RUSTSEC-2021-0013"
->>>>>>> upstream/master
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,9 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
 	# yaml-rust < clap. Not feasible to upgrade and also not possible to trigger in practice.
-	"RUSTSEC-2018-0006"
+	"RUSTSEC-2018-0006",
+   # raw-cpuid is a dep of cranelift-native. Not feasible to upgrade.
+    "RUSTSEC-2021-0013"    
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/modules/call-dispatch/src/lib.rs
+++ b/modules/call-dispatch/src/lib.rs
@@ -65,7 +65,7 @@ pub enum CallOrigin<SourceChainAccountId, TargetChainAccountPublic, TargetChainS
 	///
 	/// The account can be identified by `TargetChainAccountPublic`. The proof that the
 	/// `SourceChainAccountId` controls `TargetChainAccountPublic` is the `TargetChainSignature`
-	/// over `(Call, SourceChainAccountId, TargetChainSpecVersion, SourceChainInstanceId).encode()`.
+	/// over `(Call, SourceChainAccountId, TargetChainSpecVersion, SourceChainBridgeId).encode()`.
 	///
 	/// NOTE sending messages using this origin (or any other) does not have replay protection!
 	/// The assumption is that both the source account and the target account is controlled by
@@ -321,22 +321,22 @@ where
 	}
 }
 
-/// Proof account ownership on the target chain.
+/// Proof target account ownership from the source chain.
 ///
 /// The byte vector returned by this function will be signed with a target chain account
 /// private key. This way, the owner of `source_account_id` on the source chain proves that
 /// the target chain account private key is also under his control.
-pub fn account_ownership_proof<Call, AccountId, SpecVersion, InstanceId>(
+pub fn account_ownership_proof<Call, AccountId, SpecVersion, BridgeId>(
 	call: Call,
 	source_account_id: AccountId,
 	target_spec_version: SpecVersion,
-	source_instance_id: InstanceId,
+	source_instance_id: BridgeId,
 ) -> Vec<u8>
 where
 	Call: Encode,
 	AccountId: Encode,
 	SpecVersion: Encode,
-	InstanceId: Encode,
+	BridgeId: Encode,
 {
 	let mut proof = Vec::new();
 	call.encode_to(&mut proof);

--- a/modules/call-dispatch/src/lib.rs
+++ b/modules/call-dispatch/src/lib.rs
@@ -65,7 +65,7 @@ pub enum CallOrigin<SourceChainAccountId, TargetChainAccountPublic, TargetChainS
 	///
 	/// The account can be identified by `TargetChainAccountPublic`. The proof that the
 	/// `SourceChainAccountId` controls `TargetChainAccountPublic` is the `TargetChainSignature`
-	/// over `(Call, SourceChainAccountId).encode()`.
+	/// over `(Call, SourceChainAccountId, TargetChainSpecVersion, SourceChainInstanceId).encode()`.
 	///
 	/// NOTE sending messages using this origin (or any other) does not have replay protection!
 	/// The assumption is that both the source account and the target account is controlled by

--- a/modules/call-dispatch/src/lib.rs
+++ b/modules/call-dispatch/src/lib.rs
@@ -235,11 +235,11 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Module<T, I> {
 				target_id
 			}
 			CallOrigin::TargetAccount(source_account_id, target_public, target_signature) => {
-				let proof =
-					account_ownership_proof(message.call.clone(), source_account_id, message.spec_version, bridge);
+				let digest =
+					account_ownership_digest(message.call.clone(), source_account_id, message.spec_version, bridge);
 
 				let target_account = target_public.into_account();
-				if !target_signature.verify(&proof[..], &target_account) {
+				if !target_signature.verify(&digest[..], &target_account) {
 					frame_support::debug::trace!(
 						"Message {:?}/{:?}: origin proof is invalid. Expected account: {:?} from signature: {:?}",
 						bridge,
@@ -321,12 +321,12 @@ where
 	}
 }
 
-/// Proof target account ownership from the source chain.
+/// Target account ownership digest from the source chain.
 ///
 /// The byte vector returned by this function will be signed with a target chain account
 /// private key. This way, the owner of `source_account_id` on the source chain proves that
 /// the target chain account private key is also under his control.
-pub fn account_ownership_proof<Call, AccountId, SpecVersion, BridgeId>(
+pub fn account_ownership_digest<Call, AccountId, SpecVersion, BridgeId>(
 	call: Call,
 	source_account_id: AccountId,
 	target_spec_version: SpecVersion,

--- a/modules/call-dispatch/src/lib.rs
+++ b/modules/call-dispatch/src/lib.rs
@@ -238,6 +238,9 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Module<T, I> {
 				let mut signed_message = Vec::new();
 				message.call.encode_to(&mut signed_message);
 				source_account_id.encode_to(&mut signed_message);
+				// prohibit signature reuse across bridges and spec versions
+				message.spec_version.encode_to(&mut signed_message);
+				bridge.encode_to(&mut signed_message);
 
 				let target_account = target_public.into_account();
 				if !target_signature.verify(&signed_message[..], &target_account) {

--- a/relays/substrate/src/main.rs
+++ b/relays/substrate/src/main.rs
@@ -529,27 +529,11 @@ mod tests {
 	use sp_core::Pair;
 	use sp_runtime::traits::{IdentifyAccount, Verify};
 
-	macro_rules! call_for_runtime {
-		($runtime:tt) => {
-			$runtime::Call::System($runtime::SystemCall::remark(
-				std::format!(
-					"Unix time: {}",
-					std::time::SystemTime::now()
-						.duration_since(std::time::SystemTime::UNIX_EPOCH)
-						.unwrap_or_default()
-						.as_secs(),
-				)
-				.as_bytes()
-				.to_vec()
-			))
-		}
-	}
-
 	#[test]
 	fn millau_signature_is_valid_on_rialto() {
 		let millau_sign = relay_millau_client::SigningParams::from_suri("//Dave", None).unwrap();
 
-		let call = call_for_runtime!(rialto_runtime);
+		let call = rialto_runtime::Call::System(rialto_runtime::SystemCall::remark(vec![]));
 
 		let millau_public: bp_millau::AccountSigner = millau_sign.signer.public().clone().into();
 		let millau_account_id: bp_millau::AccountId = millau_public.into_account();
@@ -560,17 +544,17 @@ mod tests {
 			rialto_runtime::VERSION.spec_version,
 		);
 
-		let rialto_sign = relay_rialto_client::SigningParams::from_suri("//Dave", None).unwrap();
-		let signature = rialto_sign.signer.sign(&proof);
+		let rialto_signer = relay_rialto_client::SigningParams::from_suri("//Dave", None).unwrap();
+		let signature = rialto_signer.signer.sign(&proof);
 
-		assert!(signature.verify(&proof[..], &rialto_sign.signer.public()));
+		assert!(signature.verify(&proof[..], &rialto_signer.signer.public()));
 	}
 
 	#[test]
 	fn rialto_signature_is_valid_on_millau() {
 		let rialto_sign = relay_rialto_client::SigningParams::from_suri("//Dave", None).unwrap();
 
-		let call = call_for_runtime!(millau_runtime);
+		let call = millau_runtime::Call::System(millau_runtime::SystemCall::remark(vec![]));
 
 		let rialto_public: bp_rialto::AccountSigner = rialto_sign.signer.public().clone().into();
 		let rialto_account_id: bp_rialto::AccountId = rialto_public.into_account();
@@ -581,9 +565,9 @@ mod tests {
 			millau_runtime::VERSION.spec_version,
 		);
 
-		let millau_sign = relay_millau_client::SigningParams::from_suri("//Dave", None).unwrap();
-		let signature = millau_sign.signer.sign(&proof);
+		let millau_signer = relay_millau_client::SigningParams::from_suri("//Dave", None).unwrap();
+		let signature = millau_signer.signer.sign(&proof);
 
-		assert!(signature.verify(&proof[..], &millau_sign.signer.public()));
+		assert!(signature.verify(&proof[..], &millau_signer.signer.public()));
 	}
 }

--- a/relays/substrate/src/main.rs
+++ b/relays/substrate/src/main.rs
@@ -300,6 +300,10 @@ async fn run_command(command: cli::Command) -> Result<(), String> {
 					let mut rialto_origin_signature_message = Vec::new();
 					rialto_call.encode_to(&mut rialto_origin_signature_message);
 					millau_account_id.encode_to(&mut rialto_origin_signature_message);
+					rialto_runtime::VERSION
+						.spec_version
+						.encode_to(&mut rialto_origin_signature_message);
+					bp_runtime::MILLAU_BRIDGE_INSTANCE.encode_to(&mut rialto_origin_signature_message);
 					let rialto_origin_signature = rialto_sign.signer.sign(&rialto_origin_signature_message);
 
 					MessagePayload {
@@ -448,6 +452,11 @@ async fn run_command(command: cli::Command) -> Result<(), String> {
 					let mut millau_origin_signature_message = Vec::new();
 					millau_call.encode_to(&mut millau_origin_signature_message);
 					rialto_account_id.encode_to(&mut millau_origin_signature_message);
+					millau_runtime::VERSION
+						.spec_version
+						.encode_to(&mut millau_origin_signature_message);
+					bp_runtime::RIALTO_BRIDGE_INSTANCE.encode_to(&mut millau_origin_signature_message);
+
 					let millau_origin_signature = millau_sign.signer.sign(&millau_origin_signature_message);
 
 					MessagePayload {

--- a/relays/substrate/src/main.rs
+++ b/relays/substrate/src/main.rs
@@ -297,13 +297,13 @@ async fn run_command(command: cli::Command) -> Result<(), String> {
 					call: rialto_call.encode(),
 				},
 				cli::Origins::Target => {
-					let proof = millau_runtime::rialto_account_ownership_proof(
+					let digest = millau_runtime::rialto_account_ownership_digest(
 						rialto_call.clone(),
 						millau_account_id.clone(),
 						rialto_runtime::VERSION.spec_version,
 					);
 
-					let proof_signature = rialto_sign.signer.sign(&proof);
+					let digest_signature = rialto_sign.signer.sign(&digest);
 
 					MessagePayload {
 						spec_version: rialto_runtime::VERSION.spec_version,
@@ -311,7 +311,7 @@ async fn run_command(command: cli::Command) -> Result<(), String> {
 						origin: CallOrigin::TargetAccount(
 							millau_account_id,
 							rialto_origin_public.into(),
-							proof_signature.into(),
+							digest_signature.into(),
 						),
 						call: rialto_call.encode(),
 					}
@@ -448,13 +448,13 @@ async fn run_command(command: cli::Command) -> Result<(), String> {
 					call: millau_call.encode(),
 				},
 				cli::Origins::Target => {
-					let proof = rialto_runtime::millau_account_ownership_proof(
+					let digest = rialto_runtime::millau_account_ownership_digest(
 						millau_call.clone(),
 						rialto_account_id.clone(),
 						millau_runtime::VERSION.spec_version,
 					);
 
-					let proof_signature = millau_sign.signer.sign(&proof);
+					let digest_signature = millau_sign.signer.sign(&digest);
 
 					MessagePayload {
 						spec_version: millau_runtime::VERSION.spec_version,
@@ -462,7 +462,7 @@ async fn run_command(command: cli::Command) -> Result<(), String> {
 						origin: CallOrigin::TargetAccount(
 							rialto_account_id,
 							millau_origin_public.into(),
-							proof_signature.into(),
+							digest_signature.into(),
 						),
 						call: millau_call.encode(),
 					}
@@ -538,16 +538,16 @@ mod tests {
 		let millau_public: bp_millau::AccountSigner = millau_sign.signer.public().clone().into();
 		let millau_account_id: bp_millau::AccountId = millau_public.into_account();
 
-		let proof = millau_runtime::rialto_account_ownership_proof(
+		let digest = millau_runtime::rialto_account_ownership_digest(
 			call,
 			millau_account_id,
 			rialto_runtime::VERSION.spec_version,
 		);
 
 		let rialto_signer = relay_rialto_client::SigningParams::from_suri("//Dave", None).unwrap();
-		let signature = rialto_signer.signer.sign(&proof);
+		let signature = rialto_signer.signer.sign(&digest);
 
-		assert!(signature.verify(&proof[..], &rialto_signer.signer.public()));
+		assert!(signature.verify(&digest[..], &rialto_signer.signer.public()));
 	}
 
 	#[test]
@@ -559,15 +559,15 @@ mod tests {
 		let rialto_public: bp_rialto::AccountSigner = rialto_sign.signer.public().clone().into();
 		let rialto_account_id: bp_rialto::AccountId = rialto_public.into_account();
 
-		let proof = rialto_runtime::millau_account_ownership_proof(
+		let digest = rialto_runtime::millau_account_ownership_digest(
 			call,
 			rialto_account_id,
 			millau_runtime::VERSION.spec_version,
 		);
 
 		let millau_signer = relay_millau_client::SigningParams::from_suri("//Dave", None).unwrap();
-		let signature = millau_signer.signer.sign(&proof);
+		let signature = millau_signer.signer.sign(&digest);
 
-		assert!(signature.verify(&proof[..], &millau_signer.signer.public()));
+		assert!(signature.verify(&digest[..], &millau_signer.signer.public()));
 	}
 }


### PR DESCRIPTION
Resolves [paritytech/srlabs_findings/#42](https://github.com/paritytech/srlabs_findings/issues/42)

Currently the signature required to submit a call with origin `CallOrigin::TargetAccount` contains only the encoded call and the submitter account id on the source chain (source_account_id). This may allow signature reuse.

In order to prevent this, we include `MessagePayload.spec_version` and the `InstanceId` of the bridge in the signature.