### PR TITLE
Migrate Finality Verifier Pallet to FRAME v2

### DIFF
--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -307,10 +307,4 @@ mod tests {
 			);
 		})
 	}
-
-	#[test]
-	fn print_metadata() {
-		println!("{:#?}", TestRuntime::metadata());
-		panic!()
-	}
 }

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -161,6 +161,7 @@ pub mod pallet {
 
 #[cfg(test)]
 mod tests {
+	use super::pallet::*;
 	use super::*;
 	use crate::mock::{run_test, test_header, Origin, TestRuntime};
 	use bp_test_utils::{authority_list, make_justification_for_header};

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -73,7 +73,6 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::hooks]

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -34,15 +34,6 @@ impl_outer_origin! {
 	pub enum Origin for TestRuntime where system = frame_system {}
 }
 
-use crate::pallet as pallet_finality_verifier;
-
-type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<(), (), (), ()>;
-
-frame_support::impl_runtime_metadata!(
-	for TestRuntime with modules where Extrinsic = UncheckedExtrinsic
-		pallet_finality_verifier::Module as FinalityVerifier { index 0 } with Storage Call,
-);
-
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;


### PR DESCRIPTION
After watching Guillaume's [Substrate Seminar presentation](https://www.crowdcast.io/e/substrate-seminar/30) yesterday I figured it would be cool to try and upgrade one of our pallets to the new FRAME macros. The Finality Verifier pallet seemed like a good place to start since a) it's not being audited at the moment, and b) it's super simple (for example, it doesn't even have storage items).

It took me less than an hour to do this change while following the [migration guide](https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines).