### PR TITLE
Publish dependencies weekly instead of nightly

### DIFF
--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -7,8 +7,8 @@ on:
     paths-ignore:
       - 'README.md'
       - diagrams/
-  schedule:                                         # Nightly build
-    - cron:                                         '0 0 * * *'
+  schedule:                                         # Weekly build
+    - cron:                                         '0 0 * * 0'
 
 jobs:
 ## Publish to Docker hub


### PR DESCRIPTION
I forgot to change this a few weeks ago. Weekly might even be too much, but let's see how it goes first.