### PR TITLE
Temporarily ignore RUSTSEC-2021-0013

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,10 @@ notice = "warn"
 # output a note when they are encountered.
 ignore = [
 	# yaml-rust < clap. Not feasible to upgrade and also not possible to trigger in practice.
-	"RUSTSEC-2018-0006"
+	"RUSTSEC-2018-0006",
+	# We need to wait until Substrate updates their `wasmtime` dependency to fix this.
+	# TODO: See issue #676: https://github.com/paritytech/parity-bridges-common/issues/676
+	"RUSTSEC-2021-0013"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
This will unblock our CI pipelines. Since there are no production deployments using our build artifacts I think this is an okay temporary measure.

I've logged #676 so we don't forget to remove this once we bump Substrate.