### PR TITLE
Temporarily ignore RUSTSEC-2020-0123

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,7 +52,10 @@ ignore = [
 	"RUSTSEC-2018-0006",
 	# We need to wait until Substrate updates their `wasmtime` dependency to fix this.
 	# TODO: See issue #676: https://github.com/paritytech/parity-bridges-common/issues/676
-	"RUSTSEC-2021-0013"
+	"RUSTSEC-2021-0013",
+	# We need to wait until Substrate updates their `libp2p` dependency to fix this.
+	# TODO: See issue #681: https://github.com/paritytech/parity-bridges-common/issues/681
+	"RUSTSEC-2020-0123"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
Our CI pipelines are block again. Again, I think this is okay since we
don't have any production deployments at the moment.

I've logged #681 so we don't forget to remove this.
