### PR TITLE
Make Account Derivation More Unique

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -185,6 +185,6 @@ fn derived_dave_account_is_as_expected() {
 	let derived: AccountId = derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(dave));
 	assert_eq!(
 		derived.to_string(),
-		"5G81vRqUUysQGtN5aEThD5UsLdt4rZWSbVLkjuZzLHadp8ZD".to_string()
+		"5H4H82RaZGACXNhntuWS4Sh3m7nwSojfU5QFTHQmnmi292gQ".to_string()
 	);
 }

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -185,6 +185,6 @@ fn derived_dave_account_is_as_expected() {
 	let derived: AccountId = derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(dave));
 	assert_eq!(
 		derived.to_string(),
-		"5H4H82RaZGACXNhntuWS4Sh3m7nwSojfU5QFTHQmnmi292gQ".to_string()
+		"5DNW6UVnb7TN6wX5KwXtDYR3Eccecbdzuw89HqjyNfkzce6J".to_string()
 	);
 }

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -203,6 +203,6 @@ fn derived_dave_account_is_as_expected() {
 	let derived: AccountId = derive_account_from_millau_id(bp_runtime::SourceAccount::Account(dave));
 	assert_eq!(
 		derived.to_string(),
-		"5D2NPmFB832grto5X7yWZqGNGD5HvySTSz9JJmXPdV4dnnFZ".to_string()
+		"5HZhdv53gSJmWWtD8XR5Ypu4PgbT5JNWwGw2mkE75cN61w9t".to_string()
 	);
 }

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -203,6 +203,6 @@ fn derived_dave_account_is_as_expected() {
 	let derived: AccountId = derive_account_from_millau_id(bp_runtime::SourceAccount::Account(dave));
 	assert_eq!(
 		derived.to_string(),
-		"5Hg7WQyk8C1FmPzxY3xSjR7S6zZZC5sAL35vMr6NpW17jBhQ".to_string()
+		"5D2NPmFB832grto5X7yWZqGNGD5HvySTSz9JJmXPdV4dnnFZ".to_string()
 	);
 }

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -47,6 +47,12 @@ pub const CALL_DISPATCH_MODULE_PREFIX: &[u8] = b"pallet-bridge/call-dispatch";
 /// Message-lane module prefix.
 pub const MESSAGE_LANE_MODULE_PREFIX: &[u8] = b"pallet-bridge/message-lane";
 
+/// A unique prefix for entropy when generating cross-chain account IDs.
+pub const ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation";
+
+/// A unique prefix for entropy when generating a cross-chain account ID for the Root account.
+pub const ROOT_ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/root";
+
 /// Id of deployed module instance. We have a bunch of pallets that may be used in
 /// different bridges. E.g. message-lane pallet may be deployed twice in the same
 /// runtime to bridge ThisChain with Chain1 and Chain2. Sometimes we need to be able
@@ -80,8 +86,8 @@ where
 	AccountId: Encode,
 {
 	match id {
-		SourceAccount::Root => ("root", bridge_id).using_encoded(blake2_256),
-		SourceAccount::Account(id) => ("account", bridge_id, id).using_encoded(blake2_256),
+		SourceAccount::Root => (ROOT_ACCOUNT_DERIVATION_PREFIX, bridge_id).using_encoded(blake2_256),
+		SourceAccount::Account(id) => (ACCOUNT_DERIVATION_PREFIX, bridge_id, id).using_encoded(blake2_256),
 	}
 	.into()
 }

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -48,7 +48,7 @@ pub const CALL_DISPATCH_MODULE_PREFIX: &[u8] = b"pallet-bridge/call-dispatch";
 pub const MESSAGE_LANE_MODULE_PREFIX: &[u8] = b"pallet-bridge/message-lane";
 
 /// A unique prefix for entropy when generating cross-chain account IDs.
-pub const ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation";
+pub const ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/account";
 
 /// A unique prefix for entropy when generating a cross-chain account ID for the Root account.
 pub const ROOT_ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/root";


### PR DESCRIPTION
Closes https://github.com/paritytech/srlabs_findings/issues/45.

Since `root` and `account` aren't exactly unique prefixes it is possible that other
pallets or tools may opt to use these same prefixes when generating accounts. This could
lead to collisions and in the worst case account takeovers.

This PR makes the prefix used when deriving accounts a bit longer, reducing the chances
of collisions between us and other pallets or tools.
