### PR TITLE
Stop Importing Full Header Chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4297,7 +4297,6 @@ dependencies = [
  "finality-grandpa",
  "frame-support",
  "frame-system",
- "num-traits",
  "pallet-substrate-bridge",
  "parity-scale-codec 1.3.6",
  "serde",

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -300,18 +300,11 @@ impl pallet_substrate_bridge::Config for Runtime {
 	type BridgedChain = bp_rialto::Rialto;
 }
 
-parameter_types! {
-	// We'll use the length of a session on the bridged chain as our bound since GRANDPA is
-	// guaranteed to produce a justification every session.
-	pub const MaxElementsInSingleProof: Option<u32> = Some(bp_rialto::SESSION_LENGTH);
-}
-
 impl pallet_finality_verifier::Config for Runtime {
 	type BridgedChain = bp_rialto::Rialto;
 	type HeaderChain = pallet_substrate_bridge::Module<Runtime>;
 	type AncestryProof = Vec<bp_rialto::Header>;
 	type AncestryChecker = bp_header_chain::LinearAncestryChecker;
-	type MaxElementsInSingleProof = MaxElementsInSingleProof;
 }
 
 impl pallet_shift_session_manager::Config for Runtime {}

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -303,14 +303,15 @@ impl pallet_substrate_bridge::Config for Runtime {
 parameter_types! {
 	// We'll use the length of a session on the bridged chain as our bound since GRANDPA is
 	// guaranteed to produce a justification every session.
-	pub const MaxHeadersInSingleProof: bp_rialto::BlockNumber = bp_rialto::SESSION_LENGTH;
+	pub const MaxElementsInSingleProof: Option<u32> = Some(bp_rialto::SESSION_LENGTH);
 }
 
 impl pallet_finality_verifier::Config for Runtime {
 	type BridgedChain = bp_rialto::Rialto;
 	type HeaderChain = pallet_substrate_bridge::Module<Runtime>;
+	type AncestryProof = Vec<bp_rialto::Header>;
 	type AncestryChecker = bp_header_chain::LinearAncestryChecker;
-	type MaxHeadersInSingleProof = MaxHeadersInSingleProof;
+	type MaxElementsInSingleProof = MaxElementsInSingleProof;
 }
 
 impl pallet_shift_session_manager::Config for Runtime {}

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -407,17 +407,20 @@ impl pallet_substrate_bridge::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
 }
 
-parameter_types! {
+use core::convert::TryInto;
+frame_support::ord_parameter_types! {
 	// We'll use the length of a session on the bridged chain as our bound since GRANDPA is
 	// guaranteed to produce a justification every session.
-	pub const MaxHeadersInSingleProof: bp_millau::BlockNumber = bp_millau::SESSION_LENGTH;
+	pub const MaxElementsInSingleProof: Option<u32> =
+		Some(bp_millau::SESSION_LENGTH.try_into().unwrap_or(u32::MAX));
 }
 
 impl pallet_finality_verifier::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
 	type HeaderChain = pallet_substrate_bridge::Module<Runtime>;
+	type AncestryProof = Vec<bp_millau::Header>;
 	type AncestryChecker = bp_header_chain::LinearAncestryChecker;
-	type MaxHeadersInSingleProof = MaxHeadersInSingleProof;
+	type MaxElementsInSingleProof = MaxElementsInSingleProof;
 }
 
 impl pallet_shift_session_manager::Config for Runtime {}

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -407,20 +407,11 @@ impl pallet_substrate_bridge::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
 }
 
-use core::convert::TryInto;
-frame_support::ord_parameter_types! {
-	// We'll use the length of a session on the bridged chain as our bound since GRANDPA is
-	// guaranteed to produce a justification every session.
-	pub const MaxElementsInSingleProof: Option<u32> =
-		Some(bp_millau::SESSION_LENGTH.try_into().unwrap_or(u32::MAX));
-}
-
 impl pallet_finality_verifier::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
 	type HeaderChain = pallet_substrate_bridge::Module<Runtime>;
 	type AncestryProof = Vec<bp_millau::Header>;
 	type AncestryChecker = bp_header_chain::LinearAncestryChecker;
-	type MaxElementsInSingleProof = MaxElementsInSingleProof;
 }
 
 impl pallet_shift_session_manager::Config for Runtime {}

--- a/modules/finality-verifier/Cargo.toml
+++ b/modules/finality-verifier/Cargo.toml
@@ -11,7 +11,6 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 finality-grandpa = { version = "0.12.3", default-features = false }
 serde = { version = "1.0", optional = true }
-num-traits = { version = "0.2", default-features = false }
 
 # Bridge Dependencies
 
@@ -40,7 +39,6 @@ std = [
 	"finality-grandpa/std",
 	"frame-support/std",
 	"frame-system/std",
-	"num-traits/std",
 	"serde",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -33,7 +33,6 @@
 #![allow(clippy::large_enum_variant)]
 
 use bp_header_chain::{justification::verify_justification, AncestryChecker, HeaderChain};
-use bp_runtime::Size;
 use bp_runtime::{Chain, HeaderOf};
 use finality_grandpa::voter_set::VoterSet;
 use frame_support::{dispatch::DispatchError, ensure, traits::Get};
@@ -69,7 +68,7 @@ pub mod pallet {
 		///
 		/// Will be used by the ancestry checker to verify that the header being finalized is
 		/// related to the best finalized header in storage.
-		type AncestryProof: Parameter + Size;
+		type AncestryProof: Parameter;
 
 		/// The type through which we will verify that a given header is related to the last
 		/// finalized header in our storage pallet.
@@ -110,7 +109,7 @@ pub mod pallet {
 			let _ = ensure_signed(origin)?;
 
 			if let Some(max_len) = T::MaxElementsInSingleProof::get() {
-				let proof_len = Size::size_hint(&ancestry_proof);
+				let proof_len = T::AncestryChecker::proof_size(&ancestry_proof);
 				frame_support::debug::trace!("Got an ancestry proof of length {:?}", proof_len);
 				ensure!(proof_len < max_len.as_(), <Error<T>>::OversizedAncestryProof);
 			};

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -77,9 +77,10 @@ pub mod pallet {
 
 		/// The maximum length of elements we can have in a single ancestry proof.
 		///
-		/// It is an optional field since some proof types might not be concered about the length of
-		/// the proof when verifying ancestry, whereas for other verification time may grow with the
-		/// size of the proof (which if left unbounded would be bad).
+		/// It is an optional field since some ancestry proof types may require iterating through
+		/// the proof during verification. If left unbounded, this could be problematic. On the
+		/// other hand, some proof structures may not care about a maximum length, in which case
+		/// this does not need to be used.
 		#[pallet::constant]
 		type MaxElementsInSingleProof: Get<Option<u32>>;
 	}
@@ -94,14 +95,11 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Verify a target header is finalized according to the given finality proof.
 		///
-		/// Will use the underlying storage pallet to fetch information about the current
+		/// It will use the underlying storage pallet to fetch information about the current
 		/// authorities and best finalized header in order to verify that the header is finalized.
 		///
-		/// If successful in verification, it will write the header as well as its ancestors (from
-		/// the given `ancestry_proof`) to the underlying storage pallet.
-		///
-		/// Note that the expected format for `ancestry_proof` is a continguous list of finalized
-		/// headers containing (current_best_finalized_header, finality_target]
+		/// If successful in verification, it will write the target header to the underlying storage
+		/// pallet.
 		#[pallet::weight(0)]
 		pub fn submit_finality_proof(
 			origin: OriginFor<T>,
@@ -157,7 +155,7 @@ pub mod pallet {
 		InvalidAuthoritySet,
 		/// Failed to write a header to the underlying header chain.
 		FailedToWriteHeader,
-		/// The given ancestry proof is too large to be verified in a single transaction.
+		/// The given ancestry proof is too large to be verified efficiently.
 		OversizedAncestryProof,
 	}
 }

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -33,10 +33,12 @@
 #![allow(clippy::large_enum_variant)]
 
 use bp_header_chain::{justification::verify_justification, AncestryChecker, HeaderChain};
+use bp_runtime::Size;
 use bp_runtime::{Chain, HeaderOf};
 use finality_grandpa::voter_set::VoterSet;
 use frame_support::{dispatch::DispatchError, ensure, traits::Get};
 use frame_system::ensure_signed;
+use num_traits::AsPrimitive;
 use sp_runtime::traits::Header as HeaderT;
 use sp_std::vec::Vec;
 
@@ -66,22 +68,20 @@ pub mod pallet {
 		/// The type of ancestry proof used by the pallet.
 		///
 		/// Will be used by the ancestry checker to verify that the header being finalized is
-		/// relllated to the best finalized header in storage.
-		///
-		/// TODO
-		/// Not quite sure how to get len() of it without explicitly...maybe not needed though..for
-		/// example, with things like MMRs does it even make sense to be checking the length bound
-		/// of the proof?
-		type AncestryProof: Parameter + IntoIterator;
+		/// related to the best finalized header in storage.
+		type AncestryProof: Parameter + Size;
 
 		/// The type through which we will verify that a given header is related to the last
 		/// finalized header in our storage pallet.
 		type AncestryChecker: AncestryChecker<<Self::BridgedChain as Chain>::Header, Self::AncestryProof>;
 
-		/// The maximum length of headers we can have in a single ancestry proof. This prevents
-		/// unbounded iteration when verifying proofs.
+		/// The maximum length of elements we can have in a single ancestry proof.
+		///
+		/// It is an optional field since some proof types might not be concered about the length of
+		/// the proof when verifying ancestry, whereas for other verification time may grow with the
+		/// size of the proof (which if left unbounded would be bad).
 		#[pallet::constant]
-		type MaxHeadersInSingleProof: Get<<Self::BridgedChain as Chain>::BlockNumber>;
+		type MaxElementsInSingleProof: Get<Option<u32>>;
 	}
 
 	#[pallet::pallet]
@@ -110,6 +110,12 @@ pub mod pallet {
 			ancestry_proof: T::AncestryProof,
 		) -> DispatchResultWithPostInfo {
 			let _ = ensure_signed(origin)?;
+
+			if let Some(max_len) = T::MaxElementsInSingleProof::get() {
+				let proof_len = Size::size_hint(&ancestry_proof);
+				frame_support::debug::trace!("Got an ancestry proof of length {:?}", proof_len);
+				ensure!(proof_len < max_len.as_(), <Error<T>>::OversizedAncestryProof);
+			};
 
 			frame_support::debug::trace!("Going to try and finalize header {:?}", finality_target);
 
@@ -272,7 +278,6 @@ mod tests {
 		})
 	}
 
-	#[ignore]
 	#[test]
 	fn disallows_ancestry_proofs_which_are_too_large() {
 		run_test(|| {
@@ -282,7 +287,7 @@ mod tests {
 			let justification = [1u8; 32].encode();
 
 			let mut ancestry_proof = vec![];
-			let max_len = <TestRuntime as Config>::MaxHeadersInSingleProof::get();
+			let max_len = <TestRuntime as Config>::MaxElementsInSingleProof::get().unwrap();
 			for i in 1..=max_len + 1 {
 				ancestry_proof.push(test_header(i as u64));
 			}

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -37,7 +37,6 @@ use bp_runtime::{Chain, HeaderOf};
 use finality_grandpa::voter_set::VoterSet;
 use frame_support::{dispatch::DispatchError, ensure, traits::Get};
 use frame_system::ensure_signed;
-use num_traits::AsPrimitive;
 use sp_runtime::traits::Header as HeaderT;
 use sp_std::vec::Vec;
 

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -79,7 +79,6 @@ impl crate::pallet::Config for TestRuntime {
 	type HeaderChain = pallet_substrate_bridge::Module<TestRuntime>;
 	type AncestryProof = Vec<<Self::BridgedChain as Chain>::Header>;
 	type AncestryChecker = Checker<<Self::BridgedChain as Chain>::Header, Self::AncestryProof>;
-	type MaxElementsInSingleProof = MaxElementsInSingleProof;
 }
 
 #[derive(Debug)]
@@ -98,10 +97,6 @@ pub struct Checker<H, P>(std::marker::PhantomData<(H, P)>);
 impl<H> bp_header_chain::AncestryChecker<H, Vec<H>> for Checker<H, Vec<H>> {
 	fn are_ancestors(_ancestor: &H, _child: &H, proof: &Vec<H>) -> bool {
 		!proof.is_empty()
-	}
-
-	fn proof_size(proof: &Vec<H>) -> usize {
-		proof.len()
 	}
 }
 

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -99,6 +99,10 @@ impl<H> bp_header_chain::AncestryChecker<H, Vec<H>> for Checker<H, Vec<H>> {
 	fn are_ancestors(_ancestor: &H, _child: &H, proof: &Vec<H>) -> bool {
 		!proof.is_empty()
 	}
+
+	fn proof_size(proof: &Vec<H>) -> usize {
+		proof.len()
+	}
 }
 
 pub fn run_test<T>(test: impl FnOnce() -> T) -> T {

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -71,7 +71,7 @@ impl pallet_substrate_bridge::Config for TestRuntime {
 }
 
 parameter_types! {
-	pub const MaxHeadersInSingleProof: u8 = 5;
+	pub const MaxElementsInSingleProof: Option<u32> = Some(5);
 }
 
 impl crate::pallet::Config for TestRuntime {
@@ -79,7 +79,7 @@ impl crate::pallet::Config for TestRuntime {
 	type HeaderChain = pallet_substrate_bridge::Module<TestRuntime>;
 	type AncestryProof = Vec<<Self::BridgedChain as Chain>::Header>;
 	type AncestryChecker = Checker<<Self::BridgedChain as Chain>::Header, Self::AncestryProof>;
-	type MaxHeadersInSingleProof = MaxHeadersInSingleProof;
+	type MaxElementsInSingleProof = MaxElementsInSingleProof;
 }
 
 #[derive(Debug)]

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -77,7 +77,8 @@ parameter_types! {
 impl crate::pallet::Config for TestRuntime {
 	type BridgedChain = TestBridgedChain;
 	type HeaderChain = pallet_substrate_bridge::Module<TestRuntime>;
-	type AncestryChecker = Checker<<Self::BridgedChain as Chain>::Header, Vec<<Self::BridgedChain as Chain>::Header>>;
+	type AncestryProof = Vec<<Self::BridgedChain as Chain>::Header>;
+	type AncestryChecker = Checker<<Self::BridgedChain as Chain>::Header, Self::AncestryProof>;
 	type MaxHeadersInSingleProof = MaxHeadersInSingleProof;
 }
 

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -375,6 +375,9 @@ impl<T: Config> bp_header_chain::HeaderChain<BridgedHeader<T>, sp_runtime::Dispa
 		PalletStorage::<T>::new().current_authority_set()
 	}
 
+	// TODO: Will want to change this to only write a single finalized header instead of a chain of
+	// headers. This is because certain proof types (like MMRs) will not contain a contiguous set of
+	// headers
 	fn append_finalized_chain(
 		headers: impl IntoIterator<Item = BridgedHeader<T>>,
 	) -> Result<(), sp_runtime::DispatchError> {
@@ -394,6 +397,11 @@ impl<T: Config> bp_header_chain::HeaderChain<BridgedHeader<T>, sp_runtime::Dispa
 		}
 
 		Ok(())
+	}
+
+	fn append_header(header: BridgedHeader<T>) {
+		let mut storage = PalletStorage::<T>::new();
+		import_header_unchecked::<_, T>(&mut storage, header);
 	}
 }
 

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -906,33 +906,12 @@ mod tests {
 			init_with_origin(Origin::root()).unwrap();
 			let storage = PalletStorage::<TestRuntime>::new();
 
-			let child = test_header(2);
-			let header = test_header(3);
+			let header = test_header(2);
+			Module::<TestRuntime>::append_header(header.clone());
 
-			let header_chain = vec![child.clone(), header.clone()];
-			assert_ok!(Module::<TestRuntime>::append_finalized_chain(header_chain));
-
-			assert!(storage.header_by_hash(child.hash()).unwrap().is_finalized);
 			assert!(storage.header_by_hash(header.hash()).unwrap().is_finalized);
-
 			assert_eq!(storage.best_finalized_header().header, header);
 			assert_eq!(storage.best_headers()[0].hash, header.hash());
-		})
-	}
-
-	#[test]
-	fn prevents_unchecked_header_import_if_headers_are_unrelated() {
-		run_test(|| {
-			init_with_origin(Origin::root()).unwrap();
-
-			// Pallet is expecting test_header(2) as the child
-			let not_a_child = test_header(3);
-			let header_chain = vec![not_a_child];
-
-			assert_noop!(
-				Module::<TestRuntime>::append_finalized_chain(header_chain),
-				Error::<TestRuntime>::NotDescendant,
-			);
 		})
 	}
 
@@ -951,7 +930,7 @@ mod tests {
 			header.digest = fork_tests::change_log(0);
 
 			// Let's import our test header
-			assert_ok!(Module::<TestRuntime>::append_finalized_chain(vec![header.clone()]));
+			Module::<TestRuntime>::append_header(header.clone());
 
 			// Make sure that our header is the best finalized
 			assert_eq!(storage.best_finalized_header().header, header);
@@ -981,8 +960,8 @@ mod tests {
 			let header = test_header(3);
 
 			// Let's import our test headers
-			let header_chain = vec![schedules_change, header.clone()];
-			assert_ok!(Module::<TestRuntime>::append_finalized_chain(header_chain));
+			Module::<TestRuntime>::append_header(schedules_change);
+			Module::<TestRuntime>::append_header(header.clone());
 
 			// Make sure that our header is the best finalized
 			assert_eq!(storage.best_finalized_header().header, header);
@@ -1022,8 +1001,7 @@ mod tests {
 
 			// We are expecting an authority set change at height 2, so this header should enact
 			// that upon being imported.
-			let header_chain = vec![test_header(2)];
-			assert_ok!(Module::<TestRuntime>::append_finalized_chain(header_chain));
+			Module::<TestRuntime>::append_header(test_header(2));
 
 			// Make sure that the authority set actually changed upon importing our header
 			assert_eq!(

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -375,33 +375,8 @@ impl<T: Config> bp_header_chain::HeaderChain<BridgedHeader<T>, sp_runtime::Dispa
 		PalletStorage::<T>::new().current_authority_set()
 	}
 
-	// TODO: Will want to change this to only write a single finalized header instead of a chain of
-	// headers. This is because certain proof types (like MMRs) will not contain a contiguous set of
-	// headers
-	fn append_finalized_chain(
-		headers: impl IntoIterator<Item = BridgedHeader<T>>,
-	) -> Result<(), sp_runtime::DispatchError> {
-		let mut storage = PalletStorage::<T>::new();
-
-		let mut header_iter = headers.into_iter().peekable();
-		let first_header = header_iter.peek().ok_or(Error::<T>::NotDescendant)?;
-
-		// Quick ancestry check to make sure we're not writing complete nonsense to storage
-		ensure!(
-			<BestFinalized<T>>::get() == *first_header.parent_hash(),
-			Error::<T>::NotDescendant,
-		);
-
-		for header in header_iter {
-			import_header_unchecked::<_, T>(&mut storage, header);
-		}
-
-		Ok(())
-	}
-
 	fn append_header(header: BridgedHeader<T>) {
-		let mut storage = PalletStorage::<T>::new();
-		import_header_unchecked::<_, T>(&mut storage, header);
+		import_header_unchecked::<_, T>(&mut PalletStorage::<T>::new(), header);
 	}
 }
 

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -85,6 +85,9 @@ pub trait HeaderChain<H, E> {
 	/// This function should fail if the first header is not a child of the current best finalized
 	/// header known to the underlying pallet storage.
 	fn append_finalized_chain(headers: impl IntoIterator<Item = H>) -> Result<(), E>;
+
+	/// TODO: This is a replacement for append_finalized_chain()
+	fn append_header(header: H);
 }
 
 impl<H: Default, E> HeaderChain<H, E> for () {
@@ -98,6 +101,10 @@ impl<H: Default, E> HeaderChain<H, E> for () {
 
 	fn append_finalized_chain(_headers: impl IntoIterator<Item = H>) -> Result<(), E> {
 		Ok(())
+	}
+
+	fn append_header(_header: H) {
+		()
 	}
 }
 

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -97,20 +97,11 @@ impl<H: Default, E> HeaderChain<H, E> for () {
 pub trait AncestryChecker<H, P> {
 	/// Is the child header a descendant of the ancestor header?
 	fn are_ancestors(ancestor: &H, child: &H, proof: &P) -> bool;
-
-	/// The number of elements that the ancestry proof contains.
-	///
-	/// May be used to prevent long proofs from being verified in the runtime.
-	fn proof_size(proof: &P) -> usize;
 }
 
 impl<H, P> AncestryChecker<H, P> for () {
 	fn are_ancestors(_ancestor: &H, _child: &H, _proof: &P) -> bool {
 		true
-	}
-
-	fn proof_size(_proof: &P) -> usize {
-		0
 	}
 }
 
@@ -144,10 +135,6 @@ impl<H: HeaderT> AncestryChecker<H, Vec<H>> for LinearAncestryChecker {
 		}
 
 		true
-	}
-
-	fn proof_size(proof: &Vec<H>) -> usize {
-		proof.len()
 	}
 }
 

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -90,9 +90,7 @@ impl<H: Default, E> HeaderChain<H, E> for () {
 		AuthoritySet::default()
 	}
 
-	fn append_header(_header: H) {
-		()
-	}
+	fn append_header(_header: H) {}
 }
 
 /// A trait for checking if a given child header is a direct descendant of an ancestor.

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -69,7 +69,7 @@ pub trait InclusionProofVerifier {
 	fn verify_transaction_inclusion_proof(proof: &Self::TransactionInclusionProof) -> Option<Self::Transaction>;
 }
 
-/// A base trait for pallets which want to keep track of a full set of headers from a bridged chain.
+/// A trait for pallets which want to keep track of finalized headers from a bridged chain.
 pub trait HeaderChain<H, E> {
 	/// Get the best finalized header known to the header chain.
 	fn best_finalized() -> H;
@@ -77,16 +77,7 @@ pub trait HeaderChain<H, E> {
 	/// Get the best authority set known to the header chain.
 	fn authority_set() -> AuthoritySet;
 
-	/// Write a finalized chain of headers to the underlying pallet storage.
-	///
-	/// It is assumed that each header in this chain been finalized, and that the given headers are
-	/// in order (e.g vec![header_1, header_2, ..., header_n]).
-	///
-	/// This function should fail if the first header is not a child of the current best finalized
-	/// header known to the underlying pallet storage.
-	fn append_finalized_chain(headers: impl IntoIterator<Item = H>) -> Result<(), E>;
-
-	/// TODO: This is a replacement for append_finalized_chain()
+	/// Write a header finalized by GRANDPA to the underlying pallet storage.
 	fn append_header(header: H);
 }
 
@@ -97,10 +88,6 @@ impl<H: Default, E> HeaderChain<H, E> for () {
 
 	fn authority_set() -> AuthoritySet {
 		AuthoritySet::default()
-	}
-
-	fn append_finalized_chain(_headers: impl IntoIterator<Item = H>) -> Result<(), E> {
-		Ok(())
 	}
 
 	fn append_header(_header: H) {

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -97,11 +97,20 @@ impl<H: Default, E> HeaderChain<H, E> for () {
 pub trait AncestryChecker<H, P> {
 	/// Is the child header a descendant of the ancestor header?
 	fn are_ancestors(ancestor: &H, child: &H, proof: &P) -> bool;
+
+	/// The number of elements that the ancestry proof contains.
+	///
+	/// May be used to prevent long proofs from being verified in the runtime.
+	fn proof_size(proof: &P) -> usize;
 }
 
 impl<H, P> AncestryChecker<H, P> for () {
 	fn are_ancestors(_ancestor: &H, _child: &H, _proof: &P) -> bool {
 		true
+	}
+
+	fn proof_size(_proof: &P) -> usize {
+		0
 	}
 }
 
@@ -135,6 +144,10 @@ impl<H: HeaderT> AncestryChecker<H, Vec<H>> for LinearAncestryChecker {
 		}
 
 		true
+	}
+
+	fn proof_size(proof: &Vec<H>) -> usize {
+		proof.len()
 	}
 }
 

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -110,3 +110,10 @@ pub trait Size {
 	/// accurate.
 	fn size_hint(&self) -> u32;
 }
+
+impl<T> Size for Vec<T> {
+	fn size_hint(&self) -> u32 {
+		use core::convert::TryFrom;
+		u32::try_from(self.len()).unwrap_or(u32::MAX)
+	}
+}

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -110,10 +110,3 @@ pub trait Size {
 	/// accurate.
 	fn size_hint(&self) -> u32;
 }
-
-impl<T> Size for sp_std::vec::Vec<T> {
-	fn size_hint(&self) -> u32 {
-		use core::convert::TryFrom;
-		u32::try_from(self.len()).unwrap_or(u32::MAX)
-	}
-}

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub trait Size {
 	fn size_hint(&self) -> u32;
 }
 
-impl<T> Size for Vec<T> {
+impl<T> Size for sp_std::vec::Vec<T> {
 	fn size_hint(&self) -> u32 {
 		use core::convert::TryFrom;
 		u32::try_from(self.len()).unwrap_or(u32::MAX)


### PR DESCRIPTION
This PR removes the need to import every single header to the base bridge pallet from the
finality verifier pallet. By doing this we are opening the doors to "sparse" proof
formats to be used as ancestry proofs. Some examples of sparse proofs include storage
proofs and MMRs.