### PR TITLE
Temporarily Ignore RUSTSEC-2021-0020

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -2602,7 +2602,7 @@ dependencies = [
  "bytes 0.5.6",
  "ct-logs",
  "futures-util",
- "hyper 0.13.9",
+ "hyper 0.13.10",
  "log",
  "rustls 0.18.1",
  "rustls-native-certs",
@@ -2970,7 +2970,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "globset",
  "hashbrown 0.7.2",
- "hyper 0.13.9",
+ "hyper 0.13.10",
  "jsonrpsee-proc-macros",
  "lazy_static",
  "log",
@@ -6423,7 +6423,7 @@ dependencies = [
  "fnv",
  "futures 0.3.12",
  "futures-timer 3.0.2",
- "hyper 0.13.9",
+ "hyper 0.13.10",
  "hyper-rustls",
  "log",
  "num_cpus",
@@ -7904,7 +7904,7 @@ dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.9",
+ "hyper 0.13.10",
  "log",
  "prometheus",
  "tokio 0.2.24",

--- a/deny.toml
+++ b/deny.toml
@@ -55,7 +55,10 @@ ignore = [
 	"RUSTSEC-2021-0013",
 	# We need to wait until Substrate updates their `libp2p` dependency to fix this.
 	# TODO: See issue #681: https://github.com/paritytech/parity-bridges-common/issues/681
-	"RUSTSEC-2020-0123"
+	"RUSTSEC-2020-0123",
+	# We need to wait until Substrate updates their `hyper` dependency to fix this.
+	# TODO: See issue #710: https://github.com/paritytech/parity-bridges-common/issues/681
+	"RUSTSEC-2021-0020",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
Builds with the CI are broken again. See #710 for more details.
