### PR TITLE
Rate Limiting Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4381,6 +4381,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-rate-limiter"
+version = "0.1.0"
+dependencies = [
+ "bp-test-utils",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec 1.3.6",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-session"
 version = "2.0.1"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#0b0d124d5f9be89f614f2be8e9da038fcb9f540e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 	"modules/ethereum-contract/builtin",
 	"modules/finality-verifier",
 	"modules/currency-exchange",
+	"modules/rate-limiter",
 	"relays/ethereum",
 	"relays/substrate",
 ]

--- a/modules/rate-limiter/Cargo.toml
+++ b/modules/rate-limiter/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "pallet-rate-limiter"
+description = "A Substrate Runtime module that limits the number of Cals allowed in a given window."
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
+serde = { version = "1.0", optional = true }
+
+# Substrate Dependencies
+
+frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+
+[dev-dependencies]
+bp-test-utils = {path = "../../primitives/test-utils" }
+sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"serde",
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/modules/rate-limiter/src/lib.rs
+++ b/modules/rate-limiter/src/lib.rs
@@ -40,14 +40,12 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		/// The length of time over which requests should be tracked.
-		// TODO: Maybe don't use T::BlockNumber for the request count
 		#[pallet::constant]
-		type WindowLength: Get<<Self as frame_system::Config>::BlockNumber>;
+		type WindowLength: Get<Self::BlockNumber>;
 
 		/// The maximum number of requests allowed in a given WindowLength.
-		// TODO: Maybe don't use T::BlockNumber for the request count
 		#[pallet::constant]
-		type MaxRequests: Get<<Self as frame_system::Config>::BlockNumber>;
+		type MaxRequests: Get<u32>;
 	}
 
 	#[pallet::pallet]
@@ -85,7 +83,10 @@ pub mod pallet {
 			let request_count: <T as frame_system::Config>::BlockNumber =
 				prev_count * ((T::WindowLength::get() - elapsed_time) / T::WindowLength::get()) + curr_count;
 
-			ensure!(request_count < T::MaxRequests::get(), <Error<T>>::TooManyRequests);
+			ensure!(
+				request_count < T::MaxRequests::get().into(),
+				<Error<T>>::TooManyRequests
+			);
 
 			<CurrentWindowReqCount<T>>::mutate(|count| *count += 1);
 

--- a/modules/rate-limiter/src/lib.rs
+++ b/modules/rate-limiter/src/lib.rs
@@ -25,8 +25,8 @@ use frame_system::ensure_signed;
 use sp_runtime::traits::{Header as HeaderT, One};
 use sp_std::vec::Vec;
 
-// #[cfg(test)]
-// mod mock;
+#[cfg(test)]
+mod mock;
 
 // Re-export in crate namespace for `construct_runtime!`
 pub use pallet::*;
@@ -125,12 +125,20 @@ pub mod pallet {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::mock::{run_test, test_header, Origin, TestRuntime};
+	use crate::mock::{run_test, Origin, TestRuntime};
 	use codec::Encode;
 	use frame_support::{assert_err, assert_ok};
 
+	fn tick() {
+		let current_number = frame_system::Module::<TestRuntime>::block_number();
+		frame_system::Module::<TestRuntime>::set_block_number(current_number + 1);
+	}
+
 	#[test]
 	fn it_works() {
-		run_test(|| {})
+		run_test(|| {
+			tick();
+			assert_eq!(frame_system::Module::<TestRuntime>::block_number(), 1);
+		})
 	}
 }

--- a/modules/rate-limiter/src/lib.rs
+++ b/modules/rate-limiter/src/lib.rs
@@ -1,0 +1,92 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A pallet for limiting the number of times a Call can be dispatched in a given number of time.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+// Runtime-generated enums
+#![allow(clippy::large_enum_variant)]
+
+use frame_support::{dispatch::DispatchError, ensure, traits::Get};
+use frame_system::ensure_signed;
+use sp_runtime::traits::Header as HeaderT;
+use sp_std::vec::Vec;
+
+// #[cfg(test)]
+// mod mock;
+
+// Re-export in crate namespace for `construct_runtime!`
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The length of time over which requests should be tracked.
+		#[pallet::constant]
+		type WindowLength: Get<u32>;
+
+		/// The maximum number of requests allowed in a given WindowLength.
+		#[pallet::constant]
+		type MaxRequests: Get<u32>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_initialize(_n: T::BlockNumber) -> frame_support::weights::Weight {
+			todo!()
+		}
+
+		fn on_finalize(_n: T::BlockNumber) {
+			todo!()
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(0)]
+		pub fn dispatch_call(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			let _ = ensure_signed(origin)?;
+			Ok(().into())
+		}
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// There are too many requests for the current window to handle.
+		TooManyRequests,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::{run_test, test_header, Origin, TestRuntime};
+	use codec::Encode;
+	use frame_support::{assert_err, assert_ok};
+
+	#[test]
+	fn it_works() {
+		run_test(|| {})
+	}
+}

--- a/modules/rate-limiter/src/lib.rs
+++ b/modules/rate-limiter/src/lib.rs
@@ -20,10 +20,8 @@
 // Runtime-generated enums
 #![allow(clippy::large_enum_variant)]
 
-use frame_support::{dispatch::DispatchError, ensure, traits::Get};
+use frame_support::{ensure, traits::Get};
 use frame_system::ensure_signed;
-use sp_runtime::traits::{Header as HeaderT, One};
-use sp_std::vec::Vec;
 
 #[cfg(test)]
 mod mock;
@@ -135,7 +133,6 @@ pub mod pallet {
 mod tests {
 	use super::*;
 	use crate::mock::{run_test, Origin, TestRuntime};
-	use codec::Encode;
 	use frame_support::{assert_err, assert_ok};
 
 	fn next_block() {

--- a/modules/rate-limiter/src/mock.rs
+++ b/modules/rate-limiter/src/mock.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate as rate_limiter;
 use crate::*;
 
 use frame_support::{impl_outer_origin, parameter_types, weights::Weight};

--- a/modules/rate-limiter/src/mock.rs
+++ b/modules/rate-limiter/src/mock.rs
@@ -1,0 +1,80 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate as rate_limiter;
+use crate::*;
+
+use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
+use sp_runtime::{
+	testing::{Header, H256},
+	traits::{BlakeTwo256, IdentityLookup},
+	Perbill,
+};
+
+pub type AccountId = u64;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct TestRuntime;
+
+impl_outer_origin! {
+	pub enum Origin for TestRuntime where system = frame_system {}
+}
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Config for TestRuntime {
+	type Origin = Origin;
+	type Index = u64;
+	type Call = ();
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = ();
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type BaseCallFilter = ();
+	type SystemWeightInfo = ();
+	type DbWeight = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type SS58Prefix = ();
+}
+
+parameter_types! {
+	pub const WindowLength: u32 = 3;
+	pub const MaxRequests: u32 = 2;
+}
+
+impl Config for TestRuntime {
+	type WindowLength = WindowLength;
+	type MaxRequests = MaxRequests;
+}
+
+pub fn run_test<T>(test: impl FnOnce() -> T) -> T {
+	sp_io::TestExternalities::new(Default::default()).execute_with(test)
+}

--- a/modules/rate-limiter/src/mock.rs
+++ b/modules/rate-limiter/src/mock.rs
@@ -66,7 +66,7 @@ impl frame_system::Config for TestRuntime {
 }
 
 parameter_types! {
-	pub const WindowLength: u32 = 3;
+	pub const WindowLength: u32 = 2;
 	pub const MaxRequests: u32 = 2;
 }
 


### PR DESCRIPTION
This PR adds a pallet which is meant to provide rate limiting capabilities. The idea
behind it is that we will only allow a certain number of requests (in our case `Call`s)
over a pre-defined window of time (some number of blocks). If we get any requests once
the limit of the rolling window has been saturated they are denied.

As for the implementation, I've gone with a sliding window implementation. This is
because it is pretty simple and reasonably accurate despite being an approximation. I
considered a fixed window approach which would've been simpler, but it has problems at
the window boundaries (people can wait for a window reset and stampede the pallet at that
point in time). See [here](https://nlogn.in/design-a-scalable-rate-limiting-algorithm-system-design/) for some brief explanations of different rate-limiting algorithms.

I initially broke this out into a standalone pallet to avoid the "noise" of working
either in the Substrate or Finality pallets, but I realized that having it standalone
could be benefitial. I imagine (with a bit of work) it could be used sort of like the
Proxy or Sudo pallets are used today - they wrap a `Call`, and ensure that some
invariant(s) holds before dispatching the inner `Call`.

For today though, the main goal of this is to help address https://github.com/paritytech/srlabs_findings/issues/47.
