### PR TITLE
Limit number of pending messages at outbound lane

### DIFF
--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -163,6 +163,16 @@ impl messages::ChainWithMessageLanes for Millau {
 	type MessageLaneInstance = pallet_message_lane::DefaultInstance;
 }
 
+impl messages::ThisChainWithMessageLanes for Millau {
+	fn is_outbound_lane_enabled(lane: &LaneId) -> bool {
+		*lane == LaneId::default()
+	}
+
+	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {
+		MessageNonce::MAX
+	}
+}
+
 /// Rialto chain from message lane point of view.
 #[derive(RuntimeDebug, Clone, Copy)]
 pub struct Rialto;

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -164,6 +164,16 @@ impl messages::ChainWithMessageLanes for Rialto {
 	type MessageLaneInstance = crate::WithMillauMessageLaneInstance;
 }
 
+impl messages::ThisChainWithMessageLanes for Rialto {
+	fn is_outbound_lane_enabled(lane: &LaneId) -> bool {
+		*lane == LaneId::default()
+	}
+
+	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {
+		MessageNonce::MAX
+	}
+}
+
 /// Millau chain from message lane point of view.
 #[derive(RuntimeDebug, Clone, Copy)]
 pub struct Millau;

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -44,7 +44,7 @@ pub trait MessageBridge {
 	const RELAYER_FEE_PERCENT: u32;
 
 	/// This chain in context of message bridge.
-	type ThisChain: ChainWithMessageLanes;
+	type ThisChain: ThisChainWithMessageLanes;
 	/// Bridged chain in context of message bridge.
 	type BridgedChain: ChainWithMessageLanes;
 
@@ -102,6 +102,17 @@ pub trait ChainWithMessageLanes {
 
 	/// Instance of the message-lane pallet.
 	type MessageLaneInstance: Instance;
+}
+
+/// This chain that has `message-lane` and `call-dispatch` modules.
+pub trait ThisChainWithMessageLanes: ChainWithMessageLanes {
+	/// Are we accepting any messages to the given lane?
+	fn is_outbound_lane_enabled(lane: &LaneId) -> bool;
+
+	/// Maximal number of pending (not yet delivered) messages at this chain.
+	///
+	/// Any messages over this limit, will be rejected.
+	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce;
 }
 
 pub(crate) type ThisChain<B> = <B as MessageBridge>::ThisChain;
@@ -165,10 +176,24 @@ pub mod source {
 	/// 'Parsed' message delivery proof - inbound lane id and its state.
 	pub type ParsedMessagesDeliveryProofFromBridgedChain<B> = (LaneId, InboundLaneData<AccountIdOf<ThisChain<B>>>);
 
-	/// Message verifier that requires submitter to pay minimal delivery and dispatch fee.
+	/// Message verifier that is doing all basic checks.
+	///
+	/// This verifier assumes following:
+	///
+	/// - all message lanes are equivalent, so all checks are the same;
+	/// - messages are being dispatched using `pallet-bridge-call-dispatch` pallet on the target chain.
+	///
+	/// Following checks are made:
+	///
+	/// - message is rejected if its lane is currently blocked;
+	/// - message is rejected if there are too many pending (undelivered) messages at the outbound lane;
+	/// - check that the sender has rights to dispatch the call on target chain using provided dispatch origin;
+	/// - check that the sender has paid enough funds for both message delivery and dispatch.
 	#[derive(RuntimeDebug)]
 	pub struct FromThisChainMessageVerifier<B>(PhantomData<B>);
 
+	pub(crate) const OUTBOUND_LANE_DISABLED: &str = "The outbound message lane is disabled.";
+	pub(crate) const TOO_MANY_PENDING_MESSAGES: &str = "Too many pending messages at the lane.";
 	pub(crate) const BAD_ORIGIN: &str = "Unable to match the source origin to expected target origin.";
 	pub(crate) const TOO_LOW_FEE: &str = "Provided fee is below minimal threshold required by the lane.";
 
@@ -183,9 +208,24 @@ pub mod source {
 		fn verify_message(
 			submitter: &Sender<AccountIdOf<ThisChain<B>>>,
 			delivery_and_dispatch_fee: &BalanceOf<ThisChain<B>>,
-			_lane: &LaneId,
+			lane: &LaneId,
+			lane_outbound_data: &OutboundLaneData,
 			payload: &FromThisChainMessagePayload<B>,
 		) -> Result<(), Self::Error> {
+			// reject message if lane is blocked
+			if !ThisChain::<B>::is_outbound_lane_enabled(lane) {
+				return Err(OUTBOUND_LANE_DISABLED);
+			}
+
+			// reject message if there are too many pending messages at this lane
+			let max_pending_messages = ThisChain::<B>::maximal_pending_messages_at_outbound_lane();
+			let pending_messages = lane_outbound_data
+				.latest_generated_nonce
+				.saturating_sub(lane_outbound_data.latest_received_nonce);
+			if pending_messages > max_pending_messages {
+				return Err(TOO_MANY_PENDING_MESSAGES);
+			}
+
 			// Do the dispatch-specific check. We assume that the target chain uses
 			// `CallDispatch`, so we verify the message accordingly.
 			pallet_bridge_call_dispatch::verify_message_origin(submitter, payload).map_err(|_| BAD_ORIGIN)?;
@@ -754,6 +794,16 @@ mod tests {
 		type MessageLaneInstance = pallet_message_lane::DefaultInstance;
 	}
 
+	impl ThisChainWithMessageLanes for ThisChain {
+		fn is_outbound_lane_enabled(lane: &LaneId) -> bool {
+			lane == TEST_LANE_ID
+		}
+
+		fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {
+			MAXIMAL_PENDING_MESSAGES_AT_TEST_LANE
+		}
+	}
+
 	struct BridgedChain;
 
 	impl ChainWithMessageLanes for BridgedChain {
@@ -766,6 +816,20 @@ mod tests {
 		type Balance = BridgedChainBalance;
 
 		type MessageLaneInstance = pallet_message_lane::DefaultInstance;
+	}
+
+	impl ThisChainWithMessageLanes for BridgedChain {
+		fn is_outbound_lane_enabled(_lane: &LaneId) -> bool {
+			unreachable!()
+		}
+
+		fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {
+			unreachable!()
+		}
+	}
+
+	fn test_lane_outbound_data() -> OutboundLaneData {
+		OutboundLaneData::default()
 	}
 
 	#[test]
@@ -799,18 +863,23 @@ mod tests {
 	}
 
 	const TEST_LANE_ID: &LaneId = b"test";
+	const MAXIMAL_PENDING_MESSAGES_AT_TEST_LANE: MessageNonce = 32;
+
+	fn regular_outbound_message_payload() -> source::FromThisChainMessagePayload<OnThisChainBridge> {
+		source::FromThisChainMessagePayload::<OnThisChainBridge> {
+			spec_version: 1,
+			weight: 100,
+			origin: pallet_bridge_call_dispatch::CallOrigin::SourceRoot,
+			call: vec![42],
+		}
+	}
 
 	#[test]
 	fn message_fee_is_checked_by_verifier() {
 		const EXPECTED_MINIMAL_FEE: u32 = 5500;
 
 		// payload of the This -> Bridged chain message
-		let payload = source::FromThisChainMessagePayload::<OnThisChainBridge> {
-			spec_version: 1,
-			weight: 100,
-			origin: pallet_bridge_call_dispatch::CallOrigin::SourceRoot,
-			call: vec![42],
-		};
+		let payload = regular_outbound_message_payload();
 
 		// let's check if estimation matching hardcoded value
 		assert_eq!(
@@ -827,6 +896,7 @@ mod tests {
 				&Sender::Root,
 				&ThisChainBalance(1),
 				&TEST_LANE_ID,
+				&test_lane_outbound_data(),
 				&payload,
 			),
 			Err(source::TOO_LOW_FEE)
@@ -836,6 +906,7 @@ mod tests {
 				&Sender::Root,
 				&ThisChainBalance(1_000_000),
 				&TEST_LANE_ID,
+				&test_lane_outbound_data(),
 				&payload,
 			)
 			.is_ok(),
@@ -858,6 +929,7 @@ mod tests {
 				&Sender::Signed(ThisChainAccountId(0)),
 				&ThisChainBalance(1_000_000),
 				&TEST_LANE_ID,
+				&test_lane_outbound_data(),
 				&payload,
 			),
 			Err(source::BAD_ORIGIN)
@@ -867,6 +939,7 @@ mod tests {
 				&Sender::None,
 				&ThisChainBalance(1_000_000),
 				&TEST_LANE_ID,
+				&test_lane_outbound_data(),
 				&payload,
 			),
 			Err(source::BAD_ORIGIN)
@@ -876,6 +949,7 @@ mod tests {
 				&Sender::Root,
 				&ThisChainBalance(1_000_000),
 				&TEST_LANE_ID,
+				&test_lane_outbound_data(),
 				&payload,
 			)
 			.is_ok(),
@@ -898,6 +972,7 @@ mod tests {
 				&Sender::Signed(ThisChainAccountId(0)),
 				&ThisChainBalance(1_000_000),
 				&TEST_LANE_ID,
+				&test_lane_outbound_data(),
 				&payload,
 			),
 			Err(source::BAD_ORIGIN)
@@ -907,9 +982,42 @@ mod tests {
 				&Sender::Signed(ThisChainAccountId(1)),
 				&ThisChainBalance(1_000_000),
 				&TEST_LANE_ID,
+				&test_lane_outbound_data(),
 				&payload,
 			)
 			.is_ok(),
+		);
+	}
+
+	#[test]
+	fn message_is_rejected_when_sent_using_disabled_lane() {
+		assert_eq!(
+			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
+				&Sender::Root,
+				&ThisChainBalance(1_000_000),
+				b"dsbl",
+				&test_lane_outbound_data(),
+				&regular_outbound_message_payload(),
+			),
+			Err(source::OUTBOUND_LANE_DISABLED)
+		);
+	}
+
+	#[test]
+	fn message_is_rejected_when_there_are_too_many_pending_messages_at_outbound_lane() {
+		assert_eq!(
+			source::FromThisChainMessageVerifier::<OnThisChainBridge>::verify_message(
+				&Sender::Root,
+				&ThisChainBalance(1_000_000),
+				&TEST_LANE_ID,
+				&OutboundLaneData {
+					latest_received_nonce: 100,
+					latest_generated_nonce: 100 + MAXIMAL_PENDING_MESSAGES_AT_TEST_LANE + 1,
+					..Default::default()
+				},
+				&regular_outbound_message_payload(),
+			),
+			Err(source::TOO_MANY_PENDING_MESSAGES)
 		);
 	}
 

--- a/modules/message-lane/src/lib.rs
+++ b/modules/message-lane/src/lib.rs
@@ -292,10 +292,12 @@ decl_module! {
 				})?;
 
 			// now let's enforce any additional lane rules
+			let mut lane = outbound_lane::<T, I>(lane_id);
 			T::LaneMessageVerifier::verify_message(
 				&submitter,
 				&delivery_and_dispatch_fee,
 				&lane_id,
+				&lane.data(),
 				&payload,
 			).map_err(|err| {
 				frame_support::debug::trace!(
@@ -325,7 +327,6 @@ decl_module! {
 			})?;
 
 			// finally, save message in outbound storage and emit event
-			let mut lane = outbound_lane::<T, I>(lane_id);
 			let encoded_payload = payload.encode();
 			let encoded_payload_len = encoded_payload.len();
 			let nonce = lane.send_message(MessageData {

--- a/modules/message-lane/src/mock.rs
+++ b/modules/message-lane/src/mock.rs
@@ -21,7 +21,7 @@ use bp_message_lane::{
 		LaneMessageVerifier, MessageDeliveryAndDispatchPayment, RelayersRewards, Sender, TargetHeaderChain,
 	},
 	target_chain::{DispatchMessage, MessageDispatch, ProvedLaneMessages, ProvedMessages, SourceHeaderChain},
-	InboundLaneData, LaneId, Message, MessageData, MessageKey, MessageNonce,
+	InboundLaneData, LaneId, Message, MessageData, MessageKey, MessageNonce, OutboundLaneData,
 };
 use bp_runtime::Size;
 use codec::{Decode, Encode};
@@ -237,6 +237,7 @@ impl LaneMessageVerifier<AccountId, TestPayload, TestMessageFee> for TestLaneMes
 		_submitter: &Sender<AccountId>,
 		delivery_and_dispatch_fee: &TestMessageFee,
 		_lane: &LaneId,
+		_lane_outbound_data: &OutboundLaneData,
 		_payload: &TestPayload,
 	) -> Result<(), Self::Error> {
 		if *delivery_and_dispatch_fee != 0 {

--- a/modules/message-lane/src/outbound_lane.rs
+++ b/modules/message-lane/src/outbound_lane.rs
@@ -49,6 +49,11 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 		OutboundLane { storage }
 	}
 
+	/// Get this lane data.
+	pub fn data(&self) -> OutboundLaneData {
+		self.storage.data()
+	}
+
 	/// Send message over lane.
 	///
 	/// Returns new message nonce.

--- a/primitives/message-lane/src/source_chain.rs
+++ b/primitives/message-lane/src/source_chain.rs
@@ -16,7 +16,7 @@
 
 //! Primitives of message lane module, that are used on the source chain.
 
-use crate::{InboundLaneData, LaneId, MessageNonce};
+use crate::{InboundLaneData, LaneId, MessageNonce, OutboundLaneData};
 
 use frame_support::{Parameter, RuntimeDebug};
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug};
@@ -85,6 +85,7 @@ pub trait LaneMessageVerifier<Submitter, Payload, Fee> {
 		submitter: &Sender<Submitter>,
 		delivery_and_dispatch_fee: &Fee,
 		lane: &LaneId,
+		outbound_data: &OutboundLaneData,
 		payload: &Payload,
 	) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
from discussion inside #560 
Decay strategy may be implemented after migrating to offchain storage - then the most of changes will be in the relay code.

This PR introduces two additional checks in our default `LaneMessageVerifier`. The checks are:
1) messages that are being sent through the disabled lane are immediately rejected. For testnets I've only enabled lane `[0, 0, 0, 0]` - we don't use any other lanes here. But may change to whitelist all lanes, if you're doing some other tests there. For P+K I suggest to enable single lane initially. Then, in some later upgrades - enable all (or more lanes);
2) if there are too many pending (aka undelivered) messages at outbound lane, message is immediately rejected. For testnets there's no limit - I'm often submit a lot of messages. For P+K I suggest this being some `N * BridgedChain::MaxUnconfirmedMessagesAtInboundLane` (this constant may even come from storage for easier upgrades). This would also require support in ML clients (like in our UI) - we should get confirmation if we're close to limit + it shall warn user that his message may be rejected. And we should not allow to submit any messages if we're already at limit.

Why it is made in `LaneMessageVerifier`, not in the pallet itself? Because these checks may be lane-specific - i.e. for some kind of sudo calls we may have a separate lane without any limits. For apps that are sending large messages (which may be controlled indide the `LaneMessageVerifier` again), we may have lower limit and so on. So even if our `LaneMessageVerifier` implementation currently assumes that all lanes are identical, I feel that this may change in the future && I prefer to have this code outside of the pallet.