### PR TITLE
Fix max extrinsic weight in relay + logging

### DIFF
--- a/relays/messages-relay/src/message_lane.rs
+++ b/relays/messages-relay/src/message_lane.rs
@@ -30,9 +30,9 @@ pub trait MessageLane: Clone + Send + Sync {
 	const TARGET_NAME: &'static str;
 
 	/// Messages proof.
-	type MessagesProof: Clone + Send + Sync;
+	type MessagesProof: Clone + Debug + Send + Sync;
 	/// Messages receiving proof.
-	type MessagesReceivingProof: Clone + Send + Sync;
+	type MessagesReceivingProof: Clone + Debug + Send + Sync;
 
 	/// Number of the source header.
 	type SourceHeaderNumber: BlockNumberBase;

--- a/relays/messages-relay/src/message_race_delivery.rs
+++ b/relays/messages-relay/src/message_race_delivery.rs
@@ -238,6 +238,36 @@ type MessageDeliveryStrategyBase<P> = BasicStrategy<
 	<P as MessageLane>::MessagesProof,
 >;
 
+impl<P: MessageLane> std::fmt::Debug for MessageDeliveryStrategy<P> {
+	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+		fmt.debug_struct("MessageDeliveryStrategy")
+			.field(
+				"max_unrewarded_relayer_entries_at_target",
+				&self.max_unrewarded_relayer_entries_at_target,
+			)
+			.field(
+				"max_unconfirmed_nonces_at_target",
+				&self.max_unconfirmed_nonces_at_target,
+			)
+			.field("max_messages_in_single_batch", &self.max_messages_in_single_batch)
+			.field(
+				"max_messages_weight_in_single_batch",
+				&self.max_messages_weight_in_single_batch,
+			)
+			.field(
+				"max_messages_size_in_single_batch",
+				&self.max_messages_size_in_single_batch,
+			)
+			.field(
+				"latest_confirmed_noncs_at_source",
+				&self.latest_confirmed_nonce_at_source,
+			)
+			.field("target_nonces", &self.target_nonces)
+			.field("strategy", &self.strategy)
+			.finish()
+	}
+}
+
 impl<P: MessageLane> RaceStrategy<SourceHeaderIdOf<P>, TargetHeaderIdOf<P>, P::MessagesProof>
 	for MessageDeliveryStrategy<P>
 {

--- a/relays/messages-relay/src/message_race_strategy.rs
+++ b/relays/messages-relay/src/message_race_strategy.rs
@@ -21,7 +21,7 @@ use crate::message_race_loop::{NoncesRange, RaceState, RaceStrategy, SourceClien
 
 use bp_message_lane::MessageNonce;
 use relay_utils::HeaderId;
-use std::{collections::VecDeque, marker::PhantomData, ops::RangeInclusive};
+use std::{collections::VecDeque, fmt::Debug, marker::PhantomData, ops::RangeInclusive};
 
 /// Nonces delivery strategy.
 #[derive(Debug)]
@@ -147,9 +147,12 @@ impl<SourceHeaderNumber, SourceHeaderHash, TargetHeaderNumber, TargetHeaderHash,
 	RaceStrategy<HeaderId<SourceHeaderHash, SourceHeaderNumber>, HeaderId<TargetHeaderHash, TargetHeaderNumber>, Proof>
 	for BasicStrategy<SourceHeaderNumber, SourceHeaderHash, TargetHeaderNumber, TargetHeaderHash, SourceNoncesRange, Proof>
 where
-	SourceHeaderHash: Clone,
-	SourceHeaderNumber: Clone + Ord,
-	SourceNoncesRange: NoncesRange,
+	SourceHeaderHash: Clone + Debug,
+	SourceHeaderNumber: Clone + Ord + Debug,
+	SourceNoncesRange: NoncesRange + Debug,
+	TargetHeaderHash: Debug,
+	TargetHeaderNumber: Debug,
+	Proof: Debug,
 {
 	type SourceNoncesRange = SourceNoncesRange;
 	type ProofParameters = ();

--- a/relays/substrate/src/millau_messages_to_rialto.rs
+++ b/relays/substrate/src/millau_messages_to_rialto.rs
@@ -25,6 +25,8 @@ use async_trait::async_trait;
 use bp_message_lane::{LaneId, MessageNonce};
 use bp_runtime::{MILLAU_BRIDGE_INSTANCE, RIALTO_BRIDGE_INSTANCE};
 use bridge_runtime_common::messages::target::FromBridgedChainMessagesProof;
+use codec::Encode;
+use frame_support::dispatch::GetDispatchInfo;
 use messages_relay::message_lane::MessageLane;
 use relay_millau_client::{HeaderId as MillauHeaderId, Millau, SigningParams as MillauSigningParams};
 use relay_rialto_client::{HeaderId as RialtoHeaderId, Rialto, SigningParams as RialtoSigningParams};
@@ -63,8 +65,18 @@ impl SubstrateMessageLane for MillauMessagesToRialto {
 		let (relayers_state, proof) = proof;
 		let account_id = self.source_sign.signer.public().as_array_ref().clone().into();
 		let nonce = self.source_client.next_account_index(account_id).await?;
-		let call = millau_runtime::MessageLaneCall::receive_messages_delivery_proof(proof, relayers_state).into();
+		let call: millau_runtime::Call =
+			millau_runtime::MessageLaneCall::receive_messages_delivery_proof(proof, relayers_state).into();
+		let call_weight = call.get_dispatch_info().weight;
 		let transaction = Millau::sign_transaction(&self.source_client, &self.source_sign.signer, nonce, call);
+		log::trace!(
+			target: "bridge",
+			"Prepared Rialto -> Millau confirmation transaction. Weight: {}/{}, size: {}/{}",
+			call_weight,
+			bp_millau::max_extrinsic_weight(),
+			transaction.encode().len(),
+			bp_millau::max_extrinsic_size(),
+		);
 		Ok(transaction)
 	}
 
@@ -83,14 +95,23 @@ impl SubstrateMessageLane for MillauMessagesToRialto {
 		let messages_count = nonces_end - nonces_start + 1;
 		let account_id = self.target_sign.signer.public().as_array_ref().clone().into();
 		let nonce = self.target_client.next_account_index(account_id).await?;
-		let call = rialto_runtime::MessageLaneCall::receive_messages_proof(
+		let call: rialto_runtime::Call = rialto_runtime::MessageLaneCall::receive_messages_proof(
 			self.relayer_id_at_source.clone(),
 			proof,
 			messages_count as _,
 			dispatch_weight,
 		)
 		.into();
+		let call_weight = call.get_dispatch_info().weight;
 		let transaction = Rialto::sign_transaction(&self.target_client, &self.target_sign.signer, nonce, call);
+		log::trace!(
+			target: "bridge",
+			"Prepared Millau -> Rialto delivery transaction. Weight: {}/{}, size: {}/{}",
+			call_weight,
+			bp_rialto::max_extrinsic_weight(),
+			transaction.encode().len(),
+			bp_rialto::max_extrinsic_size(),
+		);
 		Ok(transaction)
 	}
 }
@@ -127,12 +148,27 @@ pub fn run(
 		lane.relayer_id_at_source,
 	);
 
+	// 2/3 is reserved for proofs and tx overhead
+	let max_messages_size_in_single_batch = bp_rialto::max_extrinsic_size() as usize / 3;
 	// TODO: use Millau weights after https://github.com/paritytech/parity-bridges-common/issues/390
 	let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
 		select_delivery_transaction_limits::<pallet_message_lane::weights::RialtoWeight<millau_runtime::Runtime>>(
-			bp_millau::max_extrinsic_weight(),
+			bp_rialto::max_extrinsic_weight(),
 			bp_rialto::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
 		);
+
+	log::info!(
+		target: "bridge",
+		"Starting Millau -> Rialto messages relay.\n\t\
+			Millau relayer account id: {:?}\n\t\
+			Max messages in single transaction: {}\n\t\
+			Max messages size in single transaction: {}\n\t\
+			Max messages weight in single transaction: {}",
+		lane.relayer_id_at_source,
+		max_messages_in_single_batch,
+		max_messages_size_in_single_batch,
+		max_messages_weight_in_single_batch,
+	);
 
 	messages_relay::message_lane_loop::run(
 		messages_relay::message_lane_loop::Params {
@@ -146,8 +182,7 @@ pub fn run(
 				max_unconfirmed_nonces_at_target: bp_rialto::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE,
 				max_messages_in_single_batch,
 				max_messages_weight_in_single_batch,
-				// 2/3 is reserved for proofs and tx overhead
-				max_messages_size_in_single_batch: bp_rialto::max_extrinsic_size() as usize / 3,
+				max_messages_size_in_single_batch,
 			},
 		},
 		MillauSourceClient::new(millau_client, lane.clone(), lane_id, RIALTO_BRIDGE_INSTANCE),

--- a/relays/substrate/src/millau_messages_to_rialto.rs
+++ b/relays/substrate/src/millau_messages_to_rialto.rs
@@ -142,12 +142,6 @@ pub fn run(
 		relayer_id_at_source: relayer_id_at_millau,
 	};
 
-	log::info!(
-		target: "bridge",
-		"Starting Millau -> Rialto messages relay. Millau relayer account id: {:?}",
-		lane.relayer_id_at_source,
-	);
-
 	// 2/3 is reserved for proofs and tx overhead
 	let max_messages_size_in_single_batch = bp_rialto::max_extrinsic_size() as usize / 3;
 	// TODO: use Millau weights after https://github.com/paritytech/parity-bridges-common/issues/390

--- a/relays/substrate/src/rialto_messages_to_millau.rs
+++ b/relays/substrate/src/rialto_messages_to_millau.rs
@@ -142,12 +142,6 @@ pub fn run(
 		relayer_id_at_source: relayer_id_at_rialto,
 	};
 
-	log::info!(
-		target: "bridge",
-		"Starting Rialto -> Millau messages relay. Rialto relayer account id: {:?}",
-		lane.relayer_id_at_source,
-	);
-
 	// 2/3 is reserved for proofs and tx overhead
 	let max_messages_size_in_single_batch = bp_millau::max_extrinsic_size() as usize / 3;
 	let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =

--- a/relays/substrate/src/rialto_messages_to_millau.rs
+++ b/relays/substrate/src/rialto_messages_to_millau.rs
@@ -25,6 +25,8 @@ use async_trait::async_trait;
 use bp_message_lane::{LaneId, MessageNonce};
 use bp_runtime::{MILLAU_BRIDGE_INSTANCE, RIALTO_BRIDGE_INSTANCE};
 use bridge_runtime_common::messages::target::FromBridgedChainMessagesProof;
+use codec::Encode;
+use frame_support::dispatch::GetDispatchInfo;
 use messages_relay::message_lane::MessageLane;
 use relay_millau_client::{HeaderId as MillauHeaderId, Millau, SigningParams as MillauSigningParams};
 use relay_rialto_client::{HeaderId as RialtoHeaderId, Rialto, SigningParams as RialtoSigningParams};
@@ -63,8 +65,18 @@ impl SubstrateMessageLane for RialtoMessagesToMillau {
 		let (relayers_state, proof) = proof;
 		let account_id = self.source_sign.signer.public().as_array_ref().clone().into();
 		let nonce = self.source_client.next_account_index(account_id).await?;
-		let call = rialto_runtime::MessageLaneCall::receive_messages_delivery_proof(proof, relayers_state).into();
+		let call: rialto_runtime::Call =
+			rialto_runtime::MessageLaneCall::receive_messages_delivery_proof(proof, relayers_state).into();
+		let call_weight = call.get_dispatch_info().weight;
 		let transaction = Rialto::sign_transaction(&self.source_client, &self.source_sign.signer, nonce, call);
+		log::trace!(
+			target: "bridge",
+			"Prepared Millau -> Rialto confirmation transaction. Weight: {}/{}, size: {}/{}",
+			call_weight,
+			bp_rialto::max_extrinsic_weight(),
+			transaction.encode().len(),
+			bp_rialto::max_extrinsic_size(),
+		);
 		Ok(transaction)
 	}
 
@@ -83,14 +95,23 @@ impl SubstrateMessageLane for RialtoMessagesToMillau {
 		let messages_count = nonces_end - nonces_start + 1;
 		let account_id = self.target_sign.signer.public().as_array_ref().clone().into();
 		let nonce = self.target_client.next_account_index(account_id).await?;
-		let call = millau_runtime::MessageLaneCall::receive_messages_proof(
+		let call: millau_runtime::Call = millau_runtime::MessageLaneCall::receive_messages_proof(
 			self.relayer_id_at_source.clone(),
 			proof,
 			messages_count as _,
 			dispatch_weight,
 		)
 		.into();
+		let call_weight = call.get_dispatch_info().weight;
 		let transaction = Millau::sign_transaction(&self.target_client, &self.target_sign.signer, nonce, call);
+		log::trace!(
+			target: "bridge",
+			"Prepared Rialto -> Millau delivery transaction. Weight: {}/{}, size: {}/{}",
+			call_weight,
+			bp_millau::max_extrinsic_weight(),
+			transaction.encode().len(),
+			bp_millau::max_extrinsic_size(),
+		);
 		Ok(transaction)
 	}
 }
@@ -127,11 +148,26 @@ pub fn run(
 		lane.relayer_id_at_source,
 	);
 
+	// 2/3 is reserved for proofs and tx overhead
+	let max_messages_size_in_single_batch = bp_millau::max_extrinsic_size() as usize / 3;
 	let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
 		select_delivery_transaction_limits::<pallet_message_lane::weights::RialtoWeight<rialto_runtime::Runtime>>(
-			bp_rialto::max_extrinsic_weight(),
+			bp_millau::max_extrinsic_weight(),
 			bp_millau::MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE,
 		);
+
+	log::info!(
+		target: "bridge",
+		"Starting Rialto -> Millau messages relay.\n\t\
+			Rialto relayer account id: {:?}\n\t\
+			Max messages in single transaction: {}\n\t\
+			Max messages size in single transaction: {}\n\t\
+			Max messages weight in single transaction: {}",
+		lane.relayer_id_at_source,
+		max_messages_in_single_batch,
+		max_messages_size_in_single_batch,
+		max_messages_weight_in_single_batch,
+	);
 
 	messages_relay::message_lane_loop::run(
 		messages_relay::message_lane_loop::Params {
@@ -145,8 +181,7 @@ pub fn run(
 				max_unconfirmed_nonces_at_target: bp_millau::MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE,
 				max_messages_in_single_batch,
 				max_messages_weight_in_single_batch,
-				// 2/3 is reserved for proofs and tx overhead
-				max_messages_size_in_single_batch: bp_millau::max_extrinsic_size() as usize / 3,
+				max_messages_size_in_single_batch,
 			},
 		},
 		RialtoSourceClient::new(rialto_client, lane.clone(), lane_id, MILLAU_BRIDGE_INSTANCE),


### PR DESCRIPTION
found this when working on #680 
The main issue in this PR is two changed lines in `*_messages_to_*.rs` - where I'm swapping `bp_rialto::max_extrinsic_weight()` and `bp_millau::max_extrinsic_weight()`. All other changes are about additional logging to help resolve such issues.