### PR TITLE
Finality Pallet Rate Limiter

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -300,11 +300,20 @@ impl pallet_substrate_bridge::Config for Runtime {
 	type BridgedChain = bp_rialto::Rialto;
 }
 
+parameter_types! {
+	// This is a pretty unscientific cap.
+	//
+	// Note that once this is hit the pallet will essentially throttle incoming requests down to one
+	// call per block.
+	pub const MaxRequests: u32 = 50;
+}
+
 impl pallet_finality_verifier::Config for Runtime {
 	type BridgedChain = bp_rialto::Rialto;
 	type HeaderChain = pallet_substrate_bridge::Module<Runtime>;
 	type AncestryProof = Vec<bp_rialto::Header>;
 	type AncestryChecker = bp_header_chain::LinearAncestryChecker;
+	type MaxRequests = MaxRequests;
 }
 
 impl pallet_shift_session_manager::Config for Runtime {}

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -407,11 +407,20 @@ impl pallet_substrate_bridge::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
 }
 
+parameter_types! {
+	// This is a pretty unscientific cap.
+	//
+	// Note that once this is hit the pallet will essentially throttle incoming requests down to one
+	// call per block.
+	pub const MaxRequests: u32 = 50;
+}
+
 impl pallet_finality_verifier::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
 	type HeaderChain = pallet_substrate_bridge::Module<Runtime>;
 	type AncestryProof = Vec<bp_millau::Header>;
 	type AncestryChecker = bp_header_chain::LinearAncestryChecker;
+	type MaxRequests = MaxRequests;
 }
 
 impl pallet_shift_session_manager::Config for Runtime {}

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -89,9 +89,9 @@ pub mod pallet {
 		fn on_initialize(_n: T::BlockNumber) -> frame_support::weights::Weight {
 			<RequestCount<T>>::mutate(|count| *count = count.saturating_sub(1));
 
-			(0 as Weight)
-				.saturating_add(T::DbWeight::get().reads(1 as Weight))
-				.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			(0_u64)
+				.saturating_add(T::DbWeight::get().reads(1))
+				.saturating_add(T::DbWeight::get().writes(1))
 		}
 	}
 
@@ -113,7 +113,6 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let _ = ensure_signed(origin)?;
 
-			dbg!(Self::request_count());
 			ensure!(
 				Self::request_count() < T::MaxRequests::get(),
 				<Error<T>>::TooManyRequests

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -210,7 +210,7 @@ mod tests {
 		let justification = make_justification_for_header(&header, grandpa_round, set_id, &authority_list()).encode();
 		let ancestry_proof = vec![child, header.clone()];
 
-		Module::<TestRuntime>::submit_finality_proof(Origin::signed(1), header.clone(), justification, ancestry_proof)
+		Module::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification, ancestry_proof)
 	}
 
 	fn next_block() {
@@ -226,22 +226,9 @@ mod tests {
 		run_test(|| {
 			initialize_substrate_bridge();
 
-			let child = test_header(1);
+			assert_ok!(submit_finality_proof());
+
 			let header = test_header(2);
-
-			let set_id = 1;
-			let grandpa_round = 1;
-			let justification =
-				make_justification_for_header(&header, grandpa_round, set_id, &authority_list()).encode();
-			let ancestry_proof = vec![child, header.clone()];
-
-			assert_ok!(Module::<TestRuntime>::submit_finality_proof(
-				Origin::signed(1),
-				header.clone(),
-				justification,
-				ancestry_proof,
-			));
-
 			assert_eq!(
 				pallet_substrate_bridge::Module::<TestRuntime>::best_headers(),
 				vec![(*header.number(), header.hash())]

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -71,7 +71,7 @@ impl pallet_substrate_bridge::Config for TestRuntime {
 }
 
 parameter_types! {
-	pub const MaxElementsInSingleProof: Option<u32> = Some(5);
+	pub const MaxRequests: u32 = 2;
 }
 
 impl crate::pallet::Config for TestRuntime {
@@ -79,6 +79,7 @@ impl crate::pallet::Config for TestRuntime {
 	type HeaderChain = pallet_substrate_bridge::Module<TestRuntime>;
 	type AncestryProof = Vec<<Self::BridgedChain as Chain>::Header>;
 	type AncestryChecker = Checker<<Self::BridgedChain as Chain>::Header, Self::AncestryProof>;
+	type MaxRequests = MaxRequests;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR uses Tomek's suggestion from [here](https://github.com/paritytech/parity-bridges-common/pull/714#pullrequestreview-587490435) and provides a simplified approach
to rate limiting for the finality verifier pallet.

The number I chose for `MaxRequests` is pretty arbirary. I figured that it wouldn't be
the worst thing in the world if we were wrong in choosing this number, since:

- Chances are we're not going to import a lot of finality proofs in a short period of
  time, so 50 seemed like a high enough limit if there is a burst of activity
- The pallet would be throttled to one request per block after we hit the limit, limiting
  any damage in case it's too low

The real test will be to see how it performs in practice and adjust the value
accordingly.

Closes https://github.com/paritytech/srlabs_findings/issues/47.
