### PR TITLE
Workaround for SS58Prefix issues in the UI.

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -148,7 +148,7 @@ parameter_types! {
 		read: 60_000_000, // ~0.06 ms = ~60 µs
 		write: 200_000_000, // ~0.2 ms = 200 µs
 	};
-	pub const SS58Prefix: u8 = 86;
+	pub const SS58Prefix: u8 = 42;
 }
 
 impl frame_system::Config for Runtime {

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -156,7 +156,7 @@ parameter_types! {
 		read: 60_000_000, // ~0.06 ms = ~60 µs
 		write: 200_000_000, // ~0.2 ms = 200 µs
 	};
-	pub const SS58Prefix: u8 = 84;
+	pub const SS58Prefix: u8 = 42;
 }
 
 impl frame_system::Config for Runtime {


### PR DESCRIPTION
Having SS58Prefix set to number greater than `64` create an incompatibility between [UI](https://github.com/polkadot-js/common/blob/master/packages/util-crypto/src/address/encode.ts#L26) and [Rust](https://github.com/paritytech/substrate/blob/9f6e97ebdf2d2c86da837e3d6879a07bfb11e22c/primitives/core/src/crypto.rs#L242) code.

To temporarily overcome the issue until it's solved, I've change the SS58Prefix to 42 on both chains.