### PR TITLE
Remove lower limit of messages weight

### DIFF
--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -95,17 +95,16 @@ impl MessageBridge for WithRialtoMessageBridge {
 		bp_rialto::max_extrinsic_size()
 	}
 
-	fn weight_limits_of_message_on_bridged_chain(message_payload: &[u8]) -> RangeInclusive<Weight> {
+	fn weight_limits_of_message_on_bridged_chain(_message_payload: &[u8]) -> RangeInclusive<Weight> {
 		// we don't want to relay too large messages + keep reserve for future upgrades
 		let upper_limit = messages::target::maximal_incoming_message_dispatch_weight(bp_rialto::max_extrinsic_weight());
 
-		// given Rialto chain parameters (`TransactionByteFee`, `WeightToFee`, `FeeMultiplierUpdate`),
-		// the minimal weight of the message may be computed as message.length()
-		let lower_limit = u32::try_from(message_payload.len())
-			.map(Into::into)
-			.unwrap_or(Weight::MAX);
+		// we're charging for payload bytes in `WithRialtoMessageBridge::weight_of_delivery_transaction` function
+		//
+		// this bridge may be used to deliver all kind of messages, so we're not making any assumptions about
+		// minimal dispatch weight here
 
-		lower_limit..=upper_limit
+		0..=upper_limit
 	}
 
 	fn weight_of_delivery_transaction(message_payload: &[u8]) -> Weight {

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -95,17 +95,16 @@ impl MessageBridge for WithMillauMessageBridge {
 		bp_millau::max_extrinsic_size()
 	}
 
-	fn weight_limits_of_message_on_bridged_chain(message_payload: &[u8]) -> RangeInclusive<Weight> {
+	fn weight_limits_of_message_on_bridged_chain(_message_payload: &[u8]) -> RangeInclusive<Weight> {
 		// we don't want to relay too large messages + keep reserve for future upgrades
 		let upper_limit = messages::target::maximal_incoming_message_dispatch_weight(bp_millau::max_extrinsic_weight());
 
-		// given Millau chain parameters (`TransactionByteFee`, `WeightToFee`, `FeeMultiplierUpdate`),
-		// the minimal weight of the message may be computed as message.length()
-		let lower_limit = u32::try_from(message_payload.len())
-			.map(Into::into)
-			.unwrap_or(Weight::MAX);
+		// we're charging for payload bytes in `WithMillauMessageBridge::weight_of_delivery_transaction` function
+		//
+		// this bridge may be used to deliver all kind of messages, so we're not making any assumptions about
+		// minimal dispatch weight here
 
-		lower_limit..=upper_limit
+		0..=upper_limit
 	}
 
 	fn weight_of_delivery_transaction(message_payload: &[u8]) -> Weight {


### PR DESCRIPTION
closes #721 

It may still be verified by other bridges - if e.g. bridge only needs to accept transfer calls, it may verify that weight is >= hardcoded weight of transfer call. But for our (testnets) bridge we don't need any limits like that, so this check is invalid. For example, we were unable to deliver `sudo::set_key()` with declared weight set to zero, even though dispatch weight of this call is actually zero. So the sender must have declared non-zero weight and pay extra cost just to overcome this limit.