### PR TITLE
Rework relay CLI a bit

### DIFF
--- a/deployments/bridges/rialto-millau/entrypoints/relay-headers-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-headers-millau-to-rialto-entrypoint.sh
@@ -5,7 +5,7 @@ sleep 3
 curl -v http://millau-node-alice:9933/health
 curl -v http://rialto-node-alice:9933/health
 
-/home/user/substrate-relay initialize-millau-headers-bridge-in-rialto \
+/home/user/substrate-relay init-bridge millau-to-rialto \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \
@@ -14,7 +14,7 @@ curl -v http://rialto-node-alice:9933/health
 
 # Give chain a little bit of time to process initialization transaction
 sleep 6
-/home/user/substrate-relay millau-headers-to-rialto \
+/home/user/substrate-relay relay-headers millau-to-rialto \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \

--- a/deployments/bridges/rialto-millau/entrypoints/relay-headers-rialto-to-millau-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-headers-rialto-to-millau-entrypoint.sh
@@ -5,7 +5,7 @@ sleep 3
 curl -v http://millau-node-alice:9933/health
 curl -v http://rialto-node-alice:9933/health
 
-/home/user/substrate-relay initialize-rialto-headers-bridge-in-millau \
+/home/user/substrate-relay init-bridge rialto-to-millau \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \
@@ -14,7 +14,7 @@ curl -v http://rialto-node-alice:9933/health
 
 # Give chain a little bit of time to process initialization transaction
 sleep 6
-/home/user/substrate-relay rialto-headers-to-millau \
+/home/user/substrate-relay relay-headers rialto-to-millau \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
 	--rialto-host rialto-node-alice \

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
@@ -7,7 +7,7 @@ curl -v http://rialto-node-bob:9933/health
 
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 
-/home/user/substrate-relay millau-messages-to-rialto \
+/home/user/substrate-relay relay-messages millau-to-rialto \
 	--lane $MESSAGE_LANE \
 	--millau-host millau-node-bob \
 	--millau-port 9944 \

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
@@ -7,7 +7,7 @@ curl -v http://rialto-node-bob:9933/health
 
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 
-/home/user/substrate-relay rialto-messages-to-millau \
+/home/user/substrate-relay relay-messages rialto-to-millau \
 	--lane $MESSAGE_LANE \
 	--rialto-host rialto-node-bob \
 	--rialto-port 9944 \

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -12,7 +12,7 @@ MAX_SUBMIT_DELAY_S=${MSG_EXCHANGE_GEN_MAX_SUBMIT_DELAY_S:-30}
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 FERDIE_ADDR=5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL
 
-SHARED_CMD="/home/user/substrate-relay submit-rialto-to-millau-message"
+SHARED_CMD="/home/user/substrate-relay send-message rialto-to-millau"
 SHARED_HOST="--rialto-host rialto-node-bob --rialto-port 9944"
 DAVE_SIGNER="--rialto-signer //Dave --millau-signer //Dave"
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -12,7 +12,7 @@ MAX_SUBMIT_DELAY_S=${MSG_EXCHANGE_GEN_MAX_SUBMIT_DELAY_S:-30}
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 FERDIE_ADDR=5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL
 
-SHARED_CMD=" /home/user/substrate-relay submit-millau-to-rialto-message"
+SHARED_CMD=" /home/user/substrate-relay send-message millau-to-rialto"
 SHARED_HOST="--millau-host millau-node-bob --millau-port 9944"
 DAVE_SIGNER="--rialto-signer //Dave --millau-signer //Dave"
 

--- a/relays/substrate/src/cli.rs
+++ b/relays/substrate/src/cli.rs
@@ -219,7 +219,7 @@ arg_enum! {
 	/// The origin to use when dispatching the message on the target chain.
 	///
 	/// - `Target` uses account existing on the target chain (requires target private key).
-	/// - `Origin` ses account derived from the source-chain account.
+	/// - `Origin` uses account derived from the source-chain account.
 	pub enum Origins {
 		Target,
 		Source,

--- a/relays/substrate/src/cli.rs
+++ b/relays/substrate/src/cli.rs
@@ -30,19 +30,16 @@ pub fn parse_args() -> Command {
 #[derive(StructOpt)]
 #[structopt(about = "Substrate-to-Substrate relay")]
 pub enum Command {
-	/// Initialize Millau headers bridge in Rialto.
-	InitializeMillauHeadersBridgeInRialto {
-		#[structopt(flatten)]
-		millau: MillauConnectionParams,
-		#[structopt(flatten)]
-		rialto: RialtoConnectionParams,
-		#[structopt(flatten)]
-		rialto_sign: RialtoSigningParams,
-		#[structopt(flatten)]
-		millau_bridge_params: MillauBridgeInitializationParams,
-	},
+	RelayHeaders(RelayHeaders),
+	RelayMessages(RelayMessages),
+	InitBridge(InitBridge),
+	SendMessage(SendMessage),
+}
+
+#[derive(StructOpt)]
+pub enum RelayHeaders {
 	/// Relay Millau headers to Rialto.
-	MillauHeadersToRialto {
+	MillauToRialto {
 		#[structopt(flatten)]
 		millau: MillauConnectionParams,
 		#[structopt(flatten)]
@@ -51,20 +48,9 @@ pub enum Command {
 		rialto_sign: RialtoSigningParams,
 		#[structopt(flatten)]
 		prometheus_params: PrometheusParams,
-	},
-	/// Initialize Rialto headers bridge in Millau.
-	InitializeRialtoHeadersBridgeInMillau {
-		#[structopt(flatten)]
-		rialto: RialtoConnectionParams,
-		#[structopt(flatten)]
-		millau: MillauConnectionParams,
-		#[structopt(flatten)]
-		millau_sign: MillauSigningParams,
-		#[structopt(flatten)]
-		rialto_bridge_params: RialtoBridgeInitializationParams,
 	},
 	/// Relay Rialto headers to Millau.
-	RialtoHeadersToMillau {
+	RialtoToMillau {
 		#[structopt(flatten)]
 		rialto: RialtoConnectionParams,
 		#[structopt(flatten)]
@@ -74,8 +60,12 @@ pub enum Command {
 		#[structopt(flatten)]
 		prometheus_params: PrometheusParams,
 	},
+}
+
+#[derive(StructOpt)]
+pub enum RelayMessages {
 	/// Serve given lane of Millau -> Rialto messages.
-	MillauMessagesToRialto {
+	MillauToRialto {
 		#[structopt(flatten)]
 		millau: MillauConnectionParams,
 		#[structopt(flatten)]
@@ -90,8 +80,54 @@ pub enum Command {
 		#[structopt(long)]
 		lane: HexLaneId,
 	},
+	/// Serve given lane of Rialto -> Millau messages.
+	RialtoToMillau {
+		#[structopt(flatten)]
+		rialto: RialtoConnectionParams,
+		#[structopt(flatten)]
+		rialto_sign: RialtoSigningParams,
+		#[structopt(flatten)]
+		millau: MillauConnectionParams,
+		#[structopt(flatten)]
+		millau_sign: MillauSigningParams,
+		#[structopt(flatten)]
+		prometheus_params: PrometheusParams,
+		/// Hex-encoded id of lane that should be served by relay.
+		#[structopt(long)]
+		lane: HexLaneId,
+	},
+}
+
+#[derive(StructOpt)]
+pub enum InitBridge {
+	/// Initialize Millau headers bridge in Rialto.
+	MillauToRialto {
+		#[structopt(flatten)]
+		millau: MillauConnectionParams,
+		#[structopt(flatten)]
+		rialto: RialtoConnectionParams,
+		#[structopt(flatten)]
+		rialto_sign: RialtoSigningParams,
+		#[structopt(flatten)]
+		millau_bridge_params: MillauBridgeInitializationParams,
+	},
+	/// Initialize Rialto headers bridge in Millau.
+	RialtoToMillau {
+		#[structopt(flatten)]
+		rialto: RialtoConnectionParams,
+		#[structopt(flatten)]
+		millau: MillauConnectionParams,
+		#[structopt(flatten)]
+		millau_sign: MillauSigningParams,
+		#[structopt(flatten)]
+		rialto_bridge_params: RialtoBridgeInitializationParams,
+	},
+}
+
+#[derive(StructOpt)]
+pub enum SendMessage {
 	/// Submit message to given Millau -> Rialto lane.
-	SubmitMillauToRialtoMessage {
+	MillauToRialto {
 		#[structopt(flatten)]
 		millau: MillauConnectionParams,
 		#[structopt(flatten)]
@@ -111,24 +147,8 @@ pub enum Command {
 		#[structopt(long, possible_values = &Origins::variants())]
 		origin: Origins,
 	},
-	/// Serve given lane of Rialto -> Millau messages.
-	RialtoMessagesToMillau {
-		#[structopt(flatten)]
-		rialto: RialtoConnectionParams,
-		#[structopt(flatten)]
-		rialto_sign: RialtoSigningParams,
-		#[structopt(flatten)]
-		millau: MillauConnectionParams,
-		#[structopt(flatten)]
-		millau_sign: MillauSigningParams,
-		#[structopt(flatten)]
-		prometheus_params: PrometheusParams,
-		/// Hex-encoded id of lane that should be served by relay.
-		#[structopt(long)]
-		lane: HexLaneId,
-	},
 	/// Submit message to given Rialto -> Millau lane.
-	SubmitRialtoToMillauMessage {
+	RialtoToMillau {
 		#[structopt(flatten)]
 		rialto: RialtoConnectionParams,
 		#[structopt(flatten)]

--- a/relays/substrate/src/cli.rs
+++ b/relays/substrate/src/cli.rs
@@ -26,13 +26,29 @@ pub fn parse_args() -> Command {
 	Command::from_args()
 }
 
-/// Substrate-to-Substrate relay CLI args.
+/// Substrate-to-Substrate bridge utilities.
 #[derive(StructOpt)]
 #[structopt(about = "Substrate-to-Substrate relay")]
 pub enum Command {
+	/// Start headers relay between two chains.
+	///
+	/// The on-chain bridge component should have been already initialized with
+	/// `init-bridge` sub-command.
 	RelayHeaders(RelayHeaders),
+	/// Start messages relay between two chains.
+	///
+	/// Ties up to `MessageLane` pallets on both chains and starts relaying messages.
+	/// Requires the header relay to be already running.
 	RelayMessages(RelayMessages),
+	/// Initialize on-chain bridge pallet with current header data.
+	///
+	/// Sends initialization transaction to bootstrap the bridge with current finalized block data.
 	InitBridge(InitBridge),
+	/// Send custom message over the bridge.
+	///
+	/// Allows interacting with the bridge by sending messages over `MessageLane` component.
+	/// The message is being sent to the source chain, delivered to the target chain and dispatched
+	/// there.
 	SendMessage(SendMessage),
 }
 
@@ -201,6 +217,9 @@ pub enum ToMillauMessage {
 arg_enum! {
 	#[derive(Debug)]
 	/// The origin to use when dispatching the message on the target chain.
+	///
+	/// - `Target` uses account existing on the target chain (requires target private key).
+	/// - `Origin` ses account derived from the source-chain account.
 	pub enum Origins {
 		Target,
 		Source,

--- a/relays/substrate/src/main.rs
+++ b/relays/substrate/src/main.rs
@@ -75,17 +75,10 @@ async fn run_init_bridge(command: cli::InitBridge) -> Result<(), String> {
 			rialto_sign,
 			millau_bridge_params,
 		} => {
-			let millau_client = MillauClient::new(ConnectionParams {
-				host: millau.millau_host,
-				port: millau.millau_port,
-			})
-			.await?;
-			let rialto_client = RialtoClient::new(ConnectionParams {
-				host: rialto.rialto_host,
-				port: rialto.rialto_port,
-			})
-			.await?;
+			let millau_client = millau.into_client().await?;
+			let rialto_client = rialto.into_client().await?;
 			let rialto_sign = rialto_sign.parse()?;
+
 			let rialto_signer_next_index = rialto_client
 				.next_account_index(rialto_sign.signer.public().into())
 				.await?;
@@ -119,21 +112,9 @@ async fn run_init_bridge(command: cli::InitBridge) -> Result<(), String> {
 			millau_sign,
 			rialto_bridge_params,
 		} => {
-			let rialto_client = RialtoClient::new(ConnectionParams {
-				host: rialto.rialto_host,
-				port: rialto.rialto_port,
-			})
-			.await?;
-			let millau_client = MillauClient::new(ConnectionParams {
-				host: millau.millau_host,
-				port: millau.millau_port,
-			})
-			.await?;
-			let millau_sign = MillauSigningParams::from_suri(
-				&millau_sign.millau_signer,
-				millau_sign.millau_signer_password.as_deref(),
-			)
-			.map_err(|e| format!("Failed to parse millau-signer: {:?}", e))?;
+			let rialto_client = rialto.into_client().await?;
+			let millau_client = millau.into_client().await?;
+			let millau_sign = millau_sign.parse()?;
 			let millau_signer_next_index = millau_client
 				.next_account_index(millau_sign.signer.public().into())
 				.await?;
@@ -173,16 +154,8 @@ async fn run_relay_headers(command: cli::RelayHeaders) -> Result<(), String> {
 			rialto_sign,
 			prometheus_params,
 		} => {
-			let millau_client = MillauClient::new(ConnectionParams {
-				host: millau.millau_host,
-				port: millau.millau_port,
-			})
-			.await?;
-			let rialto_client = RialtoClient::new(ConnectionParams {
-				host: rialto.rialto_host,
-				port: rialto.rialto_port,
-			})
-			.await?;
+			let millau_client = millau.into_client().await?;
+			let rialto_client = rialto.into_client().await?;
 			let rialto_sign = rialto_sign.parse()?;
 			millau_headers_to_rialto::run(millau_client, rialto_client, rialto_sign, prometheus_params.into()).await;
 		}
@@ -192,22 +165,9 @@ async fn run_relay_headers(command: cli::RelayHeaders) -> Result<(), String> {
 			millau_sign,
 			prometheus_params,
 		} => {
-			let rialto_client = RialtoClient::new(ConnectionParams {
-				host: rialto.rialto_host,
-				port: rialto.rialto_port,
-			})
-			.await?;
-			let millau_client = MillauClient::new(ConnectionParams {
-				host: millau.millau_host,
-				port: millau.millau_port,
-			})
-			.await?;
-			let millau_sign = MillauSigningParams::from_suri(
-				&millau_sign.millau_signer,
-				millau_sign.millau_signer_password.as_deref(),
-			)
-			.map_err(|e| format!("Failed to parse millau-signer: {:?}", e))?;
-
+			let rialto_client = rialto.into_client().await?;
+			let millau_client = millau.into_client().await?;
+			let millau_sign = millau_sign.parse()?;
 			rialto_headers_to_millau::run(rialto_client, millau_client, millau_sign, prometheus_params.into()).await;
 		}
 	}
@@ -224,21 +184,9 @@ async fn run_relay_messages(command: cli::RelayMessages) -> Result<(), String> {
 			prometheus_params,
 			lane,
 		} => {
-			let millau_client = MillauClient::new(ConnectionParams {
-				host: millau.millau_host,
-				port: millau.millau_port,
-			})
-			.await?;
-			let millau_sign = MillauSigningParams::from_suri(
-				&millau_sign.millau_signer,
-				millau_sign.millau_signer_password.as_deref(),
-			)
-			.map_err(|e| format!("Failed to parse millau-signer: {:?}", e))?;
-			let rialto_client = RialtoClient::new(ConnectionParams {
-				host: rialto.rialto_host,
-				port: rialto.rialto_port,
-			})
-			.await?;
+			let millau_client = millau.into_client().await?;
+			let millau_sign = millau_sign.parse()?;
+			let rialto_client = rialto.into_client().await?;
 			let rialto_sign = rialto_sign.parse()?;
 
 			millau_messages_to_rialto::run(
@@ -258,22 +206,10 @@ async fn run_relay_messages(command: cli::RelayMessages) -> Result<(), String> {
 			prometheus_params,
 			lane,
 		} => {
-			let rialto_client = RialtoClient::new(ConnectionParams {
-				host: rialto.rialto_host,
-				port: rialto.rialto_port,
-			})
-			.await?;
+			let rialto_client = rialto.into_client().await?;
 			let rialto_sign = rialto_sign.parse()?;
-			let millau_client = MillauClient::new(ConnectionParams {
-				host: millau.millau_host,
-				port: millau.millau_port,
-			})
-			.await?;
-			let millau_sign = MillauSigningParams::from_suri(
-				&millau_sign.millau_signer,
-				millau_sign.millau_signer_password.as_deref(),
-			)
-			.map_err(|e| format!("Failed to parse millau-signer: {:?}", e))?;
+			let millau_client = millau.into_client().await?;
+			let millau_sign = millau_sign.parse()?;
 
 			rialto_messages_to_millau::run(
 				rialto_client,
@@ -300,16 +236,8 @@ async fn run_send_message(command: cli::SendMessage) -> Result<(), String> {
 			origin,
 			..
 		} => {
-			let millau_client = MillauClient::new(ConnectionParams {
-				host: millau.millau_host,
-				port: millau.millau_port,
-			})
-			.await?;
-			let millau_sign = MillauSigningParams::from_suri(
-				&millau_sign.millau_signer,
-				millau_sign.millau_signer_password.as_deref(),
-			)
-			.map_err(|e| format!("Failed to parse millau-signer: {:?}", e))?;
+			let millau_client = millau.into_client().await?;
+			let millau_sign = millau_sign.parse()?;
 			let rialto_sign = rialto_sign.parse()?;
 			let rialto_call = match message {
 				cli::ToRialtoMessage::Remark => rialto_runtime::Call::System(rialto_runtime::SystemCall::remark(
@@ -408,21 +336,9 @@ async fn run_send_message(command: cli::SendMessage) -> Result<(), String> {
 			origin,
 			..
 		} => {
-			let rialto_client = RialtoClient::new(ConnectionParams {
-				host: rialto.rialto_host,
-				port: rialto.rialto_port,
-			})
-			.await?;
-			let rialto_sign = RialtoSigningParams::from_suri(
-				&rialto_sign.rialto_signer,
-				rialto_sign.rialto_signer_password.as_deref(),
-			)
-			.map_err(|e| format!("Failed to parse rialto-signer: {:?}", e))?;
-			let millau_sign = MillauSigningParams::from_suri(
-				&millau_sign.millau_signer,
-				millau_sign.millau_signer_password.as_deref(),
-			)
-			.map_err(|e| format!("Failed to parse millau-signer: {:?}", e))?;
+			let rialto_client = rialto.into_client().await?;
+			let rialto_sign = rialto_sign.parse()?;
+			let millau_sign = millau_sign.parse()?;
 
 			let millau_call = match message {
 				cli::ToMillauMessage::Remark => millau_runtime::Call::System(millau_runtime::SystemCall::remark(
@@ -536,6 +452,35 @@ impl crate::cli::RialtoSigningParams {
 			&self.rialto_signer,
 			self.rialto_signer_password.as_deref(),
 		).map_err(|e| format!("Failed to parse rialto-signer: {:?}", e))
+	}
+}
+
+impl crate::cli::MillauSigningParams {
+	/// Parse CLI parameters into typed signing params.
+	pub fn parse(self) -> Result<MillauSigningParams, String> {
+		MillauSigningParams::from_suri(
+			&self.millau_signer,
+			self.millau_signer_password.as_deref(),
+		).map_err(|e| format!("Failed to parse millau-signer: {:?}", e))
+	}
+}
+
+impl crate::cli::MillauConnectionParams {
+	/// Convert CLI connection parameters into Millau RPC Client.
+	pub async fn into_client(self) -> relay_substrate_client::Result<MillauClient> {
+		MillauClient::new(ConnectionParams {
+			host: self.millau_host,
+			port: self.millau_port,
+		}).await
+	}
+}
+impl crate::cli::RialtoConnectionParams {
+	/// Convert CLI connection parameters into Rialto RPC Client.
+	pub async fn into_client(self) -> relay_substrate_client::Result<RialtoClient> {
+		RialtoClient::new(ConnectionParams {
+			host: self.rialto_host,
+			port: self.rialto_port,
+		}).await
 	}
 }
 

--- a/scripts/send-message.sh
+++ b/scripts/send-message.sh
@@ -9,7 +9,7 @@
 case "$1" in
 	remark)
 		RUST_LOG=runtime=trace,substrate-relay=trace,bridge=trace \
-		./target/debug/substrate-relay submit-millau-to-rialto-message \
+		./target/debug/substrate-relay send-message millau-to-rialto \
 			--millau-host localhost \
 			--millau-port 20044 \
 			--millau-signer //Dave \
@@ -20,7 +20,7 @@ case "$1" in
 		;;
 	transfer)
 		RUST_LOG=runtime=trace,substrate-relay=trace,bridge=trace \
-		./target/debug/substrate-relay submit-millau-to-rialto-message \
+		./target/debug/substrate-relay send-message millau-to-rialto \
 			--millau-host localhost \
 			--millau-port 20044 \
 			--millau-signer //Dave \


### PR DESCRIPTION
This PR extracts some common parts of the CLI commands to avoid duplication and also changes the way CLI is structured a bit.

Currently the CLI is flat:
```
$ ./target/release/substrate-relay --help
substrate-relay 0.1.0
Substrate-to-Substrate relay

USAGE:
    substrate-relay <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    help                                          Prints this message or the help of the given subcommand(s)
    initialize-millau-headers-bridge-in-rialto    Initialize Millau headers bridge in Rialto
    initialize-rialto-headers-bridge-in-millau    Initialize Rialto headers bridge in Millau
    millau-headers-to-rialto                      Relay Millau headers to Rialto
    millau-messages-to-rialto                     Serve given lane of Millau -> Rialto messages
    rialto-headers-to-millau                      Relay Rialto headers to Millau
    rialto-messages-to-millau                     Serve given lane of Rialto -> Millau messages
    submit-millau-to-rialto-message               Submit message to given Millau -> Rialto lane
    submit-rialto-to-millau-message               Submit message to given Rialto -> Millau lane
```

IMHO it becomes already a bit difficult to parse long strings, and since I'm planning to add even more commands (see #607, #608, #609) I've changed it to have a bit more structure:

```
$ ./target/release/substrate-relay --help
substrate-relay 0.1.0
Substrate-to-Substrate relay

USAGE:
    substrate-relay <SUBCOMMAND>

FLAGS:
    -h, --help       
            Prints help information

    -V, --version    
            Prints version information


SUBCOMMANDS:
    help              Prints this message or the help of the given subcommand(s)
    init-bridge       Initialize on-chain bridge pallet with current header data
    relay-headers     Start headers relay between two chains
    relay-messages    Start messages relay between two chains
    send-message      Send custom message over the bridge
```

Initially I tried to split the CLI into network related commands (like `$ relay millau to-rialto headers`), but this quickly get's out of hand and is not user friendly.
Instead in the top level you will get different functions of the relayer binary first and then you see networks.

- [ ] I wanted to avoid doing too much changes, so the commands are still in a single module, but I think the next step might be extracting commands/networks/bridges into separate modules.

- [ ] Another thing worth trying in the future is avoiding duplication via macro, but while it will remove duplication I think it won't make the code more readable/maintainable, hence after a couple of failed attempts I didn't follow that direction further.