### PR TITLE
ForbidOutboundMessages and ForbidInboundMessages

### DIFF
--- a/primitives/message-lane/src/target_chain.rs
+++ b/primitives/message-lane/src/target_chain.rs
@@ -129,3 +129,32 @@ impl<DispatchPayload: Decode, Fee> From<MessageData<Fee>> for DispatchMessageDat
 		}
 	}
 }
+
+/// Structure that may be used in place of `SourceHeaderChain` and `MessageDispatch` on chains,
+/// where inbound messages are forbidden.
+pub struct ForbidInboundMessages;
+
+/// Error message that is used in `ForbidOutboundMessages` implementation.
+const ALL_INBOUND_MESSAGES_REJECTED: &str = "This chain is configured to reject all inbound messages";
+
+impl<Fee> SourceHeaderChain<Fee> for ForbidInboundMessages {
+	type Error = &'static str;
+	type MessagesProof = ();
+
+	fn verify_messages_proof(
+		_proof: Self::MessagesProof,
+		_messages_count: u32,
+	) -> Result<ProvedMessages<Message<Fee>>, Self::Error> {
+		Err(ALL_INBOUND_MESSAGES_REJECTED)
+	}
+}
+
+impl<Fee> MessageDispatch<Fee> for ForbidInboundMessages {
+	type DispatchPayload = ();
+
+	fn dispatch_weight(_message: &DispatchMessage<Self::DispatchPayload, Fee>) -> Weight {
+		Weight::MAX
+	}
+
+	fn dispatch(_message: DispatchMessage<Self::DispatchPayload, Fee>) {}
+}

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -112,6 +112,12 @@ pub trait Size {
 	fn size_hint(&self) -> u32;
 }
 
+impl Size for () {
+	fn size_hint(&self) -> u32 {
+		0
+	}
+}
+
 /// Pre-computed size.
 pub struct PreComputedSize(pub usize);
 


### PR DESCRIPTION
Message Lane is an unidirectional channel, but Message Lane Module support both outbound and inbound message lanes. So, for example, we only want to send messages from This Chain to Bridged Chain, but do not want to send messages from Bridged Chain ti This Chain, then we'll need some stubs to use in place of different traits. On This Chain - in place of `SourceHeaderChain` and `MessageDispatch` to reject all inbound messages. And on Bridged Chain - in place of `TargetHeaderChain`, `LaneMessageVerifier` and `MessageDeliveryAndDispatchPayment` to reject all outbound messages.

To avoid duplicating the same code in all runtimes, this PR introduces `ForbidOutboundMessages` and `ForbidInboundMessages` that will fail all corresponding transactions. Why separate structs instead of `()`? Because `()` would probably be treated as accept-everything, and we need reject-everything here.