### PR TITLE
CI: self-host docker build

### DIFF
--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -15,7 +15,7 @@ jobs:
 ## Publish to Docker hub
   publish:
     name:                                           Publishing
-    runs-on:                                        ubuntu-latest
+    runs-on:                                        self-hosted
     container:
       image:                                        docker:git
     steps:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -31,7 +31,7 @@ jobs:
             healthcheck: http://localhost:9616/metrics
           - project: substrate-relay
             healthcheck: http://localhost:9616/metrics
-    runs-on:                                        ubuntu-latest
+    runs-on:                                        self-hosted
     container:
       image:                                        docker:git
     steps:


### PR DESCRIPTION
Changes building and publishing containers to a self-hosted runner.
Please raise an issue to inspect your dockerfiles, it's maybe something over-optimised is going on there.
Also FYI, these self-hosted runners are subject to change soon, they'll have to be re-deployed.