### PR TITLE
Disable cache in CI builds.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,8 +42,6 @@ jobs:
         run:                       rustup toolchain add $NIGHTLY
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.2.0
       - name:                      Checking rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
         with:
@@ -101,8 +99,6 @@ jobs:
         run:                       rustup toolchain add $NIGHTLY
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.2.0
       - name:                      Building rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
         if:                        github.ref == 'refs/heads/master'

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -369,9 +369,9 @@ mod tests {
 			}
 
 			// Can still submit `MaxRequests` requests afterwards
-			assert_ok!(submit_finality_proof());
-			assert_ok!(submit_finality_proof());
-			assert_err!(submit_finality_proof(), <Error<TestRuntime>>::TooManyRequests);
+			assert_ok!(submit_finality_proof(1, 2));
+			assert_ok!(submit_finality_proof(3, 4));
+			assert_err!(submit_finality_proof(5, 6), <Error<TestRuntime>>::TooManyRequests);
 		})
 	}
 

--- a/relays/ethereum/src/main.rs
+++ b/relays/ethereum/src/main.rs
@@ -245,10 +245,10 @@ fn ethereum_deploy_contract_params(matches: &clap::ArgMatches) -> Result<Ethereu
 	});
 	let sub_initial_authorities_set_id = matches
 		.value_of("sub-authorities-set-id")
-		.map(|set| set
-			.parse()
-			.map_err(|e| format!("Failed to parse sub-authorities-set-id: {}", e))
-		)
+		.map(|set| {
+			set.parse()
+				.map_err(|e| format!("Failed to parse sub-authorities-set-id: {}", e))
+		})
 		.transpose()?;
 	let sub_initial_authorities_set = parse_hex_argument(matches, "sub-authorities-set")?;
 	let sub_initial_header = parse_hex_argument(matches, "sub-initial-header")?;
@@ -329,16 +329,17 @@ fn ethereum_exchange_params(matches: &clap::ArgMatches) -> Result<EthereumExchan
 		Some(eth_tx_hash) => ethereum_exchange::ExchangeRelayMode::Single(
 			eth_tx_hash
 				.parse()
-				.map_err(|e| format!("Failed to parse eth-tx-hash: {}", e))?
+				.map_err(|e| format!("Failed to parse eth-tx-hash: {}", e))?,
 		),
-		None => ethereum_exchange::ExchangeRelayMode::Auto(matches
-			.value_of("eth-start-with-block")
-			.map(|eth_start_with_block| {
-				eth_start_with_block
-					.parse()
-					.map_err(|e| format!("Failed to parse eth-start-with-block: {}", e))
-			})
-			.transpose()?
+		None => ethereum_exchange::ExchangeRelayMode::Auto(
+			matches
+				.value_of("eth-start-with-block")
+				.map(|eth_start_with_block| {
+					eth_start_with_block
+						.parse()
+						.map_err(|e| format!("Failed to parse eth-start-with-block: {}", e))
+				})
+				.transpose()?,
 		),
 	};
 

--- a/relays/ethereum/src/main.rs
+++ b/relays/ethereum/src/main.rs
@@ -243,14 +243,13 @@ fn ethereum_deploy_contract_params(matches: &clap::ArgMatches) -> Result<Ethereu
 	let eth_contract_code = parse_hex_argument(matches, "eth-contract-code")?.unwrap_or_else(|| {
 		hex::decode(include_str!("../res/substrate-bridge-bytecode.hex")).expect("code is hardcoded, thus valid; qed")
 	});
-	let sub_initial_authorities_set_id = match matches.value_of("sub-authorities-set-id") {
-		Some(sub_initial_authorities_set_id) => Some(
-			sub_initial_authorities_set_id
-				.parse()
-				.map_err(|e| format!("Failed to parse sub-authorities-set-id: {}", e))?,
-		),
-		None => None,
-	};
+	let sub_initial_authorities_set_id = matches
+		.value_of("sub-authorities-set-id")
+		.map(|set| set
+			.parse()
+			.map_err(|e| format!("Failed to parse sub-authorities-set-id: {}", e))
+		)
+		.transpose()?;
 	let sub_initial_authorities_set = parse_hex_argument(matches, "sub-authorities-set")?;
 	let sub_initial_header = parse_hex_argument(matches, "sub-initial-header")?;
 
@@ -270,23 +269,26 @@ fn ethereum_deploy_contract_params(matches: &clap::ArgMatches) -> Result<Ethereu
 }
 
 fn ethereum_exchange_submit_params(matches: &clap::ArgMatches) -> Result<EthereumExchangeSubmitParams, String> {
-	let eth_nonce = if let Some(eth_nonce) = matches.value_of("eth-nonce") {
-		Some(
+	let eth_nonce = matches
+		.value_of("eth-nonce")
+		.map(|eth_nonce| {
 			relay_ethereum_client::types::U256::from_dec_str(&eth_nonce)
-				.map_err(|e| format!("Failed to parse eth-nonce: {}", e))?,
-		)
-	} else {
-		None
-	};
+				.map_err(|e| format!("Failed to parse eth-nonce: {}", e))
+		})
+		.transpose()?;
 
-	let eth_amount = if let Some(eth_amount) = matches.value_of("eth-amount") {
-		eth_amount
-			.parse()
-			.map_err(|e| format!("Failed to parse eth-amount: {}", e))?
-	} else {
-		// This is in Wei, represents 1 ETH
-		1_000_000_000_000_000_000_u64.into()
-	};
+	let eth_amount = matches
+		.value_of("eth-amount")
+		.map(|eth_amount| {
+			eth_amount
+				.parse()
+				.map_err(|e| format!("Failed to parse eth-amount: {}", e))
+		})
+		.transpose()?
+		.unwrap_or_else(|| {
+			// This is in Wei, represents 1 ETH
+			1_000_000_000_000_000_000_u64.into()
+		});
 
 	// This is the well-known Substrate account of Ferdie
 	let default_recepient = hex!("1cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c");
@@ -327,16 +329,17 @@ fn ethereum_exchange_params(matches: &clap::ArgMatches) -> Result<EthereumExchan
 		Some(eth_tx_hash) => ethereum_exchange::ExchangeRelayMode::Single(
 			eth_tx_hash
 				.parse()
-				.map_err(|e| format!("Failed to parse eth-tx-hash: {}", e))?,
+				.map_err(|e| format!("Failed to parse eth-tx-hash: {}", e))?
 		),
-		None => ethereum_exchange::ExchangeRelayMode::Auto(match matches.value_of("eth-start-with-block") {
-			Some(eth_start_with_block) => Some(
+		None => ethereum_exchange::ExchangeRelayMode::Auto(matches
+			.value_of("eth-start-with-block")
+			.map(|eth_start_with_block| {
 				eth_start_with_block
 					.parse()
-					.map_err(|e| format!("Failed to parse eth-start-with-block: {}", e))?,
-			),
-			None => None,
-		}),
+					.map_err(|e| format!("Failed to parse eth-start-with-block: {}", e))
+			})
+			.transpose()?
+		),
 	};
 
 	let params = EthereumExchangeParams {


### PR DESCRIPTION
Builds are randomly running out of disk space, and the cache seems to be around 2.5G. I'd rather have predictable, but slower builds than fast and randomly failing, so trying out this.

Closes: https://github.com/paritytech/parity-bridges-common/issues/773