### PR TITLE
Overhaul releasing process

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,17 +21,21 @@ jobs:
     env:
       RUST_BACKTRACE:   full
     steps:
+      
       - name:           Cancel Previous Runs
         uses:           styfle/cancel-workflow-action@0.4.1
         with:
           access_token: ${{ github.token }}
+      
       - name:           Checkout sources & submodules
         uses:           actions/checkout@master
         with:
           fetch-depth:  5
           submodules:   recursive
+      
       - name:           Add rustfmt
         run:            rustup component add rustfmt
+      
       - name:           rust-fmt check
         uses:           actions-rs/cargo@master
         with:

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -68,12 +68,12 @@ jobs:
           tags:                    ${{ steps.prep.outputs.TAGS }}
           labels: |
             org.opencontainers.image.title=${{ matrix.project }}
-            # org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
-            # org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            # org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common"
-            # org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md"
-            # org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
-            # org.opencontainers.image.revision=${{ github.sha }}
-            # org.opencontainers.image.authors="devops-team@parity.io"
-            # org.opencontainers.image.vendor="Parity Technologies"
-            # org.opencontainers.image.licenses="GPL-3.0 License"
+            org.opencontainers.image.description=${{ matrix.project }} - component of Parity Bridges Common
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url=https://github.com/paritytech/parity-bridges-common
+            org.opencontainers.image.documentation=https://github.com/paritytech/parity-bridges-common/README.md
+            org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.authors=devops-team@parity.io
+            org.opencontainers.image.vendor=Parity Technologies
+            org.opencontainers.image.licenses=GPL-3.0 License

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -16,7 +16,7 @@ on:
     - cron:                        '0 0 * * 0'
 
 jobs:
-## Publish to Docker hub
+                                   ## Publish to Docker hub
   publish:
     name:                          Publishing
     runs-on:                       self-hosted
@@ -68,12 +68,12 @@ jobs:
           tags:                    ${{ steps.prep.outputs.TAGS }}
           labels: |
             org.opencontainers.image.title=${{ matrix.project }}
-            org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common"
-            org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md"
-            org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.authors="devops-team@parity.io"
-            org.opencontainers.image.vendor="Parity Technologies"
-            org.opencontainers.image.licenses="GPL-3.0 License"
+            # org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
+            # org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            # org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common"
+            # org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md"
+            # org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
+            # org.opencontainers.image.revision=${{ github.sha }}
+            # org.opencontainers.image.authors="devops-team@parity.io"
+            # org.opencontainers.image.vendor="Parity Technologies"
+            # org.opencontainers.image.licenses="GPL-3.0 License"

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -1,49 +1,88 @@
-name:                                               Publish Dependencies to Docker hub
+name:                              Publish Dependencies to Docker hub
 
 on:
+  pull_request:
   push:
+    branches:
+      - master
+      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:
       - '**/README.md'
       - diagrams/*
       - docs/*
-  schedule:                                         # Weekly build
-    - cron:                                         '0 0 * * 0'
+  schedule:                        # Weekly build
+    - cron:                        '0 0 * * 0'
 
 jobs:
 ## Publish to Docker hub
   publish:
-    name:                                           Publishing
-    runs-on:                                        self-hosted
+    name:                          Publishing
+    runs-on:                       self-hosted
     container:
-      image:                                        docker:git
+      image:                       docker:git
     steps:
-      - name:                                       Cancel Previous Runs
-        uses:                                       styfle/cancel-workflow-action@0.4.1
+
+      - name:                      Cancel Previous Runs
+        uses:                      styfle/cancel-workflow-action@0.4.1
         with:
-          access_token:                             ${{ github.token }}
-      - name:                                       Checkout sources & submodules
-        uses:                                       actions/checkout@master
+          access_token:            ${{ github.token }}
+
+      - name:                      Checkout sources & submodules
+        uses:                      actions/checkout@v2
         with:
-          fetch-depth:                              5
-          submodules:                               recursive
-      - name:                                       Build and push dependencies
-        uses:                                       docker/build-push-action@v1
+          fetch-depth:             5
+          submodules:              recursive
+
+      - name:                      Set up Docker Buildx
+        uses:                      docker/setup-buildx-action@v1
+
+      - name:                      Login to DockerHub
+        uses:                      docker/login-action@v1
         with:
-          username:                                 ${{ secrets.DOCKER_USER }}
-          password:                                 ${{ secrets.DOCKER_PASSWORD }}
-          repository:                               paritytech/bridge-dependencies
-          dockerfile:                               deployments/BridgeDeps.Dockerfile
-          tag_with_ref:                             true
-          tag_with_sha:                             true
-          labels:
-            org.opencontainers.image.source="https://github.com/paritytech/parity-bridges-common",
-            org.opencontainers.image.authors="devops-team@parity.io",
-            org.opencontainers.image.vendor="Parity Technologies",
-            org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common",
-            org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md",
-            org.opencontainers.image.title=${{ matrix.project }},
-            org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common",
+          username:                ${{ secrets.DOCKER_USERNAME }}
+          password:                ${{ secrets.DOCKER_PASSWORD }}
+
+      - name:                      Prepare
+        id:                        prep
+        run: |
+          DOCKER_IMAGE=paritytech/bridge-dependencies
+          VERSION=latest
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          echo ::set-output name=TAGS::${TAGS}
+          echo ::set-output name=DATE::$(date +%d-%m-%Y)
+
+      - name:                      Set up Docker Buildx
+        uses:                      docker/setup-buildx-action@v1
+
+      - name:                      Login to DockerHub
+        uses:                      docker/login-action@v1
+        with:
+          username:                ${{ secrets.DOCKER_USERNAME }}
+          password:                ${{ secrets.DOCKER_PASSWORD }}
+
+      - name:                      Build and push
+        uses:                      docker/build-push-action@v2
+        with:
+          file:                    deployments/BridgeDeps.Dockerfile
+          cache-from:              type=registry,ref=paritytech/bridge-dependencies:latest
+          cache-to:                type=inline
+          tags:                    ${{ steps.prep.outputs.TAGS }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.project }}
+            org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common"
+            org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md"
+            org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.authors="devops-team@parity.io"
+            org.opencontainers.image.vendor="Parity Technologies"
             org.opencontainers.image.licenses="GPL-3.0 License"
-          add_git_labels:                           true

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -54,8 +54,8 @@ jobs:
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          TAGS=${DOCKER_IMAGE}:${VERSION}
+          TAGS=$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -1,11 +1,7 @@
 name:                              Publish Dependencies to Docker hub
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
-      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -59,15 +59,6 @@ jobs:
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 
-      - name:                      Set up Docker Buildx
-        uses:                      docker/setup-buildx-action@v1
-
-      - name:                      Login to DockerHub
-        uses:                      docker/login-action@v1
-        with:
-          username:                ${{ secrets.DOCKER_USERNAME }}
-          password:                ${{ secrets.DOCKER_PASSWORD }}
-
       - name:                      Build and push
         uses:                      docker/build-push-action@v2
         with:

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -41,7 +41,7 @@ jobs:
       - name:                      Login to DockerHub
         uses:                      docker/login-action@v1
         with:
-          username:                ${{ secrets.DOCKER_USERNAME }}
+          username:                ${{ secrets.DOCKER_USER }}
           password:                ${{ secrets.DOCKER_PASSWORD }}
 
       - name:                      Prepare

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -63,12 +63,13 @@ jobs:
         uses:                      docker/build-push-action@v2
         with:
           file:                    deployments/BridgeDeps.Dockerfile
+          push:                    true
           cache-from:              type=registry,ref=paritytech/bridge-dependencies:latest
           cache-to:                type=inline
           tags:                    ${{ steps.prep.outputs.TAGS }}
           labels: |
-            org.opencontainers.image.title=${{ matrix.project }}
-            org.opencontainers.image.description=${{ matrix.project }} - component of Parity Bridges Common
+            org.opencontainers.image.title=bridge-dependencies
+            org.opencontainers.image.description=bridge-dependencies - component of Parity Bridges Common
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.url=https://github.com/paritytech/parity-bridges-common
             org.opencontainers.image.documentation=https://github.com/paritytech/parity-bridges-common/README.md

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,11 +1,7 @@
 name:                              Publish images to Docker hub
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
-      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,24 +1,20 @@
-name:                                               Publish images to Docker hub
+name:                              Publish images to Docker hub
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
-      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:
       - '**/README.md'
       - diagrams/*
       - docs/*
-  schedule:                                         # Nightly build
-    - cron:                                         '0 1 * * *'
+  schedule:                        # Nightly build
+    - cron:                        '0 1 * * *'
 
 jobs:
-## Publish to Docker hub
+                                   ## Publish to Docker hub
   publish:
-    name:                                           Publishing
+    name:                          Publishing
     strategy:
       matrix:
         project:
@@ -35,54 +31,67 @@ jobs:
             healthcheck: http://localhost:9616/metrics
           - project: substrate-relay
             healthcheck: http://localhost:9616/metrics
-    runs-on:                                        self-hosted
+
+    runs-on:                       ubuntu-latest
     container:
-      image:                                        docker:git
+      image:                       docker:git
     steps:
 
-      - name:                                       Cancel Previous Runs
-        uses:                                       styfle/cancel-workflow-action@0.4.1
+      - name:                      Cancel Previous Runs
+        uses:                      styfle/cancel-workflow-action@0.4.1
         with:
-          access_token:                             ${{ github.token }}
+          access_token:            ${{ github.token }}
 
-      - name:                                       Checkout sources & submodules
-        uses:                                       actions/checkout@master
+      - name:                      Checkout sources & submodules
+        uses:                      actions/checkout@master
         with:
-          fetch-depth:                              5
-          submodules:                               recursive
+          fetch-depth:             5
+          submodules:              recursive
 
-      - name:                                       Set vars
-        id:                                         vars
-        run:                                        |
-          echo ::set-output name=DATE::$(date +%d-%m-%Y)
-          if [[ ${GITHUB_REF} = refs/tags/* ]]
-          then
-            echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
-          else
-            echo ::set-output name=TAG::nightly-$(date +%d-%m-%Y)
-          fi
-
-      - name:                                       Build image for ${{ matrix.project }}
-        uses:                                       redhat-actions/buildah-build@v2.2
-        with:
-          image:                                    ${{ matrix.project }}
-          tags:                                     ${{ steps.vars.outputs.TAG }}, latest
-          dockerfiles: |
-            ./Dockerfile
-          build-args: |
-            PROJECT=${{ matrix.project }},
-            HEALTH=${{ matrix.healthcheck }}
-
-      - name:                                       Push ${{ matrix.project }} image to docker.io
-        id:                                         push-to-dockerhub
-        uses:                                       redhat-actions/push-to-registry@v2.1.1
-        with:
-          registry:                                 docker.io/paritytech
-          image:                                    ${{ matrix.project }}
-          tags:                                     ${{ steps.vars.outputs.TAG }}, latest
-          username:                                 ${{ secrets.DOCKER_USER }}
-          password:                                 ${{ secrets.DOCKER_PASSWORD }}
-
-      - name:                                       Check the image
+      - name: Prepare
+        id: prep
         run: |
-          echo "New image has been pushed to ${{ steps.push-to-dockerhub.outputs.registry-path }}"
+          DOCKER_IMAGE=paritytech/bridge-dependencies
+          VERSION=latest
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          echo ::set-output name=TAGS::${TAGS}
+          echo ::set-output name=DATE::$(date +%d-%m-%Y)
+
+      - name:                      Set up Docker Buildx
+        uses:                      docker/setup-buildx-action@v1
+
+      - name:                      Login to DockerHub
+        uses:                      docker/login-action@v1
+        with:
+          username:                ${{ secrets.DOCKER_USERNAME }}
+          password:                ${{ secrets.DOCKER_PASSWORD }}
+
+      - name:                      Build and push
+        uses:                      docker/build-push-action@v2
+        with:
+          context:                 .
+          file:                    ./Dockerfile
+          cache-from:              type=registry,ref=paritytech/bridge-dependencies:latest
+          cache-to:                type=inline
+          tags:                    ${{ steps.prep.outputs.TAGS }}
+          build-args: |
+            PROJECT=${{ matrix.project }}
+            HEALTH=${{ matrix.healthcheck }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.project }}
+            org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.documentation="${{ github.event.repository.html_url }}/README.md"
+            org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.authors="devops-team@parity.io"
+            org.opencontainers.image.vendor="Parity Technologies"
+            org.opencontainers.image.licenses="GPL-3.0 License"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -58,8 +58,7 @@ jobs:
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           fi
-          TAGS=${VERSION}
-          TAGS=$TAGS,sha-${GITHUB_SHA::8}
+          TAGS=${VERSION} sha-${GITHUB_SHA::8} latest
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 
@@ -67,7 +66,7 @@ jobs:
         uses:                                       redhat-actions/buildah-build@v2.2
         with:
           image:                                    ${{ matrix.project }}
-          tags:                                     ${{ steps.prep.outputs.TAGS }}, latest
+          tags:                                     ${{ steps.prep.outputs.TAGS }}
           dockerfiles:                              ./Dockerfile
           build-args: |
             PROJECT=${{ matrix.project }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           context:                 .
           file:                    ./Dockerfile
+          push:                    true
           cache-from:              type=registry,ref=paritytech/bridge-dependencies:latest
           cache-to:                type=inline
           tags:                    ${{ steps.prep.outputs.TAGS }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,11 @@
 name:                                               Publish images to Docker hub
 
 on:
+  pull_request:
   push:
+    branches:
+      - master
+      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:
@@ -35,15 +39,18 @@ jobs:
     container:
       image:                                        docker:git
     steps:
+
       - name:                                       Cancel Previous Runs
         uses:                                       styfle/cancel-workflow-action@0.4.1
         with:
           access_token:                             ${{ github.token }}
+
       - name:                                       Checkout sources & submodules
         uses:                                       actions/checkout@master
         with:
           fetch-depth:                              5
           submodules:                               recursive
+
       - name:                                       Set vars
         id:                                         vars
         run:                                        |
@@ -54,23 +61,28 @@ jobs:
           else
             echo ::set-output name=TAG::nightly-$(date +%d-%m-%Y)
           fi
-      - name:                                       Build and push ${{ matrix.project }}
-        uses:                                       docker/build-push-action@v1
+
+      - name:                                       Build image for ${{ matrix.project }}
+        uses:                                       redhat-actions/buildah-build@v2.2
         with:
+          image:                                    ${{ matrix.project }}
+          tags:                                     ${{ steps.vars.outputs.TAG }}, latest
+          dockerfiles: |
+            ./Dockerfile
+          build-args: |
+            PROJECT=${{ matrix.project }},
+            HEALTH=${{ matrix.healthcheck }}
+
+      - name:                                       Push ${{ matrix.project }} image to docker.io
+        id:                                         push-to-dockerhub
+        uses:                                       redhat-actions/push-to-registry@v2.1.1
+        with:
+          registry:                                 docker.io/paritytech
+          image:                                    ${{ matrix.project }}
+          tags:                                     ${{ steps.vars.outputs.TAG }}, latest
           username:                                 ${{ secrets.DOCKER_USER }}
           password:                                 ${{ secrets.DOCKER_PASSWORD }}
-          repository:                               paritytech/${{ matrix.project }}
-          build_args:                               PROJECT=${{ matrix.project }}, HEALTH=${{ matrix.healthcheck }}
-          tags:                                     ${{ steps.vars.outputs.TAG }}, latest
-          labels:
-            org.opencontainers.image.created=${{ steps.vars.outputs.DATE }},
-            org.opencontainers.image.source="https://github.com/paritytech/parity-bridges-common",
-            org.opencontainers.image.authors="devops-team@parity.io",
-            org.opencontainers.image.vendor="Parity Technologies",
-            org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common",
-            org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md",
-            org.opencontainers.image.version=${{ steps.vars.outputs.TAG }},
-            org.opencontainers.image.title=${{ matrix.project }},
-            org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common",
-            org.opencontainers.image.licenses="GPL-3.0 License"
-          add_git_labels:                           true
+
+      - name:                                       Check the image
+        run: |
+          echo "New image has been pushed to ${{ steps.push-to-dockerhub.outputs.registry-path }}"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,11 +1,7 @@
 name:                              Publish images to Docker hub
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
-      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:
@@ -59,6 +55,7 @@ jobs:
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           fi
           TAGS="${VERSION} sha-${GITHUB_SHA::8} latest"
+          echo ::set-output name=TAGS::${VERSION}
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 
@@ -71,6 +68,9 @@ jobs:
           build-args: |
             PROJECT=${{ matrix.project }}
             HEALTH=${{ matrix.healthcheck }}
+            VCS_REF=sha-${GITHUB_SHA::8}
+            BUILD_DATE=${{ steps.prep.outputs.DATE }}
+            VERSION=${{ steps.prep.outputs.VERSION }}
 
       - name:                                       Push ${{ matrix.project }} image to docker.io
         id:                                         push-to-dockerhub
@@ -85,16 +85,3 @@ jobs:
       - name:                                       Check the image
         run: |
           echo "New image has been pushed to ${{ steps.push-to-dockerhub.outputs.registry-path }}"
-
-          # labels: |
-          #   org.opencontainers.image.title=${{ matrix.project }}
-          #   org.opencontainers.image.description=${{ matrix.project }} - component of Parity Bridges Common
-          #   org.opencontainers.image.source=${{ github.event.repository.html_url }}
-          #   org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          #   org.opencontainers.image.documentation=${{ github.event.repository.html_url }}/README.md
-          #   org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
-          #   org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
-          #   org.opencontainers.image.revision=${{ github.sha }}
-          #   org.opencontainers.image.authors=devops-team@parity.io
-          #   org.opencontainers.image.vendor=Parity Technologies
-          #   org.opencontainers.image.licenses=GPL-3.0 License

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -58,7 +58,7 @@ jobs:
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           fi
-          TAGS=${VERSION} sha-${GITHUB_SHA::8} latest
+          TAGS="${VERSION} sha-${GITHUB_SHA::8} latest"
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -37,8 +37,6 @@ jobs:
             healthcheck: http://localhost:9616/metrics
 
     runs-on:                       self-hosted
-    container:
-      image:                       docker:git
     steps:
 
       - name:                      Cancel Previous Runs

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -72,7 +72,7 @@ jobs:
           tags:                                     ${{ steps.prep.outputs.TAG }}
           dockerfiles:                              ./Dockerfile
           build-args: |
-            PROJECT=${{ matrix.project }},
+            PROJECT=${{ matrix.project }}
             HEALTH=${{ matrix.healthcheck }}
 
       - name:                                       Push ${{ matrix.project }} image to docker.io

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,11 @@
 name:                              Publish images to Docker hub
 
 on:
+  pull_request:
   push:
+    branches:
+      - master
+      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:
@@ -32,7 +36,7 @@ jobs:
           - project: substrate-relay
             healthcheck: http://localhost:9616/metrics
 
-    runs-on:                       ubuntu-latest
+    runs-on:                       self-hosted
     container:
       image:                       docker:git
     steps:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -82,8 +82,6 @@ jobs:
           context:                 .
           file:                    ./Dockerfile
           push:                    true
-          cache-from:              type=registry,ref=paritytech/bridge-dependencies:latest
-          cache-to:                type=inline
           tags:                    ${{ steps.prep.outputs.TAGS }}
           build-args: |
             PROJECT=${{ matrix.project }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,11 @@
 name:                              Publish images to Docker hub
 
 on:
+  pull_request:
   push:
+    branches:
+      - master
+      - 3x8_use_buildah
     tags:
       - v*
     paths-ignore:
@@ -69,7 +73,7 @@ jobs:
       - name:                      Login to DockerHub
         uses:                      docker/login-action@v1
         with:
-          username:                ${{ secrets.DOCKER_USERNAME }}
+          username:                ${{ secrets.DOCKER_USER }}
           password:                ${{ secrets.DOCKER_PASSWORD }}
 
       - name:                      Build and push

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -62,8 +62,8 @@ jobs:
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          TAGS=${DOCKER_IMAGE}:${VERSION}
+          TAGS=$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -89,13 +89,13 @@ jobs:
             HEALTH=${{ matrix.healthcheck }}
           labels: |
             org.opencontainers.image.title=${{ matrix.project }}
-            # org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
-            # org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            # org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            # org.opencontainers.image.documentation="${{ github.event.repository.html_url }}/README.md"
-            # org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
-            # org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
-            # org.opencontainers.image.revision=${{ github.sha }}
-            # org.opencontainers.image.authors="devops-team@parity.io"
-            # org.opencontainers.image.vendor="Parity Technologies"
-            # org.opencontainers.image.licenses="GPL-3.0 License"
+            org.opencontainers.image.description=${{ matrix.project }} - component of Parity Bridges Common
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.documentation=${{ github.event.repository.html_url }}/README.md
+            org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.authors=devops-team@parity.io
+            org.opencontainers.image.vendor=Parity Technologies
+            org.opencontainers.image.licenses=GPL-3.0 License

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -53,15 +53,13 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=paritytech/bridge-dependencies
-          VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           fi
-          TAGS=${DOCKER_IMAGE}:${VERSION}
-          TAGS=$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}
+          TAGS=${VERSION}
+          TAGS=$TAGS,sha-${GITHUB_SHA::8}
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 
@@ -69,7 +67,7 @@ jobs:
         uses:                                       redhat-actions/buildah-build@v2.2
         with:
           image:                                    ${{ matrix.project }}
-          tags:                                     ${{ steps.prep.outputs.TAG }}
+          tags:                                     ${{ steps.prep.outputs.TAGS }}, latest
           dockerfiles:                              ./Dockerfile
           build-args: |
             PROJECT=${{ matrix.project }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -90,12 +90,12 @@ jobs:
           labels: |
             org.opencontainers.image.title=${{ matrix.project }}
             # org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.documentation="${{ github.event.repository.html_url }}/README.md"
-            org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.authors="devops-team@parity.io"
-            org.opencontainers.image.vendor="Parity Technologies"
-            org.opencontainers.image.licenses="GPL-3.0 License"
+            # org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            # org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            # org.opencontainers.image.documentation="${{ github.event.repository.html_url }}/README.md"
+            # org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
+            # org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
+            # org.opencontainers.image.revision=${{ github.sha }}
+            # org.opencontainers.image.authors="devops-team@parity.io"
+            # org.opencontainers.image.vendor="Parity Technologies"
+            # org.opencontainers.image.licenses="GPL-3.0 License"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,7 +36,7 @@ jobs:
           - project: substrate-relay
             healthcheck: http://localhost:9616/metrics
 
-    runs-on:                       self-hosted
+    runs-on:                       ubuntu-latest
     steps:
 
       - name:                      Cancel Previous Runs
@@ -65,34 +65,39 @@ jobs:
           echo ::set-output name=TAGS::${TAGS}
           echo ::set-output name=DATE::$(date +%d-%m-%Y)
 
-      - name:                      Set up Docker Buildx
-        uses:                      docker/setup-buildx-action@v1
-
-      - name:                      Login to DockerHub
-        uses:                      docker/login-action@v1
+      - name:                                       Build image for ${{ matrix.project }}
+        uses:                                       redhat-actions/buildah-build@v2.2
         with:
-          username:                ${{ secrets.DOCKER_USER }}
-          password:                ${{ secrets.DOCKER_PASSWORD }}
-
-      - name:                      Build and push
-        uses:                      docker/build-push-action@v2
-        with:
-          context:                 .
-          file:                    ./Dockerfile
-          push:                    true
-          tags:                    ${{ steps.prep.outputs.TAGS }}
+          image:                                    ${{ matrix.project }}
+          tags:                                     ${{ steps.prep.outputs.TAG }}
+          dockerfiles:                              ./Dockerfile
           build-args: |
-            PROJECT=${{ matrix.project }}
+            PROJECT=${{ matrix.project }},
             HEALTH=${{ matrix.healthcheck }}
-          labels: |
-            org.opencontainers.image.title=${{ matrix.project }}
-            org.opencontainers.image.description=${{ matrix.project }} - component of Parity Bridges Common
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.documentation=${{ github.event.repository.html_url }}/README.md
-            org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.authors=devops-team@parity.io
-            org.opencontainers.image.vendor=Parity Technologies
-            org.opencontainers.image.licenses=GPL-3.0 License
+
+      - name:                                       Push ${{ matrix.project }} image to docker.io
+        id:                                         push-to-dockerhub
+        uses:                                       redhat-actions/push-to-registry@v2.1.1
+        with:
+          registry:                                 docker.io/paritytech
+          image:                                    ${{ matrix.project }}
+          tags:                                     ${{ steps.prep.outputs.TAGS }}
+          username:                                 ${{ secrets.DOCKER_USER }}
+          password:                                 ${{ secrets.DOCKER_PASSWORD }}
+
+      - name:                                       Check the image
+        run: |
+          echo "New image has been pushed to ${{ steps.push-to-dockerhub.outputs.registry-path }}"
+
+          # labels: |
+          #   org.opencontainers.image.title=${{ matrix.project }}
+          #   org.opencontainers.image.description=${{ matrix.project }} - component of Parity Bridges Common
+          #   org.opencontainers.image.source=${{ github.event.repository.html_url }}
+          #   org.opencontainers.image.url=${{ github.event.repository.html_url }}
+          #   org.opencontainers.image.documentation=${{ github.event.repository.html_url }}/README.md
+          #   org.opencontainers.image.created=${{ steps.prep.outputs.DATE }}
+          #   org.opencontainers.image.version=${{ steps.prep.outputs.TAG }}
+          #   org.opencontainers.image.revision=${{ github.sha }}
+          #   org.opencontainers.image.authors=devops-team@parity.io
+          #   org.opencontainers.image.vendor=Parity Technologies
+          #   org.opencontainers.image.licenses=GPL-3.0 License

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -45,7 +45,7 @@ jobs:
           access_token:            ${{ github.token }}
 
       - name:                      Checkout sources & submodules
-        uses:                      actions/checkout@master
+        uses:                      actions/checkout@v2
         with:
           fetch-depth:             5
           submodules:              recursive

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -89,7 +89,7 @@ jobs:
             HEALTH=${{ matrix.healthcheck }}
           labels: |
             org.opencontainers.image.title=${{ matrix.project }}
-            org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
+            # org.opencontainers.image.description="${{ matrix.project }} - component of Parity Bridges Common"
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.documentation="${{ github.event.repository.html_url }}/README.md"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,19 +29,24 @@ jobs:
       RUST_BACKTRACE:              full
       NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
     steps:
+      
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
         with:
           access_token:            ${{ github.token }}
+      
       - name:                      Checkout sources & submodules
         uses:                      actions/checkout@master
         with:
           fetch-depth:             5
           submodules:              recursive
+      
       - name:                      Install Toolchain
         run:                       rustup toolchain add $NIGHTLY
+      
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+      
       - name:                      Checking rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
         with:
@@ -65,6 +70,7 @@ jobs:
           command:                 check
           toolchain:               ${{ matrix.toolchain }}
           args:                    --manifest-path ./bin/rialto/node/Cargo.toml --no-default-features --features runtime-benchmarks --verbose
+      
       - name:                      Check Millau benchmarks runtime ${{ matrix.platform }} rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
         with:
@@ -86,19 +92,24 @@ jobs:
       RUST_BACKTRACE:              full
       NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
     steps:
+      
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
         with:
           access_token:            ${{ github.token }}
+      
       - name:                      Checkout sources & submodules
         uses:                      actions/checkout@master
         with:
           fetch-depth:             5
           submodules:              recursive
+      
       - name:                      Install Toolchain
         run:                       rustup toolchain add $NIGHTLY
+      
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+      
       - name:                      Building rust-${{ matrix.toolchain }}
         uses:                      actions-rs/cargo@master
         if:                        github.ref == 'refs/heads/master'
@@ -106,6 +117,7 @@ jobs:
           command:                 build
           toolchain:               ${{ matrix.toolchain }}
           args:                    --all --verbose
+      
       - name:                      Prepare artifacts
         if:                        github.ref == 'refs/heads/master'
         run:                       |
@@ -115,6 +127,7 @@ jobs:
           mv -v target/debug/ethereum-poa-relay ./artifacts/;
           mv -v target/debug/substrate-relay ./artifacts/;
         shell:                     bash
+      
       - name:                      Upload artifacts
         if:                        github.ref == 'refs/heads/master'
         uses:                      actions/upload-artifact@v1
@@ -130,23 +143,30 @@ jobs:
       RUST_BACKTRACE:              full
       NIGHTLY:                     nightly #if necessary, specify the version, nightly-2020-10-04, etc.
     steps:
+
       - name:                      Cancel Previous Runs
         uses:                      styfle/cancel-workflow-action@0.4.1
         with:
           access_token:            ${{ github.token }}
+      
       - name:                      Checkout sources & submodules
         uses:                      actions/checkout@master
         with:
           fetch-depth:             5
           submodules:              recursive
+      
       - name:                      Install Toolchain
         run:                       rustup toolchain add $NIGHTLY
+      
       - name:                      Add WASM Utilities
         run:                       rustup target add wasm32-unknown-unknown --toolchain $NIGHTLY
+      
       - name:                      Add clippy
         run:                       rustup component add clippy --toolchain $NIGHTLY
+      
       - name:                      Rust Cache
         uses:                      Swatinem/rust-cache@v1.2.0
+      
       - name:                      Clippy
         uses:                      actions-rs/cargo@master
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-FROM docker.io/paritytech/bridge-dependencies as builder
+FROM paritytech/bridge-dependencies as builder
 WORKDIR /parity-bridges-common
 
 COPY . .
@@ -19,7 +19,7 @@ RUN strip ./target/release/${PROJECT}
 
 # In this final stage we copy over the final binary and do some checks
 # to make sure that everything looks good.
-FROM docker.io/ubuntu:20.04 as runtime
+FROM ubuntu:20.04 as runtime
 
 # show backtraces
 ENV RUST_BACKTRACE 1
@@ -31,7 +31,7 @@ RUN set -eux; \
 		libssl-dev curl && \
 	groupadd -g 1000 user && \
 	useradd -u 1000 -g user -s /bin/sh -m user && \
-# apt clean up
+	# apt clean up
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,33 +8,11 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-# This first stage prepares our dependencies to be built by `cargo-chef`.
-FROM rust as planner
-WORKDIR /parity-bridges-common
-RUN cargo install cargo-chef --version 0.1.13
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-# This second stage is where the dependencies actually get built.
-# The reason we split it from the first stage is so that the `COPY . .`
-# step doesn't blow our cache.
-FROM paritytech/bridge-dependencies AS cacher
-WORKDIR /parity-bridges-common
-RUN cargo install cargo-chef --version 0.1.13
-
-COPY --from=planner /parity-bridges-common/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
-
-# In this third stage we go ahead and build the actual binary we want.
-# This should be fairly quick since the dependencies are being built and
-# cached in the previous stage.
-FROM paritytech/bridge-dependencies as builder
+FROM paritytech/bridge-dependencies:20.04 as builder
 WORKDIR /parity-bridges-common
 RUN cargo install cargo-chef --version 0.1.13
 
 COPY . .
-COPY --from=cacher /parity-bridges-common/target target
-COPY --from=cacher $CARGO_HOME $CARGO_HOME
 
 ARG PROJECT=ethereum-poa-relay
 RUN cargo build --release --verbose -p ${PROJECT}
@@ -42,7 +20,7 @@ RUN strip ./target/release/${PROJECT}
 
 # In this final stage we copy over the final binary and do some checks
 # to make sure that everything looks good.
-FROM ubuntu:xenial as runtime
+FROM ubuntu:20.04 as runtime
 
 # show backtraces
 ENV RUST_BACKTRACE 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,22 +44,6 @@ RUN strip ./target/release/${PROJECT}
 # to make sure that everything looks good.
 FROM ubuntu:xenial as runtime
 
-# metadata
-ARG DATE=""
-ARG TAG=master
-ARG PROJECT=ethereum-poa-relay
-
-LABEL org.opencontainers.image.created=${DATE} \
-    org.opencontainers.image.source="https://github.com/paritytech/parity-bridges-common" \
-    org.opencontainers.image.authors="devops-team@parity.io" \
-    org.opencontainers.image.vendor="Parity Technologies" \
-    org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common" \
-    org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md" \
-    org.opencontainers.image.version=${TAG} \
-    org.opencontainers.image.title=${PROJECT} \
-    org.opencontainers.image.description="${PROJECT} - component of Parity Bridges Common" \
-    org.opencontainers.image.licenses="GPL-3.0 License"
-
 # show backtraces
 ENV RUST_BACKTRACE 1
 
@@ -74,6 +58,8 @@ RUN groupadd -g 1000 user \
 USER user
 
 WORKDIR /home/user
+
+ARG PROJECT=ethereum-poa-relay
 
 COPY --chown=user:user --from=builder /parity-bridges-common/target/release/${PROJECT} ./
 COPY --chown=user:user --from=builder /parity-bridges-common/deployments/local-scripts/bridge-entrypoint.sh ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,22 @@ RUN strip ./target/release/${PROJECT}
 # to make sure that everything looks good.
 FROM ubuntu:xenial as runtime
 
+# metadata
+ARG DATE=""
+ARG TAG=master
+ARG PROJECT=ethereum-poa-relay
+
+LABEL org.opencontainers.image.created=${DATE} \
+    org.opencontainers.image.source="https://github.com/paritytech/parity-bridges-common" \
+    org.opencontainers.image.authors="devops-team@parity.io" \
+    org.opencontainers.image.vendor="Parity Technologies" \
+    org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common" \
+    org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/README.md" \
+    org.opencontainers.image.version=${TAG} \
+    org.opencontainers.image.title=${PROJECT} \
+    org.opencontainers.image.description="${PROJECT} - component of Parity Bridges Common" \
+    org.opencontainers.image.licenses="GPL-3.0 License"
+
 # show backtraces
 ENV RUST_BACKTRACE 1
 
@@ -58,8 +74,6 @@ RUN groupadd -g 1000 user \
 USER user
 
 WORKDIR /home/user
-
-ARG PROJECT=ethereum-poa-relay
 
 COPY --chown=user:user --from=builder /parity-bridges-common/target/release/${PROJECT} ./
 COPY --chown=user:user --from=builder /parity-bridges-common/deployments/local-scripts/bridge-entrypoint.sh ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-FROM paritytech/bridge-dependencies:20.04 as builder
+FROM docker.io/paritytech/bridge-dependencies:20.04 as builder
 WORKDIR /parity-bridges-common
 RUN cargo install cargo-chef --version 0.1.13
 
@@ -20,7 +20,7 @@ RUN strip ./target/release/${PROJECT}
 
 # In this final stage we copy over the final binary and do some checks
 # to make sure that everything looks good.
-FROM ubuntu:20.04 as runtime
+FROM docker.io/ubuntu:20.04 as runtime
 
 # show backtraces
 ENV RUST_BACKTRACE 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,19 @@ RUN strip ./target/release/${PROJECT}
 FROM docker.io/ubuntu:20.04 as runtime
 
 # show backtraces
-ENV RUST_BACKTRACE 1
+ENV RUST_BACKTRACE 1 \
+	DEBIAN_FRONTEND=noninteractive
 
 RUN set -eux; \
 	apt-get update && \
-	apt-get install -y libssl-dev curl
-
-RUN groupadd -g 1000 user \
-  && useradd -u 1000 -g user -s /bin/sh -m user
+	apt-get install -y --no-install-recommends \
+		libssl-dev curl && \
+	groupadd -g 1000 user && \
+	useradd -u 1000 -g user -s /bin/sh -m user && \
+# apt clean up
+	apt-get autoremove -y && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 
 # switch to non-root user
 USER user

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@
 
 FROM docker.io/paritytech/bridge-dependencies:20.04 as builder
 WORKDIR /parity-bridges-common
-RUN cargo install cargo-chef --version 0.1.13
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-FROM docker.io/paritytech/bridge-dependencies:20.04 as builder
+FROM docker.io/paritytech/bridge-dependencies as builder
 WORKDIR /parity-bridges-common
 
 COPY . .
@@ -22,8 +22,8 @@ RUN strip ./target/release/${PROJECT}
 FROM docker.io/ubuntu:20.04 as runtime
 
 # show backtraces
-ENV RUST_BACKTRACE 1 \
-	DEBIAN_FRONTEND=noninteractive
+ENV RUST_BACKTRACE 1
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN set -eux; \
 	apt-get update && \
@@ -51,3 +51,20 @@ RUN ./${PROJECT} --version
 
 ENV PROJECT=$PROJECT
 ENTRYPOINT ["/home/user/bridge-entrypoint.sh"]
+
+# metadata
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG VERSION=""
+
+LABEL org.opencontainers.image.title="${PROJECT}" \
+    org.opencontainers.image.description="${PROJECT} - component of Parity Bridges Common" \
+    org.opencontainers.image.source="https://github.com/paritytech/parity-bridges-common/blob/${VCS_REF}/Dockerfile" \
+    org.opencontainers.image.url="https://github.com/paritytech/parity-bridges-common/blob/${VCS_REF}/Dockerfile" \
+    org.opencontainers.image.documentation="https://github.com/paritytech/parity-bridges-common/blob/${VCS_REF}/README.md" \
+    org.opencontainers.image.created="${BUILD_DATE}" \
+    org.opencontainers.image.version="${VERSION}" \
+    org.opencontainers.image.revision="${VCS_REF}" \
+    org.opencontainers.image.authors="devops-team@parity.io" \
+    org.opencontainers.image.vendor="Parity Technologies" \
+    org.opencontainers.image.licenses="GPL-3.0 License"

--- a/deployments/BridgeDeps.Dockerfile
+++ b/deployments/BridgeDeps.Dockerfile
@@ -2,7 +2,7 @@
 #
 # This image is meant to be used as a building block when building images for
 # the various components in the bridge repo, such as nodes and relayers.
-FROM ubuntu:xenial
+FROM ubuntu:20.04
 
 ENV LAST_DEPS_UPDATE 2020-12-21
 

--- a/deployments/BridgeDeps.Dockerfile
+++ b/deployments/BridgeDeps.Dockerfile
@@ -4,7 +4,7 @@
 # the various components in the bridge repo, such as nodes and relayers.
 FROM ubuntu:20.04
 
-ENV LAST_DEPS_UPDATE 2020-12-21
+ENV LAST_DEPS_UPDATE 2021-03-08
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN set -eux; \
@@ -12,13 +12,13 @@ RUN set -eux; \
 	apt-get install -y curl ca-certificates && \
 	apt-get install -y cmake pkg-config libssl-dev git clang libclang-dev
 
-ENV LAST_CERTS_UPDATE 2020-12-21
+ENV LAST_CERTS_UPDATE 2021-03-08
 
 RUN update-ca-certificates && \
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
-ENV LAST_RUST_UPDATE 2020-12-21
+ENV LAST_RUST_UPDATE 2021-03-08
 
 RUN rustup update stable && \
 	rustup install nightly && \

--- a/deployments/BridgeDeps.Dockerfile
+++ b/deployments/BridgeDeps.Dockerfile
@@ -5,6 +5,7 @@
 FROM ubuntu:20.04
 
 ENV LAST_DEPS_UPDATE 2020-12-21
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN set -eux; \
 	apt-get update && \

--- a/deployments/BridgeDeps.Dockerfile
+++ b/deployments/BridgeDeps.Dockerfile
@@ -27,7 +27,6 @@ RUN rustup update stable && \
 RUN rustc -vV && \
     cargo -V && \
     gcc -v && \
-    g++ -v && \
     cmake --version
 
 ENV RUST_BACKTRACE 1


### PR DESCRIPTION
-> Due to the long image builds we have to use the self-hosted runner.
-> A self-hosted runner can't `buildah`
Have to update to the newer version of the deprecated official docker action. 
This is, in fact, not bad. Now the action uses BuildX.
-> BuildX has an ugly [bug](https://github.com/docker/buildx/issues/101) 

Overhaul of publishing
- remove multistage build as it is a CI recursion
- upgrade to `ubuntu:20.04` base
- CI: move to use `buildah` actions
- chore