### PR TITLE
Stop CI from failing with new security advisories

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -16,6 +16,13 @@ on:
 jobs:
   cargo-deny:
     runs-on:            ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    # Prevent sudden announcement of a new advisory from failing CI:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
       - name:           Cancel Previous Runs
         uses:           styfle/cancel-workflow-action@0.4.1
@@ -29,4 +36,4 @@ jobs:
       - name:           Cargo deny
         uses:           EmbarkStudios/cargo-deny-action@v1
         with:
-          command:      "check --hide-inclusion-graph"
+          command:      check ${{ matrix.checks }}


### PR DESCRIPTION
Most of the time that `cargo-deny` complains about a new security advisory there's
nothing we can do because the broken crate is way too deep in our dependency tree.
This PR continues to run the advisory check, but makes sure that the CI doesn't fail
when it does encounter a new security advisory.
