### PR TITLE
Unify Substrate Bridge Pallet with Finality Verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,6 +4393,7 @@ dependencies = [
  "pallet-substrate-bridge",
  "parity-scale-codec 2.0.1",
  "serde",
+ "sp-finality-grandpa",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -559,6 +559,17 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl bp_rialto::RialtoFinalityApi<Block> for Runtime {
+		fn best_finalized() -> (bp_rialto::BlockNumber, bp_rialto::Hash) {
+			let header = BridgeFinalityVerifier::best_finalized();
+			(header.number, header.hash())
+		}
+
+		fn is_known_header(hash: bp_rialto::Hash) -> bool {
+			BridgeFinalityVerifier::is_known_header(hash)
+		}
+	}
+
 	impl bp_rialto::ToRialtoOutboundLaneApi<Block, Balance, ToRialtoMessagePayload> for Runtime {
 		fn estimate_message_delivery_and_dispatch_fee(
 			_lane_id: bp_message_lane::LaneId,

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -642,6 +642,17 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl bp_millau::MillauFinalityApi<Block> for Runtime {
+		fn best_finalized() -> (bp_millau::BlockNumber, bp_millau::Hash) {
+			let header = BridgeFinalityVerifier::best_finalized();
+			(header.number, header.hash())
+		}
+
+		fn is_known_header(hash: bp_millau::Hash) -> bool {
+			BridgeFinalityVerifier::is_known_header(hash)
+		}
+	}
+
 	impl bp_currency_exchange::RialtoCurrencyExchangeApi<Block, exchange::EthereumTransactionInclusionProof> for Runtime {
 		fn filter_transaction_proof(proof: exchange::EthereumTransactionInclusionProof) -> bool {
 			BridgeRialtoCurrencyExchange::filter_transaction_proof(&proof)

--- a/modules/finality-verifier/Cargo.toml
+++ b/modules/finality-verifier/Cargo.toml
@@ -21,6 +21,7 @@ bp-header-chain = { path = "../../primitives/header-chain", default-features = f
 
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
+sp-finality-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "master" , default-features = false }
 
@@ -40,6 +41,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"serde",
+	"sp-finality-grandpa/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -778,7 +778,7 @@ mod tests {
 	}
 
 	#[test]
-	fn disallows_imports_once_limit_is_hit_in_single_block() {
+	fn rate_limiter_disallows_imports_once_limit_is_hit_in_single_block() {
 		run_test(|| {
 			initialize_substrate_bridge();
 			assert_ok!(submit_finality_proof(1, 2));
@@ -788,7 +788,7 @@ mod tests {
 	}
 
 	#[test]
-	fn invalid_requests_do_not_count_towards_request_count() {
+	fn rate_limiter_invalid_requests_do_not_count_towards_request_count() {
 		run_test(|| {
 			let submit_invalid_request = || {
 				let child = test_header(1);
@@ -820,7 +820,7 @@ mod tests {
 	}
 
 	#[test]
-	fn allows_request_after_new_block_has_started() {
+	fn rate_limiter_allows_request_after_new_block_has_started() {
 		run_test(|| {
 			initialize_substrate_bridge();
 			assert_ok!(submit_finality_proof(1, 2));
@@ -832,7 +832,7 @@ mod tests {
 	}
 
 	#[test]
-	fn disallows_imports_once_limit_is_hit_across_different_blocks() {
+	fn rate_limiter_disallows_imports_once_limit_is_hit_across_different_blocks() {
 		run_test(|| {
 			initialize_substrate_bridge();
 			assert_ok!(submit_finality_proof(1, 2));
@@ -845,7 +845,7 @@ mod tests {
 	}
 
 	#[test]
-	fn allows_max_requests_after_long_time_with_no_activity() {
+	fn rate_limiter_allows_max_requests_after_long_time_with_no_activity() {
 		run_test(|| {
 			initialize_substrate_bridge();
 			assert_ok!(submit_finality_proof(1, 2));

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -348,10 +348,11 @@ pub mod pallet {
 	/// means it's of great importance that this function *not* called with any headers whose
 	/// finality has not been checked, otherwise you risk bricking your bridge.
 	pub(crate) fn import_header<T: Config>(header: BridgedHeader<T>) -> Result<(), sp_runtime::DispatchError> {
-		let best_finalized = <ImportedHeaders<T>>::get(<BestFinalized<T>>::get()).expect(
-			"In order to reach this point the bridge must have been initialized. Therefore
-			`ImportedHeaders` must contain an entry for `BestFinalized`.",
-		);
+		const BEST_FINALIZED_PROOF: &str = "In order to reach this point the bridge must have been
+			initialized. Afterwards, every time `BestFinalized` is updated `ImportedHeaders` is
+			also updated. Therefore `ImportedHeaders` must contain an entry for `BestFinalized`.";
+
+		let best_finalized = <ImportedHeaders<T>>::get(<BestFinalized<T>>::get()).expect(BEST_FINALIZED_PROOF);
 
 		// We do a quick check here to ensure that our header chain is making progress and isn't
 		// "travelling back in time" (which would be indicative of something bad, e.g a hard-fork).

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -197,7 +197,7 @@ pub mod pallet {
 		/// Change `ModuleOwner`.
 		///
 		/// May only be called either by root, or by `ModuleOwner`.
-		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
 		pub fn set_owner(origin: OriginFor<T>, new_owner: Option<T::AccountId>) -> DispatchResultWithPostInfo {
 			ensure_owner_or_root::<T>(origin)?;
 			match new_owner {
@@ -217,7 +217,7 @@ pub mod pallet {
 		/// Halt all pallet operations. Operations may be resumed using `resume_operations` call.
 		///
 		/// May only be called either by root, or by `ModuleOwner`.
-		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
 		pub fn halt_operations(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			ensure_owner_or_root::<T>(origin)?;
 			<IsHalted<T>>::put(true);
@@ -229,7 +229,7 @@ pub mod pallet {
 		/// Resume all pallet operations. May be called even if pallet is halted.
 		///
 		/// May only be called either by root, or by `ModuleOwner`.
-		#[pallet::weight(T::DbWeight::get().reads_writes(1, 1))]
+		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
 		pub fn resume_operations(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			ensure_owner_or_root::<T>(origin)?;
 			<IsHalted<T>>::put(false);

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -368,6 +368,7 @@ pub mod pallet {
 			// GRANDPA only includes a `delay` for forced changes, so this isn't valid.
 			ensure!(change.delay == Zero::zero(), <Error<T>>::UnsupportedScheduledChange);
 
+			// TODO [#788]: Stop manually increasing the `set_id` here.
 			let next_authorities = bp_header_chain::AuthoritySet {
 				authorities: change.next_authorities,
 				set_id: <CurrentAuthoritySet<T>>::get().set_id + 1,

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -410,6 +410,30 @@ pub mod pallet {
 	}
 }
 
+impl<T: Config> Pallet<T> {
+	/// Get the best finalized header the pallet knows of.
+	///
+	/// Returns a dummy header if there is no best header. This can only happen
+	/// if the pallet has not been initialized yet.
+	pub fn best_finalized() -> BridgedHeader<T> {
+		let hash = <BestFinalized<T>>::get();
+		<ImportedHeaders<T>>::get(hash).unwrap_or_else(|| {
+			<BridgedHeader<T>>::new(
+				Default::default(),
+				Default::default(),
+				Default::default(),
+				Default::default(),
+				Default::default(),
+			)
+		})
+	}
+
+	/// Check if a particular header is known to the bridge pallet.
+	pub fn is_known_header(hash: BridgedBlockHash<T>) -> bool {
+		<ImportedHeaders<T>>::contains_key(hash)
+	}
+}
+
 /// Data required for initializing the bridge pallet.
 ///
 /// The bridge needs to know where to start its sync from, and this provides that initial context.
@@ -521,6 +545,7 @@ mod tests {
 				BestFinalized::<TestRuntime>::get(),
 				BridgedBlockHash::<TestRuntime>::default()
 			);
+			assert_eq!(Module::<TestRuntime>::best_finalized(), test_header(0));
 
 			let init_data = init_with_origin(Origin::root()).unwrap();
 

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -532,7 +532,7 @@ mod tests {
 	#[test]
 	fn init_can_only_initialize_pallet_once() {
 		run_test(|| {
-			assert_ok!(init_with_origin(Origin::root()));
+			initialize_substrate_bridge();
 			assert_noop!(
 				init_with_origin(Origin::root()),
 				<Error<TestRuntime>>::AlreadyInitialized
@@ -715,7 +715,7 @@ mod tests {
 	#[test]
 	fn importing_header_ensures_that_chain_is_extended() {
 		run_test(|| {
-			init_with_origin(Origin::root()).unwrap();
+			initialize_substrate_bridge();
 
 			let header = test_header(3);
 			assert_ok!(pallet::import_header::<TestRuntime>(header));
@@ -734,7 +734,7 @@ mod tests {
 	#[test]
 	fn importing_header_enacts_new_authority_set() {
 		run_test(|| {
-			init_with_origin(Origin::root()).unwrap();
+			initialize_substrate_bridge();
 
 			let next_set_id = 2;
 			let next_authorities = vec![(alice(), 1), (bob(), 1)];
@@ -762,7 +762,7 @@ mod tests {
 	#[test]
 	fn importing_header_rejects_header_with_scheduled_change_delay() {
 		run_test(|| {
-			init_with_origin(Origin::root()).unwrap();
+			initialize_substrate_bridge();
 
 			// Need to update the header digest to indicate that our header signals an authority set
 			// change. However, the change doesn't happen until the next block.

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -172,8 +172,7 @@ pub mod pallet {
 		/// This function is only allowed to be called from a trusted origin and writes to storage
 		/// with practically no checks in terms of the validity of the data. It is important that
 		/// you ensure that valid data is being passed in.
-		//TODO: Update weights [#78]
-		#[pallet::weight(0)]
+		#[pallet::weight((T::DbWeight::get().reads_writes(2, 5), DispatchClass::Operational))]
 		pub fn initialize(
 			origin: OriginFor<T>,
 			init_data: super::InitializationData<BridgedHeader<T>>,

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -285,6 +285,7 @@ pub mod pallet {
 		init_data: Option<super::InitializationData<BridgedHeader<T>>>,
 	}
 
+	#[cfg(feature = "std")]
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
 			Self {

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -155,10 +155,11 @@ pub mod pallet {
 			);
 
 			let _ = T::HeaderChain::append_header(finality_target.clone())?;
-			frame_support::debug::info!("Succesfully imported finalized header with hash {:?}!", hash);
 
 			import_header::<T>(finality_target)?;
 			<RequestCount<T>>::mutate(|count| *count += 1);
+
+			frame_support::debug::info!("Succesfully imported finalized header with hash {:?}!", hash);
 
 			Ok(().into())
 		}

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -345,6 +345,8 @@ pub mod pallet {
 	/// This function will also check if the header schedules and enacts authority set changes,
 	/// updating the current authority set accordingly.
 	pub(crate) fn import_header<T: Config>(header: BridgedHeader<T>) -> Result<(), sp_runtime::DispatchError> {
+		// We do a quick check here to ensure that our header chain is making progress and isn't
+		// "travelling back in time" (which would be indicative of something bad, e.g a hard-fork).
 		let best_finalized = <ImportedHeaders<T>>::get(<BestFinalized<T>>::get()).expect("TODO");
 		ensure!(best_finalized.number() < header.number(), <Error<T>>::ConflictingFork);
 
@@ -368,6 +370,8 @@ pub mod pallet {
 		Ok(())
 	}
 
+	/// Since this writes to storage with no real checks this should only be used in functions that
+	/// were called by a trusted origin.
 	fn initialize_bridge<T: Config>(init_params: super::InitializationData<BridgedHeader<T>>) {
 		let super::InitializationData {
 			header,

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -141,10 +141,10 @@ pub mod pallet {
 			);
 
 			// We do a quick check here to ensure that our header chain is making progress and isn't
-			// "travelling back in time" (which would be indicative of something bad, e.g a hard-fork).
+			// "travelling back in time" (which could be indicative of something bad, e.g a hard-fork).
 			ensure!(
 				best_finalized.number() < finality_target.number(),
-				<Error<T>>::ConflictingFork
+				<Error<T>>::OldHeader
 			);
 
 			let authority_set = <CurrentAuthoritySet<T>>::get();
@@ -336,11 +336,8 @@ pub mod pallet {
 		FailedToWriteHeader,
 		/// There are too many requests for the current window to handle.
 		TooManyRequests,
-		/// The header being imported is on a fork which is incompatible with the current chain.
-		///
-		/// This can happen if we try and import a finalized header at a lower height than our
-		/// current `best_finalized` header.
-		ConflictingFork,
+		/// The header being imported is older than the best finalized header known to the pallet.
+		OldHeader,
 		/// The scheduled authority set change found in the header is unsupported by the pallet.
 		///
 		/// This is the case for non-standard (e.g forced) authority set changes.
@@ -798,7 +795,7 @@ mod tests {
 			initialize_substrate_bridge();
 
 			assert_ok!(submit_finality_proof(5, 6));
-			assert_err!(submit_finality_proof(3, 4), Error::<TestRuntime>::ConflictingFork);
+			assert_err!(submit_finality_proof(3, 4), Error::<TestRuntime>::OldHeader);
 			assert_ok!(submit_finality_proof(7, 8));
 		})
 	}

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -599,7 +599,6 @@ mod tests {
 	}
 
 	#[test]
-	#[ignore]
 	fn succesfully_imports_header_with_valid_finality_and_ancestry_proofs() {
 		run_test(|| {
 			initialize_substrate_bridge();
@@ -607,12 +606,8 @@ mod tests {
 			assert_ok!(submit_finality_proof(1, 2));
 
 			let header = test_header(2);
-			assert_eq!(
-				pallet_substrate_bridge::Module::<TestRuntime>::best_headers(),
-				vec![(*header.number(), header.hash())]
-			);
-
-			assert_eq!(pallet_substrate_bridge::Module::<TestRuntime>::best_finalized(), header);
+			assert_eq!(<BestFinalized<TestRuntime>>::get(), header.hash());
+			assert!(<ImportedHeaders<TestRuntime>>::contains_key(header.hash()));
 		})
 	}
 
@@ -685,18 +680,14 @@ mod tests {
 			let genesis = test_header(0);
 
 			let invalid_authority_list = vec![(alice(), u64::MAX), (bob(), u64::MAX)];
-			let init_data = pallet_substrate_bridge::InitializationData {
+			let init_data = InitializationData {
 				header: genesis,
 				authority_list: invalid_authority_list,
 				set_id: 1,
-				scheduled_change: None,
 				is_halted: false,
 			};
 
-			assert_ok!(pallet_substrate_bridge::Module::<TestRuntime>::initialize(
-				Origin::root(),
-				init_data
-			));
+			assert_ok!(Module::<TestRuntime>::initialize(Origin::root(), init_data));
 
 			let header = test_header(1);
 			let justification = [1u8; 32].encode();

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -172,32 +172,19 @@ pub mod pallet {
 
 	/// Hash of the header used to bootstrap the pallet.
 	#[pallet::storage]
-	#[pallet::getter(fn initial_hash)]
 	pub(super) type InitialHash<T: Config> = StorageValue<_, BridgedBlockHash<T>, ValueQuery>;
 
 	/// Hash of the best finalized header.
 	#[pallet::storage]
-	#[pallet::getter(fn best_finalized)]
 	pub(super) type BestFinalized<T: Config> = StorageValue<_, BridgedBlockHash<T>, ValueQuery>;
 
 	/// Headers which have been imported into the pallet.
-	// TODO: See if we have Option<Header> with autogen getter
-	// Can also make this generic, Map Hash => H: HeaderT
 	#[pallet::storage]
-	#[pallet::getter(fn imported_headers)]
 	pub(super) type ImportedHeaders<T: Config> = StorageMap<_, Identity, BridgedBlockHash<T>, BridgedHeader<T>>;
 
 	/// The current GRANDPA Authority set.
 	#[pallet::storage]
-	#[pallet::getter(fn current_authority_set)]
 	pub(super) type CurrentAuthoritySet<T: Config> = StorageValue<_, bp_header_chain::AuthoritySet, ValueQuery>;
-
-	// If we assume that `delay` is always zero when we get a ScheduledChange digest then we don't
-	// need this.
-	//
-	// #[pallet::storage]
-	// #[pallet::getter(fn next_scheduled_change)]
-	// pub(super) type NextScheduledChange<T: Config> = StorageMap<_, Identity, BridgedBlockHash<T>, BridgedHeader<T>>;
 
 	/// Optional pallet owner.
 	///
@@ -206,12 +193,10 @@ pub mod pallet {
 	/// runtime methods may still be used to do that (i.e. democracy::referendum to update halt
 	/// flag directly or call the `halt_operations`).
 	#[pallet::storage]
-	#[pallet::getter(fn module_owner)]
 	pub(super) type ModuleOwner<T: Config> = StorageValue<_, u32, OptionQuery>;
 
 	/// If true, all pallet transactions are failed immediately.
 	#[pallet::storage]
-	#[pallet::getter(fn is_halted)]
 	pub(super) type IsHalted<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::error]

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -79,7 +79,6 @@ impl frame_system::Config for TestRuntime {
 	type SS58Prefix = ();
 }
 
-// TODO: Remove this
 impl pallet_substrate_bridge::Config for TestRuntime {
 	type BridgedChain = TestBridgedChain;
 }

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -17,8 +17,7 @@
 // From construct_runtime macro
 #![allow(clippy::from_over_into)]
 
-use crate::pallet::{BridgedHeader, Config};
-use bp_runtime::{BlockNumberOf, Chain};
+use bp_runtime::Chain;
 use frame_support::{construct_runtime, parameter_types, weights::Weight};
 use sp_runtime::{
 	testing::{Header, H256},
@@ -27,8 +26,8 @@ use sp_runtime::{
 };
 
 pub type AccountId = u64;
-pub type TestHeader = BridgedHeader<TestRuntime>;
-pub type TestNumber = BlockNumberOf<<TestRuntime as Config>::BridgedChain>;
+pub type TestHeader = crate::BridgedHeader<TestRuntime>;
+pub type TestNumber = crate::BridgedBlockNumber<TestRuntime>;
 
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
@@ -79,6 +78,7 @@ impl frame_system::Config for TestRuntime {
 	type SS58Prefix = ();
 }
 
+// TODO: Remove this
 impl pallet_substrate_bridge::Config for TestRuntime {
 	type BridgedChain = TestBridgedChain;
 }

--- a/modules/finality-verifier/src/mock.rs
+++ b/modules/finality-verifier/src/mock.rs
@@ -28,6 +28,7 @@ use sp_runtime::{
 pub type AccountId = u64;
 pub type TestHeader = crate::BridgedHeader<TestRuntime>;
 pub type TestNumber = crate::BridgedBlockNumber<TestRuntime>;
+pub type TestHash = crate::BridgedBlockHash<TestRuntime>;
 
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -263,7 +263,7 @@ pub const FROM_MILLAU_UNREWARDED_RELAYERS_STATE: &str = "FromMillauInboundLaneAp
 sp_api::decl_runtime_apis! {
 	/// API for querying information about Millau headers from the Bridge Pallet instance.
 	///
-	/// This API is implemented by runtimes that are bridging with Millau chain, not the
+	/// This API is implemented by runtimes that are bridging with the Millau chain, not the
 	/// Millau runtime itself.
 	pub trait MillauHeaderApi {
 		/// Returns number and hash of the best blocks known to the bridge module.
@@ -286,6 +286,10 @@ sp_api::decl_runtime_apis! {
 		fn is_finalized_block(hash: Hash) -> bool;
 	}
 
+	/// API for querying information about the finalized Millau headers.
+	///
+	/// This API is implemented by runtimes that are bridging with the Millau chain, not the
+	/// Millau runtime itself.
 	pub trait MillauFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
 		fn best_finalized() -> (BlockNumber, Hash);

--- a/primitives/millau/src/lib.rs
+++ b/primitives/millau/src/lib.rs
@@ -238,6 +238,11 @@ pub const IS_KNOWN_MILLAU_BLOCK_METHOD: &str = "MillauHeaderApi_is_known_block";
 /// Name of the `MillauHeaderApi::incomplete_headers` runtime method.
 pub const INCOMPLETE_MILLAU_HEADERS_METHOD: &str = "MillauHeaderApi_incomplete_headers";
 
+/// Name of the `RialtoFinalityApi::best_finalized` runtime method.
+pub const BEST_FINALIZED_MILLAU_HEADER_METHOD: &str = "MillauFinalityApi_best_finalized";
+/// Name of the `RialtoFinalityApi::is_known_header` runtime method.
+pub const IS_KNOW_MILLAU_HEADER_METHOD: &str = "MillauFinalityApi_is_known_header";
+
 /// Name of the `ToMillauOutboundLaneApi::estimate_message_delivery_and_dispatch_fee` runtime method.
 pub const TO_MILLAU_ESTIMATE_MESSAGE_FEE_METHOD: &str =
 	"ToMillauOutboundLaneApi_estimate_message_delivery_and_dispatch_fee";
@@ -279,6 +284,13 @@ sp_api::decl_runtime_apis! {
 		fn is_known_block(hash: Hash) -> bool;
 		/// Returns true if the header is considered finalized by the runtime.
 		fn is_finalized_block(hash: Hash) -> bool;
+	}
+
+	pub trait MillauFinalityApi {
+		/// Returns number and hash of the best finalized header known to the bridge module.
+		fn best_finalized() -> (BlockNumber, Hash);
+		/// Returns true if the header is known to the runtime.
+		fn is_known_header(hash: Hash) -> bool;
 	}
 
 	/// Outbound message lane API for messages that are sent to Millau chain.

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -224,7 +224,7 @@ pub const FROM_RIALTO_UNREWARDED_RELAYERS_STATE: &str = "FromRialtoInboundLaneAp
 sp_api::decl_runtime_apis! {
 	/// API for querying information about Rialto headers from the Bridge Pallet instance.
 	///
-	/// This API is implemented by runtimes that are bridging with Rialto chain, not the
+	/// This API is implemented by runtimes that are bridging with the Rialto chain, not the
 	/// Rialto runtime itself.
 	pub trait RialtoHeaderApi {
 		/// Returns number and hash of the best blocks known to the bridge module.
@@ -247,6 +247,10 @@ sp_api::decl_runtime_apis! {
 		fn is_finalized_block(hash: Hash) -> bool;
 	}
 
+	/// API for querying information about the finalized Rialto headers.
+	///
+	/// This API is implemented by runtimes that are bridging with the Rialto chain, not the
+	/// Millau runtime itself.
 	pub trait RialtoFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
 		fn best_finalized() -> (BlockNumber, Hash);

--- a/primitives/rialto/src/lib.rs
+++ b/primitives/rialto/src/lib.rs
@@ -199,6 +199,11 @@ pub const IS_KNOWN_RIALTO_BLOCK_METHOD: &str = "RialtoHeaderApi_is_known_block";
 /// Name of the `RialtoHeaderApi::incomplete_headers` runtime method.
 pub const INCOMPLETE_RIALTO_HEADERS_METHOD: &str = "RialtoHeaderApi_incomplete_headers";
 
+/// Name of the `RialtoFinalityApi::best_finalized` runtime method.
+pub const BEST_FINALIZED_RIALTO_HEADER_METHOD: &str = "RialtoFinalityApi_best_finalized";
+/// Name of the `RialtoFinalityApi::is_known_header` runtime method.
+pub const IS_KNOW_RIALTO_HEADER_METHOD: &str = "RialtoFinalityApi_is_known_header";
+
 /// Name of the `ToRialtoOutboundLaneApi::estimate_message_delivery_and_dispatch_fee` runtime method.
 pub const TO_RIALTO_ESTIMATE_MESSAGE_FEE_METHOD: &str =
 	"ToRialtoOutboundLaneApi_estimate_message_delivery_and_dispatch_fee";
@@ -240,6 +245,13 @@ sp_api::decl_runtime_apis! {
 		fn is_known_block(hash: Hash) -> bool;
 		/// Returns true if the header is considered finalized by the runtime.
 		fn is_finalized_block(hash: Hash) -> bool;
+	}
+
+	pub trait RialtoFinalityApi {
+		/// Returns number and hash of the best finalized header known to the bridge module.
+		fn best_finalized() -> (BlockNumber, Hash);
+		/// Returns true if the header is known to the runtime.
+		fn is_known_header(hash: Hash) -> bool;
 	}
 
 	/// Outbound message lane API for messages that are sent to Rialto chain.


### PR DESCRIPTION
This is an alternative approach to what was started in #771. In a sense it basically just
jumps to step 3 from that list.

What I've done is taken all the relevant parts from the existing bridge pallet and
re-wrote them in FRAME v2 within the finality verifier pallet. For the most part I've
avoided changing logic around on both sides - with the exception that I did make the
assumptions outlined in #760 since that simplifies the pallet a bit.

The reason why this approach is being tried is to make the review process easier and
faster.

Some things I still need to do in this PR:

- [x] Move Runtime APIs
- [x] Fix outstanding TODOs I've left in the code

Notice that no code from the bridge pallet was removed in this PR. I plan to remove
unused code after this is merged in order to avoid making this PR too noisy.
