### PR TITLE
Update Substrate Node build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,7 +2648,7 @@ dependencies = [
  "itoa",
  "log",
  "net2",
- "rustc_version 0.2.3",
+ "rustc_version",
  "time 0.1.44",
  "tokio 0.1.22",
  "tokio-buf",
@@ -3849,7 +3849,6 @@ dependencies = [
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
- "vergen",
 ]
 
 [[package]]
@@ -4757,7 +4756,7 @@ checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
- "rustc_version 0.2.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -4791,7 +4790,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall 0.1.57",
- "rustc_version 0.2.3",
+ "rustc_version",
  "smallvec 0.6.14",
  "winapi 0.3.9",
 ]
@@ -5020,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "platforms"
-version = "0.2.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
+checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 
 [[package]]
 name = "polling"
@@ -5406,7 +5405,7 @@ checksum = "1fdf7d9dbd43f3d81d94a49c1c3df73cc2b3827995147e6cf7f89d4ec5483e73"
 dependencies = [
  "bitflags",
  "cc",
- "rustc_version 0.2.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -5734,7 +5733,6 @@ dependencies = [
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
- "vergen",
 ]
 
 [[package]]
@@ -5872,16 +5870,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
+ "semver",
 ]
 
 [[package]]
@@ -5958,7 +5947,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
 dependencies = [
- "rustc_version 0.2.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -6973,16 +6962,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
 
 [[package]]
@@ -6990,15 +6970,6 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"
@@ -7194,7 +7165,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring",
- "rustc_version 0.2.3",
+ "rustc_version",
  "sha2 0.9.3",
  "subtle 2.4.0",
  "x25519-dalek",
@@ -7896,7 +7867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version 0.2.3",
+ "rustc_version",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -8048,9 +8019,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9726c2926418239f73d4d939fcc4ceb5c6697609426c64dd3bcf664f06986afa"
+checksum = "bd540ba72520174c2c73ce96bf507eeba3cc8a481f58be92525b69110e1fa645"
 dependencies = [
  "platforms",
 ]
@@ -8947,17 +8918,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "vergen"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7141e445af09c8919f1d5f8a20dae0b20c3b57a45dee0d5823c6ed5d237f15a"
-dependencies = [
- "bitflags",
- "chrono",
- "rustc_version 0.3.3",
-]
 
 [[package]]
 name = "version_check"

--- a/bin/millau/node/Cargo.toml
+++ b/bin/millau/node/Cargo.toml
@@ -48,9 +48,8 @@ sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "ma
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 [build-dependencies]
-build-script-utils = { package = "substrate-build-script-utils", version = "2.0" }
+substrate-build-script-utils = "3.0.0"
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-vergen = "3.1.0"
 
 [features]
 default = []

--- a/bin/millau/node/build.rs
+++ b/bin/millau/node/build.rs
@@ -14,12 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-use vergen::{generate_cargo_keys, ConstantsFlags};
-
-const ERROR_MSG: &str = "Failed to generate metadata files";
+use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
-	generate_cargo_keys(ConstantsFlags::SHA_SHORT).expect(ERROR_MSG);
+	generate_cargo_keys();
 
-	build_script_utils::rerun_if_git_head_changed();
+	rerun_if_git_head_changed();
 }

--- a/bin/rialto/node/Cargo.toml
+++ b/bin/rialto/node/Cargo.toml
@@ -49,9 +49,8 @@ sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "ma
 substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
 [build-dependencies]
-build-script-utils = { package = "substrate-build-script-utils", version = "2.0" }
+substrate-build-script-utils = "3.0.0"
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
-vergen = "3.1.0"
 
 [features]
 default = []

--- a/bin/rialto/node/build.rs
+++ b/bin/rialto/node/build.rs
@@ -14,12 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-use vergen::{generate_cargo_keys, ConstantsFlags};
-
-const ERROR_MSG: &str = "Failed to generate metadata files";
+use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
-	generate_cargo_keys(ConstantsFlags::SHA_SHORT).expect(ERROR_MSG);
+	generate_cargo_keys();
 
-	build_script_utils::rerun_if_git_head_changed();
+	rerun_if_git_head_changed();
 }


### PR DESCRIPTION
It looks like the Node Template switched from using `vergen` to
`substrate-build-script-utils` almost a year ago. I guess we missed the memo, haha.
