### PR TITLE
Stop running CI when Markdown files are changed

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -10,7 +10,7 @@ on:
     tags:
       - v*
     paths-ignore:
-      - '**/README.md'
+      - '**.md'
       - diagrams/*
       - docs/*
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - v*
     paths-ignore:
-      - '**/README.md'
+      - '**.md'
       - diagrams/*
       - docs/*
   schedule:             # Weekly build

--- a/.github/workflows/publish-deps.yml
+++ b/.github/workflows/publish-deps.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
     paths-ignore:
-      - '**/README.md'
+      - '**.md'
       - diagrams/*
       - docs/*
   schedule:                                         # Weekly build

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
     paths-ignore:
-      - '**/README.md'
+      - '**.md'
       - diagrams/*
       - docs/*
   schedule:                                         # Nightly build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - v*
     paths-ignore:
-      - '**/README.md'
+      - '**.md'
       - diagrams/*
       - docs/*
   schedule:                        # Weekly build


### PR DESCRIPTION
While making a small formatting fix for #791 I noticed that the CI was running when in
reality there's no reason for it to. This PR makes is so that no checks are run when the
only files being changed in a PR are Markdown files.
