### PR TITLE
bridges: fix random_seed

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -458,7 +458,7 @@ impl_runtime_apis! {
 		}
 
 		fn random_seed() -> <Block as BlockT>::Hash {
-			RandomnessCollectiveFlip::random_seed().0
+			RandomnessCollectiveFlip::random_seed().0.into()
 		}
 	}
 

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -458,7 +458,7 @@ impl_runtime_apis! {
 		}
 
 		fn random_seed() -> <Block as BlockT>::Hash {
-			RandomnessCollectiveFlip::random_seed()
+			RandomnessCollectiveFlip::random_seed().0
 		}
 	}
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -569,7 +569,7 @@ impl_runtime_apis! {
 		}
 
 		fn random_seed() -> <Block as BlockT>::Hash {
-			RandomnessCollectiveFlip::random_seed().0
+			RandomnessCollectiveFlip::random_seed().0.into()
 		}
 	}
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -569,7 +569,7 @@ impl_runtime_apis! {
 		}
 
 		fn random_seed() -> <Block as BlockT>::Hash {
-			RandomnessCollectiveFlip::random_seed()
+			RandomnessCollectiveFlip::random_seed().0
 		}
 	}
 


### PR DESCRIPTION
Backport of https://github.com/paritytech/polkadot/pull/2504#issuecomment-791599920

Running
```bash
git subtree push --prefix=bridges bridges td-polkadot
````
ends up with 2-commit history (squash commit from polkadot repo & Andre's commit) this doesn't really share any commits with `master`, so I ended up just cherry-picking Andre's commit on top of `master`. Since after `subtree push` it was already part of the repo it was as easy as doing regular cherry-pick (no diffs/patches or anything)
