### PR TITLE
Simplify operational extrinsics

### DIFF
--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -238,30 +238,6 @@ pub mod pallet {
 
 			Ok(().into())
 		}
-
-		/// Halt all pallet operations. Operations may be resumed using `resume_operations` call.
-		///
-		/// May only be called either by root, or by `ModuleOwner`.
-		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
-		pub fn halt_operations(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			ensure_owner_or_root::<T>(origin)?;
-			<IsHalted<T>>::put(true);
-			log::warn!("Stopping pallet operations.");
-
-			Ok(().into())
-		}
-
-		/// Resume all pallet operations. May be called even if pallet is halted.
-		///
-		/// May only be called either by root, or by `ModuleOwner`.
-		#[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Operational))]
-		pub fn resume_operations(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			ensure_owner_or_root::<T>(origin)?;
-			<IsHalted<T>>::put(false);
-			log::info!("Resuming pallet operations.");
-
-			Ok(().into())
-		}
 	}
 
 	/// The current number of requests which have written to storage.


### PR DESCRIPTION
Just a small follow up from [here](https://github.com/paritytech/parity-bridges-common/pull/783#discussion_r586381898).

Instead of having two extrinsics to halt or resume pallets I've changed it so that we
have one extrinsic with a flag.

Note that I've intentionally ignored `pallet-substrate-bridge`.
