### PR TITLE
Log runtime logs from `pallet-finality-verifier`

### DIFF
--- a/deployments/networks/millau.yml
+++ b/deployments/networks/millau.yml
@@ -20,7 +20,7 @@ services:
       - --unsafe-rpc-external
       - --unsafe-ws-external
     environment:
-      RUST_LOG: runtime=trace,rpc=debug,txpool=trace,pallet_substrate_bridge=trace,pallet_bridge_call_dispatch=trace,pallet_message_lane=trace
+      RUST_LOG: runtime=trace,rpc=debug,txpool=trace,pallet_finality_verifier=trace,pallet_bridge_call_dispatch=trace,pallet_message_lane=trace
     ports:
       - "19933:9933"
       - "19944:9944"

--- a/deployments/networks/rialto.yml
+++ b/deployments/networks/rialto.yml
@@ -20,7 +20,7 @@ services:
       - --unsafe-rpc-external
       - --unsafe-ws-external
     environment:
-      RUST_LOG: runtime=trace,rpc=debug,txpool=trace,pallet_substrate_bridge=trace,pallet_bridge_call_dispatch=trace,pallet_message_lane=trace
+      RUST_LOG: runtime=trace,rpc=debug,txpool=trace,pallet_finality_verifier=trace,pallet_bridge_call_dispatch=trace,pallet_message_lane=trace
     ports:
       - "9933:9933"
       - "9944:9944"


### PR DESCRIPTION
In our testnet we're now using `pallet-finality-verifier` instead of
`pallet-substrate-bridge`. This updates our deployment logging to match that.
