### PR TITLE
Make Test Helpers `no_std` Compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-finality-grandpa",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -788,6 +789,7 @@ version = "0.1.0"
 dependencies = [
  "bp-header-chain",
  "finality-grandpa 0.14.0",
+ "sp-application-crypto",
  "sp-finality-grandpa",
  "sp-keyring",
  "sp-runtime",

--- a/primitives/header-chain/Cargo.toml
+++ b/primitives/header-chain/Cargo.toml
@@ -21,6 +21,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" , 
 
 [dev-dependencies]
 bp-test-utils = { path = "../test-utils" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 [features]
 default = ["std"]

--- a/primitives/header-chain/tests/justification.rs
+++ b/primitives/header-chain/tests/justification.rs
@@ -23,11 +23,16 @@ use codec::Encode;
 type TestHeader = sp_runtime::testing::Header;
 
 fn make_justification_for_header_1() -> GrandpaJustification<TestHeader> {
+	use sp_finality_grandpa::AuthorityId;
+	use sp_runtime::RuntimeAppPublic;
+	let alice = AuthorityId::generate_pair(Some(vec![1]));
+	let bob = AuthorityId::generate_pair(Some(vec![2]));
+
 	make_justification_for_header(
 		&test_header(1),
 		TEST_GRANDPA_ROUND,
 		TEST_GRANDPA_SET_ID,
-		&authority_list(),
+		&vec![(alice, 1), (bob, 1)], // &authority_list(),
 	)
 }
 
@@ -102,13 +107,15 @@ fn justification_with_invalid_precommit_ancestry() {
 
 #[test]
 fn valid_justification_accepted() {
-	assert_eq!(
-		verify_justification::<TestHeader>(
-			header_id::<TestHeader>(1),
-			TEST_GRANDPA_SET_ID,
-			voter_set(),
-			&make_justification_for_header_1().encode(),
-		),
-		Ok(()),
-	);
+	sp_io::TestExternalities::new(Default::default()).execute_with(|| {
+		assert_eq!(
+			verify_justification::<TestHeader>(
+				header_id::<TestHeader>(1),
+				TEST_GRANDPA_SET_ID,
+				voter_set(),
+				&make_justification_for_header_1().encode(),
+			),
+			Ok(()),
+		);
+	})
 }

--- a/primitives/test-utils/Cargo.toml
+++ b/primitives/test-utils/Cargo.toml
@@ -11,3 +11,4 @@ bp-header-chain = { path = "../header-chain" }
 sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-application-crypto = { git = "https://github.com/paritytech/substrate", branch = "master" }


### PR DESCRIPTION
I've been struggling to get #815 compiling. Today I realized that my problem was my use
of `bp-test-utils` to create valid, but dummy, justifications in the "setup" phase of the
benchmarks via `bp-test-utils::make_justification_for_header()`. The problem here is that
`bp-test-utils` is a `std` only crate, and benchmarks need to be able to compile in a
`no_std` environment.

The reason that `bp-test-utils` is `std` only is `sp-keyring`, which is used while
signing pre-commit messages. Right now I'm trying to replace `sp-keyring` with
`sp-application-crypto` since that can compile in `no_std`. Currently running into the
following error while running tests:

```
"No `keystore` associated for the current context!"
```

Another idea I had for solving this was trying to make `sp-keyring` compile to `no_std`
by changing a few data structure and hiding some functionalily behind feature flags, but
I'm not sure if that's a good rabbit hole to go down.

Any ideas for how to solve this would be helpful!
