### PR TITLE
Await finality loops from main relay function

### DIFF
--- a/relays/clients/substrate/src/finality_source.rs
+++ b/relays/clients/substrate/src/finality_source.rs
@@ -98,7 +98,7 @@ where
 	>,
 	P::Header: SourceHeader<C::BlockNumber>,
 {
-	type FinalityProofsStream = Pin<Box<dyn Stream<Item = Justification<C::BlockNumber>>>>;
+	type FinalityProofsStream = Pin<Box<dyn Stream<Item = Justification<C::BlockNumber>> + Send>>;
 
 	async fn best_finalized_block_number(&self) -> Result<P::Number, Error> {
 		// we **CAN** continue to relay finality proofs if source node is out of sync, because

--- a/relays/ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/ethereum/src/ethereum_deploy_contract.rs
@@ -48,9 +48,7 @@ pub struct EthereumDeployContractParams {
 }
 
 /// Deploy Bridge contract on Ethereum chain.
-pub fn run(params: EthereumDeployContractParams) {
-	let mut local_pool = futures::executor::LocalPool::new();
-
+pub async fn run(params: EthereumDeployContractParams) {
 	let EthereumDeployContractParams {
 		eth_params,
 		eth_sign,
@@ -61,7 +59,7 @@ pub fn run(params: EthereumDeployContractParams) {
 		eth_contract_code,
 	} = params;
 
-	let result = local_pool.run_until(async move {
+	let result = async move {
 		let eth_client = EthereumClient::new(eth_params).await.map_err(RpcError::Ethereum)?;
 		let sub_client = SubstrateClient::<Rialto>::new(sub_params).await.map_err(RpcError::Substrate)?;
 
@@ -91,7 +89,7 @@ pub fn run(params: EthereumDeployContractParams) {
 			initial_set_id,
 			initial_set,
 		).await
-	});
+	}.await;
 
 	if let Err(error) = result {
 		log::error!(target: "bridge", "{}", error);

--- a/relays/ethereum/src/ethereum_exchange_submit.rs
+++ b/relays/ethereum/src/ethereum_exchange_submit.rs
@@ -42,9 +42,7 @@ pub struct EthereumExchangeSubmitParams {
 }
 
 /// Submit single Ethereum -> Substrate exchange transaction.
-pub fn run(params: EthereumExchangeSubmitParams) {
-	let mut local_pool = futures::executor::LocalPool::new();
-
+pub async fn run(params: EthereumExchangeSubmitParams) {
 	let EthereumExchangeSubmitParams {
 		eth_params,
 		eth_sign,
@@ -53,7 +51,7 @@ pub fn run(params: EthereumExchangeSubmitParams) {
 		sub_recipient,
 	} = params;
 
-	let result: Result<_, String> = local_pool.run_until(async move {
+	let result: Result<_, String> = async move {
 		let eth_client = EthereumClient::new(eth_params)
 			.await
 			.map_err(|err| format!("error connecting to Ethereum node: {:?}", err))?;
@@ -94,7 +92,8 @@ pub fn run(params: EthereumExchangeSubmitParams) {
 			.map_err(|err| format!("error submitting transaction: {:?}", err))?;
 
 		Ok(eth_tx_unsigned)
-	});
+	}
+	.await;
 
 	match result {
 		Ok(eth_tx_unsigned) => {

--- a/relays/ethereum/src/ethereum_sync_loop.rs
+++ b/relays/ethereum/src/ethereum_sync_loop.rs
@@ -248,7 +248,7 @@ impl TargetClient<EthereumHeadersSyncPipeline> for SubstrateHeadersTarget {
 }
 
 /// Run Ethereum headers synchronization.
-pub fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
+pub async fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
 	let EthereumSyncParams {
 		eth_params,
 		sub_params,
@@ -278,7 +278,8 @@ pub fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
 		sync_params,
 		metrics_params,
 		futures::future::pending(),
-	);
+	)
+	.await;
 
 	Ok(())
 }

--- a/relays/ethereum/src/substrate_sync_loop.rs
+++ b/relays/ethereum/src/substrate_sync_loop.rs
@@ -163,7 +163,7 @@ impl TargetClient<SubstrateHeadersSyncPipeline> for EthereumHeadersTarget {
 }
 
 /// Run Substrate headers synchronization.
-pub fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
+pub async fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
 	let SubstrateSyncParams {
 		sub_params,
 		eth_params,
@@ -188,7 +188,8 @@ pub fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
 		sync_params,
 		metrics_params,
 		futures::future::pending(),
-	);
+	)
+	.await;
 
 	Ok(())
 }

--- a/relays/generic/exchange/src/exchange_loop.rs
+++ b/relays/generic/exchange/src/exchange_loop.rs
@@ -79,7 +79,7 @@ impl<BlockNumber: Clone + Copy> TransactionProofsRelayStorage for InMemoryStorag
 }
 
 /// Run proofs synchronization.
-pub fn run<P: TransactionProofPipeline>(
+pub async fn run<P: TransactionProofPipeline>(
 	storage: impl TransactionProofsRelayStorage<BlockNumber = BlockNumberOf<P>>,
 	source_client: impl SourceClient<P>,
 	target_client: impl TargetClient<P>,
@@ -119,7 +119,8 @@ pub fn run<P: TransactionProofPipeline>(
 				exit_signal.clone(),
 			)
 		},
-	);
+	)
+	.await;
 }
 
 /// Run proofs synchronization.

--- a/relays/generic/finality/src/finality_loop.rs
+++ b/relays/generic/finality/src/finality_loop.rs
@@ -91,7 +91,7 @@ pub trait TargetClient<P: FinalitySyncPipeline>: RelayClient {
 }
 
 /// Run finality proofs synchronization loop.
-pub fn run<P: FinalitySyncPipeline>(
+pub async fn run<P: FinalitySyncPipeline>(
 	source_client: impl SourceClient<P>,
 	target_client: impl TargetClient<P>,
 	sync_params: FinalitySyncParams,
@@ -132,7 +132,8 @@ pub fn run<P: FinalitySyncPipeline>(
 				exit_signal.clone(),
 			)
 		},
-	);
+	)
+	.await;
 }
 
 /// Unjustified headers container. Ordered by header number.

--- a/relays/generic/headers/src/sync_loop.rs
+++ b/relays/generic/headers/src/sync_loop.rs
@@ -112,7 +112,7 @@ impl<P: HeadersSyncPipeline> SyncMaintain<P> for () {}
 
 /// Run headers synchronization.
 #[allow(clippy::too_many_arguments)]
-pub fn run<P: HeadersSyncPipeline, TC: TargetClient<P>>(
+pub async fn run<P: HeadersSyncPipeline, TC: TargetClient<P>>(
 	source_client: impl SourceClient<P>,
 	source_tick: Duration,
 	target_client: TC,
@@ -159,7 +159,8 @@ pub fn run<P: HeadersSyncPipeline, TC: TargetClient<P>>(
 				exit_signal.clone(),
 			)
 		},
-	);
+	)
+	.await;
 }
 
 /// Run headers synchronization.

--- a/relays/generic/messages/src/message_lane_loop.rs
+++ b/relays/generic/messages/src/message_lane_loop.rs
@@ -206,7 +206,7 @@ pub struct ClientsState<P: MessageLane> {
 }
 
 /// Run message lane service loop.
-pub fn run<P: MessageLane>(
+pub async fn run<P: MessageLane>(
 	params: Params,
 	source_client: impl SourceClient<P>,
 	target_client: impl TargetClient<P>,
@@ -251,7 +251,8 @@ pub fn run<P: MessageLane>(
 				exit_signal.clone(),
 			)
 		},
-	);
+	)
+	.await;
 }
 
 /// Run one-way message delivery loop until connection with target or source node is lost, or exit signal is received.

--- a/relays/substrate/src/finality_pipeline.rs
+++ b/relays/substrate/src/finality_pipeline.rs
@@ -126,5 +126,6 @@ pub async fn run<SourceChain, TargetChain, P>(
 		},
 		metrics_params,
 		futures::future::pending(),
-	);
+	)
+	.await;
 }

--- a/relays/substrate/src/rialto_millau/millau_messages_to_rialto.rs
+++ b/relays/substrate/src/rialto_millau/millau_messages_to_rialto.rs
@@ -125,7 +125,7 @@ type MillauSourceClient = SubstrateMessagesSource<Millau, MillauMessagesToRialto
 type RialtoTargetClient = SubstrateMessagesTarget<Rialto, MillauMessagesToRialto>;
 
 /// Run Millau-to-Rialto messages sync.
-pub fn run(
+pub async fn run(
 	millau_client: MillauClient,
 	millau_sign: MillauSigningParams,
 	rialto_client: RialtoClient,
@@ -185,5 +185,6 @@ pub fn run(
 		RialtoTargetClient::new(rialto_client, lane, lane_id, MILLAU_BRIDGE_INSTANCE),
 		metrics_params,
 		futures::future::pending(),
-	);
+	)
+	.await;
 }

--- a/relays/substrate/src/rialto_millau/mod.rs
+++ b/relays/substrate/src/rialto_millau/mod.rs
@@ -198,7 +198,8 @@ async fn run_relay_messages(command: cli::RelayMessages) -> Result<(), String> {
 				rialto_sign,
 				lane.into(),
 				prometheus_params.into(),
-			);
+			)
+			.await;
 		}
 		cli::RelayMessages::RialtoToMillau {
 			rialto,
@@ -220,7 +221,8 @@ async fn run_relay_messages(command: cli::RelayMessages) -> Result<(), String> {
 				millau_sign,
 				lane.into(),
 				prometheus_params.into(),
-			);
+			)
+			.await;
 		}
 	}
 	Ok(())

--- a/relays/substrate/src/rialto_millau/rialto_messages_to_millau.rs
+++ b/relays/substrate/src/rialto_millau/rialto_messages_to_millau.rs
@@ -125,7 +125,7 @@ type RialtoSourceClient = SubstrateMessagesSource<Rialto, RialtoMessagesToMillau
 type MillauTargetClient = SubstrateMessagesTarget<Millau, RialtoMessagesToMillau>;
 
 /// Run Rialto-to-Millau messages sync.
-pub fn run(
+pub async fn run(
 	rialto_client: RialtoClient,
 	rialto_sign: RialtoSigningParams,
 	millau_client: MillauClient,
@@ -184,5 +184,6 @@ pub fn run(
 		MillauTargetClient::new(millau_client, lane, lane_id, RIALTO_BRIDGE_INSTANCE),
 		metrics_params,
 		futures::future::pending(),
-	);
+	)
+	.await;
 }


### PR DESCRIPTION
This PR unifies all top-level `awaits` - now `await`s for all `run()` functions are called from within corresponding main.rs. This is mostly required for #817 - finality relay loop needs to be made async so it can be [cancelled](https://docs.rs/async-std/1.9.0/async_std/task/struct.JoinHandle.html#method.cancel). I've also remove all `futures::executor::LocalPool` references, so now we only use executor from `async_std`