### PR TITLE
Add multiplier parameter to transaction_payment function

### DIFF
--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -37,7 +37,7 @@ use sp_std::{convert::TryFrom, ops::RangeInclusive};
 
 parameter_types! {
 	/// Rialto to Millau conversion rate. Initially we treat both tokens as equal.
-	storage RialtoToMillauConversionRate: FixedU128 = 1.into();
+	storage RialtoToMillauConversionRate: FixedU128 = FixedU128::one();
 }
 
 /// Storage key of the Millau -> Rialto message in the runtime storage.
@@ -146,9 +146,10 @@ impl messages::ThisChainWithMessageLanes for Millau {
 
 	fn transaction_payment(transaction: MessageLaneTransaction<Weight>) -> bp_millau::Balance {
 		// in our testnets, both per-byte fee and weight-to-fee are 1:1
-		messages::transaction_payment_without_multiplier(
+		messages::transaction_payment(
 			bp_millau::BlockWeights::get().get(DispatchClass::Normal).base_extrinsic,
 			1,
+			FixedU128::zero(),
 			|weight| weight as _,
 			transaction,
 		)
@@ -208,9 +209,10 @@ impl messages::BridgedChainWithMessageLanes for Rialto {
 
 	fn transaction_payment(transaction: MessageLaneTransaction<Weight>) -> bp_rialto::Balance {
 		// in our testnets, both per-byte fee and weight-to-fee are 1:1
-		messages::transaction_payment_without_multiplier(
+		messages::transaction_payment(
 			bp_rialto::BlockWeights::get().get(DispatchClass::Normal).base_extrinsic,
 			1,
+			FixedU128::zero(),
 			|weight| weight as _,
 			transaction,
 		)

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -146,9 +146,10 @@ impl messages::ThisChainWithMessageLanes for Rialto {
 
 	fn transaction_payment(transaction: MessageLaneTransaction<Weight>) -> bp_rialto::Balance {
 		// in our testnets, both per-byte fee and weight-to-fee are 1:1
-		messages::transaction_payment_without_multiplier(
+		messages::transaction_payment(
 			bp_rialto::BlockWeights::get().get(DispatchClass::Normal).base_extrinsic,
 			1,
+			FixedU128::zero(),
 			|weight| weight as _,
 			transaction,
 		)
@@ -208,9 +209,10 @@ impl messages::BridgedChainWithMessageLanes for Millau {
 
 	fn transaction_payment(transaction: MessageLaneTransaction<Weight>) -> bp_millau::Balance {
 		// in our testnets, both per-byte fee and weight-to-fee are 1:1
-		messages::transaction_payment_without_multiplier(
+		messages::transaction_payment(
 			bp_millau::BlockWeights::get().get(DispatchClass::Normal).base_extrinsic,
 			1,
+			FixedU128::zero(),
 			|weight| weight as _,
 			transaction,
 		)

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -30,7 +30,10 @@ use bp_runtime::{InstanceId, Size, StorageProofChecker};
 use codec::{Decode, Encode};
 use frame_support::{traits::Instance, weights::Weight, RuntimeDebug};
 use hash_db::Hasher;
-use sp_runtime::traits::{AtLeast32BitUnsigned, CheckedAdd, CheckedDiv, CheckedMul};
+use sp_runtime::{
+	traits::{AtLeast32BitUnsigned, CheckedAdd, CheckedDiv, CheckedMul},
+	FixedPointNumber, FixedPointOperand, FixedU128,
+};
 use sp_std::{cmp::PartialOrd, convert::TryFrom, fmt::Debug, marker::PhantomData, ops::RangeInclusive, vec::Vec};
 use sp_trie::StorageProof;
 
@@ -143,13 +146,16 @@ pub(crate) type CallOf<C> = <C as ThisChainWithMessageLanes>::Call;
 /// Raw storage proof type (just raw trie nodes).
 type RawStorageProof = Vec<Vec<u8>>;
 
-/// Compute fee of transaction at runtime where:
+/// Compute fee of transaction at runtime where regular transaction payment pallet is being used.
 ///
-/// - transaction payment pallet is being used;
-/// - fee multiplier is zero.
-pub fn transaction_payment_without_multiplier<Balance: AtLeast32BitUnsigned>(
+/// The value of `multiplier` parameter is the expected value of `pallet_transaction_payment::NextFeeMultiplier`
+/// at the moment when transaction is submitted. If you're charging this payment in advance (and that's what
+/// happens with delivery and confirmation transaction in this crate), then there's a chance that the actual
+/// fee will be larger than what is paid in advance. So the value must be chosen carefully.
+pub fn transaction_payment<Balance: AtLeast32BitUnsigned + FixedPointOperand>(
 	base_extrinsic_weight: Weight,
 	per_byte_fee: Balance,
+	multiplier: FixedU128,
 	weight_to_fee: impl Fn(Weight) -> Balance,
 	transaction: MessageLaneTransaction<Weight>,
 ) -> Balance {
@@ -160,9 +166,8 @@ pub fn transaction_payment_without_multiplier<Balance: AtLeast32BitUnsigned>(
 	let len_fee = per_byte_fee.saturating_mul(Balance::from(transaction.size));
 
 	// the adjustable part of the fee
-	//
-	// here we assume that the fee multiplier is zero, so this part is also always zero
-	let adjusted_weight_fee = Balance::zero();
+	let unadjusted_weight_fee = weight_to_fee(transaction.dispatch_weight);
+	let adjusted_weight_fee = multiplier.saturating_mul_int(unadjusted_weight_fee);
 
 	base_fee.saturating_add(len_fee).saturating_add(adjusted_weight_fee)
 }

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -1415,7 +1415,10 @@ mod tests {
 				10,
 				FixedU128::zero(),
 				|weight| weight,
-				MessageLaneTransaction { size: 50, dispatch_weight: 777 },
+				MessageLaneTransaction {
+					size: 50,
+					dispatch_weight: 777
+				},
 			),
 			100 + 50 * 10,
 		);
@@ -1429,7 +1432,10 @@ mod tests {
 				10,
 				FixedU128::one(),
 				|weight| weight,
-				MessageLaneTransaction { size: 50, dispatch_weight: 777 },
+				MessageLaneTransaction {
+					size: 50,
+					dispatch_weight: 777
+				},
 			),
 			100 + 50 * 10 + 777,
 		);

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -1406,4 +1406,32 @@ mod tests {
 			Err(target::MessageProofError::MessagesCountMismatch),
 		);
 	}
+
+	#[test]
+	fn transaction_payment_works_with_zero_multiplier() {
+		assert_eq!(
+			transaction_payment(
+				100,
+				10,
+				FixedU128::zero(),
+				|weight| weight,
+				MessageLaneTransaction { size: 50, dispatch_weight: 777 },
+			),
+			100 + 50 * 10,
+		);
+	}
+
+	#[test]
+	fn transaction_payment_works_with_non_zero_multiplier() {
+		assert_eq!(
+			transaction_payment(
+				100,
+				10,
+				FixedU128::one(),
+				|weight| weight,
+				MessageLaneTransaction { size: 50, dispatch_weight: 777 },
+			),
+			100 + 50 * 10 + 777,
+		);
+	}
 }


### PR DESCRIPTION
This change is required for all Polkadot-like chains