### PR TITLE
Tunable Justification Generator

### DIFF
--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -522,7 +522,7 @@ mod tests {
 	use super::*;
 	use crate::mock::{run_test, test_header, Origin, TestHash, TestHeader, TestNumber, TestRuntime};
 	use bp_test_utils::{
-		authority_list, keyring, make_default_justification, make_justification_for_header,
+		authority_list, make_default_justification, make_justification_for_header, JustificationGeneratorParams,
 		Keyring::{Alice, Bob},
 	};
 	use codec::Encode;
@@ -723,10 +723,9 @@ mod tests {
 
 			let header = test_header(1);
 
-			let set_id = 2;
-			let grandpa_round = 1;
-			let justification =
-				make_justification_for_header(&header, grandpa_round, set_id, &keyring(), 2, 3).encode();
+			let mut params = JustificationGeneratorParams::<TestHeader>::default();
+			params.set_id = 2;
+			let justification = make_justification_for_header(params).encode();
 
 			assert_err!(
 				Module::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification,),

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -522,7 +522,7 @@ mod tests {
 	use super::*;
 	use crate::mock::{run_test, test_header, Origin, TestHash, TestHeader, TestNumber, TestRuntime};
 	use bp_test_utils::{
-		authority_list, keyring, make_justification_for_header,
+		authority_list, keyring, make_default_justification, make_justification_for_header,
 		Keyring::{Alice, Bob},
 	};
 	use codec::Encode;
@@ -551,10 +551,7 @@ mod tests {
 
 	fn submit_finality_proof(header: u8) -> frame_support::dispatch::DispatchResultWithPostInfo {
 		let header = test_header(header.into());
-
-		let set_id = 1;
-		let grandpa_round = 1;
-		let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+		let justification = make_default_justification(&header).encode();
 
 		Module::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification)
 	}
@@ -728,7 +725,7 @@ mod tests {
 
 			let set_id = 2;
 			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring(), 2).encode();
 
 			assert_err!(
 				Module::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification,),
@@ -802,9 +799,7 @@ mod tests {
 			header.digest = change_log(0);
 
 			// Create a valid justification for the header
-			let set_id = 1;
-			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_default_justification(&header).encode();
 
 			// Let's import our test header
 			assert_ok!(Module::<TestRuntime>::submit_finality_proof(
@@ -836,9 +831,7 @@ mod tests {
 			header.digest = change_log(1);
 
 			// Create a valid justification for the header
-			let set_id = 1;
-			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_default_justification(&header).encode();
 
 			// Should not be allowed to import this header
 			assert_err!(
@@ -859,9 +852,7 @@ mod tests {
 			header.digest = forced_change_log(0);
 
 			// Create a valid justification for the header
-			let set_id = 1;
-			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_default_justification(&header).encode();
 
 			// Should not be allowed to import this header
 			assert_err!(

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -725,7 +725,8 @@ mod tests {
 
 			let set_id = 2;
 			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring(), 2).encode();
+			let justification =
+				make_justification_for_header(&header, grandpa_round, set_id, &keyring(), 2, 3).encode();
 
 			assert_err!(
 				Module::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification,),

--- a/modules/finality-verifier/src/lib.rs
+++ b/modules/finality-verifier/src/lib.rs
@@ -723,8 +723,10 @@ mod tests {
 
 			let header = test_header(1);
 
-			let mut params = JustificationGeneratorParams::<TestHeader>::default();
-			params.set_id = 2;
+			let params = JustificationGeneratorParams::<TestHeader> {
+				set_id: 2,
+				..Default::default()
+			};
 			let justification = make_justification_for_header(params).encode();
 
 			assert_err!(

--- a/modules/substrate/src/fork_tests.rs
+++ b/modules/substrate/src/fork_tests.rs
@@ -60,7 +60,7 @@ use crate::verifier::*;
 use crate::{BestFinalized, BestHeight, BridgeStorage, NextScheduledChange, PalletStorage};
 use bp_header_chain::AuthoritySet;
 use bp_test_utils::{
-	authority_list, keyring, make_justification_for_header,
+	authority_list, make_default_justification,
 	Keyring::{Alice, Bob},
 };
 use codec::Encode;
@@ -457,9 +457,7 @@ where
 				// `grandpa_round`).
 				//
 				// See for more: https://github.com/paritytech/parity-bridges-common/issues/430
-				let grandpa_round = 1;
-				let set_id = 1;
-				let justification = make_justification_for_header(header, grandpa_round, set_id, &keyring()).encode();
+				let justification = make_default_justification(header).encode();
 
 				let res = verifier
 					.import_finality_proof(header.hash(), justification.into())

--- a/modules/substrate/src/verifier.rs
+++ b/modules/substrate/src/verifier.rs
@@ -343,7 +343,7 @@ mod tests {
 	use crate::mock::*;
 	use crate::{BestFinalized, BestHeight, HeaderId, ImportedHeaders, PalletStorage};
 	use bp_test_utils::{
-		authority_list, keyring, make_justification_for_header,
+		authority_list, make_default_justification,
 		Keyring::{Alice, Bob},
 	};
 	use codec::Encode;
@@ -605,8 +605,7 @@ mod tests {
 			assert_eq!(storage.best_headers().len(), 1);
 
 			// Now lets finalize our best header
-			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_default_justification(&header).encode();
 			assert_ok!(verifier.import_finality_proof(header.hash(), justification.into()));
 
 			// Our best header should only appear once in the list of best headers
@@ -729,8 +728,7 @@ mod tests {
 			storage.update_current_authority_set(authority_set);
 
 			// We'll need this justification to finalize the header
-			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_default_justification(&header).encode();
 
 			let mut verifier = Verifier {
 				storage: storage.clone(),
@@ -754,8 +752,7 @@ mod tests {
 			let authority_set = AuthoritySet { authorities, set_id };
 			storage.update_current_authority_set(authority_set);
 
-			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_default_justification(&header).encode();
 
 			let mut verifier = Verifier {
 				storage: storage.clone(),
@@ -798,8 +795,7 @@ mod tests {
 			// This header enacts an authority set change upon finalization
 			let header = test_header(2);
 
-			let grandpa_round = 1;
-			let justification = make_justification_for_header(&header, grandpa_round, set_id, &keyring()).encode();
+			let justification = make_default_justification(&header).encode();
 
 			// Schedule a change at the height of our header
 			let set_id = 2;

--- a/primitives/header-chain/tests/justification.rs
+++ b/primitives/header-chain/tests/justification.rs
@@ -97,12 +97,22 @@ fn justification_with_invalid_precommit_ancestry() {
 
 #[test]
 fn valid_justification_accepted() {
+	use bp_test_utils::Keyring::*;
+	let depth = 5;
+
 	assert_eq!(
 		verify_justification::<TestHeader>(
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
 			&voter_set(),
-			&make_justification_for_header_1().encode(),
+			&make_justification::<TestHeader>(
+				&test_header(1),
+				TEST_GRANDPA_ROUND,
+				TEST_GRANDPA_SET_ID,
+				&[(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
+				depth,
+			)
+			.encode()
 		),
 		Ok(()),
 	);

--- a/primitives/header-chain/tests/justification.rs
+++ b/primitives/header-chain/tests/justification.rs
@@ -26,6 +26,7 @@ type TestHeader = sp_runtime::testing::Header;
 #[test]
 fn valid_justification_accepted() {
 	let depth = 5;
+	let forks = 5;
 
 	assert_eq!(
 		verify_justification::<TestHeader>(
@@ -38,6 +39,31 @@ fn valid_justification_accepted() {
 				TEST_GRANDPA_SET_ID,
 				&[(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
 				depth,
+				forks,
+			)
+			.encode()
+		),
+		Ok(()),
+	);
+}
+
+#[test]
+fn valid_justification_accepted_with_single_fork() {
+	let depth = 5;
+	let forks = 1;
+
+	assert_eq!(
+		verify_justification::<TestHeader>(
+			header_id::<TestHeader>(1),
+			TEST_GRANDPA_SET_ID,
+			&voter_set(),
+			&make_justification_for_header::<TestHeader>(
+				&test_header(1),
+				TEST_GRANDPA_ROUND,
+				TEST_GRANDPA_SET_ID,
+				&[(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
+				depth,
+				forks,
 			)
 			.encode()
 		),
@@ -116,7 +142,8 @@ fn justification_with_invalid_precommit_ancestry() {
 
 #[test]
 fn justification_is_invalid_if_we_dont_meet_threshold() {
-	let depth = 5;
+	let depth = 2;
+	let forks = 2;
 
 	// Need at least three authorities to sign off or else the voter set threshold can't be reached
 	let authorities = [(Alice, 1), (Bob, 1)];
@@ -132,6 +159,7 @@ fn justification_is_invalid_if_we_dont_meet_threshold() {
 				TEST_GRANDPA_SET_ID,
 				&authorities,
 				depth,
+				forks,
 			)
 			.encode()
 		),

--- a/primitives/header-chain/tests/justification.rs
+++ b/primitives/header-chain/tests/justification.rs
@@ -25,23 +25,21 @@ type TestHeader = sp_runtime::testing::Header;
 
 #[test]
 fn valid_justification_accepted() {
-	let depth = 5;
-	let forks = 5;
+	let params = JustificationGeneratorParams {
+		header: test_header(1),
+		round: TEST_GRANDPA_ROUND,
+		set_id: TEST_GRANDPA_SET_ID,
+		authorities: vec![(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
+		depth: 5,
+		forks: 5,
+	};
 
 	assert_eq!(
 		verify_justification::<TestHeader>(
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
 			&voter_set(),
-			&make_justification_for_header::<TestHeader>(
-				&test_header(1),
-				TEST_GRANDPA_ROUND,
-				TEST_GRANDPA_SET_ID,
-				&[(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
-				depth,
-				forks,
-			)
-			.encode()
+			&make_justification_for_header::<TestHeader>(params).encode()
 		),
 		Ok(()),
 	);
@@ -49,23 +47,21 @@ fn valid_justification_accepted() {
 
 #[test]
 fn valid_justification_accepted_with_single_fork() {
-	let depth = 5;
-	let forks = 1;
+	let params = JustificationGeneratorParams {
+		header: test_header(1),
+		round: TEST_GRANDPA_ROUND,
+		set_id: TEST_GRANDPA_SET_ID,
+		authorities: vec![(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
+		depth: 5,
+		forks: 1,
+	};
 
 	assert_eq!(
 		verify_justification::<TestHeader>(
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
 			&voter_set(),
-			&make_justification_for_header::<TestHeader>(
-				&test_header(1),
-				TEST_GRANDPA_ROUND,
-				TEST_GRANDPA_SET_ID,
-				&[(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
-				depth,
-				forks,
-			)
-			.encode()
+			&make_justification_for_header::<TestHeader>(params).encode()
 		),
 		Ok(()),
 	);
@@ -142,26 +138,22 @@ fn justification_with_invalid_precommit_ancestry() {
 
 #[test]
 fn justification_is_invalid_if_we_dont_meet_threshold() {
-	let depth = 2;
-	let forks = 2;
-
 	// Need at least three authorities to sign off or else the voter set threshold can't be reached
-	let authorities = [(Alice, 1), (Bob, 1)];
+	let params = JustificationGeneratorParams {
+		header: test_header(1),
+		round: TEST_GRANDPA_ROUND,
+		set_id: TEST_GRANDPA_SET_ID,
+		authorities: vec![(Alice, 1), (Bob, 1)],
+		depth: 2,
+		forks: 2,
+	};
 
 	assert_eq!(
 		verify_justification::<TestHeader>(
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
 			&voter_set(),
-			&make_justification_for_header::<TestHeader>(
-				&test_header(1),
-				TEST_GRANDPA_ROUND,
-				TEST_GRANDPA_SET_ID,
-				&authorities,
-				depth,
-				forks,
-			)
-			.encode()
+			&make_justification_for_header::<TestHeader>(params).encode()
 		),
 		Err(Error::InvalidJustificationCommit),
 	);

--- a/primitives/test-utils/src/lib.rs
+++ b/primitives/test-utils/src/lib.rs
@@ -62,8 +62,10 @@ impl<H: HeaderT> Default for JustificationGeneratorParams<H> {
 
 /// Make a valid GRANDPA justification with sensible defaults
 pub fn make_default_justification<H: HeaderT>(header: &H) -> GrandpaJustification<H> {
-	let mut params = JustificationGeneratorParams::<H>::default();
-	params.header = header.clone();
+	let params = JustificationGeneratorParams::<H> {
+		header: header.clone(),
+		..Default::default()
+	};
 
 	make_justification_for_header(params)
 }

--- a/primitives/test-utils/src/lib.rs
+++ b/primitives/test-utils/src/lib.rs
@@ -57,6 +57,7 @@ pub fn make_justification_for_header<H: HeaderT>(
 	let mut precommits = vec![];
 	let mut votes_ancestries = vec![];
 
+	assert!(depth != 0, "Can't have a chain of zero length.");
 	assert!(
 		forks as usize <= authorities.len(),
 		"If we have more forks than authorities we can't create valid pre-commits for all the forks."

--- a/primitives/test-utils/src/lib.rs
+++ b/primitives/test-utils/src/lib.rs
@@ -108,10 +108,10 @@ fn generate_chain<H: HeaderT>(fork_id: u8, depth: u32, ancestor: &H) -> Vec<H> {
 
 		// Modifying the digest so headers at the same height but in different forks have different
 		// hashes
-		let digest = header.digest_mut();
-		*digest = sp_runtime::Digest {
-			logs: vec![sp_runtime::DigestItem::Other(vec![fork_id])],
-		};
+		header
+			.digest_mut()
+			.logs
+			.push(sp_runtime::DigestItem::Other(vec![fork_id]));
 
 		headers.push(header);
 	}

--- a/primitives/test-utils/src/lib.rs
+++ b/primitives/test-utils/src/lib.rs
@@ -103,17 +103,17 @@ fn generate_chain<H: HeaderT>(fork_id: u8, depth: u32, ancestor: &H) -> Vec<H> {
 		let parent = &headers[(i - 1) as usize];
 		let (hash, num) = (parent.hash(), *parent.number());
 
-		let mut precommit_header = test_header::<H>(num + One::one());
-		precommit_header.set_parent_hash(hash);
+		let mut header = test_header::<H>(num + One::one());
+		header.set_parent_hash(hash);
 
 		// Modifying the digest so headers at the same height but in different forks have different
 		// hashes
-		let digest = precommit_header.digest_mut();
+		let digest = header.digest_mut();
 		*digest = sp_runtime::Digest {
 			logs: vec![sp_runtime::DigestItem::Other(vec![fork_id])],
 		};
 
-		headers.push(precommit_header);
+		headers.push(header);
 	}
 
 	headers


### PR DESCRIPTION
This PR updates the code we have for generating mock GRANDPA justifications in order to
make it tunable. What I mean by that is that we are now able to indicate how many
pre-commits and vote ancestries we want our justification to contain.

This is especially useful in the context of benchmarking (see #815) since we want to be
able to see how verification scales given different factors.
