### PR TITLE
Larger Test Keyring Support

### DIFF
--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -526,8 +526,8 @@ mod tests {
 	use super::*;
 	use crate::mock::{run_test, test_header, Origin, TestHash, TestHeader, TestNumber, TestRuntime};
 	use bp_test_utils::{
-		authority_list, make_default_justification, make_justification_for_header, JustificationGeneratorParams,
-		TestKeyring::{self, Alice, Bob},
+		authority_list, make_default_justification, make_justification_for_header, JustificationGeneratorParams, ALICE,
+		BOB,
 	};
 	use codec::Encode;
 	use frame_support::weights::PostDispatchInfo;
@@ -570,7 +570,7 @@ mod tests {
 
 	fn change_log(delay: u64) -> Digest<TestHash> {
 		let consensus_log = ConsensusLog::<TestNumber>::ScheduledChange(sp_finality_grandpa::ScheduledChange {
-			next_authorities: vec![(Alice.into(), 1), (Bob.into(), 1)],
+			next_authorities: vec![(ALICE.into(), 1), (BOB.into(), 1)],
 			delay,
 		});
 
@@ -583,7 +583,7 @@ mod tests {
 		let consensus_log = ConsensusLog::<TestNumber>::ForcedChange(
 			delay,
 			sp_finality_grandpa::ScheduledChange {
-				next_authorities: vec![(Alice.into(), 1), (Bob.into(), 1)],
+				next_authorities: vec![(ALICE.into(), 1), (BOB.into(), 1)],
 				delay,
 			},
 		);
@@ -727,7 +727,7 @@ mod tests {
 
 			let header = test_header(1);
 
-			let params = JustificationGeneratorParams::<TestHeader, TestKeyring> {
+			let params = JustificationGeneratorParams::<TestHeader> {
 				set_id: 2,
 				..Default::default()
 			};
@@ -760,7 +760,7 @@ mod tests {
 		run_test(|| {
 			let genesis = test_header(0);
 
-			let invalid_authority_list = vec![(Alice.into(), u64::MAX), (Bob.into(), u64::MAX)];
+			let invalid_authority_list = vec![(ALICE.into(), u64::MAX), (BOB.into(), u64::MAX)];
 			let init_data = InitializationData {
 				header: genesis,
 				authority_list: invalid_authority_list,
@@ -797,7 +797,7 @@ mod tests {
 			initialize_substrate_bridge();
 
 			let next_set_id = 2;
-			let next_authorities = vec![(Alice.into(), 1), (Bob.into(), 1)];
+			let next_authorities = vec![(ALICE.into(), 1), (BOB.into(), 1)];
 
 			// Need to update the header digest to indicate that our header signals an authority set
 			// change. The change will be enacted when we import our header.

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -527,7 +527,7 @@ mod tests {
 	use crate::mock::{run_test, test_header, Origin, TestHash, TestHeader, TestNumber, TestRuntime};
 	use bp_test_utils::{
 		authority_list, make_default_justification, make_justification_for_header, JustificationGeneratorParams,
-		Keyring::{Alice, Bob},
+		TestKeyring::{self, Alice, Bob},
 	};
 	use codec::Encode;
 	use frame_support::weights::PostDispatchInfo;
@@ -727,7 +727,7 @@ mod tests {
 
 			let header = test_header(1);
 
-			let params = JustificationGeneratorParams::<TestHeader> {
+			let params = JustificationGeneratorParams::<TestHeader, TestKeyring> {
 				set_id: 2,
 				..Default::default()
 			};

--- a/modules/substrate/src/fork_tests.rs
+++ b/modules/substrate/src/fork_tests.rs
@@ -61,7 +61,7 @@ use crate::{BestFinalized, BestHeight, BridgeStorage, NextScheduledChange, Palle
 use bp_header_chain::AuthoritySet;
 use bp_test_utils::{
 	authority_list, make_default_justification,
-	Keyring::{Alice, Bob},
+	TestKeyring::{Alice, Bob},
 };
 use codec::Encode;
 use frame_support::{IterableStorageMap, StorageValue};

--- a/modules/substrate/src/fork_tests.rs
+++ b/modules/substrate/src/fork_tests.rs
@@ -59,10 +59,7 @@ use crate::storage::ImportedHeader;
 use crate::verifier::*;
 use crate::{BestFinalized, BestHeight, BridgeStorage, NextScheduledChange, PalletStorage};
 use bp_header_chain::AuthoritySet;
-use bp_test_utils::{
-	authority_list, make_default_justification,
-	TestKeyring::{Alice, Bob},
-};
+use bp_test_utils::{authority_list, make_default_justification, ALICE, BOB};
 use codec::Encode;
 use frame_support::{IterableStorageMap, StorageValue};
 use sp_finality_grandpa::{ConsensusLog, GRANDPA_ENGINE_ID};
@@ -505,7 +502,7 @@ where
 
 pub(crate) fn change_log(delay: u64) -> Digest<TestHash> {
 	let consensus_log = ConsensusLog::<TestNumber>::ScheduledChange(sp_finality_grandpa::ScheduledChange {
-		next_authorities: vec![(Alice.into(), 1), (Bob.into(), 1)],
+		next_authorities: vec![(ALICE.into(), 1), (BOB.into(), 1)],
 		delay,
 	});
 

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -721,10 +721,7 @@ mod tests {
 	use super::*;
 	use crate::mock::{run_test, test_header, unfinalized_header, Origin, TestHeader, TestRuntime};
 	use bp_header_chain::HeaderChain;
-	use bp_test_utils::{
-		authority_list,
-		TestKeyring::{Alice, Bob},
-	};
+	use bp_test_utils::{authority_list, ALICE, BOB};
 	use frame_support::{assert_err, assert_noop, assert_ok};
 	use sp_runtime::DispatchError;
 
@@ -952,7 +949,7 @@ mod tests {
 			let storage = PalletStorage::<TestRuntime>::new();
 
 			let next_set_id = 2;
-			let next_authorities = vec![(Alice.into(), 1), (Bob.into(), 1)];
+			let next_authorities = vec![(ALICE.into(), 1), (BOB.into(), 1)];
 
 			// Need to update the header digest to indicate that our header signals an authority set
 			// change. The change will be enacted when we import our header.
@@ -981,7 +978,7 @@ mod tests {
 			let storage = PalletStorage::<TestRuntime>::new();
 
 			let next_set_id = 2;
-			let next_authorities = vec![(Alice.into(), 1), (Bob.into(), 1)];
+			let next_authorities = vec![(ALICE.into(), 1), (BOB.into(), 1)];
 
 			// Need to update the header digest to indicate that our header signals an authority set
 			// change. However, the change doesn't happen until the next block.
@@ -1010,7 +1007,7 @@ mod tests {
 		run_test(|| {
 			let storage = PalletStorage::<TestRuntime>::new();
 
-			let next_authorities = vec![(Alice.into(), 1)];
+			let next_authorities = vec![(ALICE.into(), 1)];
 			let next_set_id = 2;
 			let next_authority_set = AuthoritySet::new(next_authorities.clone(), next_set_id);
 

--- a/modules/substrate/src/lib.rs
+++ b/modules/substrate/src/lib.rs
@@ -723,7 +723,7 @@ mod tests {
 	use bp_header_chain::HeaderChain;
 	use bp_test_utils::{
 		authority_list,
-		Keyring::{Alice, Bob},
+		TestKeyring::{Alice, Bob},
 	};
 	use frame_support::{assert_err, assert_noop, assert_ok};
 	use sp_runtime::DispatchError;

--- a/modules/substrate/src/verifier.rs
+++ b/modules/substrate/src/verifier.rs
@@ -344,7 +344,7 @@ mod tests {
 	use crate::{BestFinalized, BestHeight, HeaderId, ImportedHeaders, PalletStorage};
 	use bp_test_utils::{
 		authority_list, make_default_justification,
-		Keyring::{Alice, Bob},
+		TestKeyring::{Alice, Bob},
 	};
 	use codec::Encode;
 	use frame_support::{assert_err, assert_ok};

--- a/modules/substrate/src/verifier.rs
+++ b/modules/substrate/src/verifier.rs
@@ -342,10 +342,7 @@ mod tests {
 	use super::*;
 	use crate::mock::*;
 	use crate::{BestFinalized, BestHeight, HeaderId, ImportedHeaders, PalletStorage};
-	use bp_test_utils::{
-		authority_list, make_default_justification,
-		TestKeyring::{Alice, Bob},
-	};
+	use bp_test_utils::{authority_list, make_default_justification, ALICE, BOB};
 	use codec::Encode;
 	use frame_support::{assert_err, assert_ok};
 	use frame_support::{StorageMap, StorageValue};
@@ -695,7 +692,7 @@ mod tests {
 			// This is an *invalid* authority set because the combined weight of the
 			// authorities is greater than `u64::MAX`
 			let consensus_log = ConsensusLog::<TestNumber>::ScheduledChange(sp_finality_grandpa::ScheduledChange {
-				next_authorities: vec![(Alice.into(), u64::MAX), (Bob.into(), u64::MAX)],
+				next_authorities: vec![(ALICE.into(), u64::MAX), (BOB.into(), u64::MAX)],
 				delay: 0,
 			});
 
@@ -800,7 +797,7 @@ mod tests {
 			// Schedule a change at the height of our header
 			let set_id = 2;
 			let height = *header.number();
-			let authorities = vec![Alice.into()];
+			let authorities = vec![ALICE.into()];
 			let change = schedule_next_change(authorities, set_id, height);
 			storage.schedule_next_set_change(genesis_hash, change.clone());
 

--- a/primitives/header-chain/tests/justification.rs
+++ b/primitives/header-chain/tests/justification.rs
@@ -70,10 +70,7 @@ fn valid_justification_accepted_with_single_fork() {
 #[test]
 fn valid_justification_accepted_with_arbitrary_number_of_authorities() {
 	let n = 15;
-	let mut authorities = vec![];
-	for i in 0..n {
-		authorities.push(Account(i));
-	}
+	let authorities = accounts(n);
 
 	let params = JustificationGeneratorParams {
 		header: test_header(1),

--- a/primitives/header-chain/tests/justification.rs
+++ b/primitives/header-chain/tests/justification.rs
@@ -17,7 +17,6 @@
 //! Tests for Grandpa Justification code.
 
 use bp_header_chain::justification::{verify_justification, Error};
-use bp_test_utils::TestKeyring::*;
 use bp_test_utils::*;
 use codec::Encode;
 
@@ -29,7 +28,7 @@ fn valid_justification_accepted() {
 		header: test_header(1),
 		round: TEST_GRANDPA_ROUND,
 		set_id: TEST_GRANDPA_SET_ID,
-		authorities: vec![(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
+		authorities: vec![(ALICE, 1), (BOB, 1), (CHARLIE, 1), (DAVE, 1), (EVE, 1)],
 		depth: 5,
 		forks: 5,
 	};
@@ -39,7 +38,7 @@ fn valid_justification_accepted() {
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
 			&voter_set(),
-			&make_justification_for_header::<TestHeader, TestKeyring>(params).encode()
+			&make_justification_for_header::<TestHeader>(params).encode()
 		),
 		Ok(()),
 	);
@@ -51,7 +50,7 @@ fn valid_justification_accepted_with_single_fork() {
 		header: test_header(1),
 		round: TEST_GRANDPA_ROUND,
 		set_id: TEST_GRANDPA_SET_ID,
-		authorities: vec![(Alice, 1), (Bob, 1), (Charlie, 1), (Dave, 1), (Eve, 1)],
+		authorities: vec![(ALICE, 1), (BOB, 1), (CHARLIE, 1), (DAVE, 1), (EVE, 1)],
 		depth: 5,
 		forks: 1,
 	};
@@ -61,7 +60,7 @@ fn valid_justification_accepted_with_single_fork() {
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
 			&voter_set(),
-			&make_justification_for_header::<TestHeader, TestKeyring>(params).encode()
+			&make_justification_for_header::<TestHeader>(params).encode()
 		),
 		Ok(()),
 	);
@@ -85,8 +84,8 @@ fn valid_justification_accepted_with_arbitrary_number_of_authorities() {
 		verify_justification::<TestHeader>(
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
-			&voter_set(),
-			&make_justification_for_header::<TestHeader, _>(params).encode()
+			&voter_set(), // TODO: How did this pass...
+			&make_justification_for_header::<TestHeader>(params).encode()
 		),
 		Ok(()),
 	);
@@ -168,7 +167,7 @@ fn justification_is_invalid_if_we_dont_meet_threshold() {
 		header: test_header(1),
 		round: TEST_GRANDPA_ROUND,
 		set_id: TEST_GRANDPA_SET_ID,
-		authorities: vec![(Alice, 1), (Bob, 1)],
+		authorities: vec![(ALICE, 1), (BOB, 1)],
 		depth: 2,
 		forks: 2,
 	};
@@ -178,7 +177,7 @@ fn justification_is_invalid_if_we_dont_meet_threshold() {
 			header_id::<TestHeader>(1),
 			TEST_GRANDPA_SET_ID,
 			&voter_set(),
-			&make_justification_for_header::<TestHeader, _>(params).encode()
+			&make_justification_for_header::<TestHeader>(params).encode()
 		),
 		Err(Error::InvalidJustificationCommit),
 	);

--- a/primitives/test-utils/src/keyring.rs
+++ b/primitives/test-utils/src/keyring.rs
@@ -46,16 +46,7 @@ pub trait Keyring {
 	}
 }
 
-#[derive(RuntimeDebug, Clone, Copy)]
-pub struct Account(pub u8);
-
-impl Keyring for Account {
-	fn secret(&self) -> SecretKey {
-		SecretKey::from_bytes(&[self.0; 32]).expect("A static array of the correct length is a known good.")
-	}
-}
-
-/// Set of test accounts.
+/// Set of test accounts with friendly names.
 #[derive(RuntimeDebug, Clone, Copy)]
 pub enum TestKeyring {
 	Alice,
@@ -69,6 +60,16 @@ pub enum TestKeyring {
 impl Keyring for TestKeyring {
 	fn secret(&self) -> SecretKey {
 		SecretKey::from_bytes(&[*self as u8; 32]).expect("A static array of the correct length is a known good.")
+	}
+}
+
+/// A test account which can be used to sign messages.
+#[derive(RuntimeDebug, Clone, Copy)]
+pub struct Account(pub u8);
+
+impl Keyring for Account {
+	fn secret(&self) -> SecretKey {
+		SecretKey::from_bytes(&[self.0; 32]).expect("A static array of the correct length is a known good.")
 	}
 }
 
@@ -101,4 +102,14 @@ pub fn keyring() -> Vec<(TestKeyring, u64)> {
 		(TestKeyring::Bob, 1),
 		(TestKeyring::Charlie, 1),
 	]
+}
+
+/// Get a list of "unique" accounts.
+pub fn accounts(len: u8) -> Vec<Account> {
+	let mut v = vec![];
+	for i in 0..len {
+		v.push(Account(i));
+	}
+
+	v
 }

--- a/primitives/test-utils/src/keyring.rs
+++ b/primitives/test-utils/src/keyring.rs
@@ -1,0 +1,104 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Utilities for working with test accounts.
+
+use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature, Signer};
+use finality_grandpa::voter_set::VoterSet;
+use sp_application_crypto::Public;
+use sp_finality_grandpa::{AuthorityId, AuthorityList};
+use sp_runtime::RuntimeDebug;
+
+pub trait Keyring {
+	fn public(&self) -> PublicKey {
+		(&self.secret()).into()
+	}
+
+	fn secret(&self) -> SecretKey;
+
+	fn pair(&self) -> Keypair {
+		let mut pair: [u8; 64] = [0; 64];
+
+		let secret = self.secret();
+		pair[..32].copy_from_slice(&secret.to_bytes());
+
+		let public = self.public();
+		pair[32..].copy_from_slice(&public.to_bytes());
+
+		Keypair::from_bytes(&pair).expect("We expect the SecretKey to be good, so this must also be good.")
+	}
+
+	fn sign(&self, msg: &[u8]) -> Signature {
+		self.pair().sign(msg)
+	}
+}
+
+#[derive(RuntimeDebug, Clone, Copy)]
+pub struct Account(pub u8);
+
+impl Keyring for Account {
+	fn secret(&self) -> SecretKey {
+		SecretKey::from_bytes(&[self.0; 32]).expect("A static array of the correct length is a known good.")
+	}
+}
+
+/// Set of test accounts.
+#[derive(RuntimeDebug, Clone, Copy)]
+pub enum TestKeyring {
+	Alice,
+	Bob,
+	Charlie,
+	Dave,
+	Eve,
+	Ferdie,
+}
+
+impl Keyring for TestKeyring {
+	fn secret(&self) -> SecretKey {
+		SecretKey::from_bytes(&[*self as u8; 32]).expect("A static array of the correct length is a known good.")
+	}
+}
+
+impl From<TestKeyring> for AuthorityId {
+	fn from(k: TestKeyring) -> Self {
+		AuthorityId::from_slice(&k.public().to_bytes())
+	}
+}
+
+impl From<Account> for AuthorityId {
+	fn from(p: Account) -> Self {
+		AuthorityId::from_slice(&p.public().to_bytes())
+	}
+}
+
+/// Get a valid set of voters for a Grandpa round.
+pub fn voter_set() -> VoterSet<AuthorityId> {
+	VoterSet::new(authority_list()).unwrap()
+}
+
+/// Convenience function to get a list of Grandpa authorities.
+pub fn authority_list() -> AuthorityList {
+	keyring().iter().map(|(id, w)| (AuthorityId::from(*id), *w)).collect()
+}
+
+/// Get the corresponding identities from the keyring for the "standard" authority set.
+pub fn keyring() -> Vec<(TestKeyring, u64)> {
+	vec![
+		(TestKeyring::Alice, 1),
+		(TestKeyring::Bob, 1),
+		(TestKeyring::Charlie, 1),
+	]
+}

--- a/primitives/test-utils/src/keyring.rs
+++ b/primitives/test-utils/src/keyring.rs
@@ -19,7 +19,7 @@
 use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature};
 use finality_grandpa::voter_set::VoterSet;
 use sp_application_crypto::Public;
-use sp_finality_grandpa::{AuthorityId, AuthorityList};
+use sp_finality_grandpa::{AuthorityId, AuthorityList, AuthorityWeight};
 use sp_runtime::RuntimeDebug;
 
 /// Used to indicate if a type is able to cryptographically sign messages.
@@ -101,7 +101,7 @@ pub fn authority_list() -> AuthorityList {
 }
 
 /// Get the corresponding identities from the keyring for the "standard" authority set.
-pub fn test_keyring() -> Vec<(TestKeyring, u64)> {
+pub fn test_keyring() -> Vec<(TestKeyring, AuthorityWeight)> {
 	vec![
 		(TestKeyring::Alice, 1),
 		(TestKeyring::Bob, 1),

--- a/primitives/test-utils/src/keyring.rs
+++ b/primitives/test-utils/src/keyring.rs
@@ -111,10 +111,5 @@ pub fn test_keyring() -> Vec<(TestKeyring, u64)> {
 
 /// Get a list of "unique" accounts.
 pub fn accounts(len: u8) -> Vec<Account> {
-	let mut v = vec![];
-	for i in 0..len {
-		v.push(Account(i));
-	}
-
-	v
+	(0..len).into_iter().map(Account).collect()
 }

--- a/primitives/test-utils/src/lib.rs
+++ b/primitives/test-utils/src/lib.rs
@@ -19,14 +19,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use bp_header_chain::justification::GrandpaJustification;
-use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature, Signer};
-use finality_grandpa::voter_set::VoterSet;
-use sp_application_crypto::{Public, TryFrom};
-use sp_finality_grandpa::{AuthorityId, AuthorityList, AuthorityWeight};
+use ed25519_dalek::Signer;
+use sp_application_crypto::TryFrom;
+use sp_finality_grandpa::{AuthorityId, AuthorityWeight};
 use sp_finality_grandpa::{AuthoritySignature, SetId};
 use sp_runtime::traits::{Header as HeaderT, One, Zero};
-use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
+
+// Re-export all our test account utilities
+pub use keyring::*;
+
+mod keyring;
 
 pub const TEST_GRANDPA_ROUND: u64 = 1;
 pub const TEST_GRANDPA_SET_ID: SetId = 1;
@@ -218,85 +221,4 @@ pub fn test_header<H: HeaderT>(number: H::Number) -> H {
 /// Convenience function for generating a Header ID at a given block number.
 pub fn header_id<H: HeaderT>(index: u8) -> (H::Hash, H::Number) {
 	(test_header::<H>(index.into()).hash(), index.into())
-}
-
-pub trait Keyring {
-	fn public(&self) -> PublicKey {
-		(&self.secret()).into()
-	}
-
-	fn secret(&self) -> SecretKey;
-
-	fn pair(&self) -> Keypair {
-		let mut pair: [u8; 64] = [0; 64];
-
-		let secret = self.secret();
-		pair[..32].copy_from_slice(&secret.to_bytes());
-
-		let public = self.public();
-		pair[32..].copy_from_slice(&public.to_bytes());
-
-		Keypair::from_bytes(&pair).expect("We expect the SecretKey to be good, so this must also be good.")
-	}
-
-	fn sign(&self, msg: &[u8]) -> Signature {
-		self.pair().sign(msg)
-	}
-}
-
-#[derive(RuntimeDebug, Clone, Copy)]
-pub struct Account(pub u8);
-
-impl Keyring for Account {
-	fn secret(&self) -> SecretKey {
-		SecretKey::from_bytes(&[self.0; 32]).expect("A static array of the correct length is a known good.")
-	}
-}
-
-/// Set of test accounts.
-#[derive(RuntimeDebug, Clone, Copy)]
-pub enum TestKeyring {
-	Alice,
-	Bob,
-	Charlie,
-	Dave,
-	Eve,
-	Ferdie,
-}
-
-impl Keyring for TestKeyring {
-	fn secret(&self) -> SecretKey {
-		SecretKey::from_bytes(&[*self as u8; 32]).expect("A static array of the correct length is a known good.")
-	}
-}
-
-impl From<TestKeyring> for AuthorityId {
-	fn from(k: TestKeyring) -> Self {
-		AuthorityId::from_slice(&k.public().to_bytes())
-	}
-}
-
-impl From<Account> for AuthorityId {
-	fn from(p: Account) -> Self {
-		AuthorityId::from_slice(&p.public().to_bytes())
-	}
-}
-
-/// Get a valid set of voters for a Grandpa round.
-pub fn voter_set() -> VoterSet<AuthorityId> {
-	VoterSet::new(authority_list()).unwrap()
-}
-
-/// Convenience function to get a list of Grandpa authorities.
-pub fn authority_list() -> AuthorityList {
-	keyring().iter().map(|(id, w)| (AuthorityId::from(*id), *w)).collect()
-}
-
-/// Get the corresponding identities from the keyring for the "standard" authority set.
-pub fn keyring() -> Vec<(TestKeyring, u64)> {
-	vec![
-		(TestKeyring::Alice, 1),
-		(TestKeyring::Bob, 1),
-		(TestKeyring::Charlie, 1),
-	]
 }


### PR DESCRIPTION
Another thing I realized needed to be more flexible while working through #815.

In #835 I added the ability to create justifications with a tunable number of forks.
However, this only works for the case where `forks <= authorities.len()` since each fork
has a pre-commit which needs to be signed by an authority and the same authority can't
sign off on two different pre-commits (they would be equivocating).

Our existing test keyring with friendly names (Alice, Bob, etc.) is not great for one
particular benchmark where we want to scale up the number of authorities past the number
of enum variants.

This PR adds a small wrapper and a helper function to generate an "abitrary" (really just
`u8::MAX`) number of accounts which we can then use during benchmarking.

You might ask: is `u8` enough for benchmarking if Polkadot/Kusama are going to support
1000 validators? I think this is fine since we're looking for _trends_ in benchmarking
data (e.g how this scales for every _extra_ validator and pre-commit), and `u8::MAX`
data-points seems like a reasonable amount to me. If you guys disagree I can change this,
but it'll make generating `SecretKey`s for the test accounts a more complicated.
