### PR TITLE
Fix delay in `message_lane_loop_is_able_to_recover_from_connection_errors`

### DIFF
--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -221,6 +221,7 @@ pub async fn run<P: MessageLane>(
 ) -> Result<(), String> {
 	let exit_signal = exit_signal.shared();
 	relay_utils::relay_loop(source_client, target_client)
+		.reconnect_delay(params.reconnect_delay)
 		.with_metrics(format!(
 			"{}_to_{}_MessageLane_{}",
 			P::SOURCE_NAME,

--- a/relays/utils/src/relay_loop.rs
+++ b/relays/utils/src/relay_loop.rs
@@ -37,6 +37,7 @@ pub trait Client: Clone + Send + Sync {
 /// Returns generic loop that may be customized and started.
 pub fn relay_loop<SC, TC>(source_client: SC, target_client: TC) -> Loop<SC, TC, ()> {
 	Loop {
+		reconnect_delay: RECONNECT_DELAY,
 		source_client,
 		target_client,
 		loop_metric: None,
@@ -45,6 +46,7 @@ pub fn relay_loop<SC, TC>(source_client: SC, target_client: TC) -> Loop<SC, TC, 
 
 /// Generic relay loop.
 pub struct Loop<SC, TC, LM> {
+	reconnect_delay: Duration,
 	source_client: SC,
 	target_client: TC,
 	loop_metric: Option<LM>,
@@ -58,6 +60,12 @@ pub struct LoopMetrics<SC, TC, LM> {
 }
 
 impl<SC, TC, LM> Loop<SC, TC, LM> {
+	/// Customize delay between reconnect attempts.
+	pub fn reconnect_delay(mut self, reconnect_delay: Duration) -> Self {
+		self.reconnect_delay = reconnect_delay;
+		self
+	}
+
 	/// Start building loop metrics using given prefix.
 	///
 	/// Panics if `prefix` is empty.
@@ -66,6 +74,7 @@ impl<SC, TC, LM> Loop<SC, TC, LM> {
 
 		LoopMetrics {
 			relay_loop: Loop {
+				reconnect_delay: self.reconnect_delay,
 				source_client: self.source_client,
 				target_client: self.target_client,
 				loop_metric: None,
@@ -100,7 +109,7 @@ impl<SC, TC, LM> Loop<SC, TC, LM> {
 			match result {
 				Ok(()) => break,
 				Err(failed_client) => loop {
-					async_std::task::sleep(RECONNECT_DELAY).await;
+					async_std::task::sleep(self.reconnect_delay).await;
 					if failed_client == FailedClient::Both || failed_client == FailedClient::Source {
 						match self.source_client.reconnect().await {
 							Ok(()) => (),
@@ -108,7 +117,7 @@ impl<SC, TC, LM> Loop<SC, TC, LM> {
 								log::warn!(
 									target: "bridge",
 									"Failed to reconnect to source client. Going to retry in {}s: {:?}",
-									RECONNECT_DELAY.as_secs(),
+									self.reconnect_delay.as_secs(),
 									error,
 								);
 								continue;
@@ -122,7 +131,7 @@ impl<SC, TC, LM> Loop<SC, TC, LM> {
 								log::warn!(
 									target: "bridge",
 									"Failed to reconnect to target client. Going to retry in {}s: {:?}",
-									RECONNECT_DELAY.as_secs(),
+									self.reconnect_delay.as_secs(),
 									error,
 								);
 								continue;
@@ -189,6 +198,7 @@ impl<SC, TC, LM> LoopMetrics<SC, TC, LM> {
 		}
 
 		Ok(Loop {
+			reconnect_delay: self.relay_loop.reconnect_delay,
 			source_client: self.relay_loop.source_client,
 			target_client: self.relay_loop.target_client,
 			loop_metric: self.loop_metric,


### PR DESCRIPTION
All loops after #840 had the same 10s reconnection delay => since this test tests how loop behaves after connection error, it has lasted >10s. This PR readds support for custom reconnection delay