### PR TITLE
Extract `select_bridge` macro.

### DIFF
--- a/relays/bin-substrate/src/cli/bridge.rs
+++ b/relays/bin-substrate/src/cli/bridge.rs
@@ -1,0 +1,75 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+use structopt::clap::arg_enum;
+
+arg_enum! {
+	#[derive(Debug)]
+	/// Supported full bridges (headers + messages).
+	pub enum FullBridge {
+		MillauToRialto,
+		RialtoToMillau,
+	}
+}
+
+impl FullBridge {
+	/// Return instance index of the bridge pallet in source runtime.
+	pub fn bridge_instance_index(&self) -> u8 {
+		match self {
+			Self::MillauToRialto => MILLAU_TO_RIALTO_INDEX,
+			Self::RialtoToMillau => RIALTO_TO_MILLAU_INDEX,
+		}
+	}
+}
+
+pub const RIALTO_TO_MILLAU_INDEX: u8 = 0;
+pub const MILLAU_TO_RIALTO_INDEX: u8 = 0;
+
+/// The macro allows executing bridge-specific code without going fully generic.
+///
+/// It matches on the [`FullBridge`] enum, sets bridge-specific types or imports and injects
+/// the `$generic` code at every variant.
+#[macro_export]
+macro_rules! select_full_bridge {
+	($bridge: expr, $generic: tt) => {
+		match $bridge {
+			FullBridge::MillauToRialto => {
+				type Source = relay_millau_client::Millau;
+				type Target = relay_rialto_client::Rialto;
+
+				#[allow(unused_imports)]
+				use bp_millau::derive_account_from_rialto_id as derive_account;
+
+				#[allow(unused_imports)]
+				use crate::rialto_millau::millau_messages_to_rialto::run as relay_messages;
+
+				$generic
+			}
+			FullBridge::RialtoToMillau => {
+				type Source = relay_rialto_client::Rialto;
+				type Target = relay_millau_client::Millau;
+
+				#[allow(unused_imports)]
+				use bp_rialto::derive_account_from_millau_id as derive_account;
+
+				#[allow(unused_imports)]
+				use crate::rialto_millau::rialto_messages_to_millau::run as relay_messages;
+
+				$generic
+			}
+		}
+	};
+}

--- a/relays/bin-substrate/src/cli/encode_call.rs
+++ b/relays/bin-substrate/src/cli/encode_call.rs
@@ -14,17 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::cli::bridge::FullBridge;
 use crate::cli::{AccountId, Balance, CliChain, ExplicitOrMaximal, HexBytes, HexLaneId};
+use crate::select_full_bridge;
 use frame_support::dispatch::GetDispatchInfo;
 use relay_substrate_client::Chain;
-use structopt::{clap::arg_enum, StructOpt};
+use structopt::StructOpt;
 
 /// Encode source chain runtime call.
 #[derive(StructOpt)]
 pub struct EncodeCall {
 	/// A bridge instance to encode call for.
-	#[structopt(possible_values = &EncodeCallBridge::variants(), case_insensitive = true)]
-	bridge: EncodeCallBridge,
+	#[structopt(possible_values = &FullBridge::variants(), case_insensitive = true)]
+	bridge: FullBridge,
 	#[structopt(flatten)]
 	call: Call,
 }
@@ -85,49 +87,9 @@ pub trait CliEncodeCall: Chain {
 	fn encode_call(call: &Call) -> anyhow::Result<Self::Call>;
 }
 
-arg_enum! {
-	#[derive(Debug)]
-	/// Bridge to encode call for.
-	pub enum EncodeCallBridge {
-		MillauToRialto,
-		RialtoToMillau,
-	}
-}
-
-impl EncodeCallBridge {
-	fn bridge_instance_index(&self) -> u8 {
-		match self {
-			Self::MillauToRialto => MILLAU_TO_RIALTO_INDEX,
-			Self::RialtoToMillau => RIALTO_TO_MILLAU_INDEX,
-		}
-	}
-}
-
-pub const RIALTO_TO_MILLAU_INDEX: u8 = 0;
-pub const MILLAU_TO_RIALTO_INDEX: u8 = 0;
-
-macro_rules! select_bridge {
-	($bridge: expr, $generic: tt) => {
-		match $bridge {
-			EncodeCallBridge::MillauToRialto => {
-				type Source = relay_millau_client::Millau;
-				type Target = relay_rialto_client::Rialto;
-
-				$generic
-			}
-			EncodeCallBridge::RialtoToMillau => {
-				type Source = relay_rialto_client::Rialto;
-				type Target = relay_millau_client::Millau;
-
-				$generic
-			}
-		}
-	};
-}
-
 impl EncodeCall {
 	fn encode(&mut self) -> anyhow::Result<HexBytes> {
-		select_bridge!(self.bridge, {
+		select_full_bridge!(self.bridge, {
 			preprocess_call::<Source, Target>(&mut self.call, self.bridge.bridge_instance_index());
 			let call = Source::encode_call(&self.call)?;
 

--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -25,6 +25,7 @@ use frame_support::weights::Weight;
 use sp_runtime::app_crypto::Ss58Codec;
 use structopt::{clap::arg_enum, StructOpt};
 
+pub(crate) mod bridge;
 pub(crate) mod encode_call;
 
 mod derive_account;

--- a/relays/bin-substrate/src/rialto_millau/mod.rs
+++ b/relays/bin-substrate/src/rialto_millau/mod.rs
@@ -29,7 +29,8 @@ pub type MillauClient = relay_substrate_client::Client<Millau>;
 pub type RialtoClient = relay_substrate_client::Client<Rialto>;
 
 use crate::cli::{
-	encode_call::{self, Call, CliEncodeCall, MILLAU_TO_RIALTO_INDEX, RIALTO_TO_MILLAU_INDEX},
+	bridge::{MILLAU_TO_RIALTO_INDEX, RIALTO_TO_MILLAU_INDEX},
+	encode_call::{self, Call, CliEncodeCall},
 	CliChain, ExplicitOrMaximal, HexBytes, Origins,
 };
 use codec::{Decode, Encode};
@@ -426,7 +427,7 @@ impl CliEncodeCall for Millau {
 				fee,
 				bridge_instance_index,
 			} => match *bridge_instance_index {
-				encode_call::MILLAU_TO_RIALTO_INDEX => {
+				MILLAU_TO_RIALTO_INDEX => {
 					let payload = Decode::decode(&mut &*payload.0)?;
 					millau_runtime::Call::BridgeRialtoMessages(millau_runtime::MessagesCall::send_message(
 						lane.0,
@@ -499,7 +500,7 @@ impl CliEncodeCall for Rialto {
 				fee,
 				bridge_instance_index,
 			} => match *bridge_instance_index {
-				encode_call::RIALTO_TO_MILLAU_INDEX => {
+				RIALTO_TO_MILLAU_INDEX => {
 					let payload = Decode::decode(&mut &*payload.0)?;
 					rialto_runtime::Call::BridgeMillauMessages(rialto_runtime::MessagesCall::send_message(
 						lane.0, payload, fee.0,


### PR DESCRIPTION
Multiple sub-commands now define almost identical `enum` and `select_bridge` macro.
This PR moves it to a shared file and re-uses the common stuff.

This has a (IMHO nice) consequence of needing to implement all of the commands while adding a bridge variant (or introducing a separate enum).

Related #855 