### PR TITLE
Fix Undeterministic CLI Encoding Test

### DIFF
--- a/relays/bin-substrate/src/cli/encode_call.rs
+++ b/relays/bin-substrate/src/cli/encode_call.rs
@@ -268,12 +268,8 @@ mod tests {
 
 		// then
 		assert_eq!(err.kind, structopt::clap::ErrorKind::ArgumentConflict);
-		assert_eq!(
-			err.info,
-			Some(vec![
-				"remark-size".to_string(),
-				"--remark-payload <remark-payload>".to_string()
-			])
-		);
+
+		let info = err.info.unwrap();
+		assert!(info.contains(&"remark-payload".to_string()) | info.contains(&"remark-size".to_string()))
 	}
 }


### PR DESCRIPTION
Looks like a test introduced in #868 is not deterministic. You can see our `master` build
failed [here](https://github.com/paritytech/parity-bridges-common/runs/2279623635) even though the tests in the PR passed.

This PR updates the test to check for both possible error variants, and as long as we
match on one the test will be considered successful.
