### PR TITLE
Fix widgets names

### DIFF
--- a/deployments/bridges/poa-rialto/dashboard/grafana/relay-poa-to-rialto-headers-dashboard.json
+++ b/deployments/bridges/poa-rialto/dashboard/grafana/relay-poa-to-rialto-headers-dashboard.json
@@ -239,7 +239,7 @@
         {
           "expr": "max_over_time(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"}[2m])-min_over_time(Ethereum_to_Substrate_Sync_best_block_numbers{node=\"source\"}[2m])",
           "interval": "",
-          "legendFormat": "Number of Ethereum PoA Headers Synced on Rialto",
+          "legendFormat": "Number of new Headers on Ethereum PoA (Last 2 Mins)",
           "refId": "A"
         }
       ],

--- a/deployments/bridges/poa-rialto/dashboard/grafana/relay-rialto-to-poa-headers-dashboard.json
+++ b/deployments/bridges/poa-rialto/dashboard/grafana/relay-rialto-to-poa-headers-dashboard.json
@@ -239,7 +239,7 @@
         {
           "expr": "max_over_time(Substrate_to_Ethereum_Sync_best_block_numbers{node=\"source\"}[2m])-min_over_time(Substrate_to_Ethereum_Sync_best_block_numbers{node=\"source\"}[2m])",
           "interval": "",
-          "legendFormat": "Number of Rialto Headers Synced on Ethereum PoA",
+          "legendFormat": "Number of new Headers on Rialto (Last 2 Mins)",
           "refId": "A"
         }
       ],

--- a/deployments/bridges/rialto-millau/dashboard/grafana/relay-millau-to-rialto-headers-dashboard.json
+++ b/deployments/bridges/rialto-millau/dashboard/grafana/relay-millau-to-rialto-headers-dashboard.json
@@ -239,7 +239,7 @@
         {
           "expr": "max_over_time(Millau_to_Rialto_Sync_best_block_numbers{node=\"source\"}[2m])-min_over_time(Millau_to_Rialto_Sync_best_block_numbers{node=\"source\"}[2m])",
           "interval": "",
-          "legendFormat": "Number of Millau Headers Synced on Rialto",
+          "legendFormat": "Number of new Headers on Millau (Last 2 Mins)",
           "refId": "A"
         }
       ],

--- a/deployments/bridges/rialto-millau/dashboard/grafana/relay-rialto-to-millau-headers-dashboard.json
+++ b/deployments/bridges/rialto-millau/dashboard/grafana/relay-rialto-to-millau-headers-dashboard.json
@@ -239,7 +239,7 @@
         {
           "expr": "max_over_time(Rialto_to_Millau_Sync_best_block_numbers{node=\"source\"}[2m])-min_over_time(Rialto_to_Millau_Sync_best_block_numbers{node=\"source\"}[2m])",
           "interval": "",
-          "legendFormat": "Number of Rialto Headers Synced on Millau",
+          "legendFormat": "Number of new Headers on Rialto (Last 2 Mins)",
           "refId": "A"
         }
       ],

--- a/deployments/bridges/westend-millau/dashboard/grafana/relay-westend-to-millau-headers-dashboard.json
+++ b/deployments/bridges/westend-millau/dashboard/grafana/relay-westend-to-millau-headers-dashboard.json
@@ -239,7 +239,7 @@
         {
           "expr": "max_over_time(Westend_to_Millau_Sync_best_block_numbers{node=\"source\"}[2m])-min_over_time(Westend_to_Millau_Sync_best_block_numbers{node=\"source\"}[2m])",
           "interval": "",
-          "legendFormat": "Number of Westend Headers Synced on Millau",
+          "legendFormat": "Number of new Headers on Westend (Last 2 Mins)",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
closes #876 

Actually it's the name of the widget what's incorrect - it shows number of new source headers at source in last 2 mins. It is to generate alerts if our source node is not syncing.