### PR TITLE
Grandpa Pallet Pruning

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -309,12 +309,19 @@ parameter_types! {
 	// call per block.
 	pub const MaxRequests: u32 = 50;
 	pub const WestendValidatorCount: u32 = 255;
+
+	// Number of headers to keep.
+	//
+	// assuming worst case of every header being finalized, and 6 seconds block time, we will keep
+	// headers for a week.
+	pub const HeadersToKeep: u32 = 10 * 60 * 24 * 7;
 }
 
 pub type RialtoGrandpaInstance = ();
 impl pallet_bridge_grandpa::Config for Runtime {
 	type BridgedChain = bp_rialto::Rialto;
 	type MaxRequests = MaxRequests;
+	type HeadersToKeep = HeadersToKeep;
 
 	// TODO [#391]: Use weights generated for the Millau runtime instead of Rialto ones.
 	type WeightInfo = pallet_bridge_grandpa::weights::RialtoWeight<Runtime>;
@@ -324,6 +331,7 @@ pub type WestendGrandpaInstance = pallet_bridge_grandpa::Instance1;
 impl pallet_bridge_grandpa::Config<WestendGrandpaInstance> for Runtime {
 	type BridgedChain = bp_westend::Westend;
 	type MaxRequests = MaxRequests;
+	type HeadersToKeep = HeadersToKeep;
 
 	// TODO [#391]: Use weights generated for the Millau runtime instead of Rialto ones.
 	type WeightInfo = pallet_bridge_grandpa::weights::RialtoWeight<Runtime>;

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -312,9 +312,9 @@ parameter_types! {
 
 	// Number of headers to keep.
 	//
-	// assuming worst case of every header being finalized, and 6 seconds block time, we will keep
-	// headers for a week.
-	pub const HeadersToKeep: u32 = 10 * 60 * 24 * 7;
+	// Assuming the worst case of every header being finalized, we will keep headers for at least a
+	// week.
+	pub const HeadersToKeep: u32 = 7 * bp_millau::DAYS as u32;
 }
 
 pub type RialtoGrandpaInstance = ();

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -414,11 +414,18 @@ parameter_types! {
 	// Note that once this is hit the pallet will essentially throttle incoming requests down to one
 	// call per block.
 	pub const MaxRequests: u32 = 50;
+
+	// Number of headers to keep.
+	//
+	// assuming worst case of every header being finalized, and 6 seconds block time, we will keep
+	// headers for a week.
+	pub const HeadersToKeep: u32 = 10 * 60 * 24 * 7;
 }
 
 impl pallet_bridge_grandpa::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
 	type MaxRequests = MaxRequests;
+	type HeadersToKeep = HeadersToKeep;
 	type WeightInfo = pallet_bridge_grandpa::weights::RialtoWeight<Runtime>;
 }
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -417,9 +417,9 @@ parameter_types! {
 
 	// Number of headers to keep.
 	//
-	// assuming worst case of every header being finalized, and 6 seconds block time, we will keep
-	// headers for a week.
-	pub const HeadersToKeep: u32 = 10 * 60 * 24 * 7;
+	// Assuming the worst case of every header being finalized, we will keep headers at least for a
+	// week.
+	pub const HeadersToKeep: u32 = 7 * bp_rialto::DAYS as u32;
 }
 
 impl pallet_bridge_grandpa::Config for Runtime {

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -1025,4 +1025,30 @@ mod tests {
 			assert_ok!(submit_finality_proof(7));
 		})
 	}
+
+	#[test]
+	fn should_prune_headers_over_headers_to_keep_parameter() {
+		run_test(|| {
+			initialize_substrate_bridge();
+			assert_ok!(submit_finality_proof(1));
+			let first_header = Pallet::<TestRuntime>::best_finalized();
+			next_block();
+
+			assert_ok!(submit_finality_proof(2));
+			next_block();
+			assert_ok!(submit_finality_proof(3));
+			next_block();
+			assert_ok!(submit_finality_proof(4));
+			next_block();
+			assert_ok!(submit_finality_proof(5));
+			next_block();
+
+			assert_ok!(submit_finality_proof(6));
+
+			assert!(
+				!Pallet::<TestRuntime>::is_known_header(first_header.hash()),
+				"First header should be pruned."
+			);
+		})
+	}
 }

--- a/modules/grandpa/src/mock.rs
+++ b/modules/grandpa/src/mock.rs
@@ -81,6 +81,7 @@ impl frame_system::Config for TestRuntime {
 
 parameter_types! {
 	pub const MaxRequests: u32 = 2;
+	pub const HeadersToKeep: u32 = 5;
 	pub const SessionLength: u64 = 5;
 	pub const NumValidators: u32 = 5;
 }
@@ -88,6 +89,7 @@ parameter_types! {
 impl grandpa::Config for TestRuntime {
 	type BridgedChain = TestBridgedChain;
 	type MaxRequests = MaxRequests;
+	type HeadersToKeep = HeadersToKeep;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
Resolves #419 

The dumbest pruning implementation, where we simply store `X` last headers around.
The implementation maintains a map of `Map<InsertionIndex, HeaderHash>` and there is a `Needle` which simply traverses all indexes from range `[0..HeadersToKeep)` and wraps around at the end. So the `ImportedHashes` structure has constant size and every time we overwrite an existing header we remove it from `ImportedHeaders` as well.