### PR TITLE
Use new Cargo feature resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
 	"bin/*/node",


### PR DESCRIPTION
This PR uses the [new Cargo feature resolver](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver) which was introduced in Rust 1.51.

One of the great things about this new resolver is that it'll stop `std` dependencies
from leaking into our `no_std` builds (e.g when we build the runtime).

Another perk is that it also makes building runtime benchmarks easier. Previously we were
unable to build runtime benchmarks from the top level of the repo and instead needed to
do the following:

`cargo build --manifest-path ./bin/rialto/node/Cargo.toml --features runtime-benchmarks`

Now we can simply do the following: `cargo build --features runtime-benchmarks`
