### PR TITLE
RestartNeeded from jsonrpsee is now a connection error

### DIFF
--- a/relays/client-substrate/src/error.rs
+++ b/relays/client-substrate/src/error.rs
@@ -72,6 +72,7 @@ impl MaybeConnectionError for Error {
 				// right now if connection to the ws server is dropped (after it is already established),
 				// we're getting this error
 				| Error::RpcError(RpcError::Internal(_))
+				| Error::RpcError(RpcError::RestartNeeded(_))
 				| Error::ClientNotSynced(_),
 		)
 	}


### PR DESCRIPTION
connection error means that we need to restart connection, which is exactly what `RestartNeeded` says