### PR TITLE
(temporarily) Switch to jsonrpsee master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,16 +182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,7 +282,6 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
 dependencies = [
- "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
@@ -344,7 +333,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "rustls 0.19.0",
- "webpki",
+ "webpki 0.21.4",
  "webpki-roots",
 ]
 
@@ -464,6 +453,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "beef"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
 name = "bincode"
@@ -2352,7 +2347,7 @@ checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
 dependencies = [
  "futures-io",
  "rustls 0.19.0",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2848,7 +2843,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio 0.2.25",
  "tokio-rustls",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -3237,11 +3232,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.2.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb4afbda476e2ee11cc6245055c498c116fc8002d2d60fe8338b6ee15d84c3a"
+version = "0.2.0-alpha.4"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=de7b58a881512cd5ab8bbf16a56241ca808c7765#de7b58a881512cd5ab8bbf16a56241ca808c7765"
 dependencies = [
  "Inflector",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3249,12 +3244,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.2.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42a82588b5f7830e94341bb7e79d15f46070ab6f64dde1e3b3719721b61c5bf"
+version = "0.2.0-alpha.4"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=de7b58a881512cd5ab8bbf16a56241ca808c7765#de7b58a881512cd5ab8bbf16a56241ca808c7765"
 dependencies = [
  "async-trait",
- "futures 0.3.13",
+ "beef",
+ "futures-channel",
+ "futures-util",
  "log",
  "serde",
  "serde_json",
@@ -3264,9 +3260,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.2.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0398a066fe036d198e5fea8f3dd092b7bcd0e155d1784ef9e467afc332d4c783"
+version = "0.2.0-alpha.4"
+source = "git+https://github.com/paritytech/jsonrpsee?rev=de7b58a881512cd5ab8bbf16a56241ca808c7765#de7b58a881512cd5ab8bbf16a56241ca808c7765"
 dependencies = [
  "async-std",
  "async-tls",
@@ -3276,12 +3271,11 @@ dependencies = [
  "jsonrpsee-types",
  "log",
  "pin-project 1.0.5",
- "serde",
  "serde_json",
  "soketto",
  "thiserror",
  "url 2.2.1",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -6222,7 +6216,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -6235,7 +6229,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -8868,7 +8862,7 @@ dependencies = [
  "futures-core",
  "rustls 0.18.1",
  "tokio 0.2.25",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -9761,12 +9755,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]

--- a/relays/client-ethereum/Cargo.toml
+++ b/relays/client-ethereum/Cargo.toml
@@ -10,9 +10,9 @@ bp-eth-poa = { path = "../../primitives/ethereum-poa" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 headers-relay = { path = "../headers" }
 hex-literal = "0.3"
-jsonrpsee-proc-macros = "=0.2.0-alpha.3"
-jsonrpsee-types = "=0.2.0-alpha.3"
-jsonrpsee-ws-client = "=0.2.0-alpha.3"
+jsonrpsee-proc-macros = { git = "https://github.com/paritytech/jsonrpsee", rev = "de7b58a881512cd5ab8bbf16a56241ca808c7765" }
+jsonrpsee-types = { git = "https://github.com/paritytech/jsonrpsee", rev = "de7b58a881512cd5ab8bbf16a56241ca808c7765" }
+jsonrpsee-ws-client = { git = "https://github.com/paritytech/jsonrpsee", rev = "de7b58a881512cd5ab8bbf16a56241ca808c7765" }
 libsecp256k1 = { version = "0.3.4", default-features = false, features = ["hmac"] }
 log = "0.4.11"
 relay-utils = { path = "../utils" }

--- a/relays/client-ethereum/src/client.rs
+++ b/relays/client-ethereum/src/client.rs
@@ -21,7 +21,7 @@ use crate::types::{
 };
 use crate::{ConnectionParams, Error, Result};
 
-use jsonrpsee_ws_client::{WsClient as RpcClient, WsConfig as RpcConfig};
+use jsonrpsee_ws_client::{WsClient as RpcClient, WsClientBuilder as RpcClientBuilder};
 use std::sync::Arc;
 
 /// Number of headers missing from the Ethereum node for us to consider node not synced.
@@ -46,7 +46,7 @@ impl Client {
 	/// Build client to use in connection.
 	async fn build_client(params: &ConnectionParams) -> Result<Arc<RpcClient>> {
 		let uri = format!("ws://{}:{}", params.host, params.port);
-		let client = RpcClient::new(RpcConfig::with_url(&uri)).await?;
+		let client = RpcClientBuilder::default().build(&uri).await?;
 		Ok(Arc::new(client))
 	}
 

--- a/relays/client-substrate/Cargo.toml
+++ b/relays/client-substrate/Cargo.toml
@@ -9,9 +9,9 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 async-std = "1.6.5"
 async-trait = "0.1.40"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-jsonrpsee-proc-macros = "=0.2.0-alpha.3"
-jsonrpsee-types = "=0.2.0-alpha.3"
-jsonrpsee-ws-client = "=0.2.0-alpha.3"
+jsonrpsee-proc-macros = { git = "https://github.com/paritytech/jsonrpsee", rev = "de7b58a881512cd5ab8bbf16a56241ca808c7765" }
+jsonrpsee-types = { git = "https://github.com/paritytech/jsonrpsee", rev = "de7b58a881512cd5ab8bbf16a56241ca808c7765" }
+jsonrpsee-ws-client = { git = "https://github.com/paritytech/jsonrpsee", rev = "de7b58a881512cd5ab8bbf16a56241ca808c7765" }
 log = "0.4.11"
 num-traits = "0.2"
 rand = "0.7"

--- a/relays/client-substrate/src/client.rs
+++ b/relays/client-substrate/src/client.rs
@@ -24,7 +24,7 @@ use async_std::sync::{Arc, Mutex};
 use codec::Decode;
 use frame_system::AccountInfo;
 use jsonrpsee_types::{jsonrpc::DeserializeOwned, traits::SubscriptionClient};
-use jsonrpsee_ws_client::{WsClient as RpcClient, WsConfig as RpcConfig, WsSubscription as Subscription};
+use jsonrpsee_ws_client::{WsClient as RpcClient, WsClientBuilder as RpcClientBuilder, WsSubscription as Subscription};
 use num_traits::Zero;
 use pallet_balances::AccountData;
 use sp_core::{storage::StorageKey, Bytes};
@@ -105,9 +105,11 @@ impl<C: Chain> Client<C> {
 			params.host,
 			params.port,
 		);
-		let mut config = RpcConfig::with_url(&uri);
-		config.max_notifs_per_subscription = MAX_SUBSCRIPTION_CAPACITY;
-		let client = RpcClient::new(config).await?;
+		let client = RpcClientBuilder::default()
+			.max_concurrent_requests(10)
+			.max_notifs_per_subscription(MAX_SUBSCRIPTION_CAPACITY)
+			.build(&uri)
+			.await?;
 
 		Ok(Arc::new(client))
 	}


### PR DESCRIPTION
closes #909 

I've been able to `cargo build -p polkadot` using this patch, so it should not break polkadot codebase, unless I'm missing something.