### PR TITLE
Prep for Westend to Rococo Header Sync

### DIFF
--- a/deployments/local-scripts/relay-headers-rococo-to-westend.sh
+++ b/deployments/local-scripts/relay-headers-rococo-to-westend.sh
@@ -8,7 +8,7 @@
 
 set -xeu
 
- RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay init-bridge RococoToWestend \
+RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay init-bridge RococoToWestend \
 	--source-host 127.0.0.1 \
 	--source-port 9955 \
 	--target-host 127.0.0.1 \

--- a/deployments/local-scripts/relay-headers-rococo-to-westend.sh
+++ b/deployments/local-scripts/relay-headers-rococo-to-westend.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Run an instance of the Rococo -> Westend header sync.
+#
+# Right now this relies on local Westend and Rococo networks
+# running (which include `pallet-bridge-grandpa` in their
+# runtimes), but in the future it could use use public RPC nodes.
+
+set -xeu
+
+ RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay init-bridge RococoToWestend \
+	--source-host 127.0.0.1 \
+	--source-port 9955 \
+	--target-host 127.0.0.1 \
+	--target-port 9944 \
+	--target-signer //Eve
+
+RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay relay-headers RococoToWestend \
+	--source-host 127.0.0.1 \
+	--source-port 9955 \
+	--target-host 127.0.0.1 \
+	--target-port 9944 \
+	--target-signer //Bob \
+	--prometheus-host=0.0.0.0 \

--- a/deployments/local-scripts/relay-headers-westend-to-rococo.sh
+++ b/deployments/local-scripts/relay-headers-westend-to-rococo.sh
@@ -8,7 +8,7 @@
 
 set -xeu
 
- RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay init-bridge WestendToRococo \
+RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay init-bridge WestendToRococo \
 	--source-host 127.0.0.1 \
 	--source-port 9944 \
 	--target-host 127.0.0.1 \

--- a/deployments/local-scripts/relay-headers-westend-to-rococo.sh
+++ b/deployments/local-scripts/relay-headers-westend-to-rococo.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Run an instance of the Westend -> Rococo header sync.
+#
+# Right now this relies on local Westend and Rococo networks
+# running (which include `pallet-bridge-grandpa` in their
+# runtimes), but in the future it could use use public RPC nodes.
+
+set -xeu
+
+ RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay init-bridge WestendToRococo \
+	--source-host 127.0.0.1 \
+	--source-port 9944 \
+	--target-host 127.0.0.1 \
+	--target-port 9955 \
+	--target-signer //Dave
+
+RUST_LOG=rpc=trace,bridge=trace ./target/debug/substrate-relay relay-headers WestendToRococo \
+	--source-host 127.0.0.1 \
+	--source-port 9944 \
+	--target-host 127.0.0.1 \
+	--target-port 9955 \
+	--target-signer //Charlie \
+	--prometheus-host=0.0.0.0 \

--- a/deployments/local-scripts/run-rococo-bob-node.sh
+++ b/deployments/local-scripts/run-rococo-bob-node.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Run a development instance of the Rococo Substrate bridge node.
+# To override the default port just export ROCOCO_PORT=9966
+#
+# Note: This script will not work out of the box with the bridges
+# repo since it relies on a Polkadot binary.
+
+ROCOCO_BOB_PORT="${ROCOCO_BOB_PORT:-9966}"
+
+RUST_LOG=runtime=trace,runtime::bridge=trace \
+./target/debug/polkadot --chain=rococo-local --bob --tmp \
+    --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external \
+    --port 33055 --rpc-port 9935 --ws-port $ROCOCO_BOB_PORT \

--- a/deployments/local-scripts/run-rococo-node.sh
+++ b/deployments/local-scripts/run-rococo-node.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Run a development instance of the Rococo Substrate bridge node.
+# To override the default port just export ROCOCO_PORT=9955
+#
+# Note: This script will not work out of the box with the bridges
+# repo since it relies on a Polkadot binary.
+
+ROCOCO_PORT="${ROCOCO_PORT:-9955}"
+
+RUST_LOG=runtime=trace,runtime::bridge=trace \
+./target/debug/polkadot --chain=rococo-local --alice --tmp \
+    --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external \
+    --port 33044 --rpc-port 9934 --ws-port $ROCOCO_PORT \

--- a/deployments/local-scripts/run-westend-node.sh
+++ b/deployments/local-scripts/run-westend-node.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Run a development instance of the Westend Substrate bridge node.
+# To override the default port just export WESTEND_PORT=9945
+#
+# Note: This script will not work out of the box with the bridges
+# repo since it relies on a Polkadot binary.
+
+WESTEND_PORT="${WESTEND_PORT:-9944}"
+
+RUST_LOG=runtime=trace,runtime::bridge=trace \
+./target/debug/polkadot --chain=westend-dev --alice --tmp \
+    --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external \
+    --port 33033 --rpc-port 9933 --ws-port $WESTEND_PORT \

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -32,14 +32,15 @@ pub type Rococo = PolkadotLike;
 
 pub type UncheckedExtrinsic = bp_polkadot_core::UncheckedExtrinsic<Call>;
 
+// NOTE: This needs to be kept up to date with the Rococo runtime found in the Polkadot repo.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_version::create_runtime_str!("rococo"),
-	impl_name: sp_version::create_runtime_str!("parity-rococo-v1-1"),
+	impl_name: sp_version::create_runtime_str!("parity-rococo-v1.5"),
 	authoring_version: 0,
-	spec_version: 30,
+	spec_version: 231,
 	impl_version: 0,
 	apis: sp_version::create_apis_vec![[]],
-	transaction_version: 6,
+	transaction_version: 0,
 };
 
 /// Rococo Runtime `Call` enum.

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -32,12 +32,12 @@ pub type Westend = PolkadotLike;
 
 pub type UncheckedExtrinsic = bp_polkadot_core::UncheckedExtrinsic<Call>;
 
-/// Runtime version.
+// NOTE: This needs to be kept up to date with the Westend runtime found in the Polkadot repo.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_version::create_runtime_str!("westend"),
 	impl_name: sp_version::create_runtime_str!("parity-westend"),
 	authoring_version: 2,
-	spec_version: 50,
+	spec_version: 51,
 	impl_version: 0,
 	apis: sp_version::create_apis_vec![[]],
 	transaction_version: 5,


### PR DESCRIPTION
This PR updates the RuntimeVersion for used in the bridges repo to match those used by
Westend and Rococo at the moment. It also adds some helper scripts for running local
nodes and the header relay.
