### PR TITLE
Make sure that relayers have dates in logs.

### DIFF
--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -89,8 +89,23 @@ pub enum Command {
 }
 
 impl Command {
+	// Initialize logger depending on the command.
+	fn init_logger(&self) {
+		use relay_utils::initialize::{initialize_logger, initialize_relay};
+
+		match self {
+			Self::RelayHeaders(_) | Self::RelayMessages(_) | Self::RelayHeadersAndMessages(_) | Self::InitBridge(_) => {
+				initialize_relay();
+			}
+			_ => {
+				initialize_logger(false);
+			}
+		}
+	}
+
 	/// Run the command.
 	pub async fn run(self) -> anyhow::Result<()> {
+		self.init_logger();
 		match self {
 			Self::RelayHeaders(arg) => arg.run().await?,
 			Self::RelayMessages(arg) => arg.run().await?,

--- a/relays/bin-substrate/src/main.rs
+++ b/relays/bin-substrate/src/main.rs
@@ -18,8 +18,6 @@
 
 #![warn(missing_docs)]
 
-use relay_utils::initialize::initialize_logger;
-
 mod chains;
 mod cli;
 mod finality_pipeline;
@@ -31,7 +29,6 @@ mod messages_target;
 mod on_demand_headers;
 
 fn main() {
-	initialize_logger(false);
 	let command = cli::parse_args();
 	let run = command.run();
 	let result = async_std::task::block_on(run);


### PR DESCRIPTION
In #845 I accidentally disabled dates from relayers as well, I somehow thought that they use `initialize_relay` function and forgot that we share the same CLI. This PR tries to bring the old behavior back.