### PR TITLE
Remove deprecated Runtime Header APIs

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -308,7 +308,6 @@ parameter_types! {
 	// Note that once this is hit the pallet will essentially throttle incoming requests down to one
 	// call per block.
 	pub const MaxRequests: u32 = 50;
-	pub const WestendValidatorCount: u32 = 255;
 
 	// Number of headers to keep.
 	//

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -259,31 +259,6 @@ pub const FROM_MILLAU_LATEST_CONFIRMED_NONCE_METHOD: &str = "FromMillauInboundLa
 pub const FROM_MILLAU_UNREWARDED_RELAYERS_STATE: &str = "FromMillauInboundLaneApi_unrewarded_relayers_state";
 
 sp_api::decl_runtime_apis! {
-	/// API for querying information about Millau headers from the Bridge Pallet instance.
-	///
-	/// This API is implemented by runtimes that are bridging with the Millau chain, not the
-	/// Millau runtime itself.
-	pub trait MillauHeaderApi {
-		/// Returns number and hash of the best blocks known to the bridge module.
-		///
-		/// Will return multiple headers if there are many headers at the same "best" height.
-		///
-		/// The caller should only submit an `import_header` transaction that makes
-		/// (or leads to making) other header the best one.
-		fn best_blocks() -> Vec<(BlockNumber, Hash)>;
-		/// Returns number and hash of the best finalized block known to the bridge module.
-		fn finalized_block() -> (BlockNumber, Hash);
-		/// Returns numbers and hashes of headers that require finality proofs.
-		///
-		/// An empty response means that there are no headers which currently require a
-		/// finality proof.
-		fn incomplete_headers() -> Vec<(BlockNumber, Hash)>;
-		/// Returns true if the header is known to the runtime.
-		fn is_known_block(hash: Hash) -> bool;
-		/// Returns true if the header is considered finalized by the runtime.
-		fn is_finalized_block(hash: Hash) -> bool;
-	}
-
 	/// API for querying information about the finalized Millau headers.
 	///
 	/// This API is implemented by runtimes that are bridging with the Millau chain, not the

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -220,31 +220,6 @@ pub const FROM_RIALTO_LATEST_CONFIRMED_NONCE_METHOD: &str = "FromRialtoInboundLa
 pub const FROM_RIALTO_UNREWARDED_RELAYERS_STATE: &str = "FromRialtoInboundLaneApi_unrewarded_relayers_state";
 
 sp_api::decl_runtime_apis! {
-	/// API for querying information about Rialto headers from the Bridge Pallet instance.
-	///
-	/// This API is implemented by runtimes that are bridging with the Rialto chain, not the
-	/// Rialto runtime itself.
-	pub trait RialtoHeaderApi {
-		/// Returns number and hash of the best blocks known to the bridge module.
-		///
-		/// Will return multiple headers if there are many headers at the same "best" height.
-		///
-		/// The caller should only submit an `import_header` transaction that makes
-		/// (or leads to making) other header the best one.
-		fn best_blocks() -> Vec<(BlockNumber, Hash)>;
-		/// Returns number and hash of the best finalized block known to the bridge module.
-		fn finalized_block() -> (BlockNumber, Hash);
-		/// Returns numbers and hashes of headers that require finality proofs.
-		///
-		/// An empty response means that there are no headers which currently require a
-		/// finality proof.
-		fn incomplete_headers() -> Vec<(BlockNumber, Hash)>;
-		/// Returns true if the header is known to the runtime.
-		fn is_known_block(hash: Hash) -> bool;
-		/// Returns true if the header is considered finalized by the runtime.
-		fn is_finalized_block(hash: Hash) -> bool;
-	}
-
 	/// API for querying information about the finalized Rialto headers.
 	///
 	/// This API is implemented by runtimes that are bridging with the Rialto chain, not the


### PR DESCRIPTION
Looks like I forgot to remove these during #866.
