### PR TITLE
Endow accounts and add `bridgeIds` to chainspec.

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -71,6 +71,9 @@ impl Alternative {
 			serde_json::json!({
 				"tokenDecimals": 9,
 				"tokenSymbol": "MLAU",
+				"bridgeIds": {
+					"Rialto": bp_runtime::RIALTO_BRIDGE_INSTANCE,
+				}
 			})
 			.as_object()
 			.expect("Map given; qed")

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -94,7 +94,7 @@ impl Alternative {
 							get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-								get_account_id_from_seed::<sr25519::Public>("Bob"),
+								get_account_id_from_seed::<sr25519::Public>("Alice"),
 							)),
 						],
 						true,
@@ -142,13 +142,13 @@ impl Alternative {
 								pallet_bridge_messages::DefaultInstance,
 							>::relayer_fund_account_id(),
 							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-								get_account_id_from_seed::<sr25519::Public>("Bob"),
+								get_account_id_from_seed::<sr25519::Public>("Alice"),
 							)),
 							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-								get_account_id_from_seed::<sr25519::Public>("Dave"),
+								get_account_id_from_seed::<sr25519::Public>("Charlie"),
 							)),
 							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-								get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+								get_account_id_from_seed::<sr25519::Public>("Eve"),
 							)),
 						],
 						true,

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -90,6 +90,9 @@ impl Alternative {
 							get_account_id_from_seed::<sr25519::Public>("Bob"),
 							get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
+								get_account_id_from_seed::<sr25519::Public>("Bob"),
+							)),
 						],
 						true,
 					)
@@ -136,7 +139,13 @@ impl Alternative {
 								pallet_bridge_messages::DefaultInstance,
 							>::relayer_fund_account_id(),
 							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
+								get_account_id_from_seed::<sr25519::Public>("Bob"),
+							)),
+							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
 								get_account_id_from_seed::<sr25519::Public>("Dave"),
+							)),
+							derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
+								get_account_id_from_seed::<sr25519::Public>("Ferdie"),
 							)),
 						],
 						true,
@@ -168,7 +177,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		},
 		pallet_balances: BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 50)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 20)).collect(),
 		},
 		pallet_aura: AuraConfig {
 			authorities: Vec::new(),

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -72,6 +72,9 @@ impl Alternative {
 			json!({
 				"tokenDecimals": 9,
 				"tokenSymbol": "RLT",
+				"bridgeIds": {
+					"Millau": bp_runtime::MILLAU_BRIDGE_INSTANCE,
+				}
 			})
 			.as_object()
 			.expect("Map given; qed")
@@ -178,7 +181,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		},
 		pallet_balances: BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 50)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 20)).collect(),
 		},
 		pallet_aura: AuraConfig {
 			authorities: Vec::new(),

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -91,6 +91,9 @@ impl Alternative {
 							get_account_id_from_seed::<sr25519::Public>("Bob"),
 							get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 							get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+							derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
+								get_account_id_from_seed::<sr25519::Public>("Bob"),
+							)),
 						],
 						true,
 					)
@@ -137,7 +140,13 @@ impl Alternative {
 								pallet_bridge_messages::DefaultInstance,
 							>::relayer_fund_account_id(),
 							derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
+								get_account_id_from_seed::<sr25519::Public>("Bob"),
+							)),
+							derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
 								get_account_id_from_seed::<sr25519::Public>("Dave"),
+							)),
+							derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
+								get_account_id_from_seed::<sr25519::Public>("Ferdie"),
 							)),
 						],
 						true,


### PR DESCRIPTION
Closes #943 

Endows a bit more accounts for testing (Bob, Dave, Ferdie and Alice/Charile/Eve on other chain) and also adds chain spec property which defines configured `bridgeIds`, which will be useful for https://github.com/paritytech/parity-bridges-ui/issues/86