### PR TITLE
Bump endowment amounts on Rialto and Millau

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -180,7 +180,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		},
 		pallet_balances: BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 20)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 40)).collect(),
 		},
 		pallet_aura: AuraConfig {
 			authorities: Vec::new(),

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -181,7 +181,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		},
 		pallet_balances: BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 20)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 40)).collect(),
 		},
 		pallet_aura: AuraConfig {
 			authorities: Vec::new(),


### PR DESCRIPTION
Looks like these amounts were reduced in #951, which has caused some problems with
accounts not having enough funds for things like initializing the bridge.

This PR makes everyone a little richer 💰
