### PR TITLE
Increase account endowment amount

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -180,7 +180,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		},
 		pallet_balances: BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 40)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 50)).collect(),
 		},
 		pallet_aura: AuraConfig {
 			authorities: Vec::new(),

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -181,7 +181,7 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		},
 		pallet_balances: BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 40)).collect(),
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 50)).collect(),
 		},
 		pallet_aura: AuraConfig {
 			authorities: Vec::new(),


### PR DESCRIPTION
Looks like the changes in #957 didn't bump the endowment amounts enough. I'm seeing
errors on our testnet deployments related to insufficient funds.
