### PR TITLE
Pass source and target chain ids to account_ownership_digest

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -72,7 +72,7 @@ impl Alternative {
 				"tokenDecimals": 9,
 				"tokenSymbol": "MLAU",
 				"bridgeIds": {
-					"Rialto": bp_runtime::RIALTO_BRIDGE_INSTANCE,
+					"Rialto": bp_runtime::RIALTO_CHAIN_ID,
 				}
 			})
 			.as_object()

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -642,7 +642,7 @@ impl_runtime_apis! {
 /// The byte vector returned by this function should be signed with a Rialto account private key.
 /// This way, the owner of `millau_account_id` on Millau proves that the Rialto account private key
 /// is also under his control.
-pub fn rialto_account_ownership_digest<Call, AccountId, SpecVersion>(
+pub fn millau_to_rialto_account_ownership_digest<Call, AccountId, SpecVersion>(
 	rialto_call: &Call,
 	millau_account_id: AccountId,
 	rialto_spec_version: SpecVersion,
@@ -656,7 +656,8 @@ where
 		rialto_call,
 		millau_account_id,
 		rialto_spec_version,
-		bp_runtime::MILLAU_BRIDGE_INSTANCE,
+		bp_runtime::MILLAU_CHAIN_ID,
+		bp_runtime::RIALTO_CHAIN_ID,
 	)
 }
 

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -23,7 +23,7 @@ use bp_messages::{
 	target_chain::{ProvedMessages, SourceHeaderChain},
 	InboundLaneData, LaneId, Message, MessageNonce, Parameter as MessagesParameter,
 };
-use bp_runtime::{InstanceId, RIALTO_BRIDGE_INSTANCE};
+use bp_runtime::{ChainId, MILLAU_CHAIN_ID, RIALTO_CHAIN_ID};
 use bridge_runtime_common::messages::{self, MessageBridge, MessageTransaction};
 use codec::{Decode, Encode};
 use frame_support::{
@@ -72,8 +72,6 @@ pub type FromRialtoMessageDispatch = messages::target::FromBridgedChainMessageDi
 pub struct WithRialtoMessageBridge;
 
 impl MessageBridge for WithRialtoMessageBridge {
-	const INSTANCE: InstanceId = RIALTO_BRIDGE_INSTANCE;
-
 	const RELAYER_FEE_PERCENT: u32 = 10;
 
 	type ThisChain = Millau;
@@ -90,6 +88,8 @@ impl MessageBridge for WithRialtoMessageBridge {
 pub struct Millau;
 
 impl messages::ChainWithMessages for Millau {
+	const ID: ChainId = MILLAU_CHAIN_ID;
+
 	type Hash = bp_millau::Hash;
 	type AccountId = bp_millau::AccountId;
 	type Signer = bp_millau::AccountSigner;
@@ -141,6 +141,8 @@ impl messages::ThisChainWithMessages for Millau {
 pub struct Rialto;
 
 impl messages::ChainWithMessages for Rialto {
+	const ID: ChainId = RIALTO_CHAIN_ID;
+
 	type Hash = bp_rialto::Hash;
 	type AccountId = bp_rialto::AccountId;
 	type Signer = bp_rialto::AccountSigner;

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -73,7 +73,7 @@ impl Alternative {
 				"tokenDecimals": 9,
 				"tokenSymbol": "RLT",
 				"bridgeIds": {
-					"Millau": bp_runtime::MILLAU_BRIDGE_INSTANCE,
+					"Millau": bp_runtime::MILLAU_CHAIN_ID,
 				}
 			})
 			.as_object()

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -1026,7 +1026,7 @@ impl_runtime_apis! {
 /// The byte vector returned by this function should be signed with a Millau account private key.
 /// This way, the owner of `rialto_account_id` on Rialto proves that the 'millau' account private key
 /// is also under his control.
-pub fn millau_account_ownership_digest<Call, AccountId, SpecVersion>(
+pub fn rialto_to_millau_account_ownership_digest<Call, AccountId, SpecVersion>(
 	millau_call: &Call,
 	rialto_account_id: AccountId,
 	millau_spec_version: SpecVersion,
@@ -1040,7 +1040,8 @@ where
 		millau_call,
 		rialto_account_id,
 		millau_spec_version,
-		bp_runtime::RIALTO_BRIDGE_INSTANCE,
+		bp_runtime::RIALTO_CHAIN_ID,
+		bp_runtime::MILLAU_CHAIN_ID,
 	)
 }
 

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -23,7 +23,7 @@ use bp_messages::{
 	target_chain::{ProvedMessages, SourceHeaderChain},
 	InboundLaneData, LaneId, Message, MessageNonce, Parameter as MessagesParameter,
 };
-use bp_runtime::{InstanceId, MILLAU_BRIDGE_INSTANCE};
+use bp_runtime::{ChainId, MILLAU_CHAIN_ID, RIALTO_CHAIN_ID};
 use bridge_runtime_common::messages::{self, MessageBridge, MessageTransaction};
 use codec::{Decode, Encode};
 use frame_support::{
@@ -72,8 +72,6 @@ pub type ToMillauMessagesDeliveryProof = messages::source::FromBridgedChainMessa
 pub struct WithMillauMessageBridge;
 
 impl MessageBridge for WithMillauMessageBridge {
-	const INSTANCE: InstanceId = MILLAU_BRIDGE_INSTANCE;
-
 	const RELAYER_FEE_PERCENT: u32 = 10;
 
 	type ThisChain = Rialto;
@@ -90,6 +88,8 @@ impl MessageBridge for WithMillauMessageBridge {
 pub struct Rialto;
 
 impl messages::ChainWithMessages for Rialto {
+	const ID: ChainId = RIALTO_CHAIN_ID;
+
 	type Hash = bp_rialto::Hash;
 	type AccountId = bp_rialto::AccountId;
 	type Signer = bp_rialto::AccountSigner;
@@ -141,6 +141,8 @@ impl messages::ThisChainWithMessages for Rialto {
 pub struct Millau;
 
 impl messages::ChainWithMessages for Millau {
+	const ID: ChainId = MILLAU_CHAIN_ID;
+
 	type Hash = bp_millau::Hash;
 	type AccountId = bp_millau::AccountId;
 	type Signer = bp_millau::AccountSigner;

--- a/deployments/types-millau.json
+++ b/deployments/types-millau.json
@@ -67,7 +67,7 @@
     "set_id": "SetId"
   },
   "Id": "[u8; 4]",
-  "InstanceId": "Id",
+  "ChainId": "Id",
   "LaneId": "Id",
   "MessageNonce": "u64",
   "MessageId": "(Id, u64)",

--- a/deployments/types-rialto.json
+++ b/deployments/types-rialto.json
@@ -67,7 +67,7 @@
     "set_id": "SetId"
   },
   "Id": "[u8; 4]",
-  "InstanceId": "Id",
+  "ChainId": "Id",
   "LaneId": "Id",
   "MessageNonce": "u64",
   "MessageId": "(Id, u64)",

--- a/deployments/types/common.json
+++ b/deployments/types/common.json
@@ -67,7 +67,7 @@
 		"set_id": "SetId"
 	},
 	"Id": "[u8; 4]",
-	"InstanceId": "Id",
+	"ChainId": "Id",
 	"LaneId": "Id",
 	"MessageNonce": "u64",
 	"MessageId": "(Id, u64)",

--- a/modules/dispatch/src/lib.rs
+++ b/modules/dispatch/src/lib.rs
@@ -25,7 +25,7 @@
 #![warn(missing_docs)]
 
 use bp_message_dispatch::{CallOrigin, MessageDispatch, MessagePayload, SpecVersion, Weight};
-use bp_runtime::{derive_account_id, InstanceId, SourceAccount};
+use bp_runtime::{derive_account_id, ChainId, SourceAccount};
 use codec::{Decode, Encode};
 use frame_support::{
 	decl_event, decl_module, decl_storage,
@@ -90,21 +90,21 @@ decl_event!(
 		<T as Config<I>>::MessageId
 	{
 		/// Message has been rejected before reaching dispatch.
-		MessageRejected(InstanceId, MessageId),
+		MessageRejected(ChainId, MessageId),
 		/// Message has been rejected by dispatcher because of spec version mismatch.
 		/// Last two arguments are: expected and passed spec version.
-		MessageVersionSpecMismatch(InstanceId, MessageId, SpecVersion, SpecVersion),
+		MessageVersionSpecMismatch(ChainId, MessageId, SpecVersion, SpecVersion),
 		/// Message has been rejected by dispatcher because of weight mismatch.
 		/// Last two arguments are: expected and passed call weight.
-		MessageWeightMismatch(InstanceId, MessageId, Weight, Weight),
+		MessageWeightMismatch(ChainId, MessageId, Weight, Weight),
 		/// Message signature mismatch.
-		MessageSignatureMismatch(InstanceId, MessageId),
+		MessageSignatureMismatch(ChainId, MessageId),
 		/// Message has been dispatched with given result.
-		MessageDispatched(InstanceId, MessageId, DispatchResult),
+		MessageDispatched(ChainId, MessageId, DispatchResult),
 		/// We have failed to decode Call from the message.
-		MessageCallDecodeFailed(InstanceId, MessageId),
+		MessageCallDecodeFailed(ChainId, MessageId),
 		/// The call from the message has been rejected by the call filter.
-		MessageCallRejected(InstanceId, MessageId),
+		MessageCallRejected(ChainId, MessageId),
 		/// Phantom member, never used. Needed to handle multiple pallet instances.
 		_Dummy(PhantomData<I>),
 	}
@@ -126,13 +126,18 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		message.weight
 	}
 
-	fn dispatch(bridge: InstanceId, id: T::MessageId, message: Result<Self::Message, ()>) {
+	fn dispatch(source_chain: ChainId, target_chain: ChainId, id: T::MessageId, message: Result<Self::Message, ()>) {
 		// emit special even if message has been rejected by external component
 		let message = match message {
 			Ok(message) => message,
 			Err(_) => {
-				log::trace!(target: "runtime::bridge-dispatch", "Message {:?}/{:?}: rejected before actual dispatch", bridge, id);
-				Self::deposit_event(RawEvent::MessageRejected(bridge, id));
+				log::trace!(
+					target: "runtime::bridge-dispatch",
+					"Message {:?}/{:?}: rejected before actual dispatch",
+					source_chain,
+					id,
+				);
+				Self::deposit_event(RawEvent::MessageRejected(source_chain, id));
 				return;
 			}
 		};
@@ -143,13 +148,13 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		if message.spec_version != expected_version {
 			log::trace!(
 				"Message {:?}/{:?}: spec_version mismatch. Expected {:?}, got {:?}",
-				bridge,
+				source_chain,
 				id,
 				expected_version,
 				message.spec_version,
 			);
 			Self::deposit_event(RawEvent::MessageVersionSpecMismatch(
-				bridge,
+				source_chain,
 				id,
 				expected_version,
 				message.spec_version,
@@ -161,8 +166,13 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		let call = match message.call.into() {
 			Ok(call) => call,
 			Err(_) => {
-				log::trace!(target: "runtime::bridge-dispatch", "Failed to decode Call from message {:?}/{:?}", bridge, id,);
-				Self::deposit_event(RawEvent::MessageCallDecodeFailed(bridge, id));
+				log::trace!(
+					target: "runtime::bridge-dispatch",
+					"Failed to decode Call from message {:?}/{:?}",
+					source_chain,
+					id,
+				);
+				Self::deposit_event(RawEvent::MessageCallDecodeFailed(source_chain, id));
 				return;
 			}
 		};
@@ -170,25 +180,31 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		// prepare dispatch origin
 		let origin_account = match message.origin {
 			CallOrigin::SourceRoot => {
-				let hex_id = derive_account_id::<T::SourceChainAccountId>(bridge, SourceAccount::Root);
+				let hex_id = derive_account_id::<T::SourceChainAccountId>(source_chain, SourceAccount::Root);
 				let target_id = T::AccountIdConverter::convert(hex_id);
 				log::trace!(target: "runtime::bridge-dispatch", "Root Account: {:?}", &target_id);
 				target_id
 			}
 			CallOrigin::TargetAccount(source_account_id, target_public, target_signature) => {
-				let digest = account_ownership_digest(&call, source_account_id, message.spec_version, bridge);
+				let digest = account_ownership_digest(
+					&call,
+					source_account_id,
+					message.spec_version,
+					source_chain,
+					target_chain,
+				);
 
 				let target_account = target_public.into_account();
 				if !target_signature.verify(&digest[..], &target_account) {
 					log::trace!(
 						target: "runtime::bridge-dispatch",
 						"Message {:?}/{:?}: origin proof is invalid. Expected account: {:?} from signature: {:?}",
-						bridge,
+						source_chain,
 						id,
 						target_account,
 						target_signature,
 					);
-					Self::deposit_event(RawEvent::MessageSignatureMismatch(bridge, id));
+					Self::deposit_event(RawEvent::MessageSignatureMismatch(source_chain, id));
 					return;
 				}
 
@@ -196,7 +212,7 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 				target_account
 			}
 			CallOrigin::SourceAccount(source_account_id) => {
-				let hex_id = derive_account_id(bridge, SourceAccount::Account(source_account_id));
+				let hex_id = derive_account_id(source_chain, SourceAccount::Account(source_account_id));
 				let target_id = T::AccountIdConverter::convert(hex_id);
 				log::trace!(target: "runtime::bridge-dispatch", "Source Account: {:?}", &target_id);
 				target_id
@@ -208,11 +224,11 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 			log::trace!(
 				target: "runtime::bridge-dispatch",
 				"Message {:?}/{:?}: the call ({:?}) is rejected by filter",
-				bridge,
+				source_chain,
 				id,
 				call,
 			);
-			Self::deposit_event(RawEvent::MessageCallRejected(bridge, id));
+			Self::deposit_event(RawEvent::MessageCallRejected(source_chain, id));
 			return;
 		}
 
@@ -225,13 +241,13 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 			log::trace!(
 				target: "runtime::bridge-dispatch",
 				"Message {:?}/{:?}: passed weight is too low. Expected at least {:?}, got {:?}",
-				bridge,
+				source_chain,
 				id,
 				expected_weight,
 				message.weight,
 			);
 			Self::deposit_event(RawEvent::MessageWeightMismatch(
-				bridge,
+				source_chain,
 				id,
 				expected_weight,
 				message.weight,
@@ -248,7 +264,7 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		log::trace!(
 			target: "runtime::bridge-dispatch",
 			"Message {:?}/{:?} has been dispatched. Weight: {} of {}. Result: {:?}",
-			bridge,
+			source_chain,
 			id,
 			actual_call_weight,
 			message.weight,
@@ -256,7 +272,7 @@ impl<T: Config<I>, I: Instance> MessageDispatch<T::MessageId> for Pallet<T, I> {
 		);
 
 		Self::deposit_event(RawEvent::MessageDispatched(
-			bridge,
+			source_chain,
 			id,
 			dispatch_result.map(drop).map_err(|e| e.error),
 		));
@@ -303,23 +319,24 @@ where
 /// The byte vector returned by this function will be signed with a target chain account
 /// private key. This way, the owner of `source_account_id` on the source chain proves that
 /// the target chain account private key is also under his control.
-pub fn account_ownership_digest<Call, AccountId, SpecVersion, BridgeId>(
+pub fn account_ownership_digest<Call, AccountId, SpecVersion>(
 	call: &Call,
 	source_account_id: AccountId,
 	target_spec_version: SpecVersion,
-	source_instance_id: BridgeId,
+	source_chain_id: ChainId,
+	target_chain_id: ChainId,
 ) -> Vec<u8>
 where
 	Call: Encode,
 	AccountId: Encode,
 	SpecVersion: Encode,
-	BridgeId: Encode,
 {
 	let mut proof = Vec::new();
 	call.encode_to(&mut proof);
 	source_account_id.encode_to(&mut proof);
 	target_spec_version.encode_to(&mut proof);
-	source_instance_id.encode_to(&mut proof);
+	source_chain_id.encode_to(&mut proof);
+	target_chain_id.encode_to(&mut proof);
 
 	proof
 }
@@ -341,6 +358,9 @@ mod tests {
 
 	type AccountId = u64;
 	type MessageId = [u8; 4];
+
+	const SOURCE_CHAIN_ID: ChainId = *b"srce";
+	const TARGET_CHAIN_ID: ChainId = *b"trgt";
 
 	#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 	pub struct TestAccountPublic(AccountId);
@@ -495,7 +515,6 @@ mod tests {
 	#[test]
 	fn should_fail_on_spec_version_mismatch() {
 		new_test_ext().execute_with(|| {
-			let bridge = b"ethb".to_owned();
 			let id = [0; 4];
 
 			const BAD_SPEC_VERSION: SpecVersion = 99;
@@ -504,14 +523,14 @@ mod tests {
 			message.spec_version = BAD_SPEC_VERSION;
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
 					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageVersionSpecMismatch(
-						bridge,
+						SOURCE_CHAIN_ID,
 						id,
 						TEST_SPEC_VERSION,
 						BAD_SPEC_VERSION
@@ -525,21 +544,23 @@ mod tests {
 	#[test]
 	fn should_fail_on_weight_mismatch() {
 		new_test_ext().execute_with(|| {
-			let bridge = b"ethb".to_owned();
 			let id = [0; 4];
 			let mut message =
 				prepare_root_message(Call::System(<frame_system::Call<TestRuntime>>::remark(vec![1, 2, 3])));
 			message.weight = 0;
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
 					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageWeightMismatch(
-						bridge, id, 1345000, 0,
+						SOURCE_CHAIN_ID,
+						id,
+						1345000,
+						0,
 					)),
 					topics: vec![],
 				}],
@@ -550,7 +571,6 @@ mod tests {
 	#[test]
 	fn should_fail_on_signature_mismatch() {
 		new_test_ext().execute_with(|| {
-			let bridge = b"ethb".to_owned();
 			let id = [0; 4];
 
 			let call_origin = CallOrigin::TargetAccount(1, TestAccountPublic(1), TestSignature(99));
@@ -560,14 +580,15 @@ mod tests {
 			);
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
 					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageSignatureMismatch(
-						bridge, id
+						SOURCE_CHAIN_ID,
+						id
 					)),
 					topics: vec![],
 				}],
@@ -578,17 +599,19 @@ mod tests {
 	#[test]
 	fn should_emit_event_for_rejected_messages() {
 		new_test_ext().execute_with(|| {
-			let bridge = b"ethb".to_owned();
 			let id = [0; 4];
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Err(()));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Err(()));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
-					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageRejected(bridge, id)),
+					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageRejected(
+						SOURCE_CHAIN_ID,
+						id
+					)),
 					topics: vec![],
 				}],
 			);
@@ -598,7 +621,6 @@ mod tests {
 	#[test]
 	fn should_fail_on_call_decode() {
 		new_test_ext().execute_with(|| {
-			let bridge = b"ethb".to_owned();
 			let id = [0; 4];
 
 			let mut message =
@@ -606,14 +628,15 @@ mod tests {
 			message.call.0 = vec![];
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
 					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageCallDecodeFailed(
-						bridge, id
+						SOURCE_CHAIN_ID,
+						id
 					)),
 					topics: vec![],
 				}],
@@ -624,7 +647,6 @@ mod tests {
 	#[test]
 	fn should_emit_event_for_rejected_calls() {
 		new_test_ext().execute_with(|| {
-			let bridge = b"ethb".to_owned();
 			let id = [0; 4];
 
 			let call = Call::System(<frame_system::Call<TestRuntime>>::fill_block(Perbill::from_percent(75)));
@@ -633,13 +655,16 @@ mod tests {
 			message.weight = weight;
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
-					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageCallRejected(bridge, id)),
+					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageCallRejected(
+						SOURCE_CHAIN_ID,
+						id
+					)),
 					topics: vec![],
 				}],
 			);
@@ -649,19 +674,18 @@ mod tests {
 	#[test]
 	fn should_dispatch_bridge_message_from_root_origin() {
 		new_test_ext().execute_with(|| {
-			let bridge = b"ethb".to_owned();
 			let id = [0; 4];
 			let message = prepare_root_message(Call::System(<frame_system::Call<TestRuntime>>::remark(vec![1, 2, 3])));
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
 					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageDispatched(
-						bridge,
+						SOURCE_CHAIN_ID,
 						id,
 						Ok(())
 					)),
@@ -675,20 +699,19 @@ mod tests {
 	fn should_dispatch_bridge_message_from_target_origin() {
 		new_test_ext().execute_with(|| {
 			let id = [0; 4];
-			let bridge = b"ethb".to_owned();
 
 			let call = Call::System(<frame_system::Call<TestRuntime>>::remark(vec![]));
 			let message = prepare_target_message(call);
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
 					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageDispatched(
-						bridge,
+						SOURCE_CHAIN_ID,
 						id,
 						Ok(())
 					)),
@@ -702,20 +725,19 @@ mod tests {
 	fn should_dispatch_bridge_message_from_source_origin() {
 		new_test_ext().execute_with(|| {
 			let id = [0; 4];
-			let bridge = b"ethb".to_owned();
 
 			let call = Call::System(<frame_system::Call<TestRuntime>>::remark(vec![]));
 			let message = prepare_source_message(call);
 
 			System::set_block_number(1);
-			Dispatch::dispatch(bridge, id, Ok(message));
+			Dispatch::dispatch(SOURCE_CHAIN_ID, TARGET_CHAIN_ID, id, Ok(message));
 
 			assert_eq!(
 				System::events(),
 				vec![EventRecord {
 					phase: Phase::Initialization,
 					event: Event::call_dispatch(call_dispatch::Event::<TestRuntime>::MessageDispatched(
-						bridge,
+						SOURCE_CHAIN_ID,
 						id,
 						Ok(())
 					)),

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -31,7 +31,7 @@ pub type Kusama = PolkadotLike;
 // We use this to get the account on Kusama (target) which is derived from Polkadot's (source)
 // account.
 pub fn derive_account_from_polkadot_id(id: bp_runtime::SourceAccount<AccountId>) -> AccountId {
-	let encoded_id = bp_runtime::derive_account_id(bp_runtime::POLKADOT_BRIDGE_INSTANCE, id);
+	let encoded_id = bp_runtime::derive_account_id(bp_runtime::POLKADOT_CHAIN_ID, id);
 	AccountIdConverter::convert(encoded_id)
 }
 

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -201,7 +201,7 @@ impl sp_runtime::traits::Convert<sp_core::H256, AccountId> for AccountIdConverte
 ///
 /// Note that this should only be used for testing.
 pub fn derive_account_from_rialto_id(id: bp_runtime::SourceAccount<AccountId>) -> AccountId {
-	let encoded_id = bp_runtime::derive_account_id(bp_runtime::RIALTO_BRIDGE_INSTANCE, id);
+	let encoded_id = bp_runtime::derive_account_id(bp_runtime::RIALTO_CHAIN_ID, id);
 	AccountIdConverter::convert(encoded_id)
 }
 

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -31,7 +31,7 @@ pub type Polkadot = PolkadotLike;
 // We use this to get the account on Polkadot (target) which is derived from Kusama's (source)
 // account.
 pub fn derive_account_from_kusama_id(id: bp_runtime::SourceAccount<AccountId>) -> AccountId {
-	let encoded_id = bp_runtime::derive_account_id(bp_runtime::KUSAMA_BRIDGE_INSTANCE, id);
+	let encoded_id = bp_runtime::derive_account_id(bp_runtime::KUSAMA_CHAIN_ID, id);
 	AccountIdConverter::convert(encoded_id)
 }
 

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -162,7 +162,7 @@ impl Convert<sp_core::H256, AccountId> for AccountIdConverter {
 //
 // Note that this should only be used for testing.
 pub fn derive_account_from_millau_id(id: bp_runtime::SourceAccount<AccountId>) -> AccountId {
-	let encoded_id = bp_runtime::derive_account_id(bp_runtime::MILLAU_BRIDGE_INSTANCE, id);
+	let encoded_id = bp_runtime::derive_account_id(bp_runtime::MILLAU_CHAIN_ID, id);
 	AccountIdConverter::convert(encoded_id)
 }
 

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -86,7 +86,7 @@ impl sp_runtime::traits::Dispatchable for Call {
 // We use this to get the account on Westend (target) which is derived from Rococo's (source)
 // account.
 pub fn derive_account_from_rococo_id(id: bp_runtime::SourceAccount<AccountId>) -> AccountId {
-	let encoded_id = bp_runtime::derive_account_id(bp_runtime::ROCOCO_BRIDGE_INSTANCE, id);
+	let encoded_id = bp_runtime::derive_account_id(bp_runtime::ROCOCO_CHAIN_ID, id);
 	AccountIdConverter::convert(encoded_id)
 }
 

--- a/primitives/chain-wococo/src/lib.rs
+++ b/primitives/chain-wococo/src/lib.rs
@@ -86,7 +86,7 @@ impl sp_runtime::traits::Dispatchable for Call {
 // We use this to get the account on Wococo (target) which is derived from Rococo's (source)
 // account.
 pub fn derive_account_from_rococo_id(id: bp_runtime::SourceAccount<AccountId>) -> AccountId {
-	let encoded_id = bp_runtime::derive_account_id(bp_runtime::ROCOCO_BRIDGE_INSTANCE, id);
+	let encoded_id = bp_runtime::derive_account_id(bp_runtime::ROCOCO_CHAIN_ID, id);
 	AccountIdConverter::convert(encoded_id)
 }
 

--- a/primitives/message-dispatch/src/lib.rs
+++ b/primitives/message-dispatch/src/lib.rs
@@ -19,7 +19,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 
-use bp_runtime::{InstanceId, Size};
+use bp_runtime::{ChainId, Size};
 use codec::{Decode, Encode};
 use frame_support::RuntimeDebug;
 use sp_std::prelude::*;
@@ -43,7 +43,8 @@ pub trait MessageDispatch<MessageId> {
 
 	/// Dispatches the message internally.
 	///
-	/// `bridge` indicates instance of deployed bridge where the message came from.
+	/// `source_chain` indicates the chain where the message came from.
+	/// `target_chain` indicates the chain where message dispatch happens.
 	///
 	/// `id` is a short unique identifier of the message.
 	///
@@ -51,7 +52,7 @@ pub trait MessageDispatch<MessageId> {
 	/// a sign that some other component has rejected the message even before it has
 	/// reached `dispatch` method (right now this may only be caused if we fail to decode
 	/// the whole message).
-	fn dispatch(bridge: InstanceId, id: MessageId, message: Result<Self::Message, ()>);
+	fn dispatch(source_chain: ChainId, target_chain: ChainId, id: MessageId, message: Result<Self::Message, ()>);
 }
 
 /// Origin of a Call when it is dispatched on the target chain.

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -33,25 +33,25 @@ mod chain;
 mod storage_proof;
 
 /// Use this when something must be shared among all instances.
-pub const NO_INSTANCE_ID: InstanceId = [0, 0, 0, 0];
+pub const NO_INSTANCE_ID: ChainId = [0, 0, 0, 0];
 
 /// Bridge-with-Rialto instance id.
-pub const RIALTO_BRIDGE_INSTANCE: InstanceId = *b"rlto";
+pub const RIALTO_CHAIN_ID: ChainId = *b"rlto";
 
 /// Bridge-with-Millau instance id.
-pub const MILLAU_BRIDGE_INSTANCE: InstanceId = *b"mlau";
+pub const MILLAU_CHAIN_ID: ChainId = *b"mlau";
 
 /// Bridge-with-Polkadot instance id.
-pub const POLKADOT_BRIDGE_INSTANCE: InstanceId = *b"pdot";
+pub const POLKADOT_CHAIN_ID: ChainId = *b"pdot";
 
 /// Bridge-with-Kusama instance id.
-pub const KUSAMA_BRIDGE_INSTANCE: InstanceId = *b"ksma";
+pub const KUSAMA_CHAIN_ID: ChainId = *b"ksma";
 
 /// Bridge-with-Rococo instance id.
-pub const ROCOCO_BRIDGE_INSTANCE: InstanceId = *b"roco";
+pub const ROCOCO_CHAIN_ID: ChainId = *b"roco";
 
 /// Bridge-with-Wococo instance id.
-pub const WOCOCO_BRIDGE_INSTANCE: InstanceId = *b"woco";
+pub const WOCOCO_CHAIN_ID: ChainId = *b"woco";
 
 /// Call-dispatch module prefix.
 pub const CALL_DISPATCH_MODULE_PREFIX: &[u8] = b"pallet-bridge/dispatch";
@@ -62,11 +62,13 @@ pub const ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/
 /// A unique prefix for entropy when generating a cross-chain account ID for the Root account.
 pub const ROOT_ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/root";
 
-/// Id of deployed module instance. We have a bunch of pallets that may be used in
-/// different bridges. E.g. messages pallet may be deployed twice in the same
-/// runtime to bridge ThisChain with Chain1 and Chain2. Sometimes we need to be able
-/// to identify deployed instance dynamically. This type is used for that.
-pub type InstanceId = [u8; 4];
+/// Unique identifier of the chain.
+///
+/// In addition to its main function (identifying the chain), this type may also be used to
+/// identify module instance. We have a bunch of pallets that may be used in different bridges. E.g.
+/// messages pallet may be deployed twice in the same runtime to bridge ThisChain with Chain1 and Chain2.
+/// Sometimes we need to be able to identify deployed instance dynamically. This type may be used for that.
+pub type ChainId = [u8; 4];
 
 /// Type of accounts on the source chain.
 pub enum SourceAccount<T> {
@@ -90,7 +92,7 @@ pub enum SourceAccount<T> {
 /// Note: If the same `bridge_id` is used across different chains (for example, if one source chain
 /// is bridged to multiple target chains), then all the derived accounts would be the same across
 /// the different chains. This could negatively impact users' privacy across chains.
-pub fn derive_account_id<AccountId>(bridge_id: InstanceId, id: SourceAccount<AccountId>) -> H256
+pub fn derive_account_id<AccountId>(bridge_id: ChainId, id: SourceAccount<AccountId>) -> H256
 where
 	AccountId: Encode,
 {
@@ -107,7 +109,7 @@ where
 ///
 /// The account ID can be the same across different instances of `pallet-bridge-messages` if the same
 /// `bridge_id` is used.
-pub fn derive_relayer_fund_account_id(bridge_id: InstanceId) -> H256 {
+pub fn derive_relayer_fund_account_id(bridge_id: ChainId) -> H256 {
 	("relayer-fund-account", bridge_id).using_encoded(blake2_256).into()
 }
 

--- a/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
+++ b/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
@@ -23,7 +23,7 @@ use crate::messages_source::SubstrateMessagesSource;
 use crate::messages_target::SubstrateMessagesTarget;
 
 use bp_messages::MessageNonce;
-use bp_runtime::{MILLAU_BRIDGE_INSTANCE, RIALTO_BRIDGE_INSTANCE};
+use bp_runtime::{MILLAU_CHAIN_ID, RIALTO_CHAIN_ID};
 use bridge_runtime_common::messages::target::FromBridgedChainMessagesProof;
 use codec::Encode;
 use frame_support::dispatch::GetDispatchInfo;
@@ -200,14 +200,14 @@ pub async fn run(
 			source_client.clone(),
 			lane.clone(),
 			lane_id,
-			RIALTO_BRIDGE_INSTANCE,
+			RIALTO_CHAIN_ID,
 			params.target_to_source_headers_relay,
 		),
 		RialtoTargetClient::new(
 			params.target_client,
 			lane,
 			lane_id,
-			MILLAU_BRIDGE_INSTANCE,
+			MILLAU_CHAIN_ID,
 			params.source_to_target_headers_relay,
 		),
 		relay_utils::relay_metrics(

--- a/relays/bin-substrate/src/chains/mod.rs
+++ b/relays/bin-substrate/src/chains/mod.rs
@@ -86,7 +86,7 @@ mod tests {
 		let millau_public: bp_millau::AccountSigner = millau_sign.public().into();
 		let millau_account_id: bp_millau::AccountId = millau_public.into_account();
 
-		let digest = millau_runtime::rialto_account_ownership_digest(
+		let digest = millau_runtime::millau_to_rialto_account_ownership_digest(
 			&call,
 			millau_account_id,
 			rialto_runtime::VERSION.spec_version,
@@ -107,7 +107,7 @@ mod tests {
 		let rialto_public: bp_rialto::AccountSigner = rialto_sign.public().into();
 		let rialto_account_id: bp_rialto::AccountId = rialto_public.into_account();
 
-		let digest = rialto_runtime::millau_account_ownership_digest(
+		let digest = rialto_runtime::rialto_to_millau_account_ownership_digest(
 			&call,
 			rialto_account_id,
 			millau_runtime::VERSION.spec_version,

--- a/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
+++ b/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
@@ -23,7 +23,7 @@ use crate::messages_source::SubstrateMessagesSource;
 use crate::messages_target::SubstrateMessagesTarget;
 
 use bp_messages::MessageNonce;
-use bp_runtime::{MILLAU_BRIDGE_INSTANCE, RIALTO_BRIDGE_INSTANCE};
+use bp_runtime::{MILLAU_CHAIN_ID, RIALTO_CHAIN_ID};
 use bridge_runtime_common::messages::target::FromBridgedChainMessagesProof;
 use codec::Encode;
 use frame_support::dispatch::GetDispatchInfo;
@@ -199,14 +199,14 @@ pub async fn run(
 			source_client.clone(),
 			lane.clone(),
 			lane_id,
-			MILLAU_BRIDGE_INSTANCE,
+			MILLAU_CHAIN_ID,
 			params.target_to_source_headers_relay,
 		),
 		MillauTargetClient::new(
 			params.target_client,
 			lane,
 			lane_id,
-			RIALTO_BRIDGE_INSTANCE,
+			RIALTO_CHAIN_ID,
 			params.source_to_target_headers_relay,
 		),
 		relay_utils::relay_metrics(

--- a/relays/bin-substrate/src/cli/bridge.rs
+++ b/relays/bin-substrate/src/cli/bridge.rs
@@ -64,7 +64,7 @@ macro_rules! select_full_bridge {
 				use bp_rialto::TO_RIALTO_ESTIMATE_MESSAGE_FEE_METHOD as ESTIMATE_MESSAGE_FEE_METHOD;
 				// Send-message
 				#[allow(unused_imports)]
-				use millau_runtime::rialto_account_ownership_digest as account_ownership_digest;
+				use millau_runtime::millau_to_rialto_account_ownership_digest as account_ownership_digest;
 
 				$generic
 			}
@@ -87,7 +87,7 @@ macro_rules! select_full_bridge {
 
 				// Send-message
 				#[allow(unused_imports)]
-				use rialto_runtime::millau_account_ownership_digest as account_ownership_digest;
+				use rialto_runtime::rialto_to_millau_account_ownership_digest as account_ownership_digest;
 
 				$generic
 			}

--- a/relays/bin-substrate/src/messages_source.rs
+++ b/relays/bin-substrate/src/messages_source.rs
@@ -23,7 +23,7 @@ use crate::on_demand_headers::OnDemandHeadersRelay;
 
 use async_trait::async_trait;
 use bp_messages::{LaneId, MessageNonce};
-use bp_runtime::InstanceId;
+use bp_runtime::ChainId;
 use bridge_runtime_common::messages::target::FromBridgedChainMessagesProof;
 use codec::{Decode, Encode};
 use frame_support::{traits::Instance, weights::Weight};
@@ -50,7 +50,7 @@ pub struct SubstrateMessagesSource<C: Chain, P: SubstrateMessageLane, R, I> {
 	client: Client<C>,
 	lane: P,
 	lane_id: LaneId,
-	instance: InstanceId,
+	instance: ChainId,
 	target_to_source_headers_relay: Option<OnDemandHeadersRelay<P::TargetChain>>,
 	_phantom: PhantomData<(R, I)>,
 }
@@ -61,7 +61,7 @@ impl<C: Chain, P: SubstrateMessageLane, R, I> SubstrateMessagesSource<C, P, R, I
 		client: Client<C>,
 		lane: P,
 		lane_id: LaneId,
-		instance: InstanceId,
+		instance: ChainId,
 		target_to_source_headers_relay: Option<OnDemandHeadersRelay<P::TargetChain>>,
 	) -> Self {
 		SubstrateMessagesSource {

--- a/relays/bin-substrate/src/messages_target.rs
+++ b/relays/bin-substrate/src/messages_target.rs
@@ -24,7 +24,7 @@ use crate::on_demand_headers::OnDemandHeadersRelay;
 
 use async_trait::async_trait;
 use bp_messages::{LaneId, MessageNonce, UnrewardedRelayersState};
-use bp_runtime::InstanceId;
+use bp_runtime::ChainId;
 use bridge_runtime_common::messages::source::FromBridgedChainMessagesDeliveryProof;
 use codec::{Decode, Encode};
 use frame_support::traits::Instance;
@@ -50,7 +50,7 @@ pub struct SubstrateMessagesTarget<C: Chain, P: SubstrateMessageLane, R, I> {
 	client: Client<C>,
 	lane: P,
 	lane_id: LaneId,
-	instance: InstanceId,
+	instance: ChainId,
 	source_to_target_headers_relay: Option<OnDemandHeadersRelay<P::SourceChain>>,
 	_phantom: PhantomData<(R, I)>,
 }
@@ -61,7 +61,7 @@ impl<C: Chain, P: SubstrateMessageLane, R, I> SubstrateMessagesTarget<C, P, R, I
 		client: Client<C>,
 		lane: P,
 		lane_id: LaneId,
-		instance: InstanceId,
+		instance: ChainId,
 		source_to_target_headers_relay: Option<OnDemandHeadersRelay<P::SourceChain>>,
 	) -> Self {
 		SubstrateMessagesTarget {


### PR DESCRIPTION
closes #950 

The only change that affects logic is that additional argument to `fn account_ownership_digest()`. I've also renamed `InstanceId` to `ChainId` (this is what all other changed lines are about), because that's how it is used now. It was introduced initially for message lane RPCs (that are gone now) to identify **instance of the messages module**. But we have started to use it everywhere to identify chains, so this name is more appropriate now. If this rename causes problems with UI or some other PRs - could just rollback the rename for now.