### PR TITLE
Revert to use InspectCmd, bump substrate `4ff92f11`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
 ]
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "3.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "serde",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2159,7 +2159,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2171,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -2183,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2210,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "sp-api",
@@ -4430,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "node-inspect"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "log",
@@ -4610,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4626,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4640,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4752,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4820,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4833,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4850,7 +4850,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client",
@@ -4883,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec 2.0.1",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -6389,7 +6389,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "sc-client-api",
@@ -6405,7 +6405,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec 2.0.1",
@@ -6426,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -6475,7 +6475,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "fnv",
@@ -6509,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6539,7 +6539,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -6551,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6582,7 +6582,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "fork-tree",
  "parity-scale-codec 2.0.1",
@@ -6641,7 +6641,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -6680,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -6710,7 +6710,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "parity-scale-codec 2.0.1",
@@ -6727,7 +6727,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "log",
  "parity-scale-codec 2.0.1",
@@ -6742,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "log",
  "parity-scale-codec 2.0.1",
@@ -6760,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "finality-grandpa 0.14.0",
@@ -6824,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.13",
@@ -6842,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6862,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6934,7 +6934,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
@@ -6951,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6979,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "libp2p",
@@ -6992,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -7001,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "hash-db",
@@ -7027,6 +7027,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-utils",
  "sp-version",
@@ -7035,7 +7036,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -7052,6 +7053,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-version",
 ]
@@ -7059,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.1.31",
  "jsonrpc-core 15.1.0",
@@ -7077,7 +7079,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "directories",
@@ -7141,7 +7143,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "log",
  "parity-scale-codec 2.0.1",
@@ -7156,7 +7158,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "chrono",
  "futures 0.3.13",
@@ -7176,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -7187,23 +7189,33 @@ dependencies = [
  "parking_lot 0.11.1",
  "regex",
  "rustc-hash",
+ "sc-client-api",
+ "sc-rpc-server",
+ "sc-telemetry",
  "sc-tracing-proc-macro",
  "serde",
  "serde_json",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+ "sp-storage",
  "sp-tracing",
  "thiserror",
  "tracing",
- "tracing-core",
  "tracing-log",
  "tracing-subscriber",
  "wasm-bindgen",
+ "wasm-timer",
  "web-sys",
 ]
 
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -7214,7 +7226,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -7236,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "futures-diagnose",
@@ -7574,6 +7586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+dependencies = [
+ "erased-serde",
+]
+
+[[package]]
 name = "sluice"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7657,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "log",
  "sp-core",
@@ -7669,7 +7690,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "hash-db",
  "log",
@@ -7686,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -7698,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "serde",
@@ -7710,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -7724,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "parity-scale-codec 2.0.1",
@@ -7736,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "sp-api",
@@ -7748,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "log",
@@ -7766,7 +7787,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "serde",
  "serde_json",
@@ -7775,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
@@ -7802,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "parity-scale-codec 2.0.1",
@@ -7819,7 +7840,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "merlin",
@@ -7841,7 +7862,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "sp-arithmetic",
@@ -7851,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "schnorrkel",
@@ -7863,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7907,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -7916,7 +7937,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7926,7 +7947,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "environmental",
  "parity-scale-codec 2.0.1",
@@ -7937,7 +7958,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "finality-grandpa 0.14.0",
  "log",
@@ -7954,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -7968,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "hash-db",
@@ -7992,7 +8013,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -8003,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8020,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -8029,7 +8050,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -8039,7 +8060,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "backtrace",
 ]
@@ -8047,16 +8068,18 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
+ "rustc-hash",
  "serde",
  "sp-core",
+ "tracing-core",
 ]
 
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -8077,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec 2.0.1",
@@ -8094,7 +8117,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -8106,7 +8129,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "serde",
  "serde_json",
@@ -8115,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "sp-api",
@@ -8128,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "parity-scale-codec 2.0.1",
  "sp-runtime",
@@ -8138,7 +8161,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "hash-db",
  "log",
@@ -8153,6 +8176,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "thiserror",
+ "tracing",
  "trie-db",
  "trie-root",
 ]
@@ -8160,12 +8184,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "impl-serde",
  "parity-scale-codec 2.0.1",
@@ -8178,7 +8202,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "log",
  "sp-core",
@@ -8191,7 +8215,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -8208,10 +8232,15 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
+ "erased-serde",
  "log",
  "parity-scale-codec 2.0.1",
+ "parking_lot 0.10.2",
+ "serde",
+ "serde_json",
+ "slog",
  "sp-std",
  "tracing",
  "tracing-core",
@@ -8221,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -8237,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -8251,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "futures 0.3.13",
  "futures-core",
@@ -8263,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "impl-serde",
  "parity-scale-codec 2.0.1",
@@ -8275,7 +8304,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec 2.0.1",
@@ -8496,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.13",
@@ -8519,7 +8548,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#b094edafd1cd5d26e49ecbf92b0ce7553cfad717"
+source = "git+https://github.com/paritytech/substrate?branch=master#4ff92f10058cfe1b379362673dd369e33a919e66"
 dependencies = [
  "async-std",
  "derive_more",

--- a/bin/millau/node/src/cli.rs
+++ b/bin/millau/node/src/cli.rs
@@ -63,7 +63,7 @@ pub enum Subcommand {
 	Revert(sc_cli::RevertCmd),
 
 	/// Inspect blocks or extrinsics.
-	Inspect(node_inspect::cli::InspectKeyCmd),
+	Inspect(node_inspect::cli::InspectCmd),
 
 	/// Benchmark runtime pallets.
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),

--- a/bin/rialto/node/src/cli.rs
+++ b/bin/rialto/node/src/cli.rs
@@ -63,7 +63,7 @@ pub enum Subcommand {
 	Revert(sc_cli::RevertCmd),
 
 	/// Inspect blocks or extrinsics.
-	Inspect(node_inspect::cli::InspectKeyCmd),
+	Inspect(node_inspect::cli::InspectCmd),
 
 	/// Benchmark runtime pallets.
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),


### PR DESCRIPTION
- Bumps substrate in `Cargo.lock` to https://github.com/paritytech/substrate/commit/4ff92f10058cfe1b379362673dd369e33a919e66
- Corrects issue in #958 with InspectKeyCmd, reverted to InspectCmd

Presently doesn't build, fails on dependency in `frame-support`

```
error: could not compile `frame-support`
error[E0277]: the trait bound `[T; N]: WrapperTypeEncode` is not satisfied
  --> cargo/git/checkouts/substrate-7e08433d4c370a21/4ff92f1/frame/support/src/traits/max_encoded_len.rs:82:40
   |
28 | pub trait MaxEncodedLen: Encode {
   |                          ------ required by this bound in `MaxEncodedLen`
...
82 | impl<T: MaxEncodedLen, const N: usize> MaxEncodedLen for [T; N] {
   |                                        ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `[T; N]`
   |
   = note: required because of the requirements on the impl of `_::_parity_scale_codec::Encode` for `[T; N]`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
```