### PR TITLE
Relays loops are trying to connect to their nodes until connection is successfully established

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5884,6 +5884,7 @@ dependencies = [
 name = "relay-ethereum-client"
 version = "0.1.0"
 dependencies = [
+ "async-std",
  "bp-eth-poa",
  "headers-relay",
  "hex-literal 0.3.1",

--- a/relays/bin-ethereum/src/ethereum_deploy_contract.rs
+++ b/relays/bin-ethereum/src/ethereum_deploy_contract.rs
@@ -60,8 +60,8 @@ pub async fn run(params: EthereumDeployContractParams) {
 	} = params;
 
 	let result = async move {
-		let eth_client = EthereumClient::new(eth_params).await.map_err(RpcError::Ethereum)?;
-		let sub_client = SubstrateClient::<Rialto>::new(sub_params).await.map_err(RpcError::Substrate)?;
+		let eth_client = EthereumClient::try_connect(eth_params).await.map_err(RpcError::Ethereum)?;
+		let sub_client = SubstrateClient::<Rialto>::try_connect(sub_params).await.map_err(RpcError::Substrate)?;
 
 		let (initial_header_id, initial_header) = prepare_initial_header(&sub_client, sub_initial_header).await?;
 		let initial_set_id = sub_initial_authorities_set_id.unwrap_or(0);

--- a/relays/bin-ethereum/src/ethereum_exchange.rs
+++ b/relays/bin-ethereum/src/ethereum_exchange.rs
@@ -335,8 +335,10 @@ async fn run_single_transaction_relay(params: EthereumExchangeParams, eth_tx_has
 		..
 	} = params;
 
-	let eth_client = EthereumClient::new(eth_params).await.map_err(RpcError::Ethereum)?;
-	let sub_client = SubstrateClient::<Rialto>::new(sub_params)
+	let eth_client = EthereumClient::try_connect(eth_params)
+		.await
+		.map_err(RpcError::Ethereum)?;
+	let sub_client = SubstrateClient::<Rialto>::try_connect(sub_params)
 		.await
 		.map_err(RpcError::Substrate)?;
 
@@ -363,12 +365,8 @@ async fn run_auto_transactions_relay_loop(
 		..
 	} = params;
 
-	let eth_client = EthereumClient::new(eth_params)
-		.await
-		.map_err(|err| format!("Error starting Ethereum client: {:?}", err))?;
-	let sub_client = SubstrateClient::<Rialto>::new(sub_params)
-		.await
-		.map_err(|err| format!("Error starting Substrate client: {:?}", err))?;
+	let eth_client = EthereumClient::new(eth_params).await;
+	let sub_client = SubstrateClient::<Rialto>::new(sub_params).await;
 
 	let eth_start_with_block_number = match eth_start_with_block_number {
 		Some(eth_start_with_block_number) => eth_start_with_block_number,

--- a/relays/bin-ethereum/src/ethereum_exchange_submit.rs
+++ b/relays/bin-ethereum/src/ethereum_exchange_submit.rs
@@ -52,7 +52,7 @@ pub async fn run(params: EthereumExchangeSubmitParams) {
 	} = params;
 
 	let result: Result<_, String> = async move {
-		let eth_client = EthereumClient::new(eth_params)
+		let eth_client = EthereumClient::try_connect(eth_params)
 			.await
 			.map_err(|err| format!("error connecting to Ethereum node: {:?}", err))?;
 

--- a/relays/bin-ethereum/src/ethereum_sync_loop.rs
+++ b/relays/bin-ethereum/src/ethereum_sync_loop.rs
@@ -270,8 +270,8 @@ pub async fn run(params: EthereumSyncParams) -> Result<(), RpcError> {
 		instance,
 	} = params;
 
-	let eth_client = EthereumClient::new(eth_params).await?;
-	let sub_client = SubstrateClient::<Rialto>::new(sub_params).await?;
+	let eth_client = EthereumClient::new(eth_params).await;
+	let sub_client = SubstrateClient::<Rialto>::new(sub_params).await;
 
 	let sign_sub_transactions = match sync_params.target_tx_mode {
 		TargetTransactionMode::Signed | TargetTransactionMode::Backup => true,

--- a/relays/bin-ethereum/src/substrate_sync_loop.rs
+++ b/relays/bin-ethereum/src/substrate_sync_loop.rs
@@ -177,8 +177,8 @@ pub async fn run(params: SubstrateSyncParams) -> Result<(), RpcError> {
 		metrics_params,
 	} = params;
 
-	let eth_client = EthereumClient::new(eth_params).await?;
-	let sub_client = SubstrateClient::<Rialto>::new(sub_params).await?;
+	let eth_client = EthereumClient::new(eth_params).await;
+	let sub_client = SubstrateClient::<Rialto>::new(sub_params).await;
 
 	let target = EthereumHeadersTarget::new(eth_client, eth_contract_address, eth_sign);
 	let source = SubstrateHeadersSource::new(sub_client);

--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -406,7 +406,7 @@ macro_rules! declare_chain_options {
 						port: self.[<$chain_prefix _port>],
 						secure: self.[<$chain_prefix _secure>],
 					})
-					.await?
+					.await
 					)
 				}
 			}

--- a/relays/client-ethereum/Cargo.toml
+++ b/relays/client-ethereum/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+async-std = "1.6.5"
 bp-eth-poa = { path = "../../primitives/ethereum-poa" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 headers-relay = { path = "../headers" }


### PR DESCRIPTION
So now all relay loops support reconnecting to their nodes if something goes wrong after loops are started. But if they fail to connect in the beginning, the process just exits with printed error. This PR changes that - all loops are now connecting using `fn new() -> Client` method, while one-shot relay subcommands (which just submit single transaction) are connecting using `fn try_connect() -> Result<Client>`.