### PR TITLE
Make sure GRANDPA shares state with RPC.

### DIFF
--- a/bin/millau/node/src/service.rs
+++ b/bin/millau/node/src/service.rs
@@ -349,7 +349,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 			network,
 			voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
 			prometheus_registry,
-			shared_voter_state: shared_voter_state.clone(),
+			shared_voter_state,
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 		};
 

--- a/bin/millau/node/src/service.rs
+++ b/bin/millau/node/src/service.rs
@@ -33,7 +33,7 @@ use sc_client_api::{ExecutorProvider, RemoteBackend};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
-use sc_finality_grandpa::SharedVoterState;
+
 use sc_keystore::LocalKeystore;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};

--- a/bin/rialto/node/src/service.rs
+++ b/bin/rialto/node/src/service.rs
@@ -216,9 +216,8 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	let name = config.network.node_name.clone();
 	let enable_grandpa = !config.disable_grandpa;
 	let prometheus_registry = config.prometheus_registry().cloned();
-	
-	let shared_voter_state = sc_finality_grandpa::SharedVoterState::empty();
 
+	let shared_voter_state = sc_finality_grandpa::SharedVoterState::empty();
 
 	let rpc_extensions_builder = {
 		use sc_finality_grandpa::FinalityProofProvider as GrandpaFinalityProofProvider;

--- a/bin/rialto/node/src/service.rs
+++ b/bin/rialto/node/src/service.rs
@@ -33,7 +33,7 @@ use sc_client_api::{ExecutorProvider, RemoteBackend};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
-use sc_finality_grandpa::SharedVoterState;
+
 use sc_keystore::LocalKeystore;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryWorker};

--- a/bin/rialto/node/src/service.rs
+++ b/bin/rialto/node/src/service.rs
@@ -351,7 +351,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 			network,
 			voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
 			prometheus_registry,
-			shared_voter_state: shared_voter_state.clone(),
+			shared_voter_state,
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 		};
 


### PR DESCRIPTION
The current setup does not work, because the state is always empty when queried through RPC.