### PR TITLE
Increase pause before starting relays (again)

### DIFF
--- a/deployments/bridges/poa-rialto/entrypoints/relay-headers-poa-to-rialto-entrypoint.sh
+++ b/deployments/bridges/poa-rialto/entrypoints/relay-headers-poa-to-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 10
+sleep 20
 curl -v http://poa-node-arthur:8545/api/health
 curl -v http://poa-node-bertha:8545/api/health
 curl -v http://poa-node-carlos:8545/api/health

--- a/deployments/bridges/poa-rialto/entrypoints/relay-headers-rialto-to-poa-entrypoint.sh
+++ b/deployments/bridges/poa-rialto/entrypoints/relay-headers-rialto-to-poa-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 10
+sleep 20
 
 curl -v http://rialto-node-bob:9933/health
 curl -v http://poa-node-bertha:8545/api/health

--- a/deployments/bridges/poa-rialto/entrypoints/relay-poa-exchange-rialto-entrypoint.sh
+++ b/deployments/bridges/poa-rialto/entrypoints/relay-poa-exchange-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 10
+sleep 20
 curl -v http://poa-node-arthur:8545/api/health
 curl -v http://poa-node-bertha:8545/api/health
 curl -v http://poa-node-carlos:8545/api/health

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 10
+sleep 20
 curl -v http://millau-node-bob:9933/health
 curl -v http://rialto-node-bob:9933/health
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 10
+sleep 20
 curl -v http://millau-node-bob:9933/health
 curl -v http://rialto-node-bob:9933/health
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 10
+sleep 20
 curl -v http://millau-node-alice:9933/health
 curl -v http://rialto-node-alice:9933/health
 

--- a/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
+++ b/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 10
+sleep 20
 curl -v http://millau-node-alice:9933/health
 curl -v https://westend-rpc.polkadot.io:443/health
 


### PR DESCRIPTION
See #974 for details - the same has happened today + it isn't reproduced when started locally + it has happened exactly after Substrate reference has been updated. On test deployments it seems that the 'correct' sleep value is somewhere between 12-14s now.