### PR TITLE
Move ChainWithBalances::NativeBalance -> Chain::Balance

### DIFF
--- a/relays/bin-substrate/src/cli/estimate_fee.rs
+++ b/relays/bin-substrate/src/cli/estimate_fee.rs
@@ -18,7 +18,7 @@ use crate::cli::bridge::FullBridge;
 use crate::cli::{Balance, CliChain, HexBytes, HexLaneId, SourceConnectionParams};
 use crate::select_full_bridge;
 use codec::{Decode, Encode};
-use relay_substrate_client::{Chain, ChainWithBalances};
+use relay_substrate_client::Chain;
 use structopt::StructOpt;
 
 /// Estimate Delivery & Dispatch Fee command.
@@ -52,7 +52,7 @@ impl EstimateFee {
 			let lane = lane.into();
 			let payload = Source::encode_message(payload).map_err(|e| anyhow::format_err!("{:?}", e))?;
 
-			let fee: <Source as ChainWithBalances>::NativeBalance =
+			let fee: <Source as Chain>::Balance =
 				estimate_message_delivery_and_dispatch_fee(&source_client, ESTIMATE_MESSAGE_FEE_METHOD, lane, payload)
 					.await?;
 

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -130,11 +130,12 @@ impl SendMessage {
 			let fee = match self.fee {
 				Some(fee) => fee,
 				None => Balance(
-					estimate_message_delivery_and_dispatch_fee::<
-						<Source as relay_substrate_client::ChainWithBalances>::NativeBalance,
-						_,
-						_,
-					>(&source_client, ESTIMATE_MESSAGE_FEE_METHOD, lane, payload.clone())
+					estimate_message_delivery_and_dispatch_fee::<<Source as Chain>::Balance, _, _>(
+						&source_client,
+						ESTIMATE_MESSAGE_FEE_METHOD,
+						lane,
+						payload.clone(),
+					)
 					.await? as _,
 				),
 			};

--- a/relays/client-kusama/src/lib.rs
+++ b/relays/client-kusama/src/lib.rs
@@ -41,6 +41,7 @@ impl Chain for Kusama {
 	type Index = bp_kusama::Nonce;
 	type SignedBlock = bp_kusama::SignedBlock;
 	type Call = ();
+	type Balance = bp_kusama::Balance;
 }
 
 /// Kusama header type used in headers sync.

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -44,11 +44,10 @@ impl Chain for Millau {
 	type Index = millau_runtime::Index;
 	type SignedBlock = millau_runtime::SignedBlock;
 	type Call = millau_runtime::Call;
+	type Balance = millau_runtime::Balance;
 }
 
 impl ChainWithBalances for Millau {
-	type NativeBalance = millau_runtime::Balance;
-
 	fn account_info_storage_key(account_id: &Self::AccountId) -> StorageKey {
 		use frame_support::storage::generator::StorageMap;
 		StorageKey(frame_system::Account::<millau_runtime::Runtime>::storage_map_final_key(

--- a/relays/client-polkadot/src/lib.rs
+++ b/relays/client-polkadot/src/lib.rs
@@ -41,6 +41,7 @@ impl Chain for Polkadot {
 	type Index = bp_polkadot::Nonce;
 	type SignedBlock = bp_polkadot::SignedBlock;
 	type Call = ();
+	type Balance = bp_polkadot::Balance;
 }
 
 /// Polkadot header type used in headers sync.

--- a/relays/client-rialto/src/lib.rs
+++ b/relays/client-rialto/src/lib.rs
@@ -44,11 +44,10 @@ impl Chain for Rialto {
 	type Index = rialto_runtime::Index;
 	type SignedBlock = rialto_runtime::SignedBlock;
 	type Call = rialto_runtime::Call;
+	type Balance = rialto_runtime::Balance;
 }
 
 impl ChainWithBalances for Rialto {
-	type NativeBalance = rialto_runtime::Balance;
-
 	fn account_info_storage_key(account_id: &Self::AccountId) -> StorageKey {
 		use frame_support::storage::generator::StorageMap;
 		StorageKey(frame_system::Account::<rialto_runtime::Runtime>::storage_map_final_key(

--- a/relays/client-rococo/src/lib.rs
+++ b/relays/client-rococo/src/lib.rs
@@ -47,11 +47,10 @@ impl Chain for Rococo {
 	type Index = bp_rococo::Index;
 	type SignedBlock = bp_rococo::SignedBlock;
 	type Call = bp_rococo::Call;
+	type Balance = bp_rococo::Balance;
 }
 
 impl ChainWithBalances for Rococo {
-	type NativeBalance = bp_rococo::Balance;
-
 	fn account_info_storage_key(account_id: &Self::AccountId) -> StorageKey {
 		StorageKey(bp_rococo::account_info_storage_key(account_id))
 	}

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -54,14 +54,16 @@ pub trait Chain: ChainBase + Clone {
 	type SignedBlock: Member + Serialize + DeserializeOwned + BlockWithJustification<Self::Header>;
 	/// The aggregated `Call` type.
 	type Call: Dispatchable + Debug;
+	/// Balance of an account in native tokens.
+	///
+	/// The chain may suport multiple tokens, but this particular type is for token that is used
+	/// to pay for transaction dispatch, to reward different relayers (headers, messages), etc.
+	type Balance: Parameter + Member + DeserializeOwned + Clone + Copy + CheckedSub + PartialOrd + Zero;
 }
 
 /// Substrate-based chain with `frame_system::Config::AccountData` set to
-/// the `pallet_balances::AccountData<NativeBalance>`.
+/// the `pallet_balances::AccountData<Balance>`.
 pub trait ChainWithBalances: Chain {
-	/// Balance of an account in native tokens.
-	type NativeBalance: Parameter + Member + DeserializeOwned + Clone + Copy + CheckedSub + PartialOrd + Zero;
-
 	/// Return runtime storage key for getting `frame_system::AccountInfo` of given account.
 	fn account_info_storage_key(account_id: &Self::AccountId) -> StorageKey;
 }

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -22,7 +22,7 @@ use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{
 	generic::SignedBlock,
 	traits::{
-		AtLeast32Bit_xxx, Block as BlockT, Dispatchable, MaybeDisplay, MaybeSerialize, MaybeSerializeDeserialize, Member,
+		AtLeast32Bit, Block as BlockT, Dispatchable, MaybeDisplay, MaybeSerialize, MaybeSerializeDeserialize, Member,
 	},
 	EncodedJustification,
 };

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -22,7 +22,7 @@ use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{
 	generic::SignedBlock,
 	traits::{
-		AtLeast32Bit, Block as BlockT, Dispatchable, MaybeDisplay, MaybeSerialize, MaybeSerializeDeserialize, Member,
+		AtLeast32Bit_xxx, Block as BlockT, Dispatchable, MaybeDisplay, MaybeSerialize, MaybeSerializeDeserialize, Member,
 	},
 	EncodedJustification,
 };

--- a/relays/client-substrate/src/client.rs
+++ b/relays/client-substrate/src/client.rs
@@ -208,7 +208,7 @@ impl<C: Chain> Client<C> {
 	}
 
 	/// Return native tokens balance of the account.
-	pub async fn free_native_balance(&self, account: C::AccountId) -> Result<C::NativeBalance>
+	pub async fn free_native_balance(&self, account: C::AccountId) -> Result<C::Balance>
 	where
 		C: ChainWithBalances,
 	{
@@ -217,7 +217,7 @@ impl<C: Chain> Client<C> {
 			.await?
 			.ok_or(Error::AccountDoesNotExist)?;
 		let decoded_account_data =
-			AccountInfo::<C::Index, AccountData<C::NativeBalance>>::decode(&mut &encoded_account_data.0[..])
+			AccountInfo::<C::Index, AccountData<C::Balance>>::decode(&mut &encoded_account_data.0[..])
 				.map_err(Error::ResponseParseFailed)?;
 		Ok(decoded_account_data.data.free)
 	}

--- a/relays/client-substrate/src/guard.rs
+++ b/relays/client-substrate/src/guard.rs
@@ -33,7 +33,7 @@ pub trait Environment<C: ChainWithBalances>: Send + Sync + 'static {
 	/// Return current runtime version.
 	async fn runtime_version(&mut self) -> Result<RuntimeVersion, String>;
 	/// Return free native balance of the account on the chain.
-	async fn free_native_balance(&mut self, account: C::AccountId) -> Result<C::NativeBalance, String>;
+	async fn free_native_balance(&mut self, account: C::AccountId) -> Result<C::Balance, String>;
 
 	/// Return current time.
 	fn now(&self) -> Instant {
@@ -85,7 +85,7 @@ pub fn abort_on_spec_version_change<C: ChainWithBalances>(mut env: impl Environm
 pub fn abort_when_account_balance_decreased<C: ChainWithBalances>(
 	mut env: impl Environment<C>,
 	account_id: C::AccountId,
-	maximal_decrease: C::NativeBalance,
+	maximal_decrease: C::Balance,
 ) {
 	const DAY: Duration = Duration::from_secs(60 * 60 * 24);
 
@@ -155,7 +155,7 @@ impl<C: ChainWithBalances> Environment<C> for Client<C> {
 		Client::<C>::runtime_version(self).await.map_err(|e| e.to_string())
 	}
 
-	async fn free_native_balance(&mut self, account: C::AccountId) -> Result<C::NativeBalance, String> {
+	async fn free_native_balance(&mut self, account: C::AccountId) -> Result<C::Balance, String> {
 		Client::<C>::free_native_balance(self, account)
 			.await
 			.map_err(|e| e.to_string())
@@ -191,11 +191,10 @@ mod tests {
 		type SignedBlock =
 			sp_runtime::generic::SignedBlock<sp_runtime::generic::Block<Self::Header, sp_runtime::OpaqueExtrinsic>>;
 		type Call = ();
+		type Balance = u32;
 	}
 
 	impl ChainWithBalances for TestChain {
-		type NativeBalance = u32;
-
 		fn account_info_storage_key(_account_id: &u32) -> sp_core::storage::StorageKey {
 			unreachable!()
 		}

--- a/relays/client-westend/src/lib.rs
+++ b/relays/client-westend/src/lib.rs
@@ -47,11 +47,10 @@ impl Chain for Westend {
 	type Index = bp_westend::Nonce;
 	type SignedBlock = bp_westend::SignedBlock;
 	type Call = bp_westend::Call;
+	type Balance = bp_westend::Balance;
 }
 
 impl ChainWithBalances for Westend {
-	type NativeBalance = bp_westend::Balance;
-
 	fn account_info_storage_key(account_id: &Self::AccountId) -> StorageKey {
 		StorageKey(bp_westend::account_info_storage_key(account_id))
 	}

--- a/relays/client-wococo/src/lib.rs
+++ b/relays/client-wococo/src/lib.rs
@@ -47,11 +47,10 @@ impl Chain for Wococo {
 	type Index = bp_wococo::Index;
 	type SignedBlock = bp_wococo::SignedBlock;
 	type Call = bp_wococo::Call;
+	type Balance = bp_wococo::Balance;
 }
 
 impl ChainWithBalances for Wococo {
-	type NativeBalance = bp_wococo::Balance;
-
 	fn account_info_storage_key(account_id: &Self::AccountId) -> StorageKey {
 		StorageKey(bp_wococo::account_info_storage_key(account_id))
 	}


### PR DESCRIPTION
Required for greedy relayer.
This means that the relayer now assumes that all chains have some base token, which is used to: (1) pay transactions fee (2) pay message delivery and dispatch fee and (3) reward relayers. If we'll ever met case where this isn't true (e.g. when relayer is rewarded with weight for its future transactions), then this would need to be changed. But now it is easier to continue with this assumption.