### PR TITLE
Allow Root to assume SourceAccount.

### DIFF
--- a/modules/dispatch/src/lib.rs
+++ b/modules/dispatch/src/lib.rs
@@ -308,7 +308,8 @@ where
 		}
 		CallOrigin::SourceAccount(ref source_account_id) => {
 			ensure!(
-				sender_origin == &RawOrigin::Signed(source_account_id.clone()),
+				sender_origin == &RawOrigin::Signed(source_account_id.clone()) ||
+					sender_origin == &RawOrigin::Root,
 				BadOrigin
 			);
 			Ok(Some(source_account_id.clone()))
@@ -806,10 +807,10 @@ mod tests {
 			Err(BadOrigin)
 		));
 
-		// If we try and send the message from Root, it is also rejected
+		// The Root account is allowed to assume any expected origin account
 		assert!(matches!(
 			verify_message_origin(&RawOrigin::Root, &message),
-			Err(BadOrigin)
+			Ok(Some(1))
 		));
 	}
 }

--- a/modules/dispatch/src/lib.rs
+++ b/modules/dispatch/src/lib.rs
@@ -308,8 +308,7 @@ where
 		}
 		CallOrigin::SourceAccount(ref source_account_id) => {
 			ensure!(
-				sender_origin == &RawOrigin::Signed(source_account_id.clone()) ||
-					sender_origin == &RawOrigin::Root,
+				sender_origin == &RawOrigin::Signed(source_account_id.clone()) || sender_origin == &RawOrigin::Root,
 				BadOrigin
 			);
 			Ok(Some(source_account_id.clone()))
@@ -808,9 +807,6 @@ mod tests {
 		));
 
 		// The Root account is allowed to assume any expected origin account
-		assert!(matches!(
-			verify_message_origin(&RawOrigin::Root, &message),
-			Ok(Some(1))
-		));
+		assert!(matches!(verify_message_origin(&RawOrigin::Root, &message), Ok(Some(1))));
 	}
 }

--- a/modules/messages/README.md
+++ b/modules/messages/README.md
@@ -152,7 +152,7 @@ all required traits and will simply reject all transactions, related to outbound
 
 The `pallet_bridge_messages::Config` trait has 2 main associated types that are used to work with
 inbound messages. The `pallet_bridge_messages::Config::SourceHeaderChain` defines how we see the
-bridged chain as the source or our inbound messages. When relayer sends us a  delivery transaction,
+bridged chain as the source or our inbound messages. When relayer sends us a delivery transaction,
 this implementation must be able to parse and verify the proof of messages wrapped in this
 transaction. Normally, you would reuse the same (configurable) type on all chains that are sending
 messages to the same bridged chain.
@@ -194,7 +194,7 @@ message needs to be read. So there's another
 When choosing values for these parameters, you must also keep in mind that if proof in your scheme
 is based on finality of headers (and it is the most obvious option for Substrate-based chains with
 finality notion), then choosing too small values for these parameters may cause significant delays
-in message delivery. That's because there too many actors involved in this scheme: 1) authorities
+in message delivery. That's because there are too many actors involved in this scheme: 1) authorities
 that are finalizing headers of the target chain need to finalize header with non-empty map; 2) the
 headers relayer then needs to submit this header and its finality proof to the source chain; 3) the
 messages relayer must then send confirmation transaction (storage proof of this map) to the source

--- a/primitives/message-dispatch/src/lib.rs
+++ b/primitives/message-dispatch/src/lib.rs
@@ -91,7 +91,7 @@ pub enum CallOrigin<SourceChainAccountId, TargetChainAccountPublic, TargetChainS
 	/// Call is sent by the `SourceChainAccountId` on the source chain. On the target chain it is
 	/// dispatched from a derived account ID.
 	///
-	/// The account ID on the target chain is derived from the source account ID This is useful if
+	/// The account ID on the target chain is derived from the source account ID. This is useful if
 	/// you need a way to represent foreign accounts on this chain for call dispatch purposes.
 	///
 	/// Note that the derived account does not need to have a private key on the target chain. This

--- a/relays/client-substrate/src/lib.rs
+++ b/relays/client-substrate/src/lib.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Tools to interact with (Open) Ethereum node using RPC methods.
+//! Tools to interact with Substrate node using RPC methods.
 
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Fixed https://github.com/paritytech/parity-bridges-common/issues/620

Another thing I notice is, [SourceRoot](https://github.com/paritytech/parity-bridges-common/blob/bf52fff13fbb1d3fc6a868d209cddddf2b8f79ef/relays/bin-substrate/src/cli/send_message.rs#L99) is not available in send_message CLI, is there an issue tracking this feature?