### PR TITLE
Make target signer optional when sending message.

### DIFF
--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -264,8 +264,6 @@ mod tests {
 			"1234",
 			"--source-signer",
 			"//Alice",
-			"--target-signer",
-			"//Bob",
 			"remark",
 			"--remark-payload",
 			"1234",

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -102,9 +102,9 @@ impl SendMessage {
 						Origins::Source => CallOrigin::SourceAccount(source_account_id),
 						Origins::Target => {
 							let target_sign = TargetSigningParams {
-								target_signer: target_signer
-									.clone()
-									.ok_or(anyhow::format_err!("The argument target_signer is not available"))?,
+								target_signer: target_signer.clone().ok_or_else(|| {
+									anyhow::format_err!("The argument target_signer is not available")
+								})?,
 								target_signer_password: target_signer_password.clone(),
 							};
 							let target_sign = target_sign.to_keypair::<Target>()?;

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -102,7 +102,8 @@ impl SendMessage {
 						Origins::Source => CallOrigin::SourceAccount(source_account_id),
 						Origins::Target => {
 							let target_sign = TargetSigningParams {
-								target_signer: target_signer.clone()
+								target_signer: target_signer
+									.clone()
 									.ok_or(anyhow::format_err!("The arguments target_signer is not available"))?,
 								target_signer_password: target_signer_password.clone(),
 							};

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -41,10 +41,10 @@ pub struct SendMessage {
 	source: SourceConnectionParams,
 	#[structopt(flatten)]
 	source_sign: SourceSigningParams,
-	/// The SURI of secret key to use when transactions are submitted to the target chain node.
+	/// The SURI of secret key to use when transactions are submitted to the Target node.
 	#[structopt(long, required_if("origin", "Target"))]
 	target_signer: Option<String>,
-	/// The password for the SURI of secret key to use when transactions are submitted to the target chain node.
+	/// The password for the SURI of secret key to use when transactions are submitted to the Target node.
 	#[structopt(long)]
 	target_signer_password: Option<String>,
 	/// Hex-encoded lane id. Defaults to `00000000`.
@@ -104,7 +104,7 @@ impl SendMessage {
 							let target_sign = TargetSigningParams {
 								target_signer: target_signer
 									.clone()
-									.ok_or(anyhow::format_err!("The arguments target_signer is not available"))?,
+									.ok_or(anyhow::format_err!("The argument target_signer is not available"))?,
 								target_signer_password: target_signer_password.clone(),
 							};
 							let target_sign = target_sign.to_keypair::<Target>()?;

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -41,9 +41,12 @@ pub struct SendMessage {
 	source: SourceConnectionParams,
 	#[structopt(flatten)]
 	source_sign: SourceSigningParams,
-	// TODO [#885] Move TargetSign to origins
-	#[structopt(flatten)]
-	target_sign: TargetSigningParams,
+	/// The SURI of secret key to use when transactions are submitted to the target chain node.
+	#[structopt(long, required_if("origin", "Target"))]
+	target_signer: Option<String>,
+	/// The password for the SURI of secret key to use when transactions are submitted to the target chain node.
+	#[structopt(long)]
+	target_signer_password: Option<String>,
 	/// Hex-encoded lane id. Defaults to `00000000`.
 	#[structopt(long, default_value = "00000000")]
 	lane: HexLaneId,
@@ -69,7 +72,8 @@ impl SendMessage {
 		crate::select_full_bridge!(self.bridge, {
 			let SendMessage {
 				source_sign,
-				target_sign,
+				target_signer,
+				target_signer_password,
 				ref mut message,
 				dispatch_weight,
 				origin,
@@ -78,7 +82,6 @@ impl SendMessage {
 			} = self;
 
 			let source_sign = source_sign.to_keypair::<Source>()?;
-			let target_sign = target_sign.to_keypair::<Target>()?;
 
 			encode_call::preprocess_call::<Source, Target>(message, bridge.bridge_instance_index());
 			let target_call = Target::encode_call(message)?;
@@ -98,6 +101,12 @@ impl SendMessage {
 					match origin {
 						Origins::Source => CallOrigin::SourceAccount(source_account_id),
 						Origins::Target => {
+							let target_sign = TargetSigningParams {
+								target_signer: target_signer.clone()
+									.ok_or(anyhow::format_err!("The arguments target_signer is not available"))?,
+								target_signer_password: target_signer_password.clone(),
+							};
+							let target_sign = target_sign.to_keypair::<Target>()?;
 							let digest = account_ownership_digest(
 								&target_call,
 								source_account_id.clone(),
@@ -320,5 +329,25 @@ mod tests {
 				call: hex!("0701081234").to_vec(),
 			}
 		);
+	}
+
+	#[test]
+	fn target_signer_must_exist_if_origin_is_target() {
+		// given
+		let send_message = SendMessage::from_iter_safe(vec![
+			"send-message",
+			"MillauToRialto",
+			"--source-port",
+			"1234",
+			"--source-signer",
+			"//Alice",
+			"--origin",
+			"Target",
+			"remark",
+			"--remark-payload",
+			"1234",
+		]);
+
+		assert!(send_message.is_err());
 	}
 }


### PR DESCRIPTION
Fix https://github.com/paritytech/parity-bridges-common/issues/885

I choose this option after finding that,

* `arg_enum` does not support struct variant,
* `structopt` field flagged with `flatten` is not able to use `require_if`
* `TargetSigningParams` is reused by a few other places, extract it from `declare_chain_options` macro seems too much change.

Also `encode-message` list in issue is not using `target_signer`, please correct me if I'm wrong.