### PR TITLE
Add temporary `canary` job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 stages:
+  - canary
   - lint
   - check
   - test
@@ -83,6 +84,16 @@ default:
     # 2. another is triggered by scripts repo $CI_PIPELINE_SOURCE == "pipeline" it's for the CI image
     #    update, it also runs all the nightly checks.
     - if: $CI_PIPELINE_SOURCE == "pipeline"
+
+#### stage:                        canary
+
+canary:
+  stage:                           canary
+  image:                           alpine:3.13
+  script:
+    - "true"
+  tags:
+    - linux-docker
 
 #### stage:                        lint
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,11 +89,10 @@ default:
 
 canary:
   stage:                           canary
+  <<:                              *kubernetes-build
   image:                           alpine:3.13
   script:
     - "true"
-  tags:
-    - kubernetes-parity-build
 
 #### stage:                        lint
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ canary:
   script:
     - "true"
   tags:
-    - linux-docker
+    - kubernetes-parity-build
 
 #### stage:                        lint
 


### PR DESCRIPTION
I would like to introduce the special dummy `canary` job with no complex rules or any conditions that would stop a job from existing on any pipeline. It should always exist (as defined per `workflow` rules, but they are very relaxed).

Why would I do that? As for now, I'm still not sure what's causing a trouble with `parity-bridges-common` pipelines creation:

* GitLab [can be quite buggy](https://gitlab.com/gitlab-org/gitlab/-/issues/25314) with its pull mirroring.
* CI/CD's `rules:` can be quite complex.
* No way to troubleshoot or render a pipeline without try-and-repeat style of debugging.
* No test facilities for GitLab CI/CD DSL.


`canary` job can narrow the search a little. At least it will show if the problem hides within the pipeline definition or within GitLab itself.