### PR TITLE
CI: fix starting the pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,9 @@ default:
 
 .test-refs:                        &test-refs
   rules:
-    # FIXME: debug
+    # FIXME: This is the cause why pipelines wouldn't start. The problem might be in our custom
+    # mirroring. This should be investigated further, but for now let's have the working
+    # pipeline.
     # - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH
     #   changes:
     #     - '**.md'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 stages:
-  - canary
   - lint
   - check
   - test
@@ -87,15 +86,6 @@ default:
     # 2. another is triggered by scripts repo $CI_PIPELINE_SOURCE == "pipeline" it's for the CI image
     #    update, it also runs all the nightly checks.
     - if: $CI_PIPELINE_SOURCE == "pipeline"
-
-#### stage:                        canary
-
-canary:
-  stage:                           canary
-  <<:                              *kubernetes-build
-  image:                           alpine:3.13
-  script:
-    - "true"
 
 #### stage:                        lint
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,12 +55,13 @@ default:
 
 .test-refs:                        &test-refs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH
-      changes:
-        - '**.md'
-        - diagrams/*
-        - docs/*
-      when:                        never
+    # FIXME: debug
+    # - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH
+    #   changes:
+    #     - '**.md'
+    #     - diagrams/*
+    #     - docs/*
+    #   when:                        never
     - if: $CI_PIPELINE_SOURCE == "pipeline"
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION
Edit: please don't merge just now, we're experimenting with something else.

It turned out that `changes` prevented every initial commit of every PR to start a pipeline.
I connect this with our custom pipelines, but this needs a deeper investigation, it also might be a Gitlab bug.

Let's have a working pipeline now and in the meanwhile, we'll update our Gitlab host and figure something out with how to deal with `changes:`.