### PR TITLE
Update `InboundLaneData` JS types definition

### DIFF
--- a/deployments/types-millau.json
+++ b/deployments/types-millau.json
@@ -77,8 +77,17 @@
   },
   "InboundRelayer": "AccountId",
   "InboundLaneData": {
-    "relayers": "Vec<(MessageNonce, MessageNonce, RelayerId)>",
+    "relayers": "Vec<UnrewardedRelayer>",
     "last_confirmed_nonce": "MessageNonce"
+  },
+  "UnrewardedRelayer": {
+    "relayer": "RelayerId",
+    "messages": "DeliveredMessages"
+  },
+  "DeliveredMessages": {
+    "begin": "MessageNonce",
+    "end": "MessageNonce",
+    "dispatch_results": "BitVec"
   },
   "OutboundLaneData": {
     "latest_generated_nonce": "MessageNonce",

--- a/deployments/types-rialto.json
+++ b/deployments/types-rialto.json
@@ -77,8 +77,17 @@
   },
   "InboundRelayer": "AccountId",
   "InboundLaneData": {
-    "relayers": "Vec<(MessageNonce, MessageNonce, RelayerId)>",
+    "relayers": "Vec<UnrewardedRelayer>",
     "last_confirmed_nonce": "MessageNonce"
+  },
+  "UnrewardedRelayer": {
+    "relayer": "RelayerId",
+    "messages": "DeliveredMessages"
+  },
+  "DeliveredMessages": {
+    "begin": "MessageNonce",
+    "end": "MessageNonce",
+    "dispatch_results": "BitVec"
   },
   "OutboundLaneData": {
     "latest_generated_nonce": "MessageNonce",

--- a/deployments/types-rococo.json
+++ b/deployments/types-rococo.json
@@ -37,8 +37,17 @@
   },
   "InboundRelayer": "AccountId",
   "InboundLaneData": {
-    "relayers": "Vec<(MessageNonce, MessageNonce, RelayerId)>",
+    "relayers": "Vec<UnrewardedRelayer>",
     "last_confirmed_nonce": "MessageNonce"
+  },
+  "UnrewardedRelayer": {
+    "relayer": "RelayerId",
+    "messages": "DeliveredMessages"
+  },
+  "DeliveredMessages": {
+    "begin": "MessageNonce",
+    "end": "MessageNonce",
+    "dispatch_results": "BitVec"
   },
   "OutboundLaneData": {
     "latest_generated_nonce": "MessageNonce",

--- a/deployments/types-wococo.json
+++ b/deployments/types-wococo.json
@@ -37,8 +37,17 @@
   },
   "InboundRelayer": "AccountId",
   "InboundLaneData": {
-    "relayers": "Vec<(MessageNonce, MessageNonce, RelayerId)>",
+    "relayers": "Vec<UnrewardedRelayer>",
     "last_confirmed_nonce": "MessageNonce"
+  },
+  "UnrewardedRelayer": {
+    "relayer": "RelayerId",
+    "messages": "DeliveredMessages"
+  },
+  "DeliveredMessages": {
+    "begin": "MessageNonce",
+    "end": "MessageNonce",
+    "dispatch_results": "BitVec"
   },
   "OutboundLaneData": {
     "latest_generated_nonce": "MessageNonce",

--- a/deployments/types/common.json
+++ b/deployments/types/common.json
@@ -27,8 +27,17 @@
 	},
 	"InboundRelayer": "AccountId",
 	"InboundLaneData": {
-		"relayers": "Vec<(MessageNonce, MessageNonce, RelayerId)>",
+		"relayers": "Vec<UnrewardedRelayer>",
 		"last_confirmed_nonce": "MessageNonce"
+	},
+	"UnrewardedRelayer": {
+		"relayer": "RelayerId",
+		"messages": "DeliveredMessages"
+	},
+	"DeliveredMessages": {
+		"begin": "MessageNonce",
+		"end": "MessageNonce",
+		"dispatch_results": "BitVec"
 	},
 	"OutboundLaneData": {
 		"latest_generated_nonce": "MessageNonce",


### PR DESCRIPTION
We've added the dispatch result in #935, so changing custom type definitions to match the Rust code now.