### PR TITLE
Use real conversion rate in greedy relayer strategy

### DIFF
--- a/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
+++ b/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
@@ -171,7 +171,7 @@ pub async fn run(
 		max_messages_weight_in_single_batch,
 	);
 
-	let (metrics_params, _) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
+	let (metrics_params, metrics_values) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
 	messages_relay::message_lane_loop::run(
 		messages_relay::message_lane_loop::Params {
 			lane: lane_id,
@@ -200,6 +200,7 @@ pub async fn run(
 			lane,
 			lane_id,
 			MILLAU_CHAIN_ID,
+			metrics_values,
 			params.source_to_target_headers_relay,
 		),
 		metrics_params,

--- a/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
+++ b/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
@@ -170,7 +170,7 @@ pub async fn run(
 		max_messages_weight_in_single_batch,
 	);
 
-	let (metrics_params, _) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
+	let (metrics_params, metrics_values) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
 	messages_relay::message_lane_loop::run(
 		messages_relay::message_lane_loop::Params {
 			lane: lane_id,
@@ -199,6 +199,7 @@ pub async fn run(
 			lane,
 			lane_id,
 			RIALTO_CHAIN_ID,
+			metrics_values,
 			params.source_to_target_headers_relay,
 		),
 		metrics_params,

--- a/relays/bin-substrate/src/chains/rococo_messages_to_wococo.rs
+++ b/relays/bin-substrate/src/chains/rococo_messages_to_wococo.rs
@@ -185,7 +185,7 @@ pub async fn run(
 		max_messages_weight_in_single_batch,
 	);
 
-	let (metrics_params, _) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
+	let (metrics_params, metrics_values) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
 	messages_relay::message_lane_loop::run(
 		messages_relay::message_lane_loop::Params {
 			lane: lane_id,
@@ -214,6 +214,7 @@ pub async fn run(
 			lane,
 			lane_id,
 			ROCOCO_CHAIN_ID,
+			metrics_values,
 			params.source_to_target_headers_relay,
 		),
 		metrics_params,

--- a/relays/bin-substrate/src/chains/wococo_messages_to_rococo.rs
+++ b/relays/bin-substrate/src/chains/wococo_messages_to_rococo.rs
@@ -185,7 +185,7 @@ pub async fn run(
 		max_messages_weight_in_single_batch,
 	);
 
-	let (metrics_params, _) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
+	let (metrics_params, metrics_values) = add_standalone_metrics(params.metrics_params, source_client.clone())?;
 	messages_relay::message_lane_loop::run(
 		messages_relay::message_lane_loop::Params {
 			lane: lane_id,
@@ -214,6 +214,7 @@ pub async fn run(
 			lane,
 			lane_id,
 			WOCOCO_CHAIN_ID,
+			metrics_values,
 			params.source_to_target_headers_relay,
 		),
 		metrics_params,

--- a/relays/bin-substrate/src/messages_lane.rs
+++ b/relays/bin-substrate/src/messages_lane.rs
@@ -201,6 +201,15 @@ pub struct StandaloneMessagesMetrics {
 	pub source_to_base_conversion_rate: Option<F64SharedRef>,
 }
 
+impl StandaloneMessagesMetrics {
+	/// Return conversion rate from target to source tokens.
+	pub async fn target_to_source_conversion_rate(&self) -> Option<f64> {
+		let target_to_base_conversion_rate = (*self.target_to_base_conversion_rate.as_ref()?.read().await)?;
+		let source_to_base_conversion_rate = (*self.source_to_base_conversion_rate.as_ref()?.read().await)?;
+		Some(target_to_base_conversion_rate / source_to_base_conversion_rate)
+	}
+}
+
 /// Add general standalone metrics for the message lane relay loop.
 pub fn add_standalone_metrics<P: SubstrateMessageLane>(
 	metrics_params: MetricsParams,

--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -212,7 +212,7 @@ pub trait TargetClient<P: MessageLane>: RelayClient {
 		nonces: RangeInclusive<MessageNonce>,
 		total_dispatch_weight: Weight,
 		total_size: u32,
-	) -> P::SourceChainBalance;
+	) -> Result<P::SourceChainBalance, Self::Error>;
 }
 
 /// State of the client.
@@ -775,10 +775,12 @@ pub(crate) mod tests {
 			nonces: RangeInclusive<MessageNonce>,
 			total_dispatch_weight: Weight,
 			total_size: u32,
-		) -> TestSourceChainBalance {
-			BASE_MESSAGE_DELIVERY_TRANSACTION_COST * (nonces.end() - nonces.start() + 1)
-				+ total_dispatch_weight
-				+ total_size as TestSourceChainBalance
+		) -> Result<TestSourceChainBalance, TestError> {
+			Ok(
+				BASE_MESSAGE_DELIVERY_TRANSACTION_COST * (nonces.end() - nonces.start() + 1)
+					+ total_dispatch_weight
+					+ total_size as TestSourceChainBalance,
+			)
 		}
 	}
 

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -654,7 +654,15 @@ async fn select_nonces_for_delivery_transaction<P: MessageLane>(
 						new_selected_unpaid_weight,
 						new_selected_size as u32,
 					)
-					.await;
+					.await
+					.map_err(|err| {
+						log::debug!(
+							target: "bridge",
+							"Failed to estimate delivery transaction cost: {:?}. No nonces selected for delivery",
+							err,
+						);
+					})
+					.ok()?;
 
 				// if it is the first message that makes reward less than cost, let's log it
 				// if this message makes batch profitable again, let's log it


### PR DESCRIPTION
related #997 

The only thing that is missing in greedy-relayer after this PR is the cli option. However, it'll be better to extract some parts of #1005 to associate our test chains with value of some other chains before doing that. Otherwise greedy relayer will never deliver any messages.