### PR TITLE
Give real value to Rialto and Millau tokens

### DIFF
--- a/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
+++ b/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
@@ -225,8 +225,8 @@ pub(crate) fn add_standalone_metrics(
 		metrics_prefix,
 		metrics_params,
 		source_client,
-		None,
-		None,
+		Some(crate::chains::MILLAU_ASSOCIATED_TOKEN_ID),
+		Some(crate::chains::RIALTO_ASSOCIATED_TOKEN_ID),
 		Some((
 			sp_core::storage::StorageKey(millau_runtime::rialto_messages::RialtoToMillauConversionRate::key().to_vec()),
 			millau_runtime::rialto_messages::INITIAL_RIALTO_TO_MILLAU_CONVERSION_RATE,

--- a/relays/bin-substrate/src/chains/mod.rs
+++ b/relays/bin-substrate/src/chains/mod.rs
@@ -32,6 +32,15 @@ mod rococo;
 mod westend;
 mod wococo;
 
+// Millau/Rialto tokens have no any real value, so the conversion rate we use is always 1:1. But we want to
+// test our code that is intended to work with real-value chains. So to keep it close to 1:1, we'll be treating
+// Rialto as BTC and Millau as wBTC (only in relayer).
+
+/// The identifier of token, which value is associated with Rialto token value by relayer.
+pub(crate) const RIALTO_ASSOCIATED_TOKEN_ID: &str = "bitcoin";
+/// The identifier of token, which value is associated with Millau token value by relayer.
+pub(crate) const MILLAU_ASSOCIATED_TOKEN_ID: &str = "wrapped-bitcoin";
+
 use relay_utils::metrics::{FloatJsonValueMetric, MetricsParams, PrometheusError, Registry};
 
 pub(crate) fn add_polkadot_kusama_price_metrics<T: finality_relay::FinalitySyncPipeline>(

--- a/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
+++ b/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
@@ -224,8 +224,8 @@ pub(crate) fn add_standalone_metrics(
 		metrics_prefix,
 		metrics_params,
 		source_client,
-		None,
-		None,
+		Some(crate::chains::RIALTO_ASSOCIATED_TOKEN_ID),
+		Some(crate::chains::MILLAU_ASSOCIATED_TOKEN_ID),
 		Some((
 			sp_core::storage::StorageKey(rialto_runtime::millau_messages::MillauToRialtoConversionRate::key().to_vec()),
 			rialto_runtime::millau_messages::INITIAL_MILLAU_TO_RIALTO_CONVERSION_RATE,


### PR DESCRIPTION
This maybe seems a controversial PR and actually I'm personally not sure if that's the right way. That's why a separate PR for this kinda "small" change. Here's my plan:
1) we assign Rialto and Millau tokens values that are always almost 1:1;
2) we switch our test-deployments relays to greedy mode. Everything should work without any issues (of course if the 'greedy' code is correct), because rate stored in the runtime is also 1:1;
3) (optionally) once in a day we are changing rate to something that differs from 1:1, meaning that greedy relay would stop relaying messages & we'll notice that from logs (or even with alerts);
4) when/if we'll accept #1005, we'll be able to follow some tokens that are not 1:1 (polkadot+kusama) && see how relayer behaves in such environment. This will probably require additional relayer (test-only) functionality to increase stuck messages fees.