### PR TITLE
Confirm delivery detects when more than expected messages are confirmed

### DIFF
--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -904,7 +904,7 @@ fn confirm_message_delivery<T: Config<I>, I: Instance>(nonce: MessageNonce) {
 		});
 	}
 	assert!(matches!(
-		outbound_lane.confirm_delivery(nonce, &relayers),
+		outbound_lane.confirm_delivery(nonce - latest_received_nonce, nonce, &relayers),
 		ReceivalConfirmationResult::ConfirmedMessages(_),
 	));
 }

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -226,6 +226,15 @@ impl DeliveredMessages {
 		}
 	}
 
+	/// Return total count of delivered messages.
+	pub fn total_messages(&self) -> MessageNonce {
+		if self.end >= self.begin {
+			self.end - self.begin + 1
+		} else {
+			0
+		}
+	}
+
 	/// Note new dispatched message.
 	pub fn note_dispatched_message(&mut self, dispatch_result: bool) {
 		self.end += 1;


### PR DESCRIPTION
This may only happen when storage of one of chains is corrupted - e.g. when target chain has 'received' `100` messages and contains no entries in unrewarded relayers vector. And the source chain has sent `100` messages, but the last confirmed message is `99`. Then the relayer may craft valid transaction, declaring that it is going to confirm `0` messages and it'll pass [this check](https://github.com/paritytech/parity-bridges-common/blob/035bee87153aef51fcf3d2605f28b3bf0cb063a2/modules/messages/src/lib.rs#L616)