### PR TITLE
Cli option for greedy relayer + run no-losses relayer by default

### DIFF
--- a/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
+++ b/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
@@ -164,11 +164,13 @@ pub async fn run(
 			Millau relayer account id: {:?}\n\t\
 			Max messages in single transaction: {}\n\t\
 			Max messages size in single transaction: {}\n\t\
-			Max messages weight in single transaction: {}",
+			Max messages weight in single transaction: {}\n\t\
+			Relayer mode: {:?}",
 		lane.relayer_id_at_source,
 		max_messages_in_single_batch,
 		max_messages_size_in_single_batch,
 		max_messages_weight_in_single_batch,
+		params.relayer_mode,
 	);
 
 	let (metrics_params, metrics_values) = add_standalone_metrics(
@@ -191,7 +193,7 @@ pub async fn run(
 				max_messages_in_single_batch,
 				max_messages_weight_in_single_batch,
 				max_messages_size_in_single_batch,
-				relayer_mode: messages_relay::message_lane_loop::RelayerMode::Altruistic,
+				relayer_mode: params.relayer_mode,
 			},
 		},
 		MillauSourceClient::new(

--- a/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
+++ b/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
@@ -163,11 +163,13 @@ pub async fn run(
 			Rialto relayer account id: {:?}\n\t\
 			Max messages in single transaction: {}\n\t\
 			Max messages size in single transaction: {}\n\t\
-			Max messages weight in single transaction: {}",
+			Max messages weight in single transaction: {}\n\t\
+			Relayer mode: {:?}",
 		lane.relayer_id_at_source,
 		max_messages_in_single_batch,
 		max_messages_size_in_single_batch,
 		max_messages_weight_in_single_batch,
+		params.relayer_mode,
 	);
 
 	let (metrics_params, metrics_values) = add_standalone_metrics(
@@ -190,7 +192,7 @@ pub async fn run(
 				max_messages_in_single_batch,
 				max_messages_weight_in_single_batch,
 				max_messages_size_in_single_batch,
-				relayer_mode: messages_relay::message_lane_loop::RelayerMode::Altruistic,
+				relayer_mode: params.relayer_mode,
 			},
 		},
 		RialtoSourceClient::new(

--- a/relays/bin-substrate/src/chains/rococo_messages_to_wococo.rs
+++ b/relays/bin-substrate/src/chains/rococo_messages_to_wococo.rs
@@ -178,11 +178,13 @@ pub async fn run(
 			Rococo relayer account id: {:?}\n\t\
 			Max messages in single transaction: {}\n\t\
 			Max messages size in single transaction: {}\n\t\
-			Max messages weight in single transaction: {}",
+			Max messages weight in single transaction: {}\n\t\
+			Relayer mode: {:?}",
 		lane.relayer_id_at_source,
 		max_messages_in_single_batch,
 		max_messages_size_in_single_batch,
 		max_messages_weight_in_single_batch,
+		params.relayer_mode,
 	);
 
 	let (metrics_params, metrics_values) = add_standalone_metrics(
@@ -205,7 +207,7 @@ pub async fn run(
 				max_messages_in_single_batch,
 				max_messages_weight_in_single_batch,
 				max_messages_size_in_single_batch,
-				relayer_mode: messages_relay::message_lane_loop::RelayerMode::Altruistic,
+				relayer_mode: params.relayer_mode,
 			},
 		},
 		RococoSourceClient::new(

--- a/relays/bin-substrate/src/chains/wococo_messages_to_rococo.rs
+++ b/relays/bin-substrate/src/chains/wococo_messages_to_rococo.rs
@@ -178,11 +178,13 @@ pub async fn run(
 			Wococo relayer account id: {:?}\n\t\
 			Max messages in single transaction: {}\n\t\
 			Max messages size in single transaction: {}\n\t\
-			Max messages weight in single transaction: {}",
+			Max messages weight in single transaction: {}\n\t\
+			Relayer mode: {:?}",
 		lane.relayer_id_at_source,
 		max_messages_in_single_batch,
 		max_messages_size_in_single_batch,
 		max_messages_weight_in_single_batch,
+		params.relayer_mode,
 	);
 
 	let (metrics_params, metrics_values) = add_standalone_metrics(
@@ -205,7 +207,7 @@ pub async fn run(
 				max_messages_in_single_batch,
 				max_messages_weight_in_single_batch,
 				max_messages_size_in_single_batch,
-				relayer_mode: messages_relay::message_lane_loop::RelayerMode::Altruistic,
+				relayer_mode: params.relayer_mode,
 			},
 		},
 		WococoSourceClient::new(

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -45,7 +45,7 @@ pub struct HeadersAndMessagesSharedParams {
 	/// Hex-encoded lane identifiers that should be served by the complex relay.
 	#[structopt(long, default_value = "00000000")]
 	lane: Vec<HexLaneId>,
-	#[structopt(long, possible_values = RelayerMode::VARIANTS, case_insensitive = true, default_value = "no-losses")]
+	#[structopt(long, possible_values = RelayerMode::VARIANTS, case_insensitive = true, default_value = "rational")]
 	relayer_mode: RelayerMode,
 	#[structopt(flatten)]
 	prometheus_params: PrometheusParams,

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -22,7 +22,7 @@
 //! 2) add `declare_bridge_options!(...)` for the bridge;
 //! 3) add bridge support to the `select_bridge! { ... }` macro.
 
-use crate::cli::{CliChain, HexLaneId, PrometheusParams};
+use crate::cli::{relay_messages::RelayerMode, CliChain, HexLaneId, PrometheusParams};
 use crate::declare_chain_options;
 use crate::messages_lane::MessagesRelayParams;
 use crate::on_demand_headers::OnDemandHeadersRelay;
@@ -30,6 +30,7 @@ use crate::on_demand_headers::OnDemandHeadersRelay;
 use futures::{FutureExt, TryFutureExt};
 use relay_utils::metrics::MetricsParams;
 use structopt::StructOpt;
+use strum::VariantNames;
 
 /// Start headers+messages relayer process.
 #[derive(StructOpt)]
@@ -44,6 +45,8 @@ pub struct HeadersAndMessagesSharedParams {
 	/// Hex-encoded lane identifiers that should be served by the complex relay.
 	#[structopt(long, default_value = "00000000")]
 	lane: Vec<HexLaneId>,
+	#[structopt(long, possible_values = RelayerMode::VARIANTS, case_insensitive = true, default_value = "no-losses")]
+	relayer_mode: RelayerMode,
 	#[structopt(flatten)]
 	prometheus_params: PrometheusParams,
 }
@@ -158,6 +161,7 @@ impl RelayHeadersAndMessages {
 			let right_sign = params.right_sign.to_keypair::<Right>()?;
 
 			let lanes = params.shared.lane;
+			let relayer_mode = params.shared.relayer_mode.into();
 
 			let metrics_params: MetricsParams = params.shared.prometheus_params.into();
 			let metrics_params = relay_utils::relay_metrics(None, metrics_params).into_params();
@@ -189,6 +193,7 @@ impl RelayHeadersAndMessages {
 					source_to_target_headers_relay: Some(left_to_right_on_demand_headers.clone()),
 					target_to_source_headers_relay: Some(right_to_left_on_demand_headers.clone()),
 					lane_id: lane,
+					relayer_mode,
 					metrics_params: metrics_params.clone().disable().metrics_prefix(
 						messages_relay::message_lane_loop::metrics_prefix::<LeftToRightMessages>(&lane),
 					),
@@ -203,6 +208,7 @@ impl RelayHeadersAndMessages {
 					source_to_target_headers_relay: Some(right_to_left_on_demand_headers.clone()),
 					target_to_source_headers_relay: Some(left_to_right_on_demand_headers.clone()),
 					lane_id: lane,
+					relayer_mode,
 					metrics_params: metrics_params.clone().disable().metrics_prefix(
 						messages_relay::message_lane_loop::metrics_prefix::<RightToLeftMessages>(&lane),
 					),

--- a/relays/bin-substrate/src/cli/relay_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_messages.rs
@@ -22,7 +22,26 @@ use crate::cli::{
 use crate::messages_lane::MessagesRelayParams;
 use crate::select_full_bridge;
 use structopt::StructOpt;
-use strum::VariantNames;
+use strum::{EnumString, EnumVariantNames, VariantNames};
+
+/// Relayer operating mode.
+#[derive(Debug, EnumString, EnumVariantNames, Clone, Copy, PartialEq)]
+#[strum(serialize_all = "kebab_case")]
+pub enum RelayerMode {
+	/// The relayer doesn't care about rewards.
+	Altruistic,
+	/// The relayer will deliver all messages and confirmations as long as he's not losing any funds.
+	NoLosses,
+}
+
+impl From<RelayerMode> for messages_relay::message_lane_loop::RelayerMode {
+	fn from(mode: RelayerMode) -> Self {
+		match mode {
+			RelayerMode::Altruistic => Self::Altruistic,
+			RelayerMode::NoLosses => Self::NoLosses,
+		}
+	}
+}
 
 /// Start messages relayer process.
 #[derive(StructOpt)]
@@ -33,6 +52,8 @@ pub struct RelayMessages {
 	/// Hex-encoded lane id that should be served by the relay. Defaults to `00000000`.
 	#[structopt(long, default_value = "00000000")]
 	lane: HexLaneId,
+	#[structopt(long, possible_values = RelayerMode::VARIANTS, case_insensitive = true, default_value = "no-losses")]
+	relayer_mode: RelayerMode,
 	#[structopt(flatten)]
 	source: SourceConnectionParams,
 	#[structopt(flatten)]
@@ -62,10 +83,51 @@ impl RelayMessages {
 				source_to_target_headers_relay: None,
 				target_to_source_headers_relay: None,
 				lane_id: self.lane.into(),
+				relayer_mode: self.relayer_mode.into(),
 				metrics_params: self.prometheus_params.into(),
 			})
 			.await
 			.map_err(|e| anyhow::format_err!("{}", e))
 		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn should_use_no_losses_relayer_mode_by_default() {
+		assert_eq!(
+			RelayMessages::from_iter(vec![
+				"relay-messages",
+				"rialto-to-millau",
+				"--source-port=0",
+				"--source-signer=//Alice",
+				"--target-port=0",
+				"--target-signer=//Alice",
+				"--lane=00000000",
+			])
+			.relayer_mode,
+			RelayerMode::NoLosses,
+		);
+	}
+
+	#[test]
+	fn should_accept_altruistic_relayer_mode() {
+		assert_eq!(
+			RelayMessages::from_iter(vec![
+				"relay-messages",
+				"rialto-to-millau",
+				"--source-port=0",
+				"--source-signer=//Alice",
+				"--target-port=0",
+				"--target-signer=//Alice",
+				"--lane=00000000",
+				"--relayer-mode=altruistic",
+			])
+			.relayer_mode,
+			RelayerMode::Altruistic,
+		);
 	}
 }

--- a/relays/bin-substrate/src/cli/relay_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_messages.rs
@@ -31,14 +31,14 @@ pub enum RelayerMode {
 	/// The relayer doesn't care about rewards.
 	Altruistic,
 	/// The relayer will deliver all messages and confirmations as long as he's not losing any funds.
-	NoLosses,
+	Rational,
 }
 
 impl From<RelayerMode> for messages_relay::message_lane_loop::RelayerMode {
 	fn from(mode: RelayerMode) -> Self {
 		match mode {
 			RelayerMode::Altruistic => Self::Altruistic,
-			RelayerMode::NoLosses => Self::NoLosses,
+			RelayerMode::Rational => Self::Rational,
 		}
 	}
 }
@@ -52,7 +52,7 @@ pub struct RelayMessages {
 	/// Hex-encoded lane id that should be served by the relay. Defaults to `00000000`.
 	#[structopt(long, default_value = "00000000")]
 	lane: HexLaneId,
-	#[structopt(long, possible_values = RelayerMode::VARIANTS, case_insensitive = true, default_value = "no-losses")]
+	#[structopt(long, possible_values = RelayerMode::VARIANTS, case_insensitive = true, default_value = "rational")]
 	relayer_mode: RelayerMode,
 	#[structopt(flatten)]
 	source: SourceConnectionParams,
@@ -97,7 +97,7 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn should_use_no_losses_relayer_mode_by_default() {
+	fn should_use_rational_relayer_mode_by_default() {
 		assert_eq!(
 			RelayMessages::from_iter(vec![
 				"relay-messages",
@@ -109,7 +109,7 @@ mod tests {
 				"--lane=00000000",
 			])
 			.relayer_mode,
-			RelayerMode::NoLosses,
+			RelayerMode::Rational,
 		);
 	}
 

--- a/relays/bin-substrate/src/messages_lane.rs
+++ b/relays/bin-substrate/src/messages_lane.rs
@@ -49,6 +49,8 @@ pub struct MessagesRelayParams<SC: Chain, SS, TC: Chain, TS> {
 	pub target_to_source_headers_relay: Option<OnDemandHeadersRelay<TC>>,
 	/// Identifier of lane that needs to be served.
 	pub lane_id: LaneId,
+	/// Relayer operating mode.
+	pub relayer_mode: messages_relay::message_lane_loop::RelayerMode,
 	/// Metrics parameters.
 	pub metrics_params: MetricsParams,
 }

--- a/relays/bin-substrate/src/messages_target.rs
+++ b/relays/bin-substrate/src/messages_target.rs
@@ -255,6 +255,13 @@ where
 					SC::NAME,
 				))
 			})?;
+		log::trace!(
+			target: "bridge",
+			"Using conversion rate {} when converting from {} tokens to {} tokens",
+			conversion_rate,
+			TC::NAME,
+			SC::NAME
+		);
 		Ok(convert_target_tokens_to_source_tokens::<SC, TC>(
 			FixedU128::from_float(conversion_rate),
 			self.client

--- a/relays/messages/src/message_lane.rs
+++ b/relays/messages/src/message_lane.rs
@@ -21,7 +21,7 @@
 
 use num_traits::{SaturatingAdd, Zero};
 use relay_utils::{BlockNumberBase, HeaderId};
-use std::fmt::Debug;
+use std::{fmt::Debug, ops::Sub};
 
 /// One-way message lane.
 pub trait MessageLane: 'static + Clone + Send + Sync {
@@ -40,7 +40,15 @@ pub trait MessageLane: 'static + Clone + Send + Sync {
 	/// 1) pay transaction fees;
 	/// 2) pay message delivery and dispatch fee;
 	/// 3) pay relayer rewards.
-	type SourceChainBalance: Clone + Copy + Debug + PartialOrd + SaturatingAdd + Zero + Send + Sync;
+	type SourceChainBalance: Clone
+		+ Copy
+		+ Debug
+		+ PartialOrd
+		+ Sub<Output = Self::SourceChainBalance>
+		+ SaturatingAdd
+		+ Zero
+		+ Send
+		+ Sync;
 	/// Number of the source header.
 	type SourceHeaderNumber: BlockNumberBase;
 	/// Hash of the source header.

--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -65,7 +65,7 @@ pub enum RelayerMode {
 	/// The relayer doesn't care about rewards.
 	Altruistic,
 	/// The relayer will deliver all messages and confirmations as long as he's not losing any funds.
-	NoLosses,
+	Rational,
 }
 
 /// Message delivery race parameters.

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -648,7 +648,7 @@ async fn select_nonces_for_delivery_transaction<P: MessageLane>(
 			RelayerMode::Altruistic => {
 				soft_selected_count = index + 1;
 			}
-			RelayerMode::NoLosses => {
+			RelayerMode::Rational => {
 				let delivery_transaction_cost = lane_target_client
 					.estimate_delivery_transaction_in_source_tokens(
 						0..=(new_selected_count as MessageNonce - 1),
@@ -699,7 +699,7 @@ async fn select_nonces_for_delivery_transaction<P: MessageLane>(
 					);
 				}
 
-				// NoLosses relayer never want to lose his funds
+				// Rational relayer never want to lose his funds
 				if total_reward >= total_cost {
 					soft_selected_count = index + 1;
 					selected_reward = total_reward;
@@ -1166,9 +1166,9 @@ mod tests {
 	}
 
 	#[async_std::test]
-	async fn no_losses_relayer_is_delivering_messages_if_cost_is_equal_to_reward() {
+	async fn rational_relayer_is_delivering_messages_if_cost_is_equal_to_reward() {
 		let (state, mut strategy) = prepare_strategy();
-		strategy.relayer_mode = RelayerMode::NoLosses;
+		strategy.relayer_mode = RelayerMode::Rational;
 
 		// so now we have:
 		// - 20..=23 with reward = cost
@@ -1180,7 +1180,7 @@ mod tests {
 	}
 
 	#[async_std::test]
-	async fn no_losses_relayer_is_not_delivering_messages_if_cost_is_larger_than_reward() {
+	async fn rational_relayer_is_not_delivering_messages_if_cost_is_larger_than_reward() {
 		let (mut state, mut strategy) = prepare_strategy();
 		let nonces = source_nonces(
 			24..=25,
@@ -1190,7 +1190,7 @@ mod tests {
 		);
 		strategy.strategy.source_nonces_updated(header_id(2), nonces);
 		state.best_finalized_source_header_id_at_best_target = Some(header_id(2));
-		strategy.relayer_mode = RelayerMode::NoLosses;
+		strategy.relayer_mode = RelayerMode::Rational;
 
 		// so now we have:
 		// - 20..=23 with reward = cost
@@ -1203,7 +1203,7 @@ mod tests {
 	}
 
 	#[async_std::test]
-	async fn no_losses_relayer_is_delivering_unpaid_messages() {
+	async fn rational_relayer_is_delivering_unpaid_messages() {
 		async fn test_with_dispatch_fee_payment(
 			dispatch_fee_payment: DispatchFeePayment,
 		) -> Option<(RangeInclusive<MessageNonce>, MessageProofParameters)> {
@@ -1221,7 +1221,7 @@ mod tests {
 			strategy.max_messages_in_single_batch = 100;
 			strategy.max_messages_weight_in_single_batch = 100;
 			strategy.max_messages_size_in_single_batch = 100;
-			strategy.relayer_mode = RelayerMode::NoLosses;
+			strategy.relayer_mode = RelayerMode::Rational;
 
 			// so now we have:
 			// - 20..=23 with reward = cost

--- a/relays/utils/src/metrics/float_json_value.rs
+++ b/relays/utils/src/metrics/float_json_value.rs
@@ -84,6 +84,7 @@ impl FloatJsonValueMetric {
 	}
 }
 
+
 #[async_trait]
 impl StandaloneMetrics for FloatJsonValueMetric {
 	fn update_interval(&self) -> Duration {

--- a/relays/utils/src/metrics/float_json_value.rs
+++ b/relays/utils/src/metrics/float_json_value.rs
@@ -84,7 +84,6 @@ impl FloatJsonValueMetric {
 	}
 }
 
-
 #[async_trait]
 impl StandaloneMetrics for FloatJsonValueMetric {
 	fn update_interval(&self) -> Duration {


### PR DESCRIPTION
closes #997

This PR adds cli option for selecting relayer mode (altruistic || no-losses). no-losses relayer is the default option (this will break wococo <> rococo, because they have no value => conversion rate is unknown => no messages will be delivered => R<>W relays need to specify `--relayer-mode=altruistic`).

What may happen after this PR is merged:
1) messages delivery will break if there's an issue in greedy relayer code (locally it is running fine, though);
2) messages delivery will start breaking from time to time if price of tokens, associated with chains will start to diverge from ideal 1:1 ratio.

I've also added some traces to be able to diagnose possible issues from logs.