### PR TITLE
Yrong README Fixup + M1 Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,26 +491,21 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.54.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
- "clap",
- "env_logger 0.7.1",
  "lazy_static",
  "lazycell",
- "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "which 3.1.1",
 ]
 
 [[package]]
@@ -1094,13 +1089,13 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.7.0",
 ]
 
 [[package]]
@@ -2246,7 +2241,7 @@ checksum = "03d47dad3685eceed8488986cad3d5027165ea5edb164331770e2059555f10a5"
 dependencies = [
  "lazy_static",
  "libc",
- "libloading",
+ "libloading 0.5.2",
  "winapi 0.3.9",
 ]
 
@@ -3427,6 +3422,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,9 +3883,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.11.4"
+version = "6.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
+checksum = "5da125e1c0f22c7cae785982115523a0738728498547f415c9054cb17c7e89f9"
 dependencies = [
  "bindgen",
  "cc",
@@ -5526,7 +5531,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which 4.0.2",
+ "which",
 ]
 
 [[package]]
@@ -10025,15 +10030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ First, we must run the two Substrate nodes.
 ./deployments/local-scripts/run-millau-node.sh
 ```
 
-Afterwards the nodes are up we can run the header relayers.
+After the nodes are up we can run the header relayers.
 
 ```bash
 ./deployments/local-scripts/relay-millau-to-rialto.sh

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ interact with and test the bridge see more details in [send message](./docs/send
 ./scripts/send-message-from-millau-rialto.sh remark
 ```
 
-After sending a message you will see the following logs showing transaction successfully sent
+After sending a message you will see the following logs showing a message was successfully sent:
 
 ```
 INFO bridge Sending message to Rialto. Size: 286. Dispatch weight: 1038000. Fee: 275,002,568

--- a/README.md
+++ b/README.md
@@ -120,51 +120,66 @@ cargo build -p substrate-relay
 
 ### Running a Dev network
 
-We will launch a dev network to demonstrate how to relay message from substrate to substrate
+We will launch a dev network to demonstrate how to relay a message between two Substrate based
+chains (named Rialto and Millau).
+
+To do this we will need two nodes, two relayers which will relay headers, and two relayers which
+will relay messages.
 
 #### Running from local scripts
 
-To run a simple dev network you can use the scripts located in 
-[`deployments/local-scripts` folder](./deployments/local-scripts). Since the relayer 
-connects to both Substrate chains it must be run last.
+To run a simple dev network you can use the scripts located in the
+[`deployments/local-scripts` folder](./deployments/local-scripts).
+
+First, we must run the two Substrate nodes.
 
 ```bash
 # In `parity-bridges-common` folder
-
 ./deployments/local-scripts/run-rialto-node.sh
 ./deployments/local-scripts/run-millau-node.sh
+```
+
+Afterwards the nodes are up we can run the header relayers.
+
+```bash
 ./deployments/local-scripts/relay-millau-to-rialto.sh
 ./deployments/local-scripts/relay-rialto-to-millau.sh
-./deployments/local-scripts/relay-messages-millau-to-rialto.sh
-./deployments/local-scripts/relay-messages-millau-to-rialto.sh
 ```
 
 At this point you should see the relayer submitting headers from the Millau Substrate chain to the
-Rialto Substrate chain as following:
+Rialto Substrate chain.
 
 ```
 # Header Relayer Logs
 [Millau_to_Rialto_Sync] [date] DEBUG bridge Going to submit finality proof of Millau header #147 to Rialto
-[Millau_to_Rialto_Sync] [date] INFO bridge Synced 147 of 147 headers
-[Millau_to_Rialto_Sync] [date] DEBUG bridge Going to submit finality proof of Millau header #148 to Rialto
-[Millau_to_Rialto_Sync] [date] INFO bridge Synced 148 of 149 headers
+[...] [date] INFO bridge Synced 147 of 147 headers
+[...] [date] DEBUG bridge Going to submit finality proof of Millau header #148 to Rialto
+[...] [date] INFO bridge Synced 148 of 149 headers
 ```
 
-You will also see the message lane relayers listening for new messages. To send a message
-see the [How to send a message section](#how-to-send-a-message).
+Finally, we can run the message relayers.
+
+```bash
+./deployments/local-scripts/relay-messages-millau-to-rialto.sh
+./deployments/local-scripts/relay-messages-millau-to-rialto.sh
+```
+
+You will also see the message lane relayers listening for new messages.
 
 ```
 # Message Relayer Logs
 [Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau::ReceivingConfirmationsDelivery about best message nonces
-[Millau_to_Rialto_MessageLane_00000000] [date] INFO bridge Synced Some(2) of Some(3) nonces in Millau::MessagesDelivery -> Rialto::MessagesDelivery race
-[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau::MessagesDelivery about message nonces
-[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received best nonces from Millau::ReceivingConfirmationsDelivery: TargetClientNonces { latest_nonce: 0, nonces_data: () }
-[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau::ReceivingConfirmationsDelivery about finalized message nonces
-[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received finalized nonces from Millau::ReceivingConfirmationsDelivery: TargetClientNonces { latest_nonce: 0, nonces_data: () }
-[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received nonces from Millau::MessagesDelivery: SourceClientNonces { new_nonces: {}, confirmed_nonce: Some(0) }
-[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau node about its state
-[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received state from Millau node: ClientState { best_self: HeaderId(1593, 0xacac***), best_finalized_self: HeaderId(1590, 0x0be81d...), best_finalized_peer_at_best_self: HeaderId(0, 0xdcdd89...) }
+[...] [date] INFO bridge Synced Some(2) of Some(3) nonces in Millau::MessagesDelivery -> Rialto::MessagesDelivery race
+[...] [date] DEBUG bridge Asking Millau::MessagesDelivery about message nonces
+[...] [date] DEBUG bridge Received best nonces from Millau::ReceivingConfirmationsDelivery: TargetClientNonces { latest_nonce: 0, nonces_data: () }
+[...] [date] DEBUG bridge Asking Millau::ReceivingConfirmationsDelivery about finalized message nonces
+[...] [date] DEBUG bridge Received finalized nonces from Millau::ReceivingConfirmationsDelivery: TargetClientNonces { latest_nonce: 0, nonces_data: () }
+[...] [date] DEBUG bridge Received nonces from Millau::MessagesDelivery: SourceClientNonces { new_nonces: {}, confirmed_nonce: Some(0) }
+[...] [date] DEBUG bridge Asking Millau node about its state
+[...] [date] DEBUG bridge Received state from Millau node: ClientState { best_self: HeaderId(1593, 0xacac***), best_finalized_self: HeaderId(1590, 0x0be81d...), best_finalized_peer_at_best_self: HeaderId(0, 0xdcdd89...) }
 ```
+
+To send a message see the ["How to send a message" section](#how-to-send-a-message).
 
 ### Full Network Docker Compose Setup
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ To send a message see the ["How to send a message" section](#how-to-send-a-messa
 For a more sophisticated deployment which includes bidirectional header sync, message passing,
 monitoring dashboards, etc. see the [Deployments README](./deployments/README.md).
 
+You should note that you can find images for all the bridge components published on
+[Docker Hub](https://hub.docker.com/u/paritytech).
+
+To run a Rialto node for example, you can use the following command:
+
+```bash
+docker run -p 30333:30333 -p 9933:9933 -p 9944:9944 \
+  -it paritytech/rialto-bridge-node --dev --tmp \
+  --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external
+```
+
 ### How to send a message
 
 In this section we'll show you how to quickly send a bridge message, if you want to

--- a/README.md
+++ b/README.md
@@ -102,10 +102,9 @@ the `relays` which are used to pass messages between chains.
 To run the Bridge you need to be able to connect the bridge relay node to the RPC interface of nodes
 on each side of the bridge (source and target chain).
 
-There are 3 ways to run the bridge, described below:
+There are 2 ways to run the bridge, described below:
 
-- building & running from source,
-- building or using Docker images for each individual component,
+- building & running from source
 - running a Docker Compose setup (recommended).
 
 ### Using the Source
@@ -119,78 +118,53 @@ cargo build -p millau-bridge-node
 cargo build -p substrate-relay
 ```
 
-### Running
+### Running a Dev network
 
-To run a simple dev network you'll can use the scripts located in
-[the `deployments/local-scripts` folder](./deployments/local-scripts). Since the relayer connects to
-both Substrate chains it must be run last.
+We will launch a dev network to demonstrate how to relay message from substrate to substrate
+
+#### Running from local scripts
+
+To run a simple dev network you can use the scripts located in 
+[`deployments/local-scripts` folder](./deployments/local-scripts). Since the relayer 
+connects to both Substrate chains it must be run last.
 
 ```bash
 # In `parity-bridges-common` folder
+
 ./deployments/local-scripts/run-rialto-node.sh
 ./deployments/local-scripts/run-millau-node.sh
 ./deployments/local-scripts/relay-millau-to-rialto.sh
+./deployments/local-scripts/relay-rialto-to-millau.sh
+./deployments/local-scripts/relay-messages-millau-to-rialto.sh
+./deployments/local-scripts/relay-messages-millau-to-rialto.sh
 ```
 
 At this point you should see the relayer submitting headers from the Millau Substrate chain to the
-Rialto Substrate chain.
+Rialto Substrate chain as following:
 
-### Local Docker Setup
-
-To get up and running quickly you can use published Docker images for the bridge nodes and relayer.
-The images are published on [Docker Hub](https://hub.docker.com/u/paritytech).
-
-To run the dev network we first run the two bridge nodes:
-
-```bash
-docker run -p 30333:30333 -p 9933:9933 -p 9944:9944 \
-           -it paritytech/rialto-bridge-node --dev --tmp \
-           --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external
-
-docker run -p 30334:30333 -p 9934:9933 -p 9945:9944 \
-           -it paritytech/millau-bridge-node --dev --tmp \
-           --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external
+```
+# Header Relayer Logs
+[Millau_to_Rialto_Sync] [date] DEBUG bridge Going to submit finality proof of Millau header #147 to Rialto
+[Millau_to_Rialto_Sync] [date] INFO bridge Synced 147 of 147 headers
+[Millau_to_Rialto_Sync] [date] DEBUG bridge Going to submit finality proof of Millau header #148 to Rialto
+[Millau_to_Rialto_Sync] [date] INFO bridge Synced 148 of 149 headers
 ```
 
-Notice that the `docker run` command will accept all the normal Substrate flags. For local
-development you should at minimum run with the `--dev` flag or else no blocks will be produced.
+You will also see the message lane relayers listening for new messages. To send a message
+see the [How to send a message section](#how-to-send-a-message).
 
-Then we need to initialize and run the relayer:
-
-```bash
-docker run --network=host -it \
-        paritytech/substrate-relay init-bridge RialtoToMillau \
-        --target-host localhost \
-        --target-port 9945 \
-        --source-host localhost \
-        --source-port 9944 \
-        --target-signer //Alice
-
-docker run --network=host -it \
-        paritytech/substrate-relay relay-headers RialtoToMillau \
-        --target-host localhost \
-        --target-port 9945 \
-        --source-host localhost \
-        --source-port 9944 \
-        --target-signer //Bob \
 ```
-
-You should now see the relayer submitting headers from the Millau chain to the Rialto chain.
-
-If you don't want to use the published Docker images you can build images yourself. You can do this
-by running the following commands at the top level of the repository.
-
-```bash
-# In `parity-bridges-common` folder
-docker build . -t local/rialto-bridge-node --build-arg PROJECT=rialto-bridge-node
-docker build . -t local/millau-bridge-node --build-arg PROJECT=millau-bridge-node
-docker build . -t local/substrate-relay --build-arg PROJECT=substrate-relay
+# Message Relayer Logs
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau::ReceivingConfirmationsDelivery about best message nonces
+[Millau_to_Rialto_MessageLane_00000000] [date] INFO bridge Synced Some(2) of Some(3) nonces in Millau::MessagesDelivery -> Rialto::MessagesDelivery race
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau::MessagesDelivery about message nonces
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received best nonces from Millau::ReceivingConfirmationsDelivery: TargetClientNonces { latest_nonce: 0, nonces_data: () }
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau::ReceivingConfirmationsDelivery about finalized message nonces
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received finalized nonces from Millau::ReceivingConfirmationsDelivery: TargetClientNonces { latest_nonce: 0, nonces_data: () }
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received nonces from Millau::MessagesDelivery: SourceClientNonces { new_nonces: {}, confirmed_nonce: Some(0) }
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Asking Millau node about its state
+[Millau_to_Rialto_MessageLane_00000000] [date] DEBUG bridge Received state from Millau node: ClientState { best_self: HeaderId(1593, 0xacac***), best_finalized_self: HeaderId(1590, 0x0be81d...), best_finalized_peer_at_best_self: HeaderId(0, 0xdcdd89...) }
 ```
-
-_Note: Building the node images will take a long time, so make sure you have some coffee handy._
-
-Once you have the images built you can use them in the previous commands by replacing
-`paritytech/<component_name>` with `local/<component_name>` everywhere.
 
 ### Full Network Docker Compose Setup
 
@@ -199,8 +173,21 @@ monitoring dashboards, etc. see the [Deployments README](./deployments/README.md
 
 ### How to send a message
 
-A straightforward way to interact with and test the bridge is sending messages. This is explained
-in the [send message](./docs/send-message.md) document.
+In this section we'll show you how to quickly send a bridge message, if you want to
+interact with and test the bridge see more details in [send message](./docs/send-message.md)
+
+```bash
+# In `parity-bridges-common` folder
+./scripts/send-message-from-millau-rialto.sh remark
+```
+
+After sending a message you will see the following logs showing transaction successfully sent
+
+```
+INFO bridge Sending message to Rialto. Size: 286. Dispatch weight: 1038000. Fee: 275,002,568
+INFO bridge Signed Millau Call: 0x7904...
+TRACE bridge Sent transaction to Millau node: 0x5e68...
+```
 
 ## Community
 


### PR DESCRIPTION
I messed up when pushing updates to `yrong`'s fork in https://github.com/paritytech/parity-bridges-common/pull/1031 and now their `master` branch is even with ours.

Now I've got a branch called `yrong/master` which I can't push back to the `yrong` remote's `master` branch (well, maybe with some more Git digging) since Git complains about this being ambiguous.

Opening this as a quick replacement (sorry @yrong I'm gonna have to steal your green square today). Thanks for your hard work on this though!