### PR TITLE
Update jsonrpsee reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,19 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
-name = "async-tls"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
-dependencies = [
- "futures-core",
- "futures-io",
- "rustls 0.19.1",
- "webpki 0.21.4",
- "webpki-roots",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +476,9 @@ name = "beef"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -2421,7 +2411,7 @@ checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
 dependencies = [
  "futures-io",
  "rustls 0.19.1",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -3001,10 +2991,10 @@ dependencies = [
  "hyper 0.13.10",
  "log",
  "rustls 0.18.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.4.0",
  "tokio 0.2.25",
- "tokio-rustls",
- "webpki 0.21.4",
+ "tokio-rustls 0.14.1",
+ "webpki",
 ]
 
 [[package]]
@@ -3406,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.2.0-alpha.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5784ee8bb31988fa2c7a755fe31b0e21aa51894a67e5c99b6d4470f0253bf31a"
+checksum = "3b4c85cfa6767333f3e5f3b2f2f765dad2727b0033ee270ae07c599bf43ed5ae"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -3419,40 +3409,44 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.2.0-alpha.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab3dabceeeeb865897661d532d47202eaae71cd2c606f53cb69f1fbc0555a51"
+checksum = "c0cf7bd4e93b3b56e59131de7f24afbea871faf914e97bcdd942c86927ab0172"
 dependencies = [
  "async-trait",
  "beef",
  "futures-channel",
  "futures-util",
+ "hyper 0.14.5",
  "log",
  "serde",
  "serde_json",
+ "soketto 0.5.0",
  "thiserror",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.2.0-alpha.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6fdb4390bd25358c62e8b778652a564a1723ba07dca0feb3da439c2253fe59f"
+checksum = "6ec51150965544e1a4468f372bdab8545243a1b045d4ab272023aac74c60de32"
 dependencies = [
- "async-std",
- "async-tls",
  "async-trait",
  "fnv",
  "futures 0.3.15",
  "jsonrpsee-types",
  "log",
  "pin-project 1.0.5",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
  "serde",
  "serde_json",
- "soketto 0.4.2",
+ "soketto 0.5.0",
  "thiserror",
+ "tokio 1.8.1",
+ "tokio-rustls 0.22.0",
+ "tokio-util 0.6.7",
  "url 2.2.1",
- "webpki 0.22.0",
 ]
 
 [[package]]
@@ -6515,7 +6509,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -6528,7 +6522,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -6541,6 +6535,18 @@ dependencies = [
  "rustls 0.18.1",
  "schannel",
  "security-framework 1.0.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework 2.3.1",
 ]
 
 [[package]]
@@ -9383,7 +9389,18 @@ dependencies = [
  "futures-core",
  "rustls 0.18.1",
  "tokio 0.2.25",
- "webpki 0.21.4",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio 1.8.1",
+ "webpki",
 ]
 
 [[package]]
@@ -10320,22 +10337,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -17,7 +17,7 @@
 //! Messages pallet benchmarking.
 
 use crate::weights_ext::EXPECTED_DEFAULT_MESSAGE_LENGTH;
-use casdgasdgarate::{
+use crate::{
 	inbound_lane::InboundLaneStorage, inbound_lane_storage, outbound_lane, outbound_lane::ReceivalConfirmationResult,
 	Call, Instance,
 };

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -17,7 +17,7 @@
 //! Messages pallet benchmarking.
 
 use crate::weights_ext::EXPECTED_DEFAULT_MESSAGE_LENGTH;
-use crate::{
+use casdgasdgarate::{
 	inbound_lane::InboundLaneStorage, inbound_lane_storage, outbound_lane, outbound_lane::ReceivalConfirmationResult,
 	Call, Instance,
 };

--- a/relays/bin-substrate/src/headers_initialize.rs
+++ b/relays/bin-substrate/src/headers_initialize.rs
@@ -108,12 +108,18 @@ async fn prepare_initialization_data<SourceChain: Chain>(
 		.map_err(|err| format!("Failed to subscribe to {} justifications: {:?}", SourceChain::NAME, err))?;
 
 	// Read next justification - the header that it finalizes will be used as initial header.
-	let justification = justifications.next().await.ok_or_else(|| {
-		format!(
-			"Failed to read {} justification from the stream: stream has ended unexpectedly",
-			SourceChain::NAME,
-		)
-	})?;
+	let justification = justifications
+		.next()
+		.await
+		.map_err(|err| err.to_string())
+		.and_then(|justification| justification.ok_or_else(|| "stream has ended unexpectedly".into()))
+		.map_err(|err| {
+			format!(
+				"Failed to read {} justification from the stream: {}",
+				SourceChain::NAME,
+				err,
+			)
+		})?;
 
 	// Read initial header.
 	let justification: GrandpaJustification<SourceChain::Header> = Decode::decode(&mut &justification.0[..])

--- a/relays/client-ethereum/Cargo.toml
+++ b/relays/client-ethereum/Cargo.toml
@@ -11,8 +11,8 @@ bp-eth-poa = { path = "../../primitives/ethereum-poa" }
 codec = { package = "parity-scale-codec", version = "2.2.0" }
 headers-relay = { path = "../headers" }
 hex-literal = "0.3"
-jsonrpsee-proc-macros = "=0.2.0-alpha.6"
-jsonrpsee-ws-client = "=0.2.0-alpha.6"
+jsonrpsee-proc-macros = "0.2"
+jsonrpsee-ws-client = "0.2"
 libsecp256k1 = { version = "0.3.4", default-features = false, features = ["hmac"] }
 log = "0.4.11"
 relay-utils = { path = "../utils" }

--- a/relays/client-ethereum/src/error.rs
+++ b/relays/client-ethereum/src/error.rs
@@ -57,10 +57,9 @@ impl MaybeConnectionError for Error {
 	fn is_connection_error(&self) -> bool {
 		matches!(
 			*self,
-			Error::RpcError(RpcError::TransportError(_))
-				// right now if connection to the ws server is dropped (after it is already established),
-				// we're getting this error
+			Error::RpcError(RpcError::Transport(_))
 				| Error::RpcError(RpcError::Internal(_))
+				| Error::RpcError(RpcError::RestartNeeded(_))
 				| Error::ClientNotSynced(_),
 		)
 	}

--- a/relays/client-substrate/Cargo.toml
+++ b/relays/client-substrate/Cargo.toml
@@ -9,8 +9,8 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 async-std = { version = "1.6.5", features = ["attributes"] }
 async-trait = "0.1.40"
 codec = { package = "parity-scale-codec", version = "2.2.0" }
-jsonrpsee-proc-macros = "=0.2.0-alpha.6"
-jsonrpsee-ws-client = "=0.2.0-alpha.6"
+jsonrpsee-proc-macros = "0.2"
+jsonrpsee-ws-client = "0.2"
 log = "0.4.11"
 num-traits = "0.2"
 rand = "0.7"

--- a/relays/client-substrate/src/error.rs
+++ b/relays/client-substrate/src/error.rs
@@ -71,9 +71,7 @@ impl MaybeConnectionError for Error {
 	fn is_connection_error(&self) -> bool {
 		matches!(
 			*self,
-			Error::RpcError(RpcError::TransportError(_))
-				// right now if connection to the ws server is dropped (after it is already established),
-				// we're getting this error
+			Error::RpcError(RpcError::Transport(_))
 				| Error::RpcError(RpcError::Internal(_))
 				| Error::RpcError(RpcError::RestartNeeded(_))
 				| Error::ClientNotSynced(_),


### PR DESCRIPTION
While currently working on turning Rialto into relay chain, I've found that both Polkadot and Substrate are referencing `jsonrpsee 0.2` && there's a "failed to select" error when I'm trying to build updated Rialto node. The node itself is very WIP and non-functional, so I'm going to extract some PRs that we'll definitely need before opening final PR (not soon).