### PR TITLE
Allow reading suri && password override from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8942,6 +8942,7 @@ dependencies = [
  "sp-version",
  "structopt",
  "strum 0.21.0",
+ "tempdir",
 ]
 
 [[package]]
@@ -9029,6 +9030,16 @@ name = "target-lexicon"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
 
 [[package]]
 name = "tempfile"

--- a/relays/bin-substrate/Cargo.toml
+++ b/relays/bin-substrate/Cargo.toml
@@ -63,3 +63,4 @@ sp-version = { git = "https://github.com/paritytech/substrate", branch = "master
 hex-literal = "0.3"
 pallet-bridge-grandpa = { path = "../../modules/grandpa" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
+tempdir = "0.3"

--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -374,24 +374,61 @@ macro_rules! declare_chain_options {
 			}
 
 			#[doc = $chain " signing params."]
-			#[derive(StructOpt, Debug, PartialEq, Eq)]
+			#[derive(StructOpt, Debug, PartialEq, Eq, Clone)]
 			pub struct [<$chain SigningParams>] {
 				#[doc = "The SURI of secret key to use when transactions are submitted to the " $chain " node."]
 				#[structopt(long)]
-				pub [<$chain_prefix _signer>]: String,
+				pub [<$chain_prefix _signer>]: Option<String>,
 				#[doc = "The password for the SURI of secret key to use when transactions are submitted to the " $chain " node."]
 				#[structopt(long)]
 				pub [<$chain_prefix _signer_password>]: Option<String>,
+
+				#[doc = "Path to the file, that contains SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overrided with " $chain_prefix " option."]
+				#[structopt(long)]
+				pub [<$chain_prefix _signer_file>]: Option<std::path::PathBuf>,
+				#[doc = "Path to the file, that password for the SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overrided with " $chain_prefix " option."]
+				#[structopt(long)]
+				pub [<$chain_prefix _signer_password_file>]: Option<std::path::PathBuf>,
 			}
 
 			impl [<$chain SigningParams>] {
 				/// Parse signing params into chain-specific KeyPair.
 				pub fn to_keypair<Chain: CliChain>(&self) -> anyhow::Result<Chain::KeyPair> {
+					let suri = match (self.[<$chain_prefix _signer>].as_ref(), self.[<$chain_prefix _signer_file>].as_ref()) {
+						(Some(suri), _) => suri.to_owned(),
+						(None, Some(suri_file)) => std::fs::read_to_string(suri_file)
+							.map_err(|err| anyhow::format_err!(
+								"Failed to read SURI from file {:?}: {}",
+								suri_file,
+								err,
+							))?,
+						(None, None) => return Err(anyhow::format_err!(
+							"One of options must be specified: '{}' or '{}'",
+							stringify!([<$chain_prefix _signer>]),
+							stringify!([<$chain_prefix _signer_file>]),
+						)),
+					};
+
+					let suri_password = match (
+						self.[<$chain_prefix _signer_password>].as_ref(),
+						self.[<$chain_prefix _signer_password_file>].as_ref(),
+					) {
+						(Some(suri_password), _) => Some(suri_password.to_owned()),
+						(None, Some(suri_password_file)) => std::fs::read_to_string(suri_password_file)
+							.map(Some)
+							.map_err(|err| anyhow::format_err!(
+								"Failed to read SURI password from file {:?}: {}",
+								suri_password_file,
+								err,
+							))?,
+						_ => None,
+					};
+
 					use sp_core::crypto::Pair;
 
 					Chain::KeyPair::from_string(
-						&self.[<$chain_prefix _signer>],
-						self.[<$chain_prefix _signer_password>].as_deref()
+						&suri,
+						suri_password.as_deref()
 					).map_err(|e| anyhow::format_err!("{:?}", e))
 				}
 			}
@@ -419,6 +456,7 @@ declare_chain_options!(Target, target);
 
 #[cfg(test)]
 mod tests {
+	use sp_core::Pair;
 	use std::str::FromStr;
 
 	use super::*;
@@ -455,5 +493,85 @@ mod tests {
 
 		// then
 		assert_eq!(hex.0, hex2.0);
+	}
+
+	#[test]
+	fn reads_suri_from_file() {
+		const ALICE: &str = "//Alice";
+		const BOB: &str = "//Bob";
+		const ALICE_PASSWORD: &str = "alice_password";
+		const BOB_PASSWORD: &str = "bob_password";
+
+		let alice = sp_core::sr25519::Pair::from_string(ALICE, Some(ALICE_PASSWORD)).unwrap();
+		let bob = sp_core::sr25519::Pair::from_string(BOB, Some(BOB_PASSWORD)).unwrap();
+		let bob_with_alice_password = sp_core::sr25519::Pair::from_string(BOB, Some(ALICE_PASSWORD)).unwrap();
+
+		let temp_dir = tempdir::TempDir::new("reads_suri_from_file").unwrap();
+		let mut suri_file_path = temp_dir.path().to_path_buf();
+		let mut password_file_path = temp_dir.path().to_path_buf();
+		suri_file_path.push("suri");
+		password_file_path.push("password");
+		std::fs::write(&suri_file_path, BOB.as_bytes()).unwrap();
+		std::fs::write(&password_file_path, BOB_PASSWORD.as_bytes()).unwrap();
+
+		// when both seed and password are read from file
+		assert_eq!(
+			TargetSigningParams {
+				target_signer: Some(ALICE.into()),
+				target_signer_password: Some(ALICE_PASSWORD.into()),
+
+				target_signer_file: None,
+				target_signer_password_file: None,
+			}
+			.to_keypair::<relay_rialto_client::Rialto>()
+			.map(|p| p.public())
+			.map_err(drop),
+			Ok(alice.public()),
+		);
+
+		// when both seed and password are read from file
+		assert_eq!(
+			TargetSigningParams {
+				target_signer: None,
+				target_signer_password: None,
+
+				target_signer_file: Some(suri_file_path.clone().into()),
+				target_signer_password_file: Some(password_file_path.clone().into()),
+			}
+			.to_keypair::<relay_rialto_client::Rialto>()
+			.map(|p| p.public())
+			.map_err(drop),
+			Ok(bob.public()),
+		);
+
+		// when password are is overriden by cli option
+		assert_eq!(
+			TargetSigningParams {
+				target_signer: None,
+				target_signer_password: Some(ALICE_PASSWORD.into()),
+
+				target_signer_file: Some(suri_file_path.clone().into()),
+				target_signer_password_file: Some(password_file_path.clone().into()),
+			}
+			.to_keypair::<relay_rialto_client::Rialto>()
+			.map(|p| p.public())
+			.map_err(drop),
+			Ok(bob_with_alice_password.public()),
+		);
+
+		// when both seed and password are overriden by cli options
+		assert_eq!(
+			TargetSigningParams {
+				target_signer: Some(ALICE.into()),
+				target_signer_password: Some(ALICE_PASSWORD.into()),
+
+				target_signer_file: Some(suri_file_path.into()),
+				target_signer_password_file: Some(password_file_path.into()),
+			}
+			.to_keypair::<relay_rialto_client::Rialto>()
+			.map(|p| p.public())
+			.map_err(drop),
+			Ok(alice.public()),
+		);
 	}
 }

--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -386,7 +386,7 @@ macro_rules! declare_chain_options {
 				#[doc = "Path to the file, that contains SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overridden with " $chain_prefix "_signer option."]
 				#[structopt(long)]
 				pub [<$chain_prefix _signer_file>]: Option<std::path::PathBuf>,
-				#[doc = "Path to the file, that password for the SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overrided with " $chain_prefix " option."]
+				#[doc = "Path to the file, that password for the SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overridden with " $chain_prefix "_signer_password option."]
 				#[structopt(long)]
 				pub [<$chain_prefix _signer_password_file>]: Option<std::path::PathBuf>,
 			}

--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -383,7 +383,7 @@ macro_rules! declare_chain_options {
 				#[structopt(long)]
 				pub [<$chain_prefix _signer_password>]: Option<String>,
 
-				#[doc = "Path to the file, that contains SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overrided with " $chain_prefix " option."]
+				#[doc = "Path to the file, that contains SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overridden with " $chain_prefix "_signer option."]
 				#[structopt(long)]
 				pub [<$chain_prefix _signer_file>]: Option<std::path::PathBuf>,
 				#[doc = "Path to the file, that password for the SURI of secret key to use when transactions are submitted to the " $chain " node. Can be overrided with " $chain_prefix " option."]

--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -535,8 +535,8 @@ mod tests {
 				target_signer: None,
 				target_signer_password: None,
 
-				target_signer_file: Some(suri_file_path.clone().into()),
-				target_signer_password_file: Some(password_file_path.clone().into()),
+				target_signer_file: Some(suri_file_path.clone()),
+				target_signer_password_file: Some(password_file_path.clone()),
 			}
 			.to_keypair::<relay_rialto_client::Rialto>()
 			.map(|p| p.public())
@@ -550,8 +550,8 @@ mod tests {
 				target_signer: None,
 				target_signer_password: Some(ALICE_PASSWORD.into()),
 
-				target_signer_file: Some(suri_file_path.clone().into()),
-				target_signer_password_file: Some(password_file_path.clone().into()),
+				target_signer_file: Some(suri_file_path.clone()),
+				target_signer_password_file: Some(password_file_path.clone()),
 			}
 			.to_keypair::<relay_rialto_client::Rialto>()
 			.map(|p| p.public())
@@ -565,8 +565,8 @@ mod tests {
 				target_signer: Some(ALICE.into()),
 				target_signer_password: Some(ALICE_PASSWORD.into()),
 
-				target_signer_file: Some(suri_file_path.into()),
-				target_signer_password_file: Some(password_file_path.into()),
+				target_signer_file: Some(suri_file_path),
+				target_signer_password_file: Some(password_file_path),
 			}
 			.to_keypair::<relay_rialto_client::Rialto>()
 			.map(|p| p.public())


### PR DESCRIPTION
closes #1000

The easiest way would be to use [Environment variable fallback](https://docs.rs/structopt/0.3.22/structopt/#environment-variable-fallback). But we're now using options like`--source-signer`, and it's not super intuitive (imho easy to make an error) to have a variable named `LEFT_SIGNER` and know that it means signer at Millau. This is especially important if you're starting multiple relay processes from single script. So imo seeing `--source-signer-file=millau-signer-suri` is better than falling back to `LEFT_SIGNER`.

Still, everything that is read from file may be overrided by the explicit cli-options. E.g. passing `--source-signer=//Alice --source-signer-file=bob-suri` will mean that `//Alice` will be used. May make it conflicting options, if it looks better to someone.