### PR TITLE
Fix Westend -> Millau sync

### DIFF
--- a/relays/client-substrate/src/client.rs
+++ b/relays/client-substrate/src/client.rs
@@ -23,8 +23,9 @@ use crate::{ConnectionParams, Error, Result};
 use async_std::sync::{Arc, Mutex};
 use codec::Decode;
 use frame_system::AccountInfo;
+use futures::{SinkExt, StreamExt};
 use jsonrpsee_ws_client::{traits::SubscriptionClient, v2::params::JsonRpcParams, DeserializeOwned};
-use jsonrpsee_ws_client::{Subscription, WsClient as RpcClient, WsClientBuilder as RpcClientBuilder};
+use jsonrpsee_ws_client::{WsClient as RpcClient, WsClientBuilder as RpcClientBuilder};
 use num_traits::{Bounded, Zero};
 use pallet_balances::AccountData;
 use pallet_transaction_payment::InclusionFee;
@@ -38,7 +39,7 @@ const SUB_API_GRANDPA_AUTHORITIES: &str = "GrandpaApi_grandpa_authorities";
 const MAX_SUBSCRIPTION_CAPACITY: usize = 4096;
 
 /// Opaque justifications subscription type.
-pub struct JustificationsSubscription(tokio::runtime::Handle, Arc<Mutex<Subscription<Bytes>>>);
+pub struct JustificationsSubscription(Arc<Mutex<futures::channel::mpsc::Receiver<Option<Bytes>>>>);
 
 /// Opaque GRANDPA authorities set.
 pub type OpaqueGrandpaAuthoritiesSet = Vec<u8>;
@@ -363,7 +364,7 @@ impl<C: Chain> Client<C> {
 
 	/// Return new justifications stream.
 	pub async fn subscribe_justifications(&self) -> Result<JustificationsSubscription> {
-		let subscription = self
+		let mut subscription = self
 			.jsonrpsee_execute(move |client| async move {
 				Ok(client
 					.subscribe(
@@ -374,10 +375,38 @@ impl<C: Chain> Client<C> {
 					.await?)
 			})
 			.await?;
-		Ok(JustificationsSubscription(
-			self.tokio.handle().clone(),
-			Arc::new(Mutex::new(subscription)),
-		))
+		let (mut sender, receiver) = futures::channel::mpsc::channel(MAX_SUBSCRIPTION_CAPACITY);
+		self.tokio.spawn(async move {
+			loop {
+				match subscription.next().await {
+					Ok(Some(justification)) => {
+						if sender.send(Some(justification)).await.is_err() {
+							break;
+						}
+					}
+					Ok(None) => {
+						log::trace!(
+							target: "bridge",
+							"{} justifications subscription stream has returned None. Stream needs to be restarted.",
+							C::NAME,
+						);
+						let _ = sender.send(None).await;
+						break;
+					}
+					Err(e) => {
+						log::trace!(
+							target: "bridge",
+							"{} justifications subscription stream has returned '{:?}'. Stream needs to be restarted.",
+							C::NAME,
+							e,
+						);
+						let _ = sender.send(None).await;
+						break;
+					}
+				}
+			}
+		});
+		Ok(JustificationsSubscription(Arc::new(Mutex::new(receiver))))
 	}
 
 	/// Execute jsonrpsee future in tokio context.
@@ -397,10 +426,8 @@ impl<C: Chain> Client<C> {
 impl JustificationsSubscription {
 	/// Return next justification from the subscription.
 	pub async fn next(&self) -> Result<Option<Bytes>> {
-		let subscription = self.1.clone();
-		self.0
-			.spawn(async move { subscription.lock().await.next().await })
-			.await?
-			.map_err(Error::RpcError)
+		let mut receiver = self.0.lock().await;
+		let justification = receiver.next().await;
+		Ok(justification.unwrap_or(None))
 	}
 }

--- a/relays/client-substrate/src/client.rs
+++ b/relays/client-substrate/src/client.rs
@@ -39,7 +39,7 @@ const SUB_API_GRANDPA_AUTHORITIES: &str = "GrandpaApi_grandpa_authorities";
 const MAX_SUBSCRIPTION_CAPACITY: usize = 4096;
 
 /// Opaque justifications subscription type.
-pub struct JustificationsSubscription(Arc<Mutex<futures::channel::mpsc::Receiver<Option<Bytes>>>>);
+pub struct JustificationsSubscription(Mutex<futures::channel::mpsc::Receiver<Option<Bytes>>>);
 
 /// Opaque GRANDPA authorities set.
 pub type OpaqueGrandpaAuthoritiesSet = Vec<u8>;
@@ -406,7 +406,7 @@ impl<C: Chain> Client<C> {
 				}
 			}
 		});
-		Ok(JustificationsSubscription(Arc::new(Mutex::new(receiver))))
+		Ok(JustificationsSubscription(Mutex::new(receiver)))
 	}
 
 	/// Execute jsonrpsee future in tokio context.


### PR DESCRIPTION
We read justifications are read from the stream using `stream.next().now_or_never()`. In current code, every time `next` is called on the stream, additional tokio task is spawned. And because of that, only one justification is read from the stream, every time we awake. Even though the stream has more unread justifications. This PR changes the way how `stream::next()` is implemented - instead of spawning tokio task every time we call `next`, it is only called once (when stream is created) and keep running, filling justifications channel. This channel is polled from `stream::next()`, meaning that we only deal with single executor there.

I've also added couple of traces to help debugging similar issues in the future