### PR TITLE
When restarting client, also "restart" tokio runtime

### DIFF
--- a/relays/client-ethereum/src/client.rs
+++ b/relays/client-ethereum/src/client.rs
@@ -76,7 +76,9 @@ impl Client {
 
 	/// Reopen client connection.
 	pub async fn reconnect(&mut self) -> Result<()> {
-		self.client = Self::build_client(&self.params).await?.1;
+		let (tokio, client) = Self::build_client(self.params.clone()).await?;
+		self.tokio = tokio;
+		self.client = client;
 		Ok(())
 	}
 }

--- a/relays/client-ethereum/src/client.rs
+++ b/relays/client-ethereum/src/client.rs
@@ -76,7 +76,7 @@ impl Client {
 
 	/// Reopen client connection.
 	pub async fn reconnect(&mut self) -> Result<()> {
-		let (tokio, client) = Self::build_client(self.params.clone()).await?;
+		let (tokio, client) = Self::build_client(&self.params).await?;
 		self.tokio = tokio;
 		self.client = client;
 		Ok(())

--- a/relays/client-substrate/src/client.rs
+++ b/relays/client-substrate/src/client.rs
@@ -125,7 +125,9 @@ impl<C: Chain> Client<C> {
 
 	/// Reopen client connection.
 	pub async fn reconnect(&mut self) -> Result<()> {
-		self.client = Self::build_client(self.params.clone()).await?.1;
+		let (tokio, client) = Self::build_client(self.params.clone()).await?;
+		self.tokio = tokio;
+		self.client = client;
 		Ok(())
 	}
 


### PR DESCRIPTION
This has happened today with Millau -> Rialto sync (this keeps appearing in logs, so 'restart' hasn't helped):
```
Error retrieving state from Rialto node: RpcError(RestartNeeded("Error reason could not be found. This is a bug. Please open an issue.")). Going to restart
Restarting relay loop
```

My guess is that's because I was dropping just-created runtime, which was used to recreate client.