### PR TITLE
Weight of `increase_message_fee` call depends on stored message size

### DIFF
--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -393,13 +393,13 @@ decl_module! {
 		}
 
 		/// Pay additional fee for the message.
-		#[weight = T::WeightInfo::increase_message_fee()]
+		#[weight = T::WeightInfo::maximal_increase_message_fee()]
 		pub fn increase_message_fee(
 			origin,
 			lane_id: LaneId,
 			nonce: MessageNonce,
 			additional_fee: T::OutboundMessageFee,
-		) -> DispatchResult {
+		) -> DispatchResultWithPostInfo {
 			ensure_not_halted::<T, I>()?;
 			// if someone tries to pay for already-delivered message, we're rejecting this intention
 			// (otherwise this additional fee will be locked forever in relayers fund)
@@ -432,7 +432,7 @@ decl_module! {
 
 			// and finally update fee in the storage
 			let message_key = MessageKey { lane_id, nonce };
-			OutboundMessages::<T, I>::mutate(message_key, |message_data| {
+			let message_size = OutboundMessages::<T, I>::mutate(message_key, |message_data| {
 				// saturating_add is fine here - overflow here means that someone controls all
 				// chain funds, which shouldn't ever happen + `pay_delivery_and_dispatch_fee`
 				// above will fail before we reach here
@@ -440,9 +440,19 @@ decl_module! {
 					.as_mut()
 					.expect("the message is sent and not yet delivered; so it is in the storage; qed");
 				message_data.fee = message_data.fee.saturating_add(&additional_fee);
+				message_data.payload.len()
 			});
 
-			Ok(())
+			// compute actual dispatch weight that depends on the stored message size
+			let actual_weight = sp_std::cmp::min(
+				T::WeightInfo::maximal_increase_message_fee(),
+				T::WeightInfo::increase_message_fee(message_size as _),
+			);
+
+			Ok(PostDispatchInfo {
+				actual_weight: Some(actual_weight),
+				pays_fee: Pays::Yes,
+			})
 		}
 
 		/// Receive messages proof from bridged chain.
@@ -2095,6 +2105,46 @@ mod tests {
 					UnrewardedRelayersState::default(),
 				),
 				Error::<TestRuntime, DefaultInstance>::TryingToConfirmMoreMessagesThanExpected,
+			);
+		});
+	}
+
+	#[test]
+	fn increase_message_fee_weight_depends_on_message_size() {
+		run_test(|| {
+			let mut small_payload = message_payload(0, 100);
+			let mut large_payload = message_payload(1, 100);
+			small_payload.extra = vec![1; 100];
+			large_payload.extra = vec![2; 16_384];
+
+			assert_ok!(Pallet::<TestRuntime>::send_message(
+				Origin::signed(1),
+				TEST_LANE_ID,
+				small_payload,
+				100,
+			));
+			assert_ok!(Pallet::<TestRuntime>::send_message(
+				Origin::signed(1),
+				TEST_LANE_ID,
+				large_payload,
+				100,
+			));
+
+			let small_weight = Pallet::<TestRuntime>::increase_message_fee(Origin::signed(1), TEST_LANE_ID, 1, 1)
+				.expect("increase_message_fee has failed")
+				.actual_weight
+				.expect("increase_message_fee always returns Some");
+
+			let large_weight = Pallet::<TestRuntime>::increase_message_fee(Origin::signed(1), TEST_LANE_ID, 2, 1)
+				.expect("increase_message_fee has failed")
+				.actual_weight
+				.expect("increase_message_fee always returns Some");
+
+			assert!(
+				large_weight > small_weight,
+				"Actual post-dispatch weigth for larger message {} must be larger than {} for small message",
+				large_weight,
+				small_weight,
 			);
 		});
 	}

--- a/modules/messages/src/mock.rs
+++ b/modules/messages/src/mock.rs
@@ -56,6 +56,8 @@ pub struct TestPayload {
 	/// Note: in correct code `dispatch_result.unspent_weight` will always be <= `declared_weight`, but for test
 	/// purposes we'll be making it larger than `declared_weight` sometimes.
 	pub dispatch_result: MessageDispatchResult,
+	/// Extra bytes that affect payload size.
+	pub extra: Vec<u8>,
 }
 pub type TestMessageFee = u64;
 pub type TestRelayer = u64;
@@ -183,7 +185,7 @@ impl Config for TestRuntime {
 
 impl Size for TestPayload {
 	fn size_hint(&self) -> u32 {
-		16
+		16 + self.extra.len() as u32
 	}
 }
 
@@ -466,6 +468,7 @@ pub const fn message_payload(id: u64, declared_weight: Weight) -> TestPayload {
 		id,
 		declared_weight,
 		dispatch_result: dispatch_result(0),
+		extra: Vec::new(),
 	}
 }
 

--- a/modules/messages/src/weights.rs
+++ b/modules/messages/src/weights.rs
@@ -51,7 +51,8 @@ pub trait WeightInfo {
 	fn send_minimal_message_worst_case() -> Weight;
 	fn send_1_kb_message_worst_case() -> Weight;
 	fn send_16_kb_message_worst_case() -> Weight;
-	fn increase_message_fee() -> Weight;
+	fn maximal_increase_message_fee() -> Weight;
+	fn increase_message_fee(i: u32) -> Weight;
 	fn receive_single_message_proof() -> Weight;
 	fn receive_two_messages_proof() -> Weight;
 	fn receive_single_message_proof_with_outbound_lane_state() -> Weight;
@@ -88,8 +89,14 @@ impl<T: frame_system::Config> WeightInfo for RialtoWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(12 as Weight))
 	}
-	fn increase_message_fee() -> Weight {
-		(6_709_925_000 as Weight)
+	fn maximal_increase_message_fee() -> Weight {
+		(6_781_470_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+	}
+	fn increase_message_fee(i: u32) -> Weight {
+		(114_963_000 as Weight)
+			.saturating_add((6_000 as Weight).saturating_mul(i as Weight))
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
@@ -202,8 +209,14 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(12 as Weight))
 	}
-	fn increase_message_fee() -> Weight {
-		(6_709_925_000 as Weight)
+	fn maximal_increase_message_fee() -> Weight {
+		(6_781_470_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+	}
+	fn increase_message_fee(i: u32) -> Weight {
+		(114_963_000 as Weight)
+			.saturating_add((6_000 as Weight).saturating_mul(i as Weight))
 			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}


### PR DESCRIPTION
related to #916

There are several ways on how to solve this particular problem:
1) we may ask submitter to provide size of message in the call. Then there'll be no need in post-dispatch weight at all. But this also has bad side effect - since we may only check payload size after it is read from the storage AND it is read what consumes most weight => then submitter may just pass zero as payload size && we'll be unable to charge larger amount, even though we have spent more time than it was scheduled;
2) instead of having two benchmarks, we may have just one. But then we'll need maximal message size for computing pre-dispatch weight. And maximal message size is what I'm trying to keep outside of basic pallet logic;
3) this PR.