### PR TITLE
Improve traces of message generator scripts

### DIFF
--- a/deployments/bridges/rialto-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-millau/docker-compose.yml
@@ -52,6 +52,7 @@ services:
   relay-messages-millau-to-rialto-generator:
     <<: *sub-bridge-relay
     environment:
+      RUST_LOG: bridge=trace
       MSG_EXCHANGE_GEN_SECONDARY_LANE: "00000001"
     entrypoint: /entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
     ports:
@@ -62,6 +63,7 @@ services:
   relay-messages-rialto-to-millau-lane-00000001:
     <<: *sub-bridge-relay
     environment:
+      RUST_LOG: bridge=trace
       MSG_EXCHANGE_GEN_LANE: "00000001"
     entrypoint: /entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
     ports:

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -25,6 +25,8 @@ rand_sleep() {
 	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
 	echo "Sleeping $SUBMIT_DELAY_S seconds..."
 	sleep $SUBMIT_DELAY_S
+	NOW=`date "+%Y-%m-%d %H:%M:%S"`
+	echo "Woke up at $NOW"
 }
 
 # start sending large messages immediately

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -25,6 +25,8 @@ rand_sleep() {
 	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
 	echo "Sleeping $SUBMIT_DELAY_S seconds..."
 	sleep $SUBMIT_DELAY_S
+	NOW=`date "+%Y-%m-%d %H:%M:%S"`
+	echo "Woke up at $NOW"
 }
 
 # start sending large messages immediately


### PR DESCRIPTION
We're (occasionally) seeing:
```
[Alerting] Messages from Millau to Rialto are not being delivered
[OK] Messages from Millau to Rialto are not being delivered
```
last couple of weeks. Every time it happens (I've seen logs twice), there are lines like "Sent 63 transactions to revalidation queue". So it looks like txpool is full of transactions, but they are not included into block (blocks near these alerts often have 2 transactions included). First step in diagnosing this issue is adding some more detailed logs. My guess is that alert appears when we're submitting large number of messages and probably our nodes just need some more time to mine all transactions => we need to increase alert interval. But this needs to be proved.