### PR TITLE
Unify error enums in substrate and ethereum clients with `thiserror`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "thiserror",
  "time 0.2.25",
 ]
 
@@ -6115,6 +6116,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "relay-utils",
+ "thiserror",
  "tokio 1.8.1",
  "web3",
 ]
@@ -6248,6 +6250,7 @@ dependencies = [
  "sp-storage",
  "sp-trie",
  "sp-version",
+ "thiserror",
  "tokio 1.8.1",
 ]
 
@@ -9172,18 +9175,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/relays/bin-ethereum/Cargo.toml
+++ b/relays/bin-ethereum/Cargo.toml
@@ -25,6 +25,7 @@ num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
 time = "0.2"
+thiserror = "1.0.26"
 
 # Bridge dependencies
 

--- a/relays/bin-ethereum/src/rpc_errors.rs
+++ b/relays/bin-ethereum/src/rpc_errors.rs
@@ -17,48 +17,30 @@
 use relay_ethereum_client::Error as EthereumNodeError;
 use relay_substrate_client::Error as SubstrateNodeError;
 use relay_utils::MaybeConnectionError;
+use thiserror::Error;
 
 /// Contains common errors that can occur when
 /// interacting with a Substrate or Ethereum node
 /// through RPC.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum RpcError {
 	/// The arguments to the RPC method failed to serialize.
-	Serialization(serde_json::Error),
+	#[error("RPC arguments serialization failed: {0}")]
+	Serialization(#[from] serde_json::Error),
 	/// An error occurred when interacting with an Ethereum node.
-	Ethereum(EthereumNodeError),
+	#[error("Ethereum node error: {0}")]
+	Ethereum(#[from] EthereumNodeError),
 	/// An error occured when interacting with a Substrate node.
-	Substrate(SubstrateNodeError),
+	#[error("Substrate node error: {0}")]
+	Substrate(#[from] SubstrateNodeError),
 	/// Error running relay loop.
+	#[error("{0}")]
 	SyncLoop(String),
 }
 
 impl From<RpcError> for String {
 	fn from(err: RpcError) -> Self {
-		match err {
-			RpcError::Serialization(e) => e.to_string(),
-			RpcError::Ethereum(e) => e.to_string(),
-			RpcError::Substrate(e) => e.to_string(),
-			RpcError::SyncLoop(e) => e,
-		}
-	}
-}
-
-impl From<serde_json::Error> for RpcError {
-	fn from(err: serde_json::Error) -> Self {
-		Self::Serialization(err)
-	}
-}
-
-impl From<EthereumNodeError> for RpcError {
-	fn from(err: EthereumNodeError) -> Self {
-		Self::Ethereum(err)
-	}
-}
-
-impl From<SubstrateNodeError> for RpcError {
-	fn from(err: SubstrateNodeError) -> Self {
-		Self::Substrate(err)
+		format!("{}", err)
 	}
 }
 

--- a/relays/client-ethereum/Cargo.toml
+++ b/relays/client-ethereum/Cargo.toml
@@ -18,3 +18,4 @@ log = "0.4.11"
 relay-utils = { path = "../utils" }
 tokio = "1.8"
 web3 = { git = "https://github.com/svyatonik/rust-web3.git", branch = "bump-deps" }
+thiserror = "1.0.26"

--- a/relays/client-ethereum/src/error.rs
+++ b/relays/client-ethereum/src/error.rs
@@ -20,47 +20,45 @@ use crate::types::U256;
 
 use jsonrpsee_ws_client::Error as RpcError;
 use relay_utils::MaybeConnectionError;
+use thiserror::Error;
 
 /// Result type used by Ethereum client.
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can occur only when interacting with
 /// an Ethereum node through RPC.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
 	/// IO error.
-	Io(std::io::Error),
+	#[error("IO error: {0}")]
+	Io(#[from] std::io::Error),
 	/// An error that can occur when making an HTTP request to
 	/// an JSON-RPC client.
-	RpcError(RpcError),
+	#[error("RPC error: {0}")]
+	RpcError(#[from] RpcError),
 	/// Failed to parse response.
+	#[error("Response parse failed: {0}")]
 	ResponseParseFailed(String),
 	/// We have received a header with missing fields.
+	#[error("Incomplete Ethereum Header Received (missing some of required fields - hash, number, logs_bloom).")]
 	IncompleteHeader,
 	/// We have received a transaction missing a `raw` field.
+	#[error("Incomplete Ethereum Transaction (missing required field - raw).")]
 	IncompleteTransaction,
 	/// An invalid Substrate block number was received from
 	/// an Ethereum node.
+	#[error("Received an invalid Substrate block from Ethereum Node.")]
 	InvalidSubstrateBlockNumber,
 	/// An invalid index has been received from an Ethereum node.
+	#[error("Received an invalid incomplete index from Ethereum Node.")]
 	InvalidIncompleteIndex,
 	/// The client we're connected to is not synced, so we can't rely on its state. Contains
 	/// number of unsynced headers.
+	#[error("Ethereum client is not synced: syncing {0} headers.")]
 	ClientNotSynced(U256),
 	/// Custom logic error.
+	#[error("{0}")]
 	Custom(String),
-}
-
-impl From<RpcError> for Error {
-	fn from(error: RpcError) -> Self {
-		Error::RpcError(error)
-	}
-}
-
-impl From<std::io::Error> for Error {
-	fn from(error: std::io::Error) -> Self {
-		Error::Io(error)
-	}
 }
 
 impl From<tokio::task::JoinError> for Error {
@@ -78,26 +76,5 @@ impl MaybeConnectionError for Error {
 				| Error::RpcError(RpcError::RestartNeeded(_))
 				| Error::ClientNotSynced(_),
 		)
-	}
-}
-
-impl ToString for Error {
-	fn to_string(&self) -> String {
-		match self {
-			Self::Io(e) => e.to_string(),
-			Self::RpcError(e) => e.to_string(),
-			Self::ResponseParseFailed(e) => e.to_string(),
-			Self::IncompleteHeader => {
-				"Incomplete Ethereum Header Received (missing some of required fields - hash, number, logs_bloom)"
-					.to_string()
-			}
-			Self::IncompleteTransaction => "Incomplete Ethereum Transaction (missing required field - raw)".to_string(),
-			Self::InvalidSubstrateBlockNumber => "Received an invalid Substrate block from Ethereum Node".to_string(),
-			Self::InvalidIncompleteIndex => "Received an invalid incomplete index from Ethereum Node".to_string(),
-			Self::ClientNotSynced(missing_headers) => {
-				format!("Ethereum client is not synced: syncing {} headers", missing_headers)
-			}
-			Self::Custom(ref e) => e.clone(),
-		}
 	}
 }

--- a/relays/client-substrate/Cargo.toml
+++ b/relays/client-substrate/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.11"
 num-traits = "0.2"
 rand = "0.7"
 tokio = "1.8"
+thiserror = "1.0.26"
 
 # Bridge dependencies
 

--- a/relays/client-substrate/src/error.rs
+++ b/relays/client-substrate/src/error.rs
@@ -19,61 +19,43 @@
 use jsonrpsee_ws_client::Error as RpcError;
 use relay_utils::MaybeConnectionError;
 use sc_rpc_api::system::Health;
+use thiserror::Error;
 
 /// Result type used by Substrate client.
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can occur only when interacting with
 /// a Substrate node through RPC.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
 	/// IO error.
-	Io(std::io::Error),
+	#[error("IO error: {0}")]
+	Io(#[from] std::io::Error),
 	/// An error that can occur when making a request to
 	/// an JSON-RPC server.
-	RpcError(RpcError),
+	#[error("RPC error: {0}")]
+	RpcError(#[from] RpcError),
 	/// The response from the server could not be SCALE decoded.
-	ResponseParseFailed(codec::Error),
+	#[error("Response parse failed: {0}")]
+	ResponseParseFailed(#[from] codec::Error),
 	/// The Substrate bridge pallet has not yet been initialized.
+	#[error("The Substrate bridge pallet has not been initialized yet.")]
 	UninitializedBridgePallet,
 	/// Account does not exist on the chain.
+	#[error("Account does not exist on the chain.")]
 	AccountDoesNotExist,
 	/// Runtime storage is missing mandatory ":code:" entry.
+	#[error("Mandatory :code: entry is missing from runtime storage.")]
 	MissingMandatoryCodeEntry,
 	/// The client we're connected to is not synced, so we can't rely on its state.
+	#[error("Substrate client is not synced {0}.")]
 	ClientNotSynced(Health),
 	/// An error has happened when we have tried to parse storage proof.
+	#[error("Error when parsing storage proof: {0:?}.")]
 	StorageProofError(bp_runtime::StorageProofError),
 	/// Custom logic error.
+	#[error("{0}")]
 	Custom(String),
-}
-
-impl std::error::Error for Error {
-	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		match self {
-			Self::Io(ref e) => Some(e),
-			Self::RpcError(ref e) => Some(e),
-			Self::ResponseParseFailed(ref e) => Some(e),
-			Self::UninitializedBridgePallet => None,
-			Self::AccountDoesNotExist => None,
-			Self::MissingMandatoryCodeEntry => None,
-			Self::ClientNotSynced(_) => None,
-			Self::StorageProofError(_) => None,
-			Self::Custom(_) => None,
-		}
-	}
-}
-
-impl From<RpcError> for Error {
-	fn from(error: RpcError) -> Self {
-		Error::RpcError(error)
-	}
-}
-
-impl From<std::io::Error> for Error {
-	fn from(error: std::io::Error) -> Self {
-		Error::Io(error)
-	}
 }
 
 impl From<tokio::task::JoinError> for Error {
@@ -91,29 +73,5 @@ impl MaybeConnectionError for Error {
 				| Error::RpcError(RpcError::RestartNeeded(_))
 				| Error::ClientNotSynced(_),
 		)
-	}
-}
-
-impl std::fmt::Display for Error {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		let s = match self {
-			Self::Io(e) => e.to_string(),
-			Self::RpcError(e) => e.to_string(),
-			Self::ResponseParseFailed(e) => e.to_string(),
-			Self::UninitializedBridgePallet => "The Substrate bridge pallet has not been initialized yet.".into(),
-			Self::AccountDoesNotExist => "Account does not exist on the chain".into(),
-			Self::MissingMandatoryCodeEntry => "Mandatory :code: entry is missing from runtime storage".into(),
-			Self::StorageProofError(e) => format!("Error when parsing storage proof: {:?}", e),
-			Self::ClientNotSynced(health) => format!("Substrate client is not synced: {}", health),
-			Self::Custom(e) => e.clone(),
-		};
-
-		write!(f, "{}", s)
-	}
-}
-
-impl From<Error> for String {
-	fn from(error: Error) -> String {
-		error.to_string()
 	}
 }


### PR DESCRIPTION
Related to https://github.com/paritytech/parity-bridges-common/issues/857