### PR TITLE
Remove unnessary deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4977,7 +4977,6 @@ dependencies = [
  "bitvec",
  "bp-message-dispatch",
  "bp-messages",
- "bp-rialto",
  "bp-runtime",
  "frame-benchmarking",
  "frame-support",

--- a/modules/messages/Cargo.toml
+++ b/modules/messages/Cargo.toml
@@ -17,7 +17,6 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 
 bp-message-dispatch = { path = "../../primitives/message-dispatch", default-features = false }
 bp-messages = { path = "../../primitives/messages", default-features = false }
-bp-rialto = { path = "../../primitives/chain-rialto", default-features = false }
 bp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 # Substrate Dependencies
@@ -41,7 +40,6 @@ std = [
 	"bp-message-dispatch/std",
 	"bp-messages/std",
 	"bp-runtime/std",
-	"bp-rialto/std",
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/modules/messages/src/weights_ext.rs
+++ b/modules/messages/src/weights_ext.rs
@@ -29,6 +29,11 @@ pub const EXPECTED_DEFAULT_MESSAGE_LENGTH: u32 = 128;
 /// we're checking here would fit 1KB.
 const SIGNED_EXTENSIONS_SIZE: u32 = 1024;
 
+/// Number of extra bytes (excluding size of storage value itself) of storage proof, built at
+/// Rialto chain. This mostly depends on number of entries (and their density) in the storage trie.
+/// Some reserve is reserved to account future chain growth.
+pub const EXTRA_STORAGE_PROOF_SIZE: u32 = 1024;
+
 /// Ensure that weights from `WeightInfoExt` implementation are looking correct.
 pub fn ensure_weights_are_correct<W: WeightInfoExt>(
 	expected_default_message_delivery_tx_weight: Weight,
@@ -344,12 +349,12 @@ pub trait WeightInfoExt: WeightInfo {
 
 impl WeightInfoExt for () {
 	fn expected_extra_storage_proof_size() -> u32 {
-		bp_rialto::EXTRA_STORAGE_PROOF_SIZE
+		EXTRA_STORAGE_PROOF_SIZE
 	}
 }
 
 impl<T: frame_system::Config> WeightInfoExt for crate::weights::RialtoWeight<T> {
 	fn expected_extra_storage_proof_size() -> u32 {
-		bp_rialto::EXTRA_STORAGE_PROOF_SIZE
+		EXTRA_STORAGE_PROOF_SIZE
 	}
 }


### PR DESCRIPTION
I guess the message pallet should not contain `bp-rialto`(A specific chain primitive) dep.