### PR TITLE
Remove fund account checks from upgrade.

### DIFF
--- a/modules/messages/src/instant_payments.rs
+++ b/modules/messages/src/instant_payments.rs
@@ -57,20 +57,15 @@ where
 {
 	type Error = &'static str;
 
-	fn initialize(relayer_fund_account: &T::AccountId) -> usize {
-		assert!(
-			frame_system::Pallet::<T>::account_exists(relayer_fund_account),
-			"The relayer fund account ({:?}) must exist for the message lanes pallet to work correctly.",
-			relayer_fund_account,
-		);
-		1
-	}
-
 	fn pay_delivery_and_dispatch_fee(
 		submitter: &Sender<T::AccountId>,
 		fee: &Currency::Balance,
 		relayer_fund_account: &T::AccountId,
 	) -> Result<(), Self::Error> {
+		if !frame_system::Pallet::<T>::account_exists(relayer_fund_account) {
+			return Err("The relayer fund account must exist for the message lanes pallet to work correctly.");
+		}
+
 		let root_account = RootAccount::get();
 		let account = match submitter {
 			Sender::Signed(submitter) => submitter,

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -184,15 +184,6 @@ pub mod pallet {
 	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
-	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
-		/// Ensure runtime invariants.
-		fn on_runtime_upgrade() -> Weight {
-			let reads = T::MessageDeliveryAndDispatchPayment::initialize(&Self::relayer_fund_account_id());
-			T::DbWeight::get().reads(reads as u64)
-		}
-	}
-
 	#[pallet::call]
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		/// Change `PalletOwner`.

--- a/primitives/messages/src/source_chain.rs
+++ b/primitives/messages/src/source_chain.rs
@@ -125,14 +125,6 @@ pub trait MessageDeliveryAndDispatchPayment<AccountId, Balance> {
 		relayers_rewards: RelayersRewards<AccountId, Balance>,
 		relayer_fund_account: &AccountId,
 	);
-
-	/// Perform some initialization in externalities-provided environment.
-	///
-	/// For instance you may ensure that particular required accounts or storage items are present.
-	/// Returns the number of storage reads performed.
-	fn initialize(_relayer_fund_account: &AccountId) -> usize {
-		0
-	}
 }
 
 /// Messages bridge API to be used from other pallets.


### PR DESCRIPTION
Reverts some stuff from: https://github.com/paritytech/parity-bridges-common/pull/624

To prevent bricking the chain after upgrade, the check for relayer account is removed from `RuntimeUpgrade` hook and instead it's now checked on every payment.

While this might seem like unnecessary cost, it should be cheap (the account will be in cache) and instead of stalling the chain completely, it's possible to simply fix the incorrect state by topping up the relayer account.