### PR TITLE
Add client methods to `SubstrateMessageLane` trait

### DIFF
--- a/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
+++ b/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
@@ -144,6 +144,14 @@ impl SubstrateMessageLane for MillauMessagesToRialto {
 		);
 		Bytes(transaction.encode())
 	}
+
+	fn source_chain_client(&self) -> Client<Self::SourceChain> {
+		self.message_lane.source_client.clone()
+	}
+
+	fn target_chain_client(&self) -> Client<Self::TargetChain> {
+		self.message_lane.target_client.clone()
+	}
 }
 
 /// Millau node as messages source.
@@ -218,19 +226,8 @@ pub async fn run(
 				relayer_mode: params.relayer_mode,
 			},
 		},
-		MillauSourceClient::new(
-			source_client.clone(),
-			lane.clone(),
-			lane_id,
-			params.target_to_source_headers_relay,
-		),
-		RialtoTargetClient::new(
-			params.target_client,
-			lane,
-			lane_id,
-			metrics_values,
-			params.source_to_target_headers_relay,
-		),
+		MillauSourceClient::new(lane.clone(), lane_id, params.target_to_source_headers_relay),
+		RialtoTargetClient::new(lane, lane_id, metrics_values, params.source_to_target_headers_relay),
 		metrics_params,
 		futures::future::pending(),
 	)

--- a/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
+++ b/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
@@ -144,6 +144,14 @@ impl SubstrateMessageLane for RialtoMessagesToMillau {
 		);
 		Bytes(transaction.encode())
 	}
+
+	fn source_chain_client(&self) -> Client<Self::SourceChain> {
+		self.message_lane.source_client.clone()
+	}
+
+	fn target_chain_client(&self) -> Client<Self::TargetChain> {
+		self.message_lane.target_client.clone()
+	}
 }
 
 /// Rialto node as messages source.
@@ -217,19 +225,8 @@ pub async fn run(
 				relayer_mode: params.relayer_mode,
 			},
 		},
-		RialtoSourceClient::new(
-			source_client.clone(),
-			lane.clone(),
-			lane_id,
-			params.target_to_source_headers_relay,
-		),
-		MillauTargetClient::new(
-			params.target_client,
-			lane,
-			lane_id,
-			metrics_values,
-			params.source_to_target_headers_relay,
-		),
+		RialtoSourceClient::new(lane.clone(), lane_id, params.target_to_source_headers_relay),
+		MillauTargetClient::new(lane, lane_id, metrics_values, params.source_to_target_headers_relay),
 		metrics_params,
 		futures::future::pending(),
 	)

--- a/relays/bin-substrate/src/chains/rococo_messages_to_wococo.rs
+++ b/relays/bin-substrate/src/chains/rococo_messages_to_wococo.rs
@@ -145,6 +145,14 @@ impl SubstrateMessageLane for RococoMessagesToWococo {
 		);
 		Bytes(transaction.encode())
 	}
+
+	fn source_chain_client(&self) -> Client<Self::SourceChain> {
+		self.message_lane.source_client.clone()
+	}
+
+	fn target_chain_client(&self) -> Client<Self::TargetChain> {
+		self.message_lane.target_client.clone()
+	}
 }
 
 /// Rococo node as messages source.
@@ -224,19 +232,8 @@ pub async fn run(
 				relayer_mode: params.relayer_mode,
 			},
 		},
-		RococoSourceClient::new(
-			source_client.clone(),
-			lane.clone(),
-			lane_id,
-			params.target_to_source_headers_relay,
-		),
-		WococoTargetClient::new(
-			params.target_client,
-			lane,
-			lane_id,
-			metrics_values,
-			params.source_to_target_headers_relay,
-		),
+		RococoSourceClient::new(lane.clone(), lane_id, params.target_to_source_headers_relay),
+		WococoTargetClient::new(lane, lane_id, metrics_values, params.source_to_target_headers_relay),
 		metrics_params,
 		futures::future::pending(),
 	)

--- a/relays/bin-substrate/src/chains/wococo_messages_to_rococo.rs
+++ b/relays/bin-substrate/src/chains/wococo_messages_to_rococo.rs
@@ -144,6 +144,14 @@ impl SubstrateMessageLane for WococoMessagesToRococo {
 		);
 		Bytes(transaction.encode())
 	}
+
+	fn source_chain_client(&self) -> Client<Self::SourceChain> {
+		self.message_lane.source_client.clone()
+	}
+
+	fn target_chain_client(&self) -> Client<Self::TargetChain> {
+		self.message_lane.target_client.clone()
+	}
 }
 
 /// Wococo node as messages source.
@@ -223,19 +231,8 @@ pub async fn run(
 				relayer_mode: params.relayer_mode,
 			},
 		},
-		WococoSourceClient::new(
-			source_client.clone(),
-			lane.clone(),
-			lane_id,
-			params.target_to_source_headers_relay,
-		),
-		RococoTargetClient::new(
-			params.target_client,
-			lane,
-			lane_id,
-			metrics_values,
-			params.source_to_target_headers_relay,
-		),
+		WococoSourceClient::new(lane.clone(), lane_id, params.target_to_source_headers_relay),
+		RococoTargetClient::new(lane, lane_id, metrics_values, params.source_to_target_headers_relay),
 		metrics_params,
 		futures::future::pending(),
 	)

--- a/relays/lib-substrate-relay/src/messages_lane.rs
+++ b/relays/lib-substrate-relay/src/messages_lane.rs
@@ -115,6 +115,12 @@ pub trait SubstrateMessageLane: 'static + Clone + Send + Sync {
 		generated_at_header: TargetHeaderIdOf<Self::MessageLane>,
 		proof: <Self::MessageLane as MessageLane>::MessagesReceivingProof,
 	) -> Bytes;
+
+	/// Get the source chain client.
+	fn source_chain_client(&self) -> Client<Self::SourceChain>;
+
+	/// Get the target chain client.
+	fn target_chain_client(&self) -> Client<Self::TargetChain>;
 }
 
 /// Substrate-to-Substrate message lane.


### PR DESCRIPTION
I am not sure if this is the best option but i was checking https://github.com/paritytech/parity-bridges-common/issues/1033 and added 2 new methods into the `SubstrateMessageLane` trait to get rid of the client arguments when creating new `SubstrateMessagesSource` and `SubstrateMessagesTarget` instances.

The implementation is the exact same for `source_chain_client()` and `target_chain_client()` in every substrate chain so i think this could be a bit better if this methods were only implemented in the trait as defaults. Unfortunately, i was not able to code that nor know if it will be possible in this scenario.

Please feel free to close this PR if it is not the approach you are looking for.