### PR TITLE
Added missing constants to Kusama/Polkadot primitives

### DIFF
--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -54,6 +54,12 @@ pub fn derive_account_from_polkadot_id(id: bp_runtime::SourceAccount<AccountId>)
 	AccountIdConverter::convert(encoded_id)
 }
 
+/// Per-byte fee for Kusama transactions.
+pub const TRANSACTION_BYTE_FEE: Balance = 10 * 1_000_000_000_000 / 30_000 / 1_000;
+
+/// Name of the With-Polkadot messages pallet instance in the Kusama runtime.
+pub const WITH_POLKADOT_MESSAGES_PALLET_NAME: &str = "BridgePolkadotMessages";
+
 /// Name of the `KusamaFinalityApi::best_finalized` runtime method.
 pub const BEST_FINALIZED_KUSAMA_HEADER_METHOD: &str = "KusamaFinalityApi_best_finalized";
 /// Name of the `KusamaFinalityApi::is_known_header` runtime method.

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -54,6 +54,12 @@ pub fn derive_account_from_kusama_id(id: bp_runtime::SourceAccount<AccountId>) -
 	AccountIdConverter::convert(encoded_id)
 }
 
+/// Per-byte fee for Polkadot transactions.
+pub const TRANSACTION_BYTE_FEE: Balance = 10 * 10_000_000_000 / 100 / 1_000;
+
+/// Name of the With-Kusama messages pallet instance in the Polkadot runtime.
+pub const WITH_KUSAMA_MESSAGES_PALLET_NAME: &str = "BridgeKusamaMessages";
+
 /// Name of the `PolkadotFinalityApi::best_finalized` runtime method.
 pub const BEST_FINALIZED_POLKADOT_HEADER_METHOD: &str = "PolkadotFinalityApi_best_finalized";
 /// Name of the `PolkadotFinalityApi::is_known_header` runtime method.

--- a/primitives/polkadot-core/src/lib.rs
+++ b/primitives/polkadot-core/src/lib.rs
@@ -138,6 +138,43 @@ pub const MAX_UNREWARDED_RELAYER_ENTRIES_AT_INBOUND_LANE: MessageNonce = 128;
 /// Maximal number of unconfirmed messages at inbound lane.
 pub const MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE: MessageNonce = 8192;
 
+// One important thing about weight-related constants here is that actually we may have
+// different weights on different Polkadot-like chains. But now all deployments are
+// almost the same, so we're exporting constants from this crate.
+
+/// Maximal weight of single message delivery confirmation transaction on Polkadot-like chain.
+///
+/// This value is a result of `pallet_bridge_messages::Pallet::receive_messages_delivery_proof` weight formula
+/// computation for the case when single message is confirmed. The result then must be rounded up to account possible
+/// future runtime upgrades.
+pub const MAX_SINGLE_MESSAGE_DELIVERY_CONFIRMATION_TX_WEIGHT: Weight = 2_000_000_000;
+
+/// Increase of delivery transaction weight on Polkadot-like chain with every additional message byte.
+///
+/// This value is a result of `pallet_bridge_messages::WeightInfoExt::storage_proof_size_overhead(1)` call. The
+/// result then must be rounded up to account possible future runtime upgrades.
+pub const ADDITIONAL_MESSAGE_BYTE_DELIVERY_WEIGHT: Weight = 25_000;
+
+/// Maximal number of bytes, included in the signed Polkadot-like transaction apart from the encoded call itself.
+///
+/// Can be computed by subtracting encoded call size from raw transaction size.
+pub const TX_EXTRA_BYTES: u32 = 256;
+
+/// Weight of single regular message delivery transaction on Polkadot-like chain.
+///
+/// This value is a result of `pallet_bridge_messages::Pallet::receive_messages_proof_weight()` call
+/// for the case when single message of `pallet_bridge_messages::EXPECTED_DEFAULT_MESSAGE_LENGTH` bytes is delivered.
+/// The message must have dispatch weight set to zero. The result then must be rounded up to account
+/// possible future runtime upgrades.
+pub const DEFAULT_MESSAGE_DELIVERY_TX_WEIGHT: Weight = 1_500_000_000;
+
+/// Weight of pay-dispatch-fee operation for inbound messages at Polkadot-like chain.
+///
+/// This value corresponds to the result of `pallet_bridge_messages::WeightInfoExt::pay_inbound_dispatch_fee_overhead()`
+/// call for your chain. Don't put too much reserve there, because it is used to **decrease**
+/// `DEFAULT_MESSAGE_DELIVERY_TX_WEIGHT` cost. So putting large reserve would make delivery transactions cheaper.
+pub const PAY_INBOUND_DISPATCH_FEE_WEIGHT: Weight = 600_000_000;
+
 /// Re-export `time_units` to make usage easier.
 pub use time_units::*;
 


### PR DESCRIPTION
related: https://github.com/paritytech/polkadot/tree/bridges-integration-2

Weight-related constants have the same value as in Rialto<>Millau - we may change it later to reduce costs if it happens that on Kusama/Polakdot weights are much lower (I doubt that)