### PR TITLE
Add --mandatory-headers-only cli option to complex relay

### DIFF
--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -57,6 +57,9 @@ pub struct HeadersAndMessagesSharedParams {
 	lane: Vec<HexLaneId>,
 	#[structopt(long, possible_values = RelayerMode::VARIANTS, case_insensitive = true, default_value = "rational")]
 	relayer_mode: RelayerMode,
+	/// If passed, only mandatory headers (headers that are changing the GRANDPA authorities set) are relayed.
+	#[structopt(long)]
+	only_mandatory_headers: bool,
 	#[structopt(flatten)]
 	prometheus_params: PrometheusParams,
 }
@@ -278,6 +281,7 @@ impl RelayHeadersAndMessages {
 				right_transactions_mortality,
 				LeftToRightFinality::new(right_client.clone(), right_sign.clone()),
 				MAX_MISSING_LEFT_HEADERS_AT_RIGHT,
+				params.shared.only_mandatory_headers,
 			);
 			let right_to_left_on_demand_headers = OnDemandHeadersRelay::new(
 				right_client.clone(),
@@ -285,6 +289,7 @@ impl RelayHeadersAndMessages {
 				left_transactions_mortality,
 				RightToLeftFinality::new(left_client.clone(), left_sign.clone()),
 				MAX_MISSING_RIGHT_HEADERS_AT_LEFT,
+				params.shared.only_mandatory_headers,
 			);
 
 			// Need 2x capacity since we consider both directions for each lane

--- a/relays/lib-substrate-relay/src/on_demand_headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand_headers.rs
@@ -59,6 +59,7 @@ impl<SourceChain: Chain> OnDemandHeadersRelay<SourceChain> {
 		target_transactions_mortality: Option<u32>,
 		pipeline: P,
 		maximal_headers_difference: SourceChain::BlockNumber,
+		only_mandatory_headers: bool,
 	) -> Self
 	where
 		SourceChain: Chain + Debug,
@@ -83,6 +84,7 @@ impl<SourceChain: Chain> OnDemandHeadersRelay<SourceChain> {
 				target_transactions_mortality,
 				pipeline,
 				maximal_headers_difference,
+				only_mandatory_headers,
 				required_header_number,
 			)
 			.await;
@@ -115,6 +117,7 @@ async fn background_task<SourceChain, TargetChain, TargetSign, P>(
 	target_transactions_mortality: Option<u32>,
 	pipeline: P,
 	maximal_headers_difference: SourceChain::BlockNumber,
+	only_mandatory_headers: bool,
 	required_header_number: RequiredHeaderNumberRef<SourceChain>,
 ) where
 	SourceChain: Chain + Debug,
@@ -230,7 +233,7 @@ async fn background_task<SourceChain, TargetChain, TargetSign, P>(
 						tick: std::cmp::max(SourceChain::AVERAGE_BLOCK_INTERVAL, TargetChain::AVERAGE_BLOCK_INTERVAL),
 						recent_finality_proofs_limit: RECENT_FINALITY_PROOFS_LIMIT,
 						stall_timeout: STALL_TIMEOUT,
-						only_mandatory_headers: false,
+						only_mandatory_headers,
 					},
 					MetricsParams::disabled(),
 					futures::future::pending(),


### PR DESCRIPTION
closes #1104 

I don't know of any way to test this at our deployments, because this option affects both directions of the bridge (and I think it is better to keep it this way for simplicity). So enabling it on Rialto<>Millau bridge, will lead to 10-minutes delays of Millau -> Rialto messages delivery => alerts. So - only manual testing here (did it locally). If we'll ever have mock clients, we could have better tests for that.