### PR TITLE
Increase pause before pinging Rialto nodes

### DIFF
--- a/deployments/bridges/poa-rialto/entrypoints/relay-headers-poa-to-rialto-entrypoint.sh
+++ b/deployments/bridges/poa-rialto/entrypoints/relay-headers-poa-to-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
+sleep 60
 curl -v http://poa-node-arthur:8545/api/health
 curl -v http://poa-node-bertha:8545/api/health
 curl -v http://poa-node-carlos:8545/api/health

--- a/deployments/bridges/poa-rialto/entrypoints/relay-headers-rialto-to-poa-entrypoint.sh
+++ b/deployments/bridges/poa-rialto/entrypoints/relay-headers-rialto-to-poa-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
+sleep 60
 
 curl -v http://rialto-node-bob:9933/health
 curl -v http://poa-node-bertha:8545/api/health

--- a/deployments/bridges/poa-rialto/entrypoints/relay-poa-exchange-rialto-entrypoint.sh
+++ b/deployments/bridges/poa-rialto/entrypoints/relay-poa-exchange-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
+sleep 60
 curl -v http://poa-node-arthur:8545/api/health
 curl -v http://poa-node-bertha:8545/api/health
 curl -v http://poa-node-carlos:8545/api/health

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
+sleep 60
 curl -v http://millau-node-bob:9933/health
 curl -v http://rialto-node-bob:9933/health
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
+sleep 60
 curl -v http://millau-node-bob:9933/health
 curl -v http://rialto-node-bob:9933/health
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
+sleep 60
 curl -v http://millau-node-alice:9933/health
 curl -v http://rialto-node-alice:9933/health
 


### PR DESCRIPTION
Rialto startup has become slower after #1053 && relay has failed to start because of failed `curl` this morning.