### PR TITLE
Box large arguments of GRANDPA pallet

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -750,4 +750,12 @@ mod tests {
 			DbWeight::get(),
 		);
 	}
+
+	#[test]
+	fn call_size() {
+		// pallets that are (to be) used by polkadot runtime
+		const MAX_CALL_SIZE: usize = 230; // value from polkadot-runtime tests
+		assert!(core::mem::size_of::<pallet_bridge_grandpa::Call<Runtime>>() <= MAX_CALL_SIZE);
+		assert!(core::mem::size_of::<pallet_bridge_messages::Call<Runtime>>() <= MAX_CALL_SIZE);
+	}
 }

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -1377,4 +1377,12 @@ mod tests {
 			additional_amount
 		});
 	}
+
+	#[test]
+	fn call_size() {
+		// pallets that are (to be) used by polkadot runtime
+		const MAX_CALL_SIZE: usize = 230; // value from polkadot-runtime tests
+		assert!(core::mem::size_of::<pallet_bridge_grandpa::Call<Runtime>>() <= MAX_CALL_SIZE);
+		assert!(core::mem::size_of::<pallet_bridge_messages::Call<Runtime>>() <= MAX_CALL_SIZE);
+	}
 }

--- a/modules/grandpa/src/benchmarking.rs
+++ b/modules/grandpa/src/benchmarking.rs
@@ -80,7 +80,7 @@ fn prepare_benchmark_data<T: Config<I>, I: 'static>(
 		.collect::<Vec<_>>();
 
 	let init_data = InitializationData {
-		header: bp_test_utils::test_header(Zero::zero()),
+		header: Box::new(bp_test_utils::test_header(Zero::zero())),
 		authority_list,
 		set_id: TEST_GRANDPA_SET_ID,
 		is_halted: false,
@@ -109,7 +109,7 @@ benchmarks_instance_pallet! {
 		let v in 1..MAX_VOTE_ANCESTRIES;
 		let caller: T::AccountId = whitelisted_caller();
 		let (header, justification) = prepare_benchmark_data::<T, I>(p, v);
-	}: submit_finality_proof(RawOrigin::Signed(caller), header, justification)
+	}: submit_finality_proof(RawOrigin::Signed(caller), Box::new(header), justification)
 	verify {
 		let header: BridgedHeader<T, I> = bp_test_utils::test_header(header_number::<T, I, _>());
 		let expected_hash = header.hash();

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -598,7 +598,7 @@ pub(crate) fn find_forced_change<H: HeaderT>(
 #[cfg(feature = "runtime-benchmarks")]
 pub fn initialize_for_benchmarks<T: Config<I>, I: 'static>(header: BridgedHeader<T, I>) {
 	initialize_bridge::<T, I>(InitializationData {
-		header,
+		Box::new(header),
 		authority_list: sp_std::vec::Vec::new(), // we don't verify any proofs in external benchmarks
 		set_id: 0,
 		is_halted: false,

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -46,7 +46,7 @@ use frame_support::{ensure, fail};
 use frame_system::{ensure_signed, RawOrigin};
 use sp_finality_grandpa::{ConsensusLog, GRANDPA_ENGINE_ID};
 use sp_runtime::traits::{BadOrigin, Header as HeaderT, Zero};
-use sp_std::convert::TryInto;
+use sp_std::{boxed::Box, convert::TryInto};
 
 #[cfg(test)]
 mod mock;
@@ -130,7 +130,7 @@ pub mod pallet {
 		))]
 		pub fn submit_finality_proof(
 			origin: OriginFor<T>,
-			finality_target: BridgedHeader<T, I>,
+			finality_target: Box<BridgedHeader<T, I>>,
 			justification: GrandpaJustification<BridgedHeader<T, I>>,
 		) -> DispatchResultWithPostInfo {
 			ensure_operational::<T, I>()?;
@@ -166,7 +166,7 @@ pub mod pallet {
 
 			let is_authorities_change_enacted = try_enact_authority_change::<T, I>(&finality_target, set_id)?;
 			<RequestCount<T, I>>::mutate(|count| *count += 1);
-			insert_header::<T, I>(finality_target, hash);
+			insert_header::<T, I>(*finality_target, hash);
 			log::info!(target: "runtime::bridge-grandpa", "Succesfully imported finalized header with hash {:?}!", hash);
 
 			// mandatory header is a header that changes authorities set. The pallet can't go further
@@ -471,7 +471,7 @@ pub mod pallet {
 		let initial_hash = header.hash();
 		<InitialHash<T, I>>::put(initial_hash);
 		<ImportedHashesPointer<T, I>>::put(0);
-		insert_header::<T, I>(header, initial_hash);
+		insert_header::<T, I>(*header, initial_hash);
 
 		let authority_set = bp_header_chain::AuthoritySet::new(authority_list, set_id);
 		<CurrentAuthoritySet<T, I>>::put(authority_set);
@@ -628,7 +628,7 @@ mod tests {
 		let genesis = test_header(0);
 
 		let init_data = InitializationData {
-			header: genesis,
+			header: Box::new(genesis),
 			authority_list: authority_list(),
 			set_id: 1,
 			is_halted: false,
@@ -641,7 +641,7 @@ mod tests {
 		let header = test_header(header.into());
 		let justification = make_default_justification(&header);
 
-		Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification)
+		Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), Box::new(header), justification)
 	}
 
 	fn next_block() {
@@ -828,7 +828,7 @@ mod tests {
 			let justification = make_justification_for_header(params);
 
 			assert_err!(
-				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification,),
+				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), Box::new(header), justification,),
 				<Error<TestRuntime>>::InvalidJustification
 			);
 		})
@@ -844,7 +844,7 @@ mod tests {
 			justification.round = 42;
 
 			assert_err!(
-				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification,),
+				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), Box::new(header), justification,),
 				<Error<TestRuntime>>::InvalidJustification
 			);
 		})
@@ -857,7 +857,7 @@ mod tests {
 
 			let invalid_authority_list = vec![(ALICE.into(), u64::MAX), (BOB.into(), u64::MAX)];
 			let init_data = InitializationData {
-				header: genesis,
+				header: Box::new(genesis),
 				authority_list: invalid_authority_list,
 				set_id: 1,
 				is_halted: false,
@@ -869,7 +869,7 @@ mod tests {
 			let justification = make_default_justification(&header);
 
 			assert_err!(
-				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification,),
+				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), Box::new(header), justification,),
 				<Error<TestRuntime>>::InvalidAuthoritySet
 			);
 		})
@@ -904,7 +904,11 @@ mod tests {
 
 			// Let's import our test header
 			assert_ok!(
-				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header.clone(), justification),
+				Pallet::<TestRuntime>::submit_finality_proof(
+					Origin::signed(1),
+					Box::new(header.clone()),
+					justification
+				),
 				PostDispatchInfo {
 					actual_weight: None,
 					pays_fee: frame_support::weights::Pays::No,
@@ -938,7 +942,7 @@ mod tests {
 
 			// Should not be allowed to import this header
 			assert_err!(
-				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification),
+				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), Box::new(header), justification),
 				<Error<TestRuntime>>::UnsupportedScheduledChange
 			);
 		})
@@ -959,7 +963,7 @@ mod tests {
 
 			// Should not be allowed to import this header
 			assert_err!(
-				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, justification),
+				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), Box::new(header), justification),
 				<Error<TestRuntime>>::UnsupportedScheduledChange
 			);
 		})
@@ -1017,7 +1021,7 @@ mod tests {
 				let mut invalid_justification = make_default_justification(&header);
 				invalid_justification.round = 42;
 
-				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), header, invalid_justification)
+				Pallet::<TestRuntime>::submit_finality_proof(Origin::signed(1), Box::new(header), invalid_justification)
 			};
 
 			initialize_substrate_bridge();

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -598,7 +598,7 @@ pub(crate) fn find_forced_change<H: HeaderT>(
 #[cfg(feature = "runtime-benchmarks")]
 pub fn initialize_for_benchmarks<T: Config<I>, I: 'static>(header: BridgedHeader<T, I>) {
 	initialize_bridge::<T, I>(InitializationData {
-		Box::new(header),
+		header: Box::new(header),
 		authority_list: sp_std::vec::Vec::new(), // we don't verify any proofs in external benchmarks
 		set_id: 0,
 		is_halted: false,

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 use sp_finality_grandpa::{AuthorityList, ConsensusLog, SetId, GRANDPA_ENGINE_ID};
 use sp_runtime::RuntimeDebug;
 use sp_runtime::{generic::OpaqueDigestItemId, traits::Header as HeaderT};
+use sp_std::boxed::Box;
 
 pub mod justification;
 
@@ -62,7 +63,7 @@ impl AuthoritySet {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct InitializationData<H: HeaderT> {
 	/// The header from which we should start syncing.
-	pub header: H,
+	pub header: Box<H>,
 	/// The initial authorities of the pallet.
 	pub authority_list: AuthorityList,
 	/// The ID of the initial authority set.

--- a/relays/bin-substrate/src/chains/kusama_headers_to_polkadot.rs
+++ b/relays/bin-substrate/src/chains/kusama_headers_to_polkadot.rs
@@ -88,7 +88,10 @@ impl SubstrateFinalitySyncPipeline for KusamaFinalityToPolkadot {
 		proof: GrandpaJustification<bp_kusama::Header>,
 	) -> Bytes {
 		let call = relay_polkadot_client::runtime::Call::BridgeKusamaGrandpa(
-			relay_polkadot_client::runtime::BridgeKusamaGrandpaCall::submit_finality_proof(header.into_inner(), proof),
+			relay_polkadot_client::runtime::BridgeKusamaGrandpaCall::submit_finality_proof(
+				Box::new(header.into_inner()),
+				proof,
+			),
 		);
 		let genesis_hash = *self.finality_pipeline.target_client.genesis_hash();
 		let transaction = Polkadot::sign_transaction(

--- a/relays/bin-substrate/src/chains/millau_headers_to_rialto.rs
+++ b/relays/bin-substrate/src/chains/millau_headers_to_rialto.rs
@@ -59,7 +59,8 @@ impl SubstrateFinalitySyncPipeline for MillauFinalityToRialto {
 		header: MillauSyncHeader,
 		proof: GrandpaJustification<bp_millau::Header>,
 	) -> Bytes {
-		let call = rialto_runtime::BridgeGrandpaMillauCall::submit_finality_proof(header.into_inner(), proof).into();
+		let call =
+			rialto_runtime::BridgeGrandpaMillauCall::submit_finality_proof(Box::new(header.into_inner()), proof).into();
 
 		let genesis_hash = *self.finality_pipeline.target_client.genesis_hash();
 		let transaction = Rialto::sign_transaction(

--- a/relays/bin-substrate/src/chains/mod.rs
+++ b/relays/bin-substrate/src/chains/mod.rs
@@ -278,11 +278,11 @@ mod rococo_tests {
 		};
 
 		let actual = relay_rococo_client::runtime::BridgeGrandpaWococoCall::submit_finality_proof(
-			header.clone(),
+			Box::new(header.clone()),
 			justification.clone(),
 		);
 		let expected = millau_runtime::BridgeGrandpaRialtoCall::<millau_runtime::Runtime>::submit_finality_proof(
-			header,
+			Box::new(header),
 			justification,
 		);
 
@@ -327,7 +327,7 @@ mod westend_tests {
 
 		let actual = bp_westend::BridgeGrandpaRococoCall::submit_finality_proof(header.clone(), justification.clone());
 		let expected = millau_runtime::BridgeGrandpaRialtoCall::<millau_runtime::Runtime>::submit_finality_proof(
-			header,
+			Box::new(header),
 			justification,
 		);
 

--- a/relays/bin-substrate/src/chains/polkadot_headers_to_kusama.rs
+++ b/relays/bin-substrate/src/chains/polkadot_headers_to_kusama.rs
@@ -88,7 +88,10 @@ impl SubstrateFinalitySyncPipeline for PolkadotFinalityToKusama {
 		proof: GrandpaJustification<bp_polkadot::Header>,
 	) -> Bytes {
 		let call = relay_kusama_client::runtime::Call::BridgePolkadotGrandpa(
-			relay_kusama_client::runtime::BridgePolkadotGrandpaCall::submit_finality_proof(header.into_inner(), proof),
+			relay_kusama_client::runtime::BridgePolkadotGrandpaCall::submit_finality_proof(
+				Box::new(header.into_inner()),
+				proof,
+			),
 		);
 		let genesis_hash = *self.finality_pipeline.target_client.genesis_hash();
 		let transaction = Kusama::sign_transaction(

--- a/relays/bin-substrate/src/chains/rialto_headers_to_millau.rs
+++ b/relays/bin-substrate/src/chains/rialto_headers_to_millau.rs
@@ -63,7 +63,7 @@ impl SubstrateFinalitySyncPipeline for RialtoFinalityToMillau {
 		let call = millau_runtime::BridgeGrandpaRialtoCall::<
 			millau_runtime::Runtime,
 			millau_runtime::RialtoGrandpaInstance,
-		>::submit_finality_proof(header.into_inner(), proof)
+		>::submit_finality_proof(Box::new(header.into_inner()), proof)
 		.into();
 
 		let genesis_hash = *self.finality_pipeline.target_client.genesis_hash();

--- a/relays/bin-substrate/src/chains/rococo_headers_to_wococo.rs
+++ b/relays/bin-substrate/src/chains/rococo_headers_to_wococo.rs
@@ -83,7 +83,10 @@ impl SubstrateFinalitySyncPipeline for RococoFinalityToWococo {
 		proof: GrandpaJustification<bp_rococo::Header>,
 	) -> Bytes {
 		let call = relay_wococo_client::runtime::Call::BridgeGrandpaRococo(
-			relay_wococo_client::runtime::BridgeGrandpaRococoCall::submit_finality_proof(header.into_inner(), proof),
+			relay_wococo_client::runtime::BridgeGrandpaRococoCall::submit_finality_proof(
+				Box::new(header.into_inner()),
+				proof,
+			),
 		);
 		let genesis_hash = *self.finality_pipeline.target_client.genesis_hash();
 		let transaction = Wococo::sign_transaction(

--- a/relays/bin-substrate/src/chains/westend_headers_to_millau.rs
+++ b/relays/bin-substrate/src/chains/westend_headers_to_millau.rs
@@ -71,7 +71,7 @@ impl SubstrateFinalitySyncPipeline for WestendFinalityToMillau {
 		let call = millau_runtime::BridgeGrandpaWestendCall::<
 			millau_runtime::Runtime,
 			millau_runtime::WestendGrandpaInstance,
-		>::submit_finality_proof(header.into_inner(), proof)
+		>::submit_finality_proof(Box::new(header.into_inner()), proof)
 		.into();
 
 		let genesis_hash = *self.finality_pipeline.target_client.genesis_hash();

--- a/relays/bin-substrate/src/chains/wococo_headers_to_rococo.rs
+++ b/relays/bin-substrate/src/chains/wococo_headers_to_rococo.rs
@@ -88,7 +88,10 @@ impl SubstrateFinalitySyncPipeline for WococoFinalityToRococo {
 		proof: GrandpaJustification<bp_wococo::Header>,
 	) -> Bytes {
 		let call = relay_rococo_client::runtime::Call::BridgeGrandpaWococo(
-			relay_rococo_client::runtime::BridgeGrandpaWococoCall::submit_finality_proof(header.into_inner(), proof),
+			relay_rococo_client::runtime::BridgeGrandpaWococoCall::submit_finality_proof(
+				Box::new(header.into_inner()),
+				proof,
+			),
 		);
 		let genesis_hash = *self.finality_pipeline.target_client.genesis_hash();
 		let transaction = Rococo::sign_transaction(

--- a/relays/client-kusama/src/runtime.rs
+++ b/relays/client-kusama/src/runtime.rs
@@ -96,7 +96,7 @@ pub enum BalancesCall {
 pub enum BridgePolkadotGrandpaCall {
 	#[codec(index = 0)]
 	submit_finality_proof(
-		<PolkadotLike as Chain>::Header,
+		Box<<PolkadotLike as Chain>::Header>,
 		bp_header_chain::justification::GrandpaJustification<<PolkadotLike as Chain>::Header>,
 	),
 	#[codec(index = 1)]

--- a/relays/client-polkadot/src/runtime.rs
+++ b/relays/client-polkadot/src/runtime.rs
@@ -96,7 +96,7 @@ pub enum BalancesCall {
 pub enum BridgeKusamaGrandpaCall {
 	#[codec(index = 0)]
 	submit_finality_proof(
-		<PolkadotLike as Chain>::Header,
+		Box<<PolkadotLike as Chain>::Header>,
 		bp_header_chain::justification::GrandpaJustification<<PolkadotLike as Chain>::Header>,
 	),
 	#[codec(index = 1)]

--- a/relays/client-rococo/src/runtime.rs
+++ b/relays/client-rococo/src/runtime.rs
@@ -85,7 +85,7 @@ pub enum SystemCall {
 pub enum BridgeGrandpaWococoCall {
 	#[codec(index = 0)]
 	submit_finality_proof(
-		<PolkadotLike as Chain>::Header,
+		Box<<PolkadotLike as Chain>::Header>,
 		bp_header_chain::justification::GrandpaJustification<<PolkadotLike as Chain>::Header>,
 	),
 	#[codec(index = 1)]

--- a/relays/client-wococo/src/runtime.rs
+++ b/relays/client-wococo/src/runtime.rs
@@ -85,7 +85,7 @@ pub enum SystemCall {
 pub enum BridgeGrandpaRococoCall {
 	#[codec(index = 0)]
 	submit_finality_proof(
-		<PolkadotLike as Chain>::Header,
+		Box<<PolkadotLike as Chain>::Header>,
 		bp_header_chain::justification::GrandpaJustification<<PolkadotLike as Chain>::Header>,
 	),
 	#[codec(index = 1)]

--- a/relays/lib-substrate-relay/src/headers_initialize.rs
+++ b/relays/lib-substrate-relay/src/headers_initialize.rs
@@ -213,7 +213,7 @@ async fn prepare_initialization_data<SourceChain: Chain>(
 	}
 
 	Ok(InitializationData {
-		header: initial_header,
+		header: Box::new(initial_header),
 		authority_list: initial_authorities_set,
 		set_id: if schedules_change {
 			initial_authorities_set_id + 1


### PR DESCRIPTION
I've just found that our pallets are failing [this test](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/src/lib.rs#L1872). So I've boxed header-related arguments of GRANDPA pallet + added tests for pallets that are (to be) used by Polkadot/Kusama. In future we'll need to add blanket tests for Rialto/Millau calls (like Polkadot does), but now it fails because there are other pallets (poa?) that are failing this test.

We'll also need to think about boxing arguments of messages pallet - it is around 200 bytes now. But now it is not a super-high priority.

I assume that the call encoding stays the same (I'm not sure though) && it doesn't break existing relays. But I've left label because call signature has been changed.

It doesn't break runtimes (because encoding is the same as I assume), but it changes metadata. So I'm not sure - if breaksruntime fits here or not? What are we going to do with pallet deployed at Rococo/Wococo then? Would it lead to tx version bump or jsut spec version bump - I'm too far from this right now, but we need to take care of this when syncing code to polkadot repo