### PR TITLE
Fix CI problems (caused by building multiple runtimes in parallel)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,10 +93,8 @@ clippy-nightly:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
-  variables:
-    RUSTC_WRAPPER:                 ""
   script:
-    - cargo +nightly clippy --all-targets
+    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets
 
 fmt:
   stage:                           lint
@@ -118,21 +116,17 @@ check:
   stage:                           check
   <<:                              *docker-env
   <<:                              *test-refs
-  variables:
-    RUSTC_WRAPPER:                 ""
   script:                          &check-script
-    - time cargo check --locked --verbose --workspace
+    - SKIP_WASM_BUILD=1 time cargo check --locked --verbose --workspace
     # Check Rialto benchmarks runtime
-    - time cargo check -p rialto-runtime --locked --features runtime-benchmarks --verbose
+    - SKIP_WASM_BUILD=1 time cargo check -p rialto-runtime --locked --features runtime-benchmarks --verbose
     # Check Millau benchmarks runtime
-    - time cargo check -p millau-runtime --locked --features runtime-benchmarks --verbose
+    - SKIP_WASM_BUILD=1 time cargo check -p millau-runtime --locked --features runtime-benchmarks --verbose
 
 check-nightly:
   stage:                           check
   <<:                              *docker-env
   <<:                              *nightly-test
-  variables:
-    RUSTC_WRAPPER:                 ""
   script:
     - rustup default nightly
     - *check-script
@@ -143,18 +137,18 @@ test:
   stage:                           test
   <<:                              *docker-env
   <<:                              *test-refs
-  variables:
-    # RUSTFLAGS:                     "-D warnings"
-    RUSTC_WRAPPER:                 ""
+#  variables:
+#    RUSTFLAGS:                     "-D warnings"
   script:                          &test-script
-    - time cargo test --locked --verbose --workspace
+    - time cargo build --release --verbose -p millau-runtime
+    - time cargo build --release --verbose -p rialto-runtime
+    - time cargo build --release --verbose -p rialto-parachain-runtime
+    - SKIP_WASM_BUILD=1 time cargo test --verbose --workspace
 
 test-nightly:
   stage:                           test
   <<:                              *docker-env
   <<:                              *nightly-test
-  variables:
-    RUSTC_WRAPPER:                 ""
   script:
     - rustup default nightly
     - *test-script
@@ -196,7 +190,12 @@ build:
   <<:                              *collect-artifacts
   # master
   script:                          &build-script
-    - time cargo build --release --verbose --workspace
+    - time cargo build --release --verbose -p millau-runtime
+    - time cargo build --release --verbose -p rialto-runtime
+    - time cargo build --release --verbose -p rialto-parachain-runtime
+    - time cargo build --release --verbose -p polkadot-runtime
+    - time cargo build --release --verbose -p polkadot-test-runtime
+    - SKIP_WASM_BUILD=1 time cargo build --release --verbose --workspace
   after_script:
     # Prepare artifacts
     - mkdir -p ./artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1536,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -1632,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.17",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1746,7 +1746,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -1757,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1828,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4802,7 +4802,7 @@ dependencies = [
 [[package]]
 name = "metered-channel"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -6136,7 +6136,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6153,7 +6153,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=master#5af2990cfd3711f86c7cb8606b22364208a5c32d"
+source = "git+https://github.com/paritytech/cumulus?branch=master#b5e737675895e5d130fa0f1c443bf93c6af6d47e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -6546,7 +6546,7 @@ checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-network-protocol",
@@ -6560,7 +6560,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-network-protocol",
@@ -6573,7 +6573,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -6595,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "lru",
@@ -6615,7 +6615,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.17",
@@ -6635,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -6665,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "always-assert",
  "derive_more",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -6720,7 +6720,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-network-protocol",
@@ -6752,7 +6752,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6771,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "parity-scale-codec",
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitvec 0.20.4",
  "derive_more",
@@ -6817,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitvec 0.20.4",
  "futures 0.3.17",
@@ -6837,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitvec 0.20.4",
  "futures 0.3.17",
@@ -6855,7 +6855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-subsystem",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6888,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-subsystem",
@@ -6903,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitvec 0.20.4",
  "derive_more",
@@ -6939,7 +6939,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-participation"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "polkadot-node-primitives",
@@ -6952,7 +6952,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitvec 0.20.4",
  "futures 0.3.17",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "memory-lru",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -7063,7 +7063,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7081,7 +7081,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bounded-vec",
  "futures 0.3.17",
@@ -7103,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -7132,7 +7132,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7159,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -7180,7 +7180,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-all-subsystems-gen"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -7207,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer-gen-proc-macro"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2",
@@ -7218,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -7234,7 +7234,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitvec 0.20.4",
  "frame-system",
@@ -7263,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7294,7 +7294,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.4",
@@ -7364,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitvec 0.20.4",
  "frame-election-provider-support",
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "bitflags",
  "bitvec 0.20.4",
@@ -7443,7 +7443,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "arrayvec 0.5.2",
  "derive_more",
@@ -7558,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "beefy-primitives",
  "bitvec 0.20.4",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -12663,7 +12663,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -12675,7 +12675,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12694,7 +12694,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.9"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -12711,7 +12711,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#48122d0220555bfd59d46e2971522cc4e7c9edf9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#77e92caaa276b956d3f1e4c658e745f2fce55ad0"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
I've ended up with:
1) skipping WASM build when clippy || check is running - we don't need wasm there;
2) adding explicit `cargo build --release` for all runtimes before `cargo build` && `cargo test` => runtimes are built sequentially, not in parallel;
3) running `cargo build` && `cargo test` with `SKIP_WASM_BUILD=1`, so artifacts from (2) are reused;
3) restoring sccache.

Build time has changed from ~21m to ~26m, but I have no other idea how to fix it now. `cargo metadata` is not helping - it has decreased failures rate, but they are still there.