### PR TITLE
Publish docker images when tag of specific format(e.g. v2021-09-27, v2021-09-27-1) is pushed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,7 @@ default:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]{4}-[0-9]{2}-[0-9]{2}.*$/  # i.e. v2021-09-27, v2021-09-27-1
     # there are two types of nightly pipelines:
     # 1. this one is triggered by the schedule with $PIPELINE == "nightly", it's for releasing.
     # this job runs only on nightly pipeline with the mentioned variable, against `master` branch


### PR DESCRIPTION
@hbulgarini was recently asking me if it's possible, but last time I was trying it (https://github.com/paritytech/parity-bridges-common/releases/tag/v2021-07-20) it wasn't working. Found the reason - before moving to gitlab we've been building images for all tags and after moving, we only build on tags like `v1.0`. I've added another regex for us to avoid 24h pauses in fix&try cycle.