### PR TITLE
Increase sleep before connecting Millau node

### DIFF
--- a/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
+++ b/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
+sleep 60
 curl -v http://millau-node-alice:9933/health
 curl -v https://westend-rpc.polkadot.io:443/health
 


### PR DESCRIPTION
We already have increased this for Rialto nodes, but for Millau it was unnecessary before

```
+ sleep 20
+ curl -v http://millau-node-alice:9933/health
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 192.168.64.13:9933...
* TCP_NODELAY set
* connect to 192.168.64.13 port 9933 failed: Connection refused
* Failed to connect to millau-node-alice port 9933: Connection refused
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
curl: (7) Failed to connect to millau-node-alice port 9933: Connection refused
```