### PR TITLE
Allow overriding chain URLs in docker compose environment.

### DIFF
--- a/deployments/ui/docker-compose.yml
+++ b/deployments/ui/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       VIRTUAL_PORT: 80
       LETSENCRYPT_HOST: ui.brucke.link
       LETSENCRYPT_EMAIL: admin@parity.io
-      CHAIN_1_SUBSTRATE_PROVIDER: ws://localhost:9944
-      CHAIN_2_SUBSTRATE_PROVIDER: ws://localhost:19944
+      CHAIN_1_SUBSTRATE_PROVIDER: ${UI_CHAIN_1:-ws://localhost:9944}
+      CHAIN_2_SUBSTRATE_PROVIDER: ${UI_CHAIN_2:-ws://localhost:19944}
     ports:
       - "8080:80"


### PR DESCRIPTION
This will fix the UI deployment for Rialto/Millau.