### PR TITLE
Add mut support for relay strategy

### DIFF
--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -521,7 +521,7 @@ where
 			nonces_queue_range: 0..maximal_source_queue_index + 1,
 		};
 
-		let strategy = EnforcementStrategy::new(self.relay_strategy.clone());
+		let mut strategy = EnforcementStrategy::new(self.relay_strategy.clone());
 		let range_end = strategy.decide(reference).await?;
 
 		let range_begin = source_queue[0].1.begin();

--- a/relays/messages/src/relay_strategy/altruistic_strategy.rs
+++ b/relays/messages/src/relay_strategy/altruistic_strategy.rs
@@ -37,7 +37,7 @@ impl RelayStrategy for AltruisticStrategy {
 		SourceClient: MessageLaneSourceClient<P>,
 		TargetClient: MessageLaneTargetClient<P>,
 	>(
-		&self,
+		&mut self,
 		_reference: &mut RelayReference<P, SourceClient, TargetClient>,
 	) -> bool {
 		true

--- a/relays/messages/src/relay_strategy/enforcement_strategy.rs
+++ b/relays/messages/src/relay_strategy/enforcement_strategy.rs
@@ -49,7 +49,7 @@ impl<Strategy: RelayStrategy> EnforcementStrategy<Strategy> {
 		SourceClient: MessageLaneSourceClient<P>,
 		TargetClient: MessageLaneTargetClient<P>,
 	>(
-		&self,
+		&mut self,
 		reference: RelayMessagesBatchReference<P, SourceClient, TargetClient>,
 	) -> Option<MessageNonce> {
 		let mut hard_selected_count = 0;

--- a/relays/messages/src/relay_strategy/mix_strategy.rs
+++ b/relays/messages/src/relay_strategy/mix_strategy.rs
@@ -47,7 +47,7 @@ impl RelayStrategy for MixStrategy {
 		SourceClient: MessageLaneSourceClient<P>,
 		TargetClient: MessageLaneTargetClient<P>,
 	>(
-		&self,
+		&mut self,
 		reference: &mut RelayReference<P, SourceClient, TargetClient>,
 	) -> bool {
 		match self.relayer_mode {

--- a/relays/messages/src/relay_strategy/mod.rs
+++ b/relays/messages/src/relay_strategy/mod.rs
@@ -52,7 +52,7 @@ pub trait RelayStrategy: 'static + Clone + Send + Sync {
 		SourceClient: MessageLaneSourceClient<P>,
 		TargetClient: MessageLaneTargetClient<P>,
 	>(
-		&self,
+		&mut self,
 		reference: &mut RelayReference<P, SourceClient, TargetClient>,
 	) -> bool;
 }

--- a/relays/messages/src/relay_strategy/rational_strategy.rs
+++ b/relays/messages/src/relay_strategy/rational_strategy.rs
@@ -41,7 +41,7 @@ impl RelayStrategy for RationalStrategy {
 		SourceClient: MessageLaneSourceClient<P>,
 		TargetClient: MessageLaneTargetClient<P>,
 	>(
-		&self,
+		&mut self,
 		reference: &mut RelayReference<P, SourceClient, TargetClient>,
 	) -> bool {
 		// technically, multiple confirmations will be delivered in a single transaction,


### PR DESCRIPTION
Some customized strategies need to maintain their own state and need the support of mutable 