### PR TITLE
Expose prometheus BEEFY metrics and add them to grafana dashboard

### DIFF
--- a/deployments/bridges/rialto-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-millau/docker-compose.yml
@@ -108,6 +108,7 @@ services:
       LETSENCRYPT_EMAIL: admin@parity.io
     volumes:
       - ./bridges/rialto-millau/dashboard/grafana:/etc/grafana/dashboards/rialto-millau:ro
+      - ./networks/dashboard/grafana/beefy-dashboard.json:/etc/grafana/dashboards/beefy.json
 
   prometheus-metrics:
     volumes:

--- a/deployments/networks/dashboard/grafana/beefy-dashboard.json
+++ b/deployments/networks/dashboard/grafana/beefy-dashboard.json
@@ -18,6 +18,68 @@
   "links": [],
   "panels": [
     {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                1
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "C",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                1
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "D",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Beefy best blocks not advancing",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
@@ -41,147 +103,16 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 6,
-        "w": 23,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "interval": "",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "targets": [
-        {
-          "expr": "polkadot_beefy_best_block",
-          "interval": "1",
-          "legendFormat": "Rialto(Charlie)",
-          "refId": "A"
-        },
-        {
-          "expr": "substrate_beefy_best_block",
-          "hide": false,
-          "interval": "1",
-          "legendFormat": "Millau(Charlie)",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Beefy Best block",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "yellow",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 23,
-        "x": 0,
-        "y": 6
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.3",
-      "targets": [
-        {
-          "expr": "polkadot_beefy_should_vote_on",
-          "interval": "1",
-          "legendFormat": "Rialto(Charlie) Should-Vote-On",
-          "refId": "C"
-        },
-        {
-          "expr": "polkadot_beefy_round_concluded",
-          "hide": false,
-          "interval": "1",
-          "legendFormat": "Rialto(Charlie) Round-Concluded",
-          "refId": "A"
-        },
-        {
-          "expr": "substrate_beefy_should_vote_on",
-          "interval": "1",
-          "legendFormat": "Millau(Charlie) Should-Vote-On",
-          "refId": "D"
-        },
-        {
-          "expr": "substrate_beefy_round_concluded",
-          "interval": "1",
-          "legendFormat": "Millau(Charlie) Round-Concluded",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Beefy Voting Rounds",
-      "type": "stat"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 17,
+        "h": 14,
+        "w": 12,
         "x": 0,
-        "y": 12
+        "y": 0
       },
       "hiddenSeries": false,
-      "id": 6,
+      "id": 2,
       "legend": {
         "avg": false,
         "current": false,
@@ -205,23 +136,41 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "polkadot_beefy_votes_sent",
-          "interval": "",
-          "legendFormat": "Rialto (node Charlie)",
+          "expr": "polkadot_beefy_best_block",
+          "legendFormat": "Rialto(Charlie)",
           "refId": "A"
         },
         {
-          "expr": "substrate_beefy_votes_sent",
-          "interval": "",
-          "legendFormat": "Millau (node Charlie)",
+          "expr": "substrate_beefy_best_block",
+          "legendFormat": "Millau(Charlie)",
           "refId": "B"
+        },
+        {
+          "expr": "max_over_time(substrate_beefy_best_block[5m]) - min_over_time(substrate_beefy_best_block[5m])",
+          "hide": true,
+          "legendFormat": "Millau Best Beefy blocks count in last 5 minutes",
+          "refId": "C"
+        },
+        {
+          "expr": "max_over_time(polkadot_beefy_best_block[5m]) - min_over_time(polkadot_beefy_best_block[5m])",
+          "hide": true,
+          "legendFormat": "Rialto Best Beefy blocks count in last 5 minutes",
+          "refId": "D"
         }
       ],
-      "thresholds": [],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 1
+        }
+      ],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Beefy Votes Sent",
+      "title": "Beefy Best block",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -268,12 +217,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "yellow",
                 "value": null
               },
               {
-                "color": "red",
-                "value": 1
+                "color": "yellow",
+                "value": null
               }
             ]
           }
@@ -281,12 +230,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 17,
-        "y": 12
+        "h": 14,
+        "w": 11,
+        "x": 12,
+        "y": 0
       },
-      "id": 8,
+      "id": 4,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -304,24 +253,307 @@
       "pluginVersion": "7.1.3",
       "targets": [
         {
-          "expr": "polkadot_beefy_skipped_sessions",
-          "interval": "1",
-          "legendFormat": "Rialto(Charlie)",
+          "expr": "polkadot_beefy_should_vote_on",
+          "legendFormat": "Rialto(Charlie) Should-Vote-On",
+          "refId": "C"
+        },
+        {
+          "expr": "polkadot_beefy_round_concluded",
+          "legendFormat": "Rialto(Charlie) Round-Concluded",
           "refId": "A"
         },
         {
-          "expr": "substrate_beefy_skipped_sessions",
-          "interval": "1",
-          "legendFormat": "Millau(Charlie)",
+          "expr": "substrate_beefy_should_vote_on",
+          "legendFormat": "Millau(Charlie) Should-Vote-On",
+          "refId": "D"
+        },
+        {
+          "expr": "substrate_beefy_round_concluded",
+          "legendFormat": "Millau(Charlie) Round-Concluded",
           "refId": "B"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Beefy Skipped Sessions",
+      "title": "Beefy Voting Rounds",
       "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "polkadot_beefy_votes_sent",
+          "legendFormat": "Rialto (node Charlie)",
+          "refId": "A"
+        },
+        {
+          "expr": "substrate_beefy_votes_sent",
+          "legendFormat": "Millau (node Charlie)",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Beefy Votes Sent",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          },
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "or"
+            },
+            "query": {
+              "params": [
+                "B",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "max"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Beefy Skipped Sessions alert",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 18,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "polkadot_beefy_skipped_sessions",
+          "legendFormat": "Rialto(Charlie)",
+          "refId": "A"
+        },
+        {
+          "expr": "substrate_beefy_skipped_sessions",
+          "legendFormat": "Millau(Charlie)",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 0
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Beefy Skipped Sessions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
+  "refresh": "5s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [],

--- a/deployments/networks/dashboard/grafana/beefy-dashboard.json
+++ b/deployments/networks/dashboard/grafana/beefy-dashboard.json
@@ -1,0 +1,353 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 23,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "interval": "",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.3",
+      "targets": [
+        {
+          "expr": "polkadot_beefy_best_block",
+          "interval": "1",
+          "legendFormat": "Rialto(Charlie)",
+          "refId": "A"
+        },
+        {
+          "expr": "substrate_beefy_best_block",
+          "hide": false,
+          "interval": "1",
+          "legendFormat": "Millau(Charlie)",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Beefy Best block",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 23,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.3",
+      "targets": [
+        {
+          "expr": "polkadot_beefy_should_vote_on",
+          "interval": "1",
+          "legendFormat": "Rialto(Charlie) Should-Vote-On",
+          "refId": "C"
+        },
+        {
+          "expr": "polkadot_beefy_round_concluded",
+          "hide": false,
+          "interval": "1",
+          "legendFormat": "Rialto(Charlie) Round-Concluded",
+          "refId": "A"
+        },
+        {
+          "expr": "substrate_beefy_should_vote_on",
+          "interval": "1",
+          "legendFormat": "Millau(Charlie) Should-Vote-On",
+          "refId": "D"
+        },
+        {
+          "expr": "substrate_beefy_round_concluded",
+          "interval": "1",
+          "legendFormat": "Millau(Charlie) Round-Concluded",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Beefy Voting Rounds",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 17,
+        "x": 0,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "polkadot_beefy_votes_sent",
+          "interval": "",
+          "legendFormat": "Rialto (node Charlie)",
+          "refId": "A"
+        },
+        {
+          "expr": "substrate_beefy_votes_sent",
+          "interval": "",
+          "legendFormat": "Millau (node Charlie)",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Beefy Votes Sent",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 17,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.3",
+      "targets": [
+        {
+          "expr": "polkadot_beefy_skipped_sessions",
+          "interval": "1",
+          "legendFormat": "Rialto(Charlie)",
+          "refId": "A"
+        },
+        {
+          "expr": "substrate_beefy_skipped_sessions",
+          "interval": "1",
+          "legendFormat": "Millau(Charlie)",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Beefy Skipped Sessions",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Beefy",
+  "uid": "j6cRDRh7z",
+  "version": 1
+}

--- a/deployments/networks/dashboard/prometheus/millau-targets.yml
+++ b/deployments/networks/dashboard/prometheus/millau-targets.yml
@@ -1,0 +1,2 @@
+- targets:
+  - millau-node-charlie:9615

--- a/deployments/networks/dashboard/prometheus/rialto-targets.yml
+++ b/deployments/networks/dashboard/prometheus/rialto-targets.yml
@@ -1,0 +1,2 @@
+- targets:
+  - rialto-node-charlie:9615

--- a/deployments/networks/millau.yml
+++ b/deployments/networks/millau.yml
@@ -55,9 +55,11 @@ services:
       - --enable-offchain-indexing=true
       - --unsafe-rpc-external
       - --unsafe-ws-external
+      - --prometheus-external
     ports:
       - "20133:9933"
       - "20144:9944"
+      - "20615:9615"
 
   millau-node-dave:
     <<: *millau-bridge-node
@@ -90,3 +92,10 @@ services:
     ports:
       - "20333:9933"
       - "20344:9944"
+
+  # Note: These are being overridden from the top level `monitoring` compose file.
+  prometheus-metrics:
+    volumes:
+      - ./networks/dashboard/prometheus/millau-targets.yml:/etc/prometheus/targets-millau-nodes.yml
+    depends_on:
+      - millau-node-charlie

--- a/deployments/networks/rialto.yml
+++ b/deployments/networks/rialto.yml
@@ -55,9 +55,11 @@ services:
       - --enable-offchain-indexing=true
       - --unsafe-rpc-external
       - --unsafe-ws-external
+      - --prometheus-external
     ports:
       - "10133:9933"
       - "10144:9944"
+      - "10615:9615"
 
   rialto-node-dave:
     <<: *rialto-bridge-node
@@ -97,6 +99,13 @@ services:
     volumes:
       - ./networks/entrypoints:/entrypoints
       - rialto-share:/rialto-share:z
+
+  # Note: These are being overridden from the top level `monitoring` compose file.
+  prometheus-metrics:
+    volumes:
+      - ./networks/dashboard/prometheus/rialto-targets.yml:/etc/prometheus/targets-rialto-nodes.yml
+    depends_on:
+      - rialto-node-charlie
 
 # we're using `/rialto-share` to expose Rialto chain spec to those who are interested. Right
 # now it is Rialto Parachain collator nodes. Local + tmpfs combination allows sharing writable


### PR DESCRIPTION
Fixes #1231 

Node Charlie is used to expose public RPC for both Rialto and Millau, so Beefy dashboard is also using Charlie metrics for consistency.

Beefy `debug` logs are enabled for _all_ nodes.

Dashboard looks like this:
![Screenshot from 2021-12-03 10-40-12](https://user-images.githubusercontent.com/31917973/144573274-429d8996-7908-4522-88e1-3ee448137319.png)

