### PR TITLE
Decrease startup sleep time on test deployments

### DIFF
--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 60
-curl -v http://millau-node-bob:9933/health
-curl -v http://rialto-node-bob:9933/health
+sleep 15
 
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 60
-curl -v http://millau-node-bob:9933/health
-curl -v http://rialto-node-bob:9933/health
+sleep 15
 
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -36,7 +36,7 @@ BUNCH_OF_MESSAGES_TIME=3600
 
 # give conversion rate updater some time to update Millau->Rialto conversion rate in Rialto
 # (initially rate=1 and rational relayer won't deliver any messages if it'll be changed to larger value)
-sleep 180
+sleep 120
 
 while true
 do

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -36,7 +36,7 @@ BUNCH_OF_MESSAGES_TIME=3600
 
 # give conversion rate updater some time to update Rialto->Millau conversion rate in Millau
 # (initially rate=1 and rational relayer won't deliver any messages if it'll be changed to larger value)
-sleep 180
+sleep 120
 
 while true
 do

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-resubmitter-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-resubmitter-entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 20
-curl -v http://millau-node-alice:9933/health
+sleep 15
 
 # //Dave is signing Millau -> Rialto message-send transactions, which are causing problems.
 #

--- a/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 60
-curl -v http://millau-node-alice:9933/health
-curl -v http://rialto-node-alice:9933/health
+sleep 15
 
 /home/user/substrate-relay init-bridge millau-to-rialto \
 	--source-host millau-node-alice \

--- a/deployments/bridges/rialto-millau/entrypoints/relay-token-swap-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-token-swap-generator-entrypoint.sh
@@ -25,7 +25,7 @@ rand_sleep() {
 
 # give conversion rate updater some time to update Rialto->Millau conversion rate in Millau
 # (initially rate=1 and rational relayer won't deliver any messages if it'll be changed to larger value)
-sleep 180
+sleep 120
 
 while true
 do

--- a/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
+++ b/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 60
-curl -v http://millau-node-alice:9933/health
-curl -v https://westend-rpc.polkadot.io:443/health
+sleep 15
 
 /home/user/substrate-relay init-bridge westend-to-millau \
 	--source-host westend-rpc.polkadot.io \

--- a/deployments/networks/entrypoints/rialto-parachain-registrar-entrypoint.sh
+++ b/deployments/networks/entrypoints/rialto-parachain-registrar-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -xeu
 
-sleep 60
-curl -v http://rialto-node-alice:9933/health
-curl -v http://rialto-parachain-collator-alice:9933/health
+sleep 15
 
 /home/user/substrate-relay register-parachain rialto-parachain \
 	--parachain-host rialto-parachain-collator-alice \


### PR DESCRIPTION
Follow-up of our test-deployments scaling. Needs to be tested first.

I've also removed curl calls, because relayer is now able to recover from connection errors both on startup and while running its loops. So imo now it is just an additional excessive thing that breaks sometimes.

UPD: restarted our test-deployments at 10:27 UTC - seems that all is working without any issues now.