### PR TITLE
Temporary use pinned bridges-ci image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-FROM paritytech/bridges-ci:latest as builder
+FROM paritytech/bridges-ci:e8a9ef25-20211215 as builder
 WORKDIR /parity-bridges-common
 
 COPY . .


### PR DESCRIPTION
Our nightly docker uild pipeline has failed: https://gitlab.parity.io/parity/parity-bridges-common/-/jobs/1295704 - forgot that we are referencing bridges-ci from other dockerfile