### PR TITLE
Move "common" code of messages pallet benchmarks helpers to the parity-bridges-common library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,9 @@ dependencies = [
  "bp-runtime",
  "ed25519-dalek",
  "frame-support",
+ "frame-system",
  "hash-db",
+ "pallet-balances",
  "pallet-bridge-dispatch",
  "pallet-bridge-grandpa",
  "pallet-bridge-messages",
@@ -968,6 +970,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-trie",
+ "sp-version",
 ]
 
 [[package]]

--- a/bin/runtime-common/Cargo.toml
+++ b/bin/runtime-common/Cargo.toml
@@ -25,12 +25,15 @@ pallet-bridge-messages = { path = "../../modules/messages", default-features = f
 # Substrate dependencies
 
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false, optional = true }
 
 [features]
 default = ["std"]
@@ -54,7 +57,10 @@ std = [
 ]
 runtime-benchmarks = [
 	"ed25519-dalek/u64_backend",
+	"frame-system",
+	"pallet-balances",
 	"pallet-bridge-grandpa/runtime-benchmarks",
 	"pallet-bridge-messages/runtime-benchmarks",
 	"sp-state-machine",
+	"sp-version",
 ]

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -176,7 +176,7 @@ pub type BalanceOf<C> = <C as ChainWithMessages>::Balance;
 pub type CallOf<C> = <C as ThisChainWithMessages>::Call;
 
 /// Raw storage proof type (just raw trie nodes).
-type RawStorageProof = Vec<Vec<u8>>;
+pub type RawStorageProof = Vec<Vec<u8>>;
 
 /// Compute fee of transaction at runtime where regular transaction payment pallet is being used.
 ///

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -41,6 +41,7 @@ const SEED: u32 = 0;
 pub struct Pallet<T: Config<I>, I: 'static>(crate::Pallet<T, I>);
 
 /// Proof size requirements.
+#[derive(Clone, Copy, Debug)]
 pub enum ProofSize {
 	/// The proof is expected to be minimal. If value size may be changed, then it is expected to
 	/// have given size.
@@ -54,6 +55,7 @@ pub enum ProofSize {
 }
 
 /// Benchmark-specific message parameters.
+#[derive(Debug)]
 pub struct MessageParams<ThisAccountId> {
 	/// Size of the message payload.
 	pub size: u32,
@@ -62,6 +64,7 @@ pub struct MessageParams<ThisAccountId> {
 }
 
 /// Benchmark-specific message proof parameters.
+#[derive(Debug)]
 pub struct MessageProofParams {
 	/// Id of the lane.
 	pub lane: LaneId,
@@ -76,6 +79,7 @@ pub struct MessageProofParams {
 }
 
 /// Benchmark-specific message delivery proof parameters.
+#[derive(Debug)]
 pub struct MessageDeliveryProofParams<ThisChainAccountId> {
 	/// Id of the lane.
 	pub lane: LaneId,


### PR DESCRIPTION
closes #1268 

This PR just moves code around + reorganizes a bit. Number of code lines in the runtime (means separate copies for Millau, Polkadot and Kusama) are down from ~150 to ~40, which is imo good enough.