### PR TITLE
Support version mode CLI options in send-message subcommand

### DIFF
--- a/relays/bin-substrate/src/cli/encode_call.rs
+++ b/relays/bin-substrate/src/cli/encode_call.rs
@@ -308,8 +308,8 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn should_encode_bridge_send_message_call() {
+	#[async_std::test]
+	async fn should_encode_bridge_send_message_call() {
 		// given
 		let encode_message = SendMessage::from_iter(vec![
 			"send-message",
@@ -325,6 +325,7 @@ mod tests {
 			"remark",
 		])
 		.encode_payload()
+		.await
 		.unwrap();
 
 		let mut encode_call = EncodeCall::from_iter(vec![


### PR DESCRIPTION
closes #1283 

So right now Rococo has runtime version `9141` and Wococo is `9140`. "Release" relay thinks that both have `9140`. Since they're testnets, this is fine (given that headers+messages relay is running with `*-version-mode=Auto` CLI option). But relay still uses `9140` when encoding messages from Wococo to Rococo, meaning that they'll be delivered, but dispatch will fail with `MessageVersionSpecMismatch` error. This PR allows message submitter to provide custom version or to read actual version from the target node.