### PR TITLE
Use raw balance value if tokenDecimals property is missing

### DIFF
--- a/relays/lib-substrate-relay/src/messages_metrics.rs
+++ b/relays/lib-substrate-relay/src/messages_metrics.rs
@@ -211,8 +211,8 @@ where
 			token_decimals
 		})
 		.unwrap_or_else(|| {
-			// turns out it is normal not to have this property - e.g. when polkadot binary is started
-			// using `polkadot-local` chain. Let's use minimal nominal here
+			// turns out it is normal not to have this property - e.g. when polkadot binary is
+			// started using `polkadot-local` chain. Let's use minimal nominal here
 			log::info!(target: "bridge", "Using default (zero) `tokenDecimals` value for {}", C::NAME);
 			0
 		});

--- a/relays/lib-substrate-relay/src/messages_metrics.rs
+++ b/relays/lib-substrate-relay/src/messages_metrics.rs
@@ -202,9 +202,20 @@ where
 		return Ok(metrics)
 	}
 
-	let token_decimals = client.token_decimals().await?.ok_or_else(|| {
-		SubstrateError::Custom(format!("Missing token decimals from {} system properties", C::NAME))
-	})?;
+	// if `tokenDecimals` is missing from system properties, we'll be using
+	let token_decimals = client
+		.token_decimals()
+		.await?
+		.map(|token_decimals| {
+			log::info!(target: "bridge", "Read `tokenDecimals` for {}: {}", C::NAME, token_decimals);
+			token_decimals
+		})
+		.unwrap_or_else(|| {
+			// turns out it is normal not to have this property - e.g. when polkadot binary is started
+			// using `polkadot-local` chain. Let's use minimal nominal here
+			log::info!(target: "bridge", "Using default (zero) `tokenDecimals` value for {}", C::NAME);
+			0
+		});
 	let token_decimals = u32::try_from(token_decimals).map_err(|e| {
 		anyhow::format_err!(
 			"Token decimals value ({}) of {} doesn't fit into u32: {:?}",


### PR DESCRIPTION
Apparently the code introduced in #1291 is overreacting to errors. E.g. when running local Rococo/Wococo nodes, `tokenDecimals` property is missing from the chain properties. The solution is to use raw balance value in this case. On real chains we shall not see this.