### PR TITLE
Fix mandatory headers scanning in on-demand relay

### DIFF
--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -133,10 +133,6 @@ macro_rules! select_bridge {
 				type LeftAccountIdConverter = bp_millau::AccountIdConverter;
 				type RightAccountIdConverter = bp_rialto::AccountIdConverter;
 
-				const MAX_MISSING_LEFT_HEADERS_AT_RIGHT: bp_millau::BlockNumber =
-					bp_millau::SESSION_LENGTH;
-				const MAX_MISSING_RIGHT_HEADERS_AT_LEFT: bp_rialto::BlockNumber =
-					bp_rialto::SESSION_LENGTH;
 				const LEFT_RUNTIME_VERSION: Option<sp_version::RuntimeVersion> =
 					Some(millau_runtime::VERSION);
 				const RIGHT_RUNTIME_VERSION: Option<sp_version::RuntimeVersion> =
@@ -184,11 +180,6 @@ macro_rules! select_bridge {
 
 				type LeftAccountIdConverter = bp_rococo::AccountIdConverter;
 				type RightAccountIdConverter = bp_wococo::AccountIdConverter;
-
-				const MAX_MISSING_LEFT_HEADERS_AT_RIGHT: bp_rococo::BlockNumber =
-					bp_rococo::SESSION_LENGTH;
-				const MAX_MISSING_RIGHT_HEADERS_AT_LEFT: bp_wococo::BlockNumber =
-					bp_wococo::SESSION_LENGTH;
 
 				const LEFT_RUNTIME_VERSION: Option<sp_version::RuntimeVersion> =
 					Some(bp_rococo::VERSION);
@@ -267,11 +258,6 @@ macro_rules! select_bridge {
 
 				type LeftAccountIdConverter = bp_kusama::AccountIdConverter;
 				type RightAccountIdConverter = bp_polkadot::AccountIdConverter;
-
-				const MAX_MISSING_LEFT_HEADERS_AT_RIGHT: bp_kusama::BlockNumber =
-					bp_kusama::SESSION_LENGTH;
-				const MAX_MISSING_RIGHT_HEADERS_AT_LEFT: bp_polkadot::BlockNumber =
-					bp_polkadot::SESSION_LENGTH;
 
 				const LEFT_RUNTIME_VERSION: Option<sp_version::RuntimeVersion> =
 					Some(bp_kusama::VERSION);
@@ -543,14 +529,12 @@ impl RelayHeadersAndMessages {
 				left_client.clone(),
 				right_client.clone(),
 				left_to_right_transaction_params,
-				MAX_MISSING_LEFT_HEADERS_AT_RIGHT,
 				params.shared.only_mandatory_headers,
 			);
 			let right_to_left_on_demand_headers = OnDemandHeadersRelay::new::<RightToLeftFinality>(
 				right_client.clone(),
 				left_client.clone(),
 				right_to_left_transaction_params,
-				MAX_MISSING_RIGHT_HEADERS_AT_LEFT,
 				params.shared.only_mandatory_headers,
 			);
 

--- a/relays/lib-substrate-relay/src/on_demand_headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand_headers.rs
@@ -401,15 +401,6 @@ async fn find_mandatory_header_in_range<P: SubstrateFinalitySyncPipeline>(
 	finality_source: &SubstrateFinalitySource<P>,
 	range: (BlockNumberOf<P::SourceChain>, BlockNumberOf<P::SourceChain>),
 ) -> Result<Option<BlockNumberOf<P::SourceChain>>, relay_substrate_client::Error> {
-	log::trace!(
-		target: "bridge",
-		"Scanning mandatory {} headers range {:?}..={:?} in {}",
-		P::SourceChain::NAME,
-		range.0,
-		range.1,
-		on_demand_headers_relay_name::<P::SourceChain, P::TargetChain>(),
-	);
-
 	let mut current = range.0;
 	while current <= range.1 {
 		let header: SyncHeader<HeaderOf<P::SourceChain>> =

--- a/relays/lib-substrate-relay/src/on_demand_headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand_headers.rs
@@ -432,12 +432,7 @@ mod tests {
 	#[async_std::test]
 	async fn mandatory_headers_scan_range_selects_range_if_some_headers_are_missing() {
 		assert_eq!(
-			mandatory_headers_scan_range::<TestChain>(
-				AT_SOURCE,
-				AT_TARGET,
-				0,
-			)
-			.await,
+			mandatory_headers_scan_range::<TestChain>(AT_SOURCE, AT_TARGET, 0,).await,
 			Some((AT_TARGET.unwrap() + 1, AT_SOURCE.unwrap())),
 		);
 	}
@@ -445,12 +440,8 @@ mod tests {
 	#[async_std::test]
 	async fn mandatory_headers_scan_range_selects_nothing_if_already_queued() {
 		assert_eq!(
-			mandatory_headers_scan_range::<TestChain>(
-				AT_SOURCE,
-				AT_TARGET,
-				AT_SOURCE.unwrap(),
-			)
-			.await,
+			mandatory_headers_scan_range::<TestChain>(AT_SOURCE, AT_TARGET, AT_SOURCE.unwrap(),)
+				.await,
 			None,
 		);
 	}

--- a/relays/lib-substrate-relay/src/on_demand_headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand_headers.rs
@@ -298,8 +298,8 @@ async fn mandatory_headers_scan_range<C: Chain>(
 	let best_finalized_source_header_at_source =
 		best_finalized_source_header_at_source.unwrap_or(best_finalized_source_header_at_target);
 
-	// if relay is already asked to sync headers, don't do anything yet
-	if required_header_number > best_finalized_source_header_at_target {
+	// if relay is already asked to sync more headers than we have at source, don't do anything yet
+	if required_header_number >= best_finalized_source_header_at_source {
 		return None
 	}
 


### PR DESCRIPTION
There are some leftovers left from previous version of on-demand-headers relay, which were not caught by Rialto<>Millau bridge and are hard to reproduce locally (without knowing the issue). But luckily, they were caught by Rococo <> Wococo deployment.

The main thing here is removal of `maximal_headers_difference`. Previous version of pallet+relay was requiring all headers to be synced => if on-demand relay was seeing  `maximal_headers_difference` missing in grandpa pallet, it was started syncing. Now we have different concept and on-demand relay only relay headers that are: (1) required by the message relay (optionally) or (2) are mandatory. Unfortunately, during migration, some code has not been fixed and this PR does the thing.