### PR TITLE
Increase relay balance guard limits for Polkadot<>Kusama bridge

### DIFF
--- a/relays/bin-substrate/src/chains/kusama_headers_to_polkadot.rs
+++ b/relays/bin-substrate/src/chains/kusama_headers_to_polkadot.rs
@@ -24,11 +24,11 @@ use substrate_relay_helper::{finality_pipeline::SubstrateFinalitySyncPipeline, T
 /// relay as gone wild.
 ///
 /// Actual value, returned by `maximal_balance_decrease_per_day_is_sane` test is approximately 21
-/// DOT, and initial value of this constant was rounded up to 30 DOTs. But for actual Kusama <>
+/// DOT, and initial value of this constant was rounded up to 30 DOT. But for actual Kusama <>
 /// Polkadot deployment we'll be using the same account for delivering finality (free for mandatory
 /// headers) and messages. It means that we can't predict maximal loss. But to protect funds against
 /// relay/deployment issues, let's limit it so something that is much larger than this estimation -
-/// e.g. to 100 DOTs.
+/// e.g. to 100 DOT.
 // TODO: https://github.com/paritytech/parity-bridges-common/issues/1307
 pub(crate) const MAXIMAL_BALANCE_DECREASE_PER_DAY: bp_polkadot::Balance = 100 * 10_000_000_000;
 

--- a/relays/bin-substrate/src/chains/kusama_headers_to_polkadot.rs
+++ b/relays/bin-substrate/src/chains/kusama_headers_to_polkadot.rs
@@ -24,8 +24,13 @@ use substrate_relay_helper::{finality_pipeline::SubstrateFinalitySyncPipeline, T
 /// relay as gone wild.
 ///
 /// Actual value, returned by `maximal_balance_decrease_per_day_is_sane` test is approximately 21
-/// DOT, but let's round up to 30 DOT here.
-pub(crate) const MAXIMAL_BALANCE_DECREASE_PER_DAY: bp_polkadot::Balance = 30_000_000_000;
+/// DOT, and initial value of this constant was rounded up to 30 DOTs. But for actual Kusama <>
+/// Polkadot deployment we'll be using the same account for delivering finality (free for mandatory
+/// headers) and messages. It means that we can't predict maximal loss. But to protect funds against
+/// relay/deployment issues, let's limit it so something that is much larger than this estimation -
+/// e.g. to 100 DOTs.
+// TODO: https://github.com/paritytech/parity-bridges-common/issues/1307
+pub(crate) const MAXIMAL_BALANCE_DECREASE_PER_DAY: bp_polkadot::Balance = 100 * 10_000_000_000;
 
 /// Description of Kusama -> Polkadot finalized headers bridge.
 #[derive(Clone, Debug)]

--- a/relays/bin-substrate/src/chains/polkadot_headers_to_kusama.rs
+++ b/relays/bin-substrate/src/chains/polkadot_headers_to_kusama.rs
@@ -28,7 +28,7 @@ use substrate_relay_helper::{finality_pipeline::SubstrateFinalitySyncPipeline, T
 /// Polkadot deployment we'll be using the same account for delivering finality (free for mandatory
 /// headers) and messages. It means that we can't predict maximal loss. But to protect funds against
 /// relay/deployment issues, let's limit it so something that is much larger than this estimation -
-/// e.g. to 2 KSMs.
+/// e.g. to 2 KSM.
 // TODO: https://github.com/paritytech/parity-bridges-common/issues/1307
 pub(crate) const MAXIMAL_BALANCE_DECREASE_PER_DAY: bp_kusama::Balance = 2 * 1_000_000_000_000;
 

--- a/relays/bin-substrate/src/chains/polkadot_headers_to_kusama.rs
+++ b/relays/bin-substrate/src/chains/polkadot_headers_to_kusama.rs
@@ -24,8 +24,13 @@ use substrate_relay_helper::{finality_pipeline::SubstrateFinalitySyncPipeline, T
 /// relay as gone wild.
 ///
 /// Actual value, returned by `maximal_balance_decrease_per_day_is_sane` test is approximately 0.001
-/// KSM, but let's round up to 0.1 KSM here.
-pub(crate) const MAXIMAL_BALANCE_DECREASE_PER_DAY: bp_polkadot::Balance = 100_000_000_000;
+/// KSM, and initial value of this constant was rounded up to 0.1 KSM. But for actual Kusama <>
+/// Polkadot deployment we'll be using the same account for delivering finality (free for mandatory
+/// headers) and messages. It means that we can't predict maximal loss. But to protect funds against
+/// relay/deployment issues, let's limit it so something that is much larger than this estimation -
+/// e.g. to 2 KSMs.
+// TODO: https://github.com/paritytech/parity-bridges-common/issues/1307
+pub(crate) const MAXIMAL_BALANCE_DECREASE_PER_DAY: bp_kusama::Balance = 2 * 1_000_000_000_000;
 
 /// Description of Polkadot -> Kusama finalized headers bridge.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
closes #1300 
related to #1307 

I've tried to explain this increase in comments and in related issues, but will try to expand my PoV here. Relay guards shall protect us from incorrect relay behavior - e.g. when relay starts spamming with transactions or it crafts some invalid transactions, which eventually accepted to the pool and fail. So it shan't protect from high load or something like that. Hence, the quite large selected values.