### PR TITLE
Fix benchmarks before using it in Polkadot/Kusama/Rococo runtimes

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -860,7 +860,7 @@ impl_runtime_apis! {
 				fn prepare_outbound_message(
 					params: MessageParams<Self::AccountId>,
 				) -> (rialto_messages::ToRialtoMessagePayload, Balance) {
-					prepare_outbound_message::<WithRialtoMessageBridge>(params)
+					(prepare_outbound_message::<WithRialtoMessageBridge>(params), Self::message_fee())
 				}
 
 				fn prepare_message_proof(

--- a/bin/runtime-common/src/messages_benchmarking.rs
+++ b/bin/runtime-common/src/messages_benchmarking.rs
@@ -46,7 +46,7 @@ use sp_version::RuntimeVersion;
 /// Prepare outbound message for the `send_message` call.
 pub fn prepare_outbound_message<B>(
 	params: MessageParams<AccountIdOf<ThisChain<B>>>,
-) -> (FromThisChainMessagePayload<B>, BalanceOf<ThisChain<B>>)
+) -> FromThisChainMessagePayload<B>
 where
 	B: MessageBridge,
 	BalanceOf<ThisChain<B>>: From<u64>,
@@ -54,14 +54,13 @@ where
 	let message_payload = vec![0; params.size as usize];
 	let dispatch_origin = bp_message_dispatch::CallOrigin::SourceAccount(params.sender_account);
 
-	let message = FromThisChainMessagePayload::<B> {
+	FromThisChainMessagePayload::<B> {
 		spec_version: 0,
 		weight: params.size as _,
 		origin: dispatch_origin,
 		call: message_payload,
 		dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
-	};
-	(message, pallet_bridge_messages::benchmarking::MESSAGE_FEE.into())
+	}
 }
 
 /// Prepare proof of messages for the `receive_messages_proof` call.


### PR DESCRIPTION
There are two fixes:
1) I've replaced `MESSAGE_FEE` constant with benchmarks config method to be able to customize it from runtime;
2) on our testnets (Rialto/Millau), relayers fund account is created at genesis, on P/K/R it is not. Since we've recently stopped accepting new messages if relayer account isn't created, benchmarks started to fail on P/K/R. So I'm explicitly creating this account when required.

This PR is touching runtime code, but this code is only related to benchmarks and it's just a refactoring => audit isn't required.