### PR TITLE
Encode and estimate Rococo/Wococo/Kusama/Polkadot messages

### DIFF
--- a/primitives/polkadot-core/src/lib.rs
+++ b/primitives/polkadot-core/src/lib.rs
@@ -17,7 +17,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use bp_messages::MessageNonce;
-use bp_runtime::Chain;
+use bp_runtime::{Chain, EncodedOrDecodedCall};
 use frame_support::{
 	dispatch::Dispatchable,
 	parameter_types,
@@ -228,8 +228,12 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 pub type Balance = u128;
 
 /// Unchecked Extrinsic type.
-pub type UncheckedExtrinsic<Call> =
-	generic::UncheckedExtrinsic<AccountAddress, Call, Signature, SignedExtensions<Call>>;
+pub type UncheckedExtrinsic<Call> = generic::UncheckedExtrinsic<
+	AccountAddress,
+	EncodedOrDecodedCall<Call>,
+	Signature,
+	SignedExtensions<Call>,
+>;
 
 /// Account address, used by the Polkadot-like chain.
 pub type Address = MultiAddress<AccountId, ()>;
@@ -336,12 +340,12 @@ where
 
 	fn pre_dispatch(
 		self,
-		who: &Self::AccountId,
-		call: &Self::Call,
-		info: &DispatchInfoOf<Self::Call>,
-		len: usize,
+		_who: &Self::AccountId,
+		_call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
 	) -> Result<Self::Pre, TransactionValidityError> {
-		Ok(self.validate(who, call, info, len).map(|_| ())?)
+		Ok(())
 	}
 }
 

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
+use codec::{Decode, Encode};
 use frame_support::{weights::Weight, Parameter};
 use num_traits::{AsPrimitive, Bounded, CheckedSub, Saturating, SaturatingAdd, Zero};
 use sp_runtime::{
@@ -23,7 +24,69 @@ use sp_runtime::{
 	},
 	FixedPointOperand,
 };
-use sp_std::{convert::TryFrom, fmt::Debug, hash::Hash, str::FromStr};
+use sp_std::{convert::TryFrom, fmt::Debug, hash::Hash, str::FromStr, vec, vec::Vec};
+
+/// Chain call, that is either SCALE-encoded, or decoded.
+#[derive(Debug, Clone)]
+pub enum EncodedOrDecodedCall<ChainCall> {
+	/// The call that is SCALE-encoded.
+	///
+	/// This variant is used when we the chain runtime is not undled with the relay, but
+	/// we still need the represent call in some RPC calls or transactions.
+	Encoded(Vec<u8>),
+	/// The decoded call.
+	Decoded(ChainCall),
+}
+
+impl<ChainCall: Clone + Decode> EncodedOrDecodedCall<ChainCall> {
+	/// Returns decoded call.
+	pub fn to_decoded(&self) -> Result<ChainCall, codec::Error> {
+		match self {
+			Self::Encoded(ref encoded_call) =>
+				ChainCall::decode(&mut &encoded_call[..]).map_err(Into::into),
+			Self::Decoded(ref decoded_call) => Ok(decoded_call.clone()),
+		}
+	}
+
+	/// Converts self to decoded call.
+	pub fn into_decoded(self) -> Result<ChainCall, codec::Error> {
+		match self {
+			Self::Encoded(encoded_call) =>
+				ChainCall::decode(&mut &encoded_call[..]).map_err(Into::into),
+			Self::Decoded(decoded_call) => Ok(decoded_call),
+		}
+	}
+}
+
+impl<ChainCall> From<ChainCall> for EncodedOrDecodedCall<ChainCall> {
+	fn from(call: ChainCall) -> EncodedOrDecodedCall<ChainCall> {
+		EncodedOrDecodedCall::Decoded(call)
+	}
+}
+
+impl<ChainCall: Decode> Decode for EncodedOrDecodedCall<ChainCall> {
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		// having encoded version is better than decoded, because decoding isn't required
+		// everywhere and for mocked calls it may lead to **unneeded** errors
+		match input.remaining_len()? {
+			Some(remaining_len) => {
+				let mut encoded_call = vec![0u8; remaining_len];
+				input.read(&mut encoded_call)?;
+				Ok(EncodedOrDecodedCall::Encoded(encoded_call))
+			},
+			None => Ok(EncodedOrDecodedCall::Decoded(ChainCall::decode(input)?)),
+		}
+	}
+}
+
+impl<ChainCall: Encode> Encode for EncodedOrDecodedCall<ChainCall> {
+	fn encode(&self) -> Vec<u8> {
+		match *self {
+			Self::Encoded(ref encoded_call) => encoded_call.clone(),
+			Self::Decoded(ref decoded_call) => decoded_call.encode(),
+		}
+	}
+}
 
 /// Minimal Substrate-based chain representation that may be used from no_std environment.
 pub trait Chain: Send + Sync + 'static {

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -31,7 +31,7 @@ use sp_std::{convert::TryFrom, fmt::Debug, hash::Hash, str::FromStr, vec, vec::V
 pub enum EncodedOrDecodedCall<ChainCall> {
 	/// The call that is SCALE-encoded.
 	///
-	/// This variant is used when we the chain runtime is not undled with the relay, but
+	/// This variant is used when we the chain runtime is not bundled with the relay, but
 	/// we still need the represent call in some RPC calls or transactions.
 	Encoded(Vec<u8>),
 	/// The decoded call.

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -25,8 +25,8 @@ use sp_io::hashing::blake2_256;
 use sp_std::{convert::TryFrom, vec, vec::Vec};
 
 pub use chain::{
-	AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, HashOf, HasherOf, HeaderOf,
-	IndexOf, SignatureOf, TransactionEraOf,
+	AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, EncodedOrDecodedCall, HashOf,
+	HasherOf, HeaderOf, IndexOf, SignatureOf, TransactionEraOf,
 };
 pub use frame_support::storage::storage_prefix as storage_value_final_key;
 pub use storage_proof::{Error as StorageProofError, StorageProofChecker};

--- a/relays/bin-substrate/src/chains/kusama.rs
+++ b/relays/bin-substrate/src/chains/kusama.rs
@@ -104,7 +104,7 @@ impl CliChain for Kusama {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Kusama's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, dispatch_weight } => {
 				type Source = Kusama;
 				type Target = relay_polkadot_client::Polkadot;
 
@@ -116,13 +116,13 @@ impl CliChain for Kusama {
 					bridge::KUSAMA_TO_POLKADOT_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify weight of the encoded Polkadot call"))
+				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Polkadot call"))
 				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,
-					weight,
+					dispatch_weight,
 					origin,
 					&call,
 					DispatchFeePayment::AtSourceChain,

--- a/relays/bin-substrate/src/chains/kusama.rs
+++ b/relays/bin-substrate/src/chains/kusama.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
+use anyhow::anyhow;
+use bp_message_dispatch::{CallOrigin, MessagePayload};
+use bp_runtime::EncodedOrDecodedCall;
 use codec::Decode;
 use frame_support::weights::{DispatchClass, DispatchInfo, Pays, Weight};
 use relay_kusama_client::Kusama;
@@ -21,8 +24,10 @@ use sp_version::RuntimeVersion;
 
 use crate::cli::{
 	bridge,
-	encode_call::{Call, CliEncodeCall},
-	encode_message, CliChain,
+	encode_call::{self, Call, CliEncodeCall},
+	encode_message,
+	send_message::{self, DispatchFeePayment},
+	CliChain,
 };
 
 /// Weight of the `system::remark` call at Kusama.
@@ -32,13 +37,15 @@ use crate::cli::{
 pub(crate) const SYSTEM_REMARK_CALL_WEIGHT: Weight = 2 * 1_345_000;
 
 impl CliEncodeCall for Kusama {
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call> {
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>> {
 		Ok(match call {
+			Call::Raw { data } => EncodedOrDecodedCall::Encoded(data.0.clone()),
 			Call::Remark { remark_payload, .. } => relay_kusama_client::runtime::Call::System(
 				relay_kusama_client::runtime::SystemCall::remark(
 					remark_payload.as_ref().map(|x| x.0.clone()).unwrap_or_default(),
 				),
-			),
+			)
+			.into(),
 			Call::BridgeSendMessage { lane, payload, fee, bridge_instance_index } =>
 				match *bridge_instance_index {
 					bridge::KUSAMA_TO_POLKADOT_INDEX => {
@@ -48,6 +55,7 @@ impl CliEncodeCall for Kusama {
 								lane.0, payload, fee.0,
 							),
 						)
+						.into()
 					},
 					_ => anyhow::bail!(
 						"Unsupported target bridge pallet with instance index: {}",
@@ -58,13 +66,11 @@ impl CliEncodeCall for Kusama {
 		})
 	}
 
-	fn get_dispatch_info(
-		call: &relay_kusama_client::runtime::Call,
-	) -> anyhow::Result<DispatchInfo> {
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo> {
 		match *call {
-			relay_kusama_client::runtime::Call::System(
+			EncodedOrDecodedCall::Decoded(relay_kusama_client::runtime::Call::System(
 				relay_kusama_client::runtime::SystemCall::remark(_),
-			) => Ok(DispatchInfo {
+			)) => Ok(DispatchInfo {
 				weight: crate::chains::kusama::SYSTEM_REMARK_CALL_WEIGHT,
 				class: DispatchClass::Normal,
 				pays_fee: Pays::Yes,
@@ -78,7 +84,12 @@ impl CliChain for Kusama {
 	const RUNTIME_VERSION: RuntimeVersion = bp_kusama::VERSION;
 
 	type KeyPair = sp_core::sr25519::Pair;
-	type MessagePayload = ();
+	type MessagePayload = MessagePayload<
+		bp_kusama::AccountId,
+		bp_polkadot::AccountPublic,
+		bp_polkadot::Signature,
+		Vec<u8>,
+	>;
 
 	fn ss58_format() -> u16 {
 		sp_core::crypto::Ss58AddressFormat::from(
@@ -88,8 +99,35 @@ impl CliChain for Kusama {
 	}
 
 	fn encode_message(
-		_message: encode_message::MessagePayload,
+		message: encode_message::MessagePayload,
 	) -> anyhow::Result<Self::MessagePayload> {
-		anyhow::bail!("Sending messages from Kusama is not yet supported.")
+		match message {
+			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
+				.map_err(|e| anyhow!("Failed to decode Kusama's MessagePayload: {:?}", e)),
+			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+				type Source = Kusama;
+				type Target = relay_polkadot_client::Polkadot;
+
+				sender.enforce_chain::<Source>();
+				let spec_version = Target::RUNTIME_VERSION.spec_version;
+				let origin = CallOrigin::SourceAccount(sender.raw_id());
+				encode_call::preprocess_call::<Source, Target>(
+					&mut call,
+					bridge::KUSAMA_TO_POLKADOT_INDEX,
+				);
+				let call = Target::encode_call(&call)?;
+				let weight = weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify weight of the encoded Polkadot call"))
+				})?;
+
+				Ok(send_message::message_payload(
+					spec_version,
+					weight,
+					origin,
+					&call,
+					DispatchFeePayment::AtSourceChain,
+				))
+			},
+		}
 	}
 }

--- a/relays/bin-substrate/src/chains/kusama.rs
+++ b/relays/bin-substrate/src/chains/kusama.rs
@@ -117,7 +117,9 @@ impl CliChain for Kusama {
 				);
 				let call = Target::encode_call(&call)?;
 				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Polkadot call"))
+					Err(anyhow::format_err!(
+						"Please specify dispatch weight of the encoded Polkadot call"
+					))
 				})?;
 
 				Ok(send_message::message_payload(

--- a/relays/bin-substrate/src/chains/kusama_messages_to_polkadot.rs
+++ b/relays/bin-substrate/src/chains/kusama_messages_to_polkadot.rs
@@ -82,7 +82,7 @@ pub(crate) async fn update_polkadot_to_kusama_conversion_rate(
 	let (spec_version, transaction_version) = client.simple_runtime_version().await?;
 	client
 		.submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
-			Bytes(
+			Ok(Bytes(
 				Kusama::sign_transaction(SignParam {
 					spec_version,
 					transaction_version,
@@ -96,12 +96,12 @@ pub(crate) async fn update_polkadot_to_kusama_conversion_rate(
 									sp_runtime::FixedU128::from_float(updated_rate),
 								)
 							)
-						),
+						).into(),
 						transaction_nonce,
 					),
-				})
+				})?
 				.encode(),
-			)
+			))
 		})
 		.await
 		.map(drop)

--- a/relays/bin-substrate/src/chains/millau.rs
+++ b/relays/bin-substrate/src/chains/millau.rs
@@ -25,24 +25,27 @@ use crate::cli::{
 };
 use anyhow::anyhow;
 use bp_message_dispatch::{CallOrigin, MessagePayload};
+use bp_runtime::EncodedOrDecodedCall;
 use codec::Decode;
 use frame_support::weights::{DispatchInfo, GetDispatchInfo};
 use relay_millau_client::Millau;
 use sp_version::RuntimeVersion;
 
 impl CliEncodeCall for Millau {
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call> {
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>> {
 		Ok(match call {
-			Call::Raw { data } => Decode::decode(&mut &*data.0)?,
+			Call::Raw { data } => Self::Call::decode(&mut &*data.0)?.into(),
 			Call::Remark { remark_payload, .. } =>
 				millau_runtime::Call::System(millau_runtime::SystemCall::remark {
 					remark: remark_payload.as_ref().map(|x| x.0.clone()).unwrap_or_default(),
-				}),
+				})
+				.into(),
 			Call::Transfer { recipient, amount } =>
 				millau_runtime::Call::Balances(millau_runtime::BalancesCall::transfer {
 					dest: recipient.raw_id(),
 					value: amount.cast(),
-				}),
+				})
+				.into(),
 			Call::BridgeSendMessage { lane, payload, fee, bridge_instance_index } =>
 				match *bridge_instance_index {
 					bridge::MILLAU_TO_RIALTO_INDEX => {
@@ -54,6 +57,7 @@ impl CliEncodeCall for Millau {
 								delivery_and_dispatch_fee: fee.cast(),
 							},
 						)
+						.into()
 					},
 					_ => anyhow::bail!(
 						"Unsupported target bridge pallet with instance index: {}",
@@ -63,8 +67,8 @@ impl CliEncodeCall for Millau {
 		})
 	}
 
-	fn get_dispatch_info(call: &millau_runtime::Call) -> anyhow::Result<DispatchInfo> {
-		Ok(call.get_dispatch_info())
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo> {
+		Ok(call.to_decoded()?.get_dispatch_info())
 	}
 }
 
@@ -90,7 +94,7 @@ impl CliChain for Millau {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Millau's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
 				type Source = Millau;
 				type Target = relay_rialto_client::Rialto;
 
@@ -102,7 +106,9 @@ impl CliChain for Millau {
 					bridge::MILLAU_TO_RIALTO_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = call.get_dispatch_info().weight;
+				let weight = weight.map(Ok).unwrap_or_else(|| {
+					call.to_decoded().map(|call| call.get_dispatch_info().weight)
+				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,

--- a/relays/bin-substrate/src/chains/millau.rs
+++ b/relays/bin-substrate/src/chains/millau.rs
@@ -94,7 +94,7 @@ impl CliChain for Millau {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Millau's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, dispatch_weight } => {
 				type Source = Millau;
 				type Target = relay_rialto_client::Rialto;
 
@@ -106,13 +106,13 @@ impl CliChain for Millau {
 					bridge::MILLAU_TO_RIALTO_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = weight.map(Ok).unwrap_or_else(|| {
+				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
 					call.to_decoded().map(|call| call.get_dispatch_info().weight)
 				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,
-					weight,
+					dispatch_weight,
 					origin,
 					&call,
 					DispatchFeePayment::AtSourceChain,

--- a/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
+++ b/relays/bin-substrate/src/chains/millau_messages_to_rialto.rs
@@ -74,7 +74,7 @@ pub(crate) async fn update_rialto_to_millau_conversion_rate(
 	let (spec_version, transaction_version) = client.simple_runtime_version().await?;
 	client
 		.submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
-			Bytes(
+			Ok(Bytes(
 				Millau::sign_transaction(SignParam {
 					spec_version,
 					transaction_version,
@@ -82,17 +82,16 @@ pub(crate) async fn update_rialto_to_millau_conversion_rate(
 					signer,
 					era: relay_substrate_client::TransactionEra::immortal(),
 					unsigned: UnsignedTransaction::new(
-						millau_runtime::MessagesCall::update_pallet_parameter {
+						millau_runtime::Call::from(millau_runtime::MessagesCall::update_pallet_parameter {
 							parameter: millau_runtime::rialto_messages::MillauToRialtoMessagesParameter::RialtoToMillauConversionRate(
 								sp_runtime::FixedU128::from_float(updated_rate),
 							),
-						}
-							.into(),
+						}).into(),
 						transaction_nonce,
 					),
-				})
+				})?
 				.encode(),
-			)
+			))
 		})
 		.await
 		.map(drop)

--- a/relays/bin-substrate/src/chains/mod.rs
+++ b/relays/bin-substrate/src/chains/mod.rs
@@ -210,8 +210,9 @@ mod tests {
 			genesis_hash: Default::default(),
 			signer: sp_keyring::AccountKeyring::Alice.pair(),
 			era: relay_substrate_client::TransactionEra::immortal(),
-			unsigned: UnsignedTransaction::new(rialto_call.clone(), 0),
-		});
+			unsigned: UnsignedTransaction::new(rialto_call.clone().into(), 0),
+		})
+		.unwrap();
 		let extra_bytes_in_transaction = rialto_tx.encode().len() - rialto_call.encode().len();
 		assert!(
 			bp_rialto::TX_EXTRA_BYTES as usize >= extra_bytes_in_transaction,
@@ -231,8 +232,9 @@ mod tests {
 			genesis_hash: Default::default(),
 			signer: sp_keyring::AccountKeyring::Alice.pair(),
 			era: relay_substrate_client::TransactionEra::immortal(),
-			unsigned: UnsignedTransaction::new(millau_call.clone(), 0),
-		});
+			unsigned: UnsignedTransaction::new(millau_call.clone().into(), 0),
+		})
+		.unwrap();
 		let extra_bytes_in_transaction = millau_tx.encode().len() - millau_call.encode().len();
 		assert!(
 			bp_millau::TX_EXTRA_BYTES as usize >= extra_bytes_in_transaction,

--- a/relays/bin-substrate/src/chains/polkadot.rs
+++ b/relays/bin-substrate/src/chains/polkadot.rs
@@ -117,7 +117,9 @@ impl CliChain for Polkadot {
 				);
 				let call = Target::encode_call(&call)?;
 				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Kusama call"))
+					Err(anyhow::format_err!(
+						"Please specify dispatch weight of the encoded Kusama call"
+					))
 				})?;
 
 				Ok(send_message::message_payload(

--- a/relays/bin-substrate/src/chains/polkadot.rs
+++ b/relays/bin-substrate/src/chains/polkadot.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
+use anyhow::anyhow;
+use bp_message_dispatch::{CallOrigin, MessagePayload};
+use bp_runtime::EncodedOrDecodedCall;
 use codec::Decode;
 use frame_support::weights::{DispatchClass, DispatchInfo, Pays, Weight};
 use relay_polkadot_client::Polkadot;
@@ -21,8 +24,10 @@ use sp_version::RuntimeVersion;
 
 use crate::cli::{
 	bridge,
-	encode_call::{Call, CliEncodeCall},
-	encode_message, CliChain,
+	encode_call::{self, Call, CliEncodeCall},
+	encode_message,
+	send_message::{self, DispatchFeePayment},
+	CliChain,
 };
 
 /// Weight of the `system::remark` call at Polkadot.
@@ -32,13 +37,15 @@ use crate::cli::{
 pub(crate) const SYSTEM_REMARK_CALL_WEIGHT: Weight = 2 * 1_345_000;
 
 impl CliEncodeCall for Polkadot {
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call> {
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>> {
 		Ok(match call {
+			Call::Raw { data } => EncodedOrDecodedCall::Encoded(data.0.clone()),
 			Call::Remark { remark_payload, .. } => relay_polkadot_client::runtime::Call::System(
 				relay_polkadot_client::runtime::SystemCall::remark(
 					remark_payload.as_ref().map(|x| x.0.clone()).unwrap_or_default(),
 				),
-			),
+			)
+			.into(),
 			Call::BridgeSendMessage { lane, payload, fee, bridge_instance_index } =>
 				match *bridge_instance_index {
 					bridge::POLKADOT_TO_KUSAMA_INDEX => {
@@ -48,6 +55,7 @@ impl CliEncodeCall for Polkadot {
 								lane.0, payload, fee.0,
 							),
 						)
+						.into()
 					},
 					_ => anyhow::bail!(
 						"Unsupported target bridge pallet with instance index: {}",
@@ -58,13 +66,11 @@ impl CliEncodeCall for Polkadot {
 		})
 	}
 
-	fn get_dispatch_info(
-		call: &relay_polkadot_client::runtime::Call,
-	) -> anyhow::Result<DispatchInfo> {
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo> {
 		match *call {
-			relay_polkadot_client::runtime::Call::System(
+			EncodedOrDecodedCall::Decoded(relay_polkadot_client::runtime::Call::System(
 				relay_polkadot_client::runtime::SystemCall::remark(_),
-			) => Ok(DispatchInfo {
+			)) => Ok(DispatchInfo {
 				weight: crate::chains::polkadot::SYSTEM_REMARK_CALL_WEIGHT,
 				class: DispatchClass::Normal,
 				pays_fee: Pays::Yes,
@@ -78,7 +84,12 @@ impl CliChain for Polkadot {
 	const RUNTIME_VERSION: RuntimeVersion = bp_polkadot::VERSION;
 
 	type KeyPair = sp_core::sr25519::Pair;
-	type MessagePayload = ();
+	type MessagePayload = MessagePayload<
+		bp_polkadot::AccountId,
+		bp_kusama::AccountPublic,
+		bp_kusama::Signature,
+		Vec<u8>,
+	>;
 
 	fn ss58_format() -> u16 {
 		sp_core::crypto::Ss58AddressFormat::from(
@@ -88,8 +99,35 @@ impl CliChain for Polkadot {
 	}
 
 	fn encode_message(
-		_message: encode_message::MessagePayload,
+		message: encode_message::MessagePayload,
 	) -> anyhow::Result<Self::MessagePayload> {
-		anyhow::bail!("Sending messages from Polkadot is not yet supported.")
+		match message {
+			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
+				.map_err(|e| anyhow!("Failed to decode Polkadot's MessagePayload: {:?}", e)),
+			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+				type Source = Polkadot;
+				type Target = relay_kusama_client::Kusama;
+
+				sender.enforce_chain::<Source>();
+				let spec_version = Target::RUNTIME_VERSION.spec_version;
+				let origin = CallOrigin::SourceAccount(sender.raw_id());
+				encode_call::preprocess_call::<Source, Target>(
+					&mut call,
+					bridge::POLKADOT_TO_KUSAMA_INDEX,
+				);
+				let call = Target::encode_call(&call)?;
+				let weight = weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify weight of the encoded Kusama call"))
+				})?;
+
+				Ok(send_message::message_payload(
+					spec_version,
+					weight,
+					origin,
+					&call,
+					DispatchFeePayment::AtSourceChain,
+				))
+			},
+		}
 	}
 }

--- a/relays/bin-substrate/src/chains/polkadot.rs
+++ b/relays/bin-substrate/src/chains/polkadot.rs
@@ -104,7 +104,7 @@ impl CliChain for Polkadot {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Polkadot's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, dispatch_weight } => {
 				type Source = Polkadot;
 				type Target = relay_kusama_client::Kusama;
 
@@ -116,13 +116,13 @@ impl CliChain for Polkadot {
 					bridge::POLKADOT_TO_KUSAMA_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify weight of the encoded Kusama call"))
+				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Kusama call"))
 				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,
-					weight,
+					dispatch_weight,
 					origin,
 					&call,
 					DispatchFeePayment::AtSourceChain,

--- a/relays/bin-substrate/src/chains/polkadot_messages_to_kusama.rs
+++ b/relays/bin-substrate/src/chains/polkadot_messages_to_kusama.rs
@@ -82,7 +82,7 @@ pub(crate) async fn update_kusama_to_polkadot_conversion_rate(
 	let (spec_version, transaction_version) = client.simple_runtime_version().await?;
 	client
 		.submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
-			Bytes(
+			Ok(Bytes(
 				Polkadot::sign_transaction(SignParam {
 					spec_version,
 					transaction_version,
@@ -96,12 +96,12 @@ pub(crate) async fn update_kusama_to_polkadot_conversion_rate(
 									sp_runtime::FixedU128::from_float(updated_rate),
 								)
 							)
-						),
+						).into(),
 						transaction_nonce,
 					)
-				})
+				})?
 				.encode(),
-			)
+			))
 		})
 		.await
 		.map(drop)

--- a/relays/bin-substrate/src/chains/rialto.rs
+++ b/relays/bin-substrate/src/chains/rialto.rs
@@ -93,7 +93,7 @@ impl CliChain for Rialto {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Rialto's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, dispatch_weight } => {
 				type Source = Rialto;
 				type Target = relay_millau_client::Millau;
 
@@ -105,13 +105,13 @@ impl CliChain for Rialto {
 					bridge::RIALTO_TO_MILLAU_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = weight.map(Ok).unwrap_or_else(|| {
+				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
 					call.to_decoded().map(|call| call.get_dispatch_info().weight)
 				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,
-					weight,
+					dispatch_weight,
 					origin,
 					&call,
 					DispatchFeePayment::AtSourceChain,

--- a/relays/bin-substrate/src/chains/rialto.rs
+++ b/relays/bin-substrate/src/chains/rialto.rs
@@ -25,24 +25,27 @@ use crate::cli::{
 };
 use anyhow::anyhow;
 use bp_message_dispatch::{CallOrigin, MessagePayload};
+use bp_runtime::EncodedOrDecodedCall;
 use codec::Decode;
 use frame_support::weights::{DispatchInfo, GetDispatchInfo};
 use relay_rialto_client::Rialto;
 use sp_version::RuntimeVersion;
 
 impl CliEncodeCall for Rialto {
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call> {
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>> {
 		Ok(match call {
-			Call::Raw { data } => Decode::decode(&mut &*data.0)?,
+			Call::Raw { data } => Self::Call::decode(&mut &*data.0)?.into(),
 			Call::Remark { remark_payload, .. } =>
 				rialto_runtime::Call::System(rialto_runtime::SystemCall::remark {
 					remark: remark_payload.as_ref().map(|x| x.0.clone()).unwrap_or_default(),
-				}),
+				})
+				.into(),
 			Call::Transfer { recipient, amount } =>
 				rialto_runtime::Call::Balances(rialto_runtime::BalancesCall::transfer {
 					dest: recipient.raw_id().into(),
 					value: amount.0,
-				}),
+				})
+				.into(),
 			Call::BridgeSendMessage { lane, payload, fee, bridge_instance_index } =>
 				match *bridge_instance_index {
 					bridge::RIALTO_TO_MILLAU_INDEX => {
@@ -54,6 +57,7 @@ impl CliEncodeCall for Rialto {
 								delivery_and_dispatch_fee: fee.0,
 							},
 						)
+						.into()
 					},
 					_ => anyhow::bail!(
 						"Unsupported target bridge pallet with instance index: {}",
@@ -63,8 +67,8 @@ impl CliEncodeCall for Rialto {
 		})
 	}
 
-	fn get_dispatch_info(call: &rialto_runtime::Call) -> anyhow::Result<DispatchInfo> {
-		Ok(call.get_dispatch_info())
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo> {
+		Ok(call.to_decoded()?.get_dispatch_info())
 	}
 }
 
@@ -89,7 +93,7 @@ impl CliChain for Rialto {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Rialto's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
 				type Source = Rialto;
 				type Target = relay_millau_client::Millau;
 
@@ -101,7 +105,9 @@ impl CliChain for Rialto {
 					bridge::RIALTO_TO_MILLAU_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = call.get_dispatch_info().weight;
+				let weight = weight.map(Ok).unwrap_or_else(|| {
+					call.to_decoded().map(|call| call.get_dispatch_info().weight)
+				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,

--- a/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
+++ b/relays/bin-substrate/src/chains/rialto_messages_to_millau.rs
@@ -74,7 +74,7 @@ pub(crate) async fn update_millau_to_rialto_conversion_rate(
 	let (spec_version, transaction_version) = client.simple_runtime_version().await?;
 	client
 		.submit_signed_extrinsic(signer_id, move |_, transaction_nonce| {
-			Bytes(
+			Ok(Bytes(
 				Rialto::sign_transaction(SignParam {
 					spec_version,
 					transaction_version,
@@ -82,17 +82,16 @@ pub(crate) async fn update_millau_to_rialto_conversion_rate(
 					signer,
 					era: relay_substrate_client::TransactionEra::immortal(),
 					unsigned: UnsignedTransaction::new(
-						rialto_runtime::MessagesCall::update_pallet_parameter {
+						rialto_runtime::Call::from(rialto_runtime::MessagesCall::update_pallet_parameter {
 							parameter: rialto_runtime::millau_messages::RialtoToMillauMessagesParameter::MillauToRialtoConversionRate(
 								sp_runtime::FixedU128::from_float(updated_rate),
 							),
-						}
-						.into(),
+						}).into(),
 						transaction_nonce,
 					)
-				})
+				})?
 				.encode(),
-			)
+			))
 		})
 		.await
 		.map(drop)

--- a/relays/bin-substrate/src/chains/rialto_parachain.rs
+++ b/relays/bin-substrate/src/chains/rialto_parachain.rs
@@ -21,34 +21,37 @@ use crate::cli::{
 	encode_message, CliChain,
 };
 use bp_message_dispatch::MessagePayload;
+use bp_runtime::EncodedOrDecodedCall;
 use codec::Decode;
 use frame_support::weights::{DispatchInfo, GetDispatchInfo};
 use relay_rialto_parachain_client::RialtoParachain;
 use sp_version::RuntimeVersion;
 
 impl CliEncodeCall for RialtoParachain {
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call> {
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>> {
 		Ok(match call {
-			Call::Raw { data } => Decode::decode(&mut &*data.0)?,
+			Call::Raw { data } => Self::Call::decode(&mut &*data.0)?.into(),
 			Call::Remark { remark_payload, .. } => rialto_parachain_runtime::Call::System(
 				rialto_parachain_runtime::SystemCall::remark {
 					remark: remark_payload.as_ref().map(|x| x.0.clone()).unwrap_or_default(),
 				},
-			),
+			)
+			.into(),
 			Call::Transfer { recipient, amount } => rialto_parachain_runtime::Call::Balances(
 				rialto_parachain_runtime::BalancesCall::transfer {
 					dest: recipient.raw_id().into(),
 					value: amount.0,
 				},
-			),
+			)
+			.into(),
 			Call::BridgeSendMessage { .. } => {
 				anyhow::bail!("Bridge messages are not (yet) supported here",)
 			},
 		})
 	}
 
-	fn get_dispatch_info(call: &rialto_parachain_runtime::Call) -> anyhow::Result<DispatchInfo> {
-		Ok(call.get_dispatch_info())
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo> {
+		Ok(call.to_decoded()?.get_dispatch_info())
 	}
 }
 

--- a/relays/bin-substrate/src/chains/rococo.rs
+++ b/relays/bin-substrate/src/chains/rococo.rs
@@ -15,6 +15,8 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::anyhow;
+use bp_message_dispatch::{CallOrigin, MessagePayload};
+use bp_runtime::EncodedOrDecodedCall;
 use codec::Decode;
 use frame_support::weights::{DispatchClass, DispatchInfo, Pays, Weight};
 use relay_rococo_client::Rococo;
@@ -22,8 +24,10 @@ use sp_version::RuntimeVersion;
 
 use crate::cli::{
 	bridge,
-	encode_call::{Call, CliEncodeCall},
-	encode_message, CliChain,
+	encode_call::{self, Call, CliEncodeCall},
+	encode_message,
+	send_message::{self, DispatchFeePayment},
+	CliChain,
 };
 
 /// Weight of the `system::remark` call at Rococo.
@@ -33,13 +37,15 @@ use crate::cli::{
 pub(crate) const SYSTEM_REMARK_CALL_WEIGHT: Weight = 2 * 1_345_000;
 
 impl CliEncodeCall for Rococo {
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call> {
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>> {
 		Ok(match call {
+			Call::Raw { data } => EncodedOrDecodedCall::Encoded(data.0.clone()),
 			Call::Remark { remark_payload, .. } => relay_rococo_client::runtime::Call::System(
 				relay_rococo_client::runtime::SystemCall::remark(
 					remark_payload.as_ref().map(|x| x.0.clone()).unwrap_or_default(),
 				),
-			),
+			)
+			.into(),
 			Call::BridgeSendMessage { lane, payload, fee, bridge_instance_index } =>
 				match *bridge_instance_index {
 					bridge::ROCOCO_TO_WOCOCO_INDEX => {
@@ -49,6 +55,7 @@ impl CliEncodeCall for Rococo {
 								lane.0, payload, fee.0,
 							),
 						)
+						.into()
 					},
 					_ => anyhow::bail!(
 						"Unsupported target bridge pallet with instance index: {}",
@@ -59,13 +66,11 @@ impl CliEncodeCall for Rococo {
 		})
 	}
 
-	fn get_dispatch_info(
-		call: &relay_rococo_client::runtime::Call,
-	) -> anyhow::Result<DispatchInfo> {
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo> {
 		match *call {
-			relay_rococo_client::runtime::Call::System(
+			EncodedOrDecodedCall::Decoded(relay_rococo_client::runtime::Call::System(
 				relay_rococo_client::runtime::SystemCall::remark(_),
-			) => Ok(DispatchInfo {
+			)) => Ok(DispatchInfo {
 				weight: SYSTEM_REMARK_CALL_WEIGHT,
 				class: DispatchClass::Normal,
 				pays_fee: Pays::Yes,
@@ -79,15 +84,47 @@ impl CliChain for Rococo {
 	const RUNTIME_VERSION: RuntimeVersion = bp_rococo::VERSION;
 
 	type KeyPair = sp_core::sr25519::Pair;
-	type MessagePayload = ();
+	type MessagePayload = MessagePayload<
+		bp_rococo::AccountId,
+		bp_wococo::AccountPublic,
+		bp_wococo::Signature,
+		Vec<u8>,
+	>;
 
 	fn ss58_format() -> u16 {
 		42
 	}
 
 	fn encode_message(
-		_message: encode_message::MessagePayload,
+		message: encode_message::MessagePayload,
 	) -> anyhow::Result<Self::MessagePayload> {
-		Err(anyhow!("Sending messages from Rococo is not yet supported."))
+		match message {
+			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
+				.map_err(|e| anyhow!("Failed to decode Rococo's MessagePayload: {:?}", e)),
+			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+				type Source = Rococo;
+				type Target = relay_wococo_client::Wococo;
+
+				sender.enforce_chain::<Source>();
+				let spec_version = Target::RUNTIME_VERSION.spec_version;
+				let origin = CallOrigin::SourceAccount(sender.raw_id());
+				encode_call::preprocess_call::<Source, Target>(
+					&mut call,
+					bridge::ROCOCO_TO_WOCOCO_INDEX,
+				);
+				let call = Target::encode_call(&call)?;
+				let weight = weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify weight of the encoded Wococo call"))
+				})?;
+
+				Ok(send_message::message_payload(
+					spec_version,
+					weight,
+					origin,
+					&call,
+					DispatchFeePayment::AtSourceChain,
+				))
+			},
+		}
 	}
 }

--- a/relays/bin-substrate/src/chains/rococo.rs
+++ b/relays/bin-substrate/src/chains/rococo.rs
@@ -114,7 +114,9 @@ impl CliChain for Rococo {
 				);
 				let call = Target::encode_call(&call)?;
 				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Wococo call"))
+					Err(anyhow::format_err!(
+						"Please specify dispatch weight of the encoded Wococo call"
+					))
 				})?;
 
 				Ok(send_message::message_payload(

--- a/relays/bin-substrate/src/chains/rococo.rs
+++ b/relays/bin-substrate/src/chains/rococo.rs
@@ -101,7 +101,7 @@ impl CliChain for Rococo {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Rococo's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, dispatch_weight } => {
 				type Source = Rococo;
 				type Target = relay_wococo_client::Wococo;
 
@@ -113,13 +113,13 @@ impl CliChain for Rococo {
 					bridge::ROCOCO_TO_WOCOCO_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify weight of the encoded Wococo call"))
+				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Wococo call"))
 				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,
-					weight,
+					dispatch_weight,
 					origin,
 					&call,
 					DispatchFeePayment::AtSourceChain,

--- a/relays/bin-substrate/src/chains/wococo.rs
+++ b/relays/bin-substrate/src/chains/wococo.rs
@@ -95,7 +95,7 @@ impl CliChain for Wococo {
 		match message {
 			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
 				.map_err(|e| anyhow!("Failed to decode Wococo's MessagePayload: {:?}", e)),
-			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+			encode_message::MessagePayload::Call { mut call, mut sender, dispatch_weight } => {
 				type Source = Wococo;
 				type Target = relay_rococo_client::Rococo;
 
@@ -107,13 +107,13 @@ impl CliChain for Wococo {
 					bridge::WOCOCO_TO_ROCOCO_INDEX,
 				);
 				let call = Target::encode_call(&call)?;
-				let weight = weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify weight of the encoded Rococo call"))
+				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Rococo call"))
 				})?;
 
 				Ok(send_message::message_payload(
 					spec_version,
-					weight,
+					dispatch_weight,
 					origin,
 					&call,
 					DispatchFeePayment::AtSourceChain,

--- a/relays/bin-substrate/src/chains/wococo.rs
+++ b/relays/bin-substrate/src/chains/wococo.rs
@@ -108,7 +108,9 @@ impl CliChain for Wococo {
 				);
 				let call = Target::encode_call(&call)?;
 				let dispatch_weight = dispatch_weight.map(Ok).unwrap_or_else(|| {
-					Err(anyhow::format_err!("Please specify dispatch weight of the encoded Rococo call"))
+					Err(anyhow::format_err!(
+						"Please specify dispatch weight of the encoded Rococo call"
+					))
 				})?;
 
 				Ok(send_message::message_payload(

--- a/relays/bin-substrate/src/chains/wococo.rs
+++ b/relays/bin-substrate/src/chains/wococo.rs
@@ -15,6 +15,8 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::anyhow;
+use bp_message_dispatch::{CallOrigin, MessagePayload};
+use bp_runtime::EncodedOrDecodedCall;
 use codec::Decode;
 use frame_support::weights::{DispatchClass, DispatchInfo, Pays};
 use relay_wococo_client::Wococo;
@@ -22,18 +24,22 @@ use sp_version::RuntimeVersion;
 
 use crate::cli::{
 	bridge,
-	encode_call::{Call, CliEncodeCall},
-	encode_message, CliChain,
+	encode_call::{self, Call, CliEncodeCall},
+	encode_message,
+	send_message::{self, DispatchFeePayment},
+	CliChain,
 };
 
 impl CliEncodeCall for Wococo {
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call> {
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>> {
 		Ok(match call {
+			Call::Raw { data } => EncodedOrDecodedCall::Encoded(data.0.clone()),
 			Call::Remark { remark_payload, .. } => relay_wococo_client::runtime::Call::System(
 				relay_wococo_client::runtime::SystemCall::remark(
 					remark_payload.as_ref().map(|x| x.0.clone()).unwrap_or_default(),
 				),
-			),
+			)
+			.into(),
 			Call::BridgeSendMessage { lane, payload, fee, bridge_instance_index } =>
 				match *bridge_instance_index {
 					bridge::WOCOCO_TO_ROCOCO_INDEX => {
@@ -43,6 +49,7 @@ impl CliEncodeCall for Wococo {
 								lane.0, payload, fee.0,
 							),
 						)
+						.into()
 					},
 					_ => anyhow::bail!(
 						"Unsupported target bridge pallet with instance index: {}",
@@ -53,18 +60,16 @@ impl CliEncodeCall for Wococo {
 		})
 	}
 
-	fn get_dispatch_info(
-		call: &relay_wococo_client::runtime::Call,
-	) -> anyhow::Result<DispatchInfo> {
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo> {
 		match *call {
-			relay_wococo_client::runtime::Call::System(
+			EncodedOrDecodedCall::Decoded(relay_wococo_client::runtime::Call::System(
 				relay_wococo_client::runtime::SystemCall::remark(_),
-			) => Ok(DispatchInfo {
+			)) => Ok(DispatchInfo {
 				weight: crate::chains::rococo::SYSTEM_REMARK_CALL_WEIGHT,
 				class: DispatchClass::Normal,
 				pays_fee: Pays::Yes,
 			}),
-			_ => anyhow::bail!("Unsupported Rococo call: {:?}", call),
+			_ => anyhow::bail!("Unsupported Wococo call: {:?}", call),
 		}
 	}
 }
@@ -73,15 +78,47 @@ impl CliChain for Wococo {
 	const RUNTIME_VERSION: RuntimeVersion = bp_wococo::VERSION;
 
 	type KeyPair = sp_core::sr25519::Pair;
-	type MessagePayload = ();
+	type MessagePayload = MessagePayload<
+		bp_wococo::AccountId,
+		bp_rococo::AccountPublic,
+		bp_rococo::Signature,
+		Vec<u8>,
+	>;
 
 	fn ss58_format() -> u16 {
 		42
 	}
 
 	fn encode_message(
-		_message: encode_message::MessagePayload,
+		message: encode_message::MessagePayload,
 	) -> anyhow::Result<Self::MessagePayload> {
-		Err(anyhow!("Sending messages from Wococo is not yet supported."))
+		match message {
+			encode_message::MessagePayload::Raw { data } => MessagePayload::decode(&mut &*data.0)
+				.map_err(|e| anyhow!("Failed to decode Wococo's MessagePayload: {:?}", e)),
+			encode_message::MessagePayload::Call { mut call, mut sender, weight } => {
+				type Source = Wococo;
+				type Target = relay_rococo_client::Rococo;
+
+				sender.enforce_chain::<Source>();
+				let spec_version = Target::RUNTIME_VERSION.spec_version;
+				let origin = CallOrigin::SourceAccount(sender.raw_id());
+				encode_call::preprocess_call::<Source, Target>(
+					&mut call,
+					bridge::WOCOCO_TO_ROCOCO_INDEX,
+				);
+				let call = Target::encode_call(&call)?;
+				let weight = weight.map(Ok).unwrap_or_else(|| {
+					Err(anyhow::format_err!("Please specify weight of the encoded Rococo call"))
+				})?;
+
+				Ok(send_message::message_payload(
+					spec_version,
+					weight,
+					origin,
+					&call,
+					DispatchFeePayment::AtSourceChain,
+				))
+			},
+		}
 	}
 }

--- a/relays/bin-substrate/src/cli/encode_call.rs
+++ b/relays/bin-substrate/src/cli/encode_call.rs
@@ -20,6 +20,7 @@ use crate::{
 	},
 	select_full_bridge,
 };
+use bp_runtime::EncodedOrDecodedCall;
 use frame_support::weights::DispatchInfo;
 use relay_substrate_client::Chain;
 use structopt::StructOpt;
@@ -85,10 +86,10 @@ pub enum Call {
 
 pub trait CliEncodeCall: Chain {
 	/// Encode a CLI call.
-	fn encode_call(call: &Call) -> anyhow::Result<Self::Call>;
+	fn encode_call(call: &Call) -> anyhow::Result<EncodedOrDecodedCall<Self::Call>>;
 
 	/// Get dispatch info for the call.
-	fn get_dispatch_info(call: &Self::Call) -> anyhow::Result<DispatchInfo>;
+	fn get_dispatch_info(call: &EncodedOrDecodedCall<Self::Call>) -> anyhow::Result<DispatchInfo>;
 }
 
 impl EncodeCall {
@@ -100,7 +101,10 @@ impl EncodeCall {
 			let encoded = HexBytes::encode(&call);
 
 			log::info!(target: "bridge", "Generated {} call: {:#?}", Source::NAME, call);
-			log::info!(target: "bridge", "Weight of {} call: {}", Source::NAME, Source::get_dispatch_info(&call)?.weight);
+			log::info!(target: "bridge", "Weight of {} call: {}", Source::NAME, Source::get_dispatch_info(&call)
+				.map(|dispatch_info| format!("{}", dispatch_info.weight))
+				.unwrap_or_else(|_| "<unknown>".to_string())
+			);
 			log::info!(target: "bridge", "Encoded {} call: {:?}", Source::NAME, encoded);
 
 			Ok(encoded)

--- a/relays/bin-substrate/src/cli/encode_message.rs
+++ b/relays/bin-substrate/src/cli/encode_message.rs
@@ -18,6 +18,7 @@ use crate::{
 	cli::{bridge::FullBridge, AccountId, CliChain, HexBytes},
 	select_full_bridge,
 };
+use frame_support::weights::Weight;
 use structopt::StructOpt;
 use strum::VariantNames;
 
@@ -37,6 +38,12 @@ pub enum MessagePayload {
 		/// SS58 encoded Source account that will send the payload.
 		#[structopt(long)]
 		sender: AccountId,
+		/// Weight of the call.
+		///
+		/// It must be specified if the chain runtime is not bundled with the relay, or if
+		/// you want to override bundled weight.
+		#[structopt(long)]
+		weight: Option<Weight>,
 	},
 }
 

--- a/relays/bin-substrate/src/cli/encode_message.rs
+++ b/relays/bin-substrate/src/cli/encode_message.rs
@@ -43,7 +43,7 @@ pub enum MessagePayload {
 		/// It must be specified if the chain runtime is not bundled with the relay, or if
 		/// you want to override bundled weight.
 		#[structopt(long)]
-		weight: Option<Weight>,
+		dispatch_weight: Option<Weight>,
 	},
 }
 
@@ -104,6 +104,8 @@ mod tests {
 			"call",
 			"--sender",
 			&sender,
+			"--dispatch-weight",
+			"42",
 			"remark",
 			"--remark-size",
 			"12",
@@ -113,6 +115,6 @@ mod tests {
 		let hex = encode_message.encode().unwrap();
 
 		// then
-		assert_eq!(format!("{:?}", hex), "0x01000000000000000000000002d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d003c000130000000000000000000000000");
+		assert_eq!(format!("{:?}", hex), "0x010000002a0000000000000002d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d003c000130000000000000000000000000");
 	}
 }

--- a/relays/bin-substrate/src/cli/estimate_fee.rs
+++ b/relays/bin-substrate/src/cli/estimate_fee.rs
@@ -103,7 +103,7 @@ mod tests {
 			"call",
 			"--sender",
 			&alice,
-			"--weight",
+			"--dispatch-weight",
 			"42",
 			"remark",
 			"--remark-payload",
@@ -132,7 +132,7 @@ mod tests {
 						remark_payload: Some(HexBytes(vec![0x12, 0x34])),
 						remark_size: None,
 					},
-					weight: Some(42),
+					dispatch_weight: Some(42),
 				}
 			}
 		);

--- a/relays/bin-substrate/src/cli/estimate_fee.rs
+++ b/relays/bin-substrate/src/cli/estimate_fee.rs
@@ -103,6 +103,8 @@ mod tests {
 			"call",
 			"--sender",
 			&alice,
+			"--weight",
+			"42",
 			"remark",
 			"--remark-payload",
 			"1234",
@@ -129,7 +131,8 @@ mod tests {
 					call: encode_call::Call::Remark {
 						remark_payload: Some(HexBytes(vec![0x12, 0x34])),
 						remark_size: None,
-					}
+					},
+					weight: Some(42),
 				}
 			}
 		);

--- a/relays/bin-substrate/src/cli/init_bridge.rs
+++ b/relays/bin-substrate/src/cli/init_bridge.rs
@@ -222,7 +222,7 @@ impl InitBridge {
 				target_client.clone(),
 				target_sign.public().into(),
 				move |transaction_nonce, initialization_data| {
-					Bytes(
+					Ok(Bytes(
 						Target::sign_transaction(SignParam {
 							spec_version,
 							transaction_version,
@@ -230,12 +230,12 @@ impl InitBridge {
 							signer: target_sign,
 							era: relay_substrate_client::TransactionEra::immortal(),
 							unsigned: UnsignedTransaction::new(
-								encode_init_bridge(initialization_data),
+								encode_init_bridge(initialization_data).into(),
 								transaction_nonce,
 							),
-						})
+						})?
 						.encode(),
-					)
+					))
 				},
 			)
 			.await;

--- a/relays/bin-substrate/src/cli/register_parachain.rs
+++ b/relays/bin-substrate/src/cli/register_parachain.rs
@@ -132,7 +132,7 @@ impl RegisterParachain {
 					.submit_and_watch_signed_extrinsic(
 						relay_sudo_account.clone(),
 						move |_, transaction_nonce| {
-							Bytes(
+							Ok(Bytes(
 								Relaychain::sign_transaction(SignParam {
 									spec_version,
 									transaction_version,
@@ -140,12 +140,12 @@ impl RegisterParachain {
 									signer: reserve_parachain_signer,
 									era: relay_substrate_client::TransactionEra::immortal(),
 									unsigned: UnsignedTransaction::new(
-										reserve_parachain_id_call,
+										reserve_parachain_id_call.into(),
 										transaction_nonce,
 									),
-								})
+								})?
 								.encode(),
-							)
+							))
 						},
 					)
 					.await?,
@@ -181,7 +181,7 @@ impl RegisterParachain {
 					.submit_and_watch_signed_extrinsic(
 						relay_sudo_account.clone(),
 						move |_, transaction_nonce| {
-							Bytes(
+							Ok(Bytes(
 								Relaychain::sign_transaction(SignParam {
 									spec_version,
 									transaction_version,
@@ -189,12 +189,12 @@ impl RegisterParachain {
 									signer: register_parathread_signer,
 									era: relay_substrate_client::TransactionEra::immortal(),
 									unsigned: UnsignedTransaction::new(
-										register_parathread_call,
+										register_parathread_call.into(),
 										transaction_nonce,
 									),
-								})
+								})?
 								.encode(),
-							)
+							))
 						},
 					)
 					.await?,
@@ -243,17 +243,20 @@ impl RegisterParachain {
 			let force_lease_signer = relay_sign.clone();
 			relay_client
 				.submit_signed_extrinsic(relay_sudo_account.clone(), move |_, transaction_nonce| {
-					Bytes(
+					Ok(Bytes(
 						Relaychain::sign_transaction(SignParam {
 							spec_version,
 							transaction_version,
 							genesis_hash: relay_genesis_hash,
 							signer: force_lease_signer,
 							era: relay_substrate_client::TransactionEra::immortal(),
-							unsigned: UnsignedTransaction::new(force_lease_call, transaction_nonce),
-						})
+							unsigned: UnsignedTransaction::new(
+								force_lease_call.into(),
+								transaction_nonce,
+							),
+						})?
 						.encode(),
-					)
+					))
 				})
 				.await?;
 			log::info!(target: "bridge", "Registered parachain leases: {:?}. Waiting for onboarding", para_id);

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -615,17 +615,17 @@ where
 	let (spec_version, transaction_version) = client.simple_runtime_version().await?;
 	client
 		.submit_signed_extrinsic(sign.public().into(), move |_, transaction_nonce| {
-			Bytes(
+			Ok(Bytes(
 				C::sign_transaction(SignParam {
 					spec_version,
 					transaction_version,
 					genesis_hash,
 					signer: sign,
 					era: relay_substrate_client::TransactionEra::immortal(),
-					unsigned: UnsignedTransaction::new(call, transaction_nonce),
-				})
+					unsigned: UnsignedTransaction::new(call.into(), transaction_nonce),
+				})?
 				.encode(),
-			)
+			))
 		})
 		.await
 		.map(drop)

--- a/relays/bin-substrate/src/cli/resubmit_transactions.rs
+++ b/relays/bin-substrate/src/cli/resubmit_transactions.rs
@@ -445,7 +445,7 @@ async fn update_transaction_tip<C: Chain, S: TransactionSignScheme<Chain = C>>(
 					signer: key_pair.clone(),
 					era: relay_substrate_client::TransactionEra::immortal(),
 					unsigned: unsigned_tx.clone(),
-				}),
+				})?,
 			)
 			.await??
 			.priority;
@@ -468,7 +468,7 @@ async fn update_transaction_tip<C: Chain, S: TransactionSignScheme<Chain = C>>(
 			signer: key_pair.clone(),
 			era: relay_substrate_client::TransactionEra::immortal(),
 			unsigned: unsigned_tx,
-		}),
+		})?,
 	))
 }
 

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -200,7 +200,7 @@ impl SendMessage {
 						signer: source_sign.clone(),
 						era: relay_substrate_client::TransactionEra::immortal(),
 						unsigned: UnsignedTransaction::new(send_message_call.clone(), 0),
-					})
+					})?
 					.encode(),
 				))
 				.await?;
@@ -213,7 +213,7 @@ impl SendMessage {
 						signer: source_sign.clone(),
 						era: relay_substrate_client::TransactionEra::immortal(),
 						unsigned: UnsignedTransaction::new(send_message_call, transaction_nonce),
-					})
+					})?
 					.encode();
 
 					log::info!(
@@ -241,7 +241,7 @@ impl SendMessage {
 						HexBytes::encode(&signed_source_call)
 					);
 
-					Bytes(signed_source_call)
+					Ok(Bytes(signed_source_call))
 				})
 				.await?;
 		});

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -124,7 +124,11 @@ impl SendMessage {
 			let payload = {
 				let target_call_weight = prepare_call_dispatch_weight(
 					dispatch_weight,
-					|| Ok(ExplicitOrMaximal::Explicit(Target::get_dispatch_info(&target_call)?.weight)),
+					|| {
+						Ok(ExplicitOrMaximal::Explicit(
+							Target::get_dispatch_info(&target_call)?.weight,
+						))
+					},
 					compute_maximal_message_dispatch_weight(Target::max_extrinsic_weight()),
 				)?;
 				let source_sender_public: MultiSigner = source_sign.public().into();
@@ -255,7 +259,11 @@ fn prepare_call_dispatch_weight(
 	weight_from_pre_dispatch_call: impl Fn() -> anyhow::Result<ExplicitOrMaximal<Weight>>,
 	maximal_allowed_weight: Weight,
 ) -> anyhow::Result<Weight> {
-	match user_specified_dispatch_weight.clone().map(Ok).unwrap_or_else(weight_from_pre_dispatch_call)? {
+	match user_specified_dispatch_weight
+		.clone()
+		.map(Ok)
+		.unwrap_or_else(weight_from_pre_dispatch_call)?
+	{
 		ExplicitOrMaximal::Explicit(weight) => Ok(weight),
 		ExplicitOrMaximal::Maximal => Ok(maximal_allowed_weight),
 	}

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -124,9 +124,9 @@ impl SendMessage {
 			let payload = {
 				let target_call_weight = prepare_call_dispatch_weight(
 					dispatch_weight,
-					ExplicitOrMaximal::Explicit(Target::get_dispatch_info(&target_call)?.weight),
+					|| Ok(ExplicitOrMaximal::Explicit(Target::get_dispatch_info(&target_call)?.weight)),
 					compute_maximal_message_dispatch_weight(Target::max_extrinsic_weight()),
-				);
+				)?;
 				let source_sender_public: MultiSigner = source_sign.public().into();
 				let source_account_id = source_sender_public.into_account();
 
@@ -252,12 +252,12 @@ impl SendMessage {
 
 fn prepare_call_dispatch_weight(
 	user_specified_dispatch_weight: &Option<ExplicitOrMaximal<Weight>>,
-	weight_from_pre_dispatch_call: ExplicitOrMaximal<Weight>,
+	weight_from_pre_dispatch_call: impl Fn() -> anyhow::Result<ExplicitOrMaximal<Weight>>,
 	maximal_allowed_weight: Weight,
-) -> Weight {
-	match user_specified_dispatch_weight.clone().unwrap_or(weight_from_pre_dispatch_call) {
-		ExplicitOrMaximal::Explicit(weight) => weight,
-		ExplicitOrMaximal::Maximal => maximal_allowed_weight,
+) -> anyhow::Result<Weight> {
+	match user_specified_dispatch_weight.clone().map(Ok).unwrap_or_else(weight_from_pre_dispatch_call)? {
+		ExplicitOrMaximal::Explicit(weight) => Ok(weight),
+		ExplicitOrMaximal::Maximal => Ok(maximal_allowed_weight),
 	}
 }
 

--- a/relays/bin-substrate/src/cli/swap_tokens.rs
+++ b/relays/bin-substrate/src/cli/swap_tokens.rs
@@ -245,7 +245,7 @@ impl SwapTokens {
 					.submit_and_watch_signed_extrinsic(
 						accounts.source_account_at_this_chain.clone(),
 						move |_, transaction_nonce| {
-							Bytes(
+							Ok(Bytes(
 								Source::sign_transaction(SignParam {
 									spec_version,
 									transaction_version,
@@ -253,12 +253,12 @@ impl SwapTokens {
 									signer: create_swap_signer,
 									era: relay_substrate_client::TransactionEra::immortal(),
 									unsigned: UnsignedTransaction::new(
-										create_swap_call,
+										create_swap_call.into(),
 										transaction_nonce,
 									),
-								})
+								})?
 								.encode(),
-							)
+							))
 						},
 					)
 					.await?,
@@ -386,7 +386,7 @@ impl SwapTokens {
 						.submit_and_watch_signed_extrinsic(
 							accounts.target_account_at_bridged_chain.clone(),
 							move |_, transaction_nonce| {
-								Bytes(
+								Ok(Bytes(
 									Target::sign_transaction(SignParam {
 										spec_version,
 										transaction_version,
@@ -394,12 +394,12 @@ impl SwapTokens {
 										signer: target_sign,
 										era: relay_substrate_client::TransactionEra::immortal(),
 										unsigned: UnsignedTransaction::new(
-											send_message_call,
+											send_message_call.into(),
 											transaction_nonce,
 										),
-									})
+									})?
 									.encode(),
-								)
+								))
 							},
 						)
 						.await?,
@@ -430,7 +430,7 @@ impl SwapTokens {
 						.submit_and_watch_signed_extrinsic(
 							accounts.source_account_at_this_chain.clone(),
 							move |_, transaction_nonce| {
-								Bytes(
+								Ok(Bytes(
 									Source::sign_transaction(SignParam {
 										spec_version,
 										transaction_version,
@@ -438,12 +438,12 @@ impl SwapTokens {
 										signer: source_sign,
 										era: relay_substrate_client::TransactionEra::immortal(),
 										unsigned: UnsignedTransaction::new(
-											cancel_swap_call,
+											cancel_swap_call.into(),
 											transaction_nonce,
 										),
-									})
+									})?
 									.encode(),
-								)
+								))
 							},
 						)
 						.await?,

--- a/relays/client-kusama/src/lib.rs
+++ b/relays/client-kusama/src/lib.rs
@@ -20,8 +20,8 @@ use bp_messages::MessageNonce;
 use codec::Encode;
 use frame_support::weights::Weight;
 use relay_substrate_client::{
-	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages, SignParam,
-	TransactionSignScheme, UnsignedTransaction,
+	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
+	Error as SubstrateError, SignParam, TransactionSignScheme, UnsignedTransaction,
 };
 use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
@@ -101,7 +101,7 @@ impl TransactionSignScheme for Kusama {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction = crate::runtime::UncheckedExtrinsic;
 
-	fn sign_transaction(param: SignParam<Self>) -> Self::SignedTransaction {
+	fn sign_transaction(param: SignParam<Self>) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			param.unsigned.call.clone(),
 			bp_kusama::SignedExtensions::new(
@@ -119,12 +119,12 @@ impl TransactionSignScheme for Kusama {
 		let signer: sp_runtime::MultiSigner = param.signer.public().into();
 		let (call, extra, _) = raw_payload.deconstruct();
 
-		bp_kusama::UncheckedExtrinsic::new_signed(
+		Ok(bp_kusama::UncheckedExtrinsic::new_signed(
 			call,
 			sp_runtime::MultiAddress::Id(signer.into_account()),
 			signature.into(),
 			extra,
-		)
+		))
 	}
 
 	fn is_signed(tx: &Self::SignedTransaction) -> bool {

--- a/relays/client-polkadot/src/lib.rs
+++ b/relays/client-polkadot/src/lib.rs
@@ -20,8 +20,8 @@ use bp_messages::MessageNonce;
 use codec::Encode;
 use frame_support::weights::Weight;
 use relay_substrate_client::{
-	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages, SignParam,
-	TransactionSignScheme, UnsignedTransaction,
+	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
+	Error as SubstrateError, SignParam, TransactionSignScheme, UnsignedTransaction,
 };
 use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
@@ -102,7 +102,7 @@ impl TransactionSignScheme for Polkadot {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction = crate::runtime::UncheckedExtrinsic;
 
-	fn sign_transaction(param: SignParam<Self>) -> Self::SignedTransaction {
+	fn sign_transaction(param: SignParam<Self>) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			param.unsigned.call.clone(),
 			bp_polkadot::SignedExtensions::new(
@@ -120,12 +120,12 @@ impl TransactionSignScheme for Polkadot {
 		let signer: sp_runtime::MultiSigner = param.signer.public().into();
 		let (call, extra, _) = raw_payload.deconstruct();
 
-		bp_polkadot::UncheckedExtrinsic::new_signed(
+		Ok(bp_polkadot::UncheckedExtrinsic::new_signed(
 			call,
 			sp_runtime::MultiAddress::Id(signer.into_account()),
 			signature.into(),
 			extra,
-		)
+		))
 	}
 
 	fn is_signed(tx: &Self::SignedTransaction) -> bool {

--- a/relays/client-rialto/src/lib.rs
+++ b/relays/client-rialto/src/lib.rs
@@ -20,8 +20,8 @@ use bp_messages::MessageNonce;
 use codec::{Compact, Decode, Encode};
 use frame_support::weights::Weight;
 use relay_substrate_client::{
-	BalanceOf, Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages, IndexOf,
-	SignParam, TransactionSignScheme, UnsignedTransaction,
+	BalanceOf, Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
+	Error as SubstrateError, IndexOf, SignParam, TransactionSignScheme, UnsignedTransaction,
 };
 use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
@@ -103,7 +103,7 @@ impl TransactionSignScheme for Rialto {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction = rialto_runtime::UncheckedExtrinsic;
 
-	fn sign_transaction(param: SignParam<Self>) -> Self::SignedTransaction {
+	fn sign_transaction(param: SignParam<Self>) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::from_raw(
 			param.unsigned.call.clone(),
 			(
@@ -129,12 +129,12 @@ impl TransactionSignScheme for Rialto {
 		let signer: sp_runtime::MultiSigner = param.signer.public().into();
 		let (call, extra, _) = raw_payload.deconstruct();
 
-		rialto_runtime::UncheckedExtrinsic::new_signed(
-			call,
+		Ok(rialto_runtime::UncheckedExtrinsic::new_signed(
+			call.into_decoded()?,
 			signer.into_account().into(),
 			signature.into(),
 			extra,
-		)
+		))
 	}
 
 	fn is_signed(tx: &Self::SignedTransaction) -> bool {
@@ -151,7 +151,7 @@ impl TransactionSignScheme for Rialto {
 	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self::Chain>> {
 		let extra = &tx.signature.as_ref()?.2;
 		Some(UnsignedTransaction {
-			call: tx.function,
+			call: tx.function.into(),
 			nonce: Compact::<IndexOf<Self::Chain>>::decode(&mut &extra.4.encode()[..]).ok()?.into(),
 			tip: Compact::<BalanceOf<Self::Chain>>::decode(&mut &extra.6.encode()[..])
 				.ok()?

--- a/relays/client-rococo/src/lib.rs
+++ b/relays/client-rococo/src/lib.rs
@@ -20,8 +20,8 @@ use bp_messages::MessageNonce;
 use codec::Encode;
 use frame_support::weights::Weight;
 use relay_substrate_client::{
-	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages, SignParam,
-	TransactionSignScheme, UnsignedTransaction,
+	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
+	Error as SubstrateError, SignParam, TransactionSignScheme, UnsignedTransaction,
 };
 use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
@@ -104,7 +104,7 @@ impl TransactionSignScheme for Rococo {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction = crate::runtime::UncheckedExtrinsic;
 
-	fn sign_transaction(param: SignParam<Self>) -> Self::SignedTransaction {
+	fn sign_transaction(param: SignParam<Self>) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			param.unsigned.call.clone(),
 			bp_rococo::SignedExtensions::new(
@@ -122,12 +122,12 @@ impl TransactionSignScheme for Rococo {
 		let signer: sp_runtime::MultiSigner = param.signer.public().into();
 		let (call, extra, _) = raw_payload.deconstruct();
 
-		bp_rococo::UncheckedExtrinsic::new_signed(
+		Ok(bp_rococo::UncheckedExtrinsic::new_signed(
 			call,
 			sp_runtime::MultiAddress::Id(signer.into_account()),
 			signature.into(),
 			extra,
-		)
+		))
 	}
 
 	fn is_signed(tx: &Self::SignedTransaction) -> bool {

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -15,7 +15,7 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use bp_messages::MessageNonce;
-use bp_runtime::{Chain as ChainBase, HashOf, TransactionEraOf};
+use bp_runtime::{Chain as ChainBase, EncodedOrDecodedCall, HashOf, TransactionEraOf};
 use codec::{Codec, Encode};
 use frame_support::weights::{Weight, WeightToFeePolynomial};
 use jsonrpsee_ws_client::types::{DeserializeOwned, Serialize};
@@ -141,7 +141,7 @@ pub trait BlockWithJustification<Header> {
 #[derive(Clone, Debug)]
 pub struct UnsignedTransaction<C: Chain> {
 	/// Runtime call of this transaction.
-	pub call: C::Call,
+	pub call: EncodedOrDecodedCall<C::Call>,
 	/// Transaction nonce.
 	pub nonce: C::Index,
 	/// Tip included into transaction.
@@ -150,7 +150,7 @@ pub struct UnsignedTransaction<C: Chain> {
 
 impl<C: Chain> UnsignedTransaction<C> {
 	/// Create new unsigned transaction with given call, nonce and zero tip.
-	pub fn new(call: C::Call, nonce: C::Index) -> Self {
+	pub fn new(call: EncodedOrDecodedCall<C::Call>, nonce: C::Index) -> Self {
 		Self { call, nonce, tip: Zero::zero() }
 	}
 
@@ -174,7 +174,7 @@ pub trait TransactionSignScheme {
 	type SignedTransaction: Clone + Debug + Codec + Send + 'static;
 
 	/// Create transaction for given runtime call, signed by given account.
-	fn sign_transaction(param: SignParam<Self>) -> Self::SignedTransaction
+	fn sign_transaction(param: SignParam<Self>) -> Result<Self::SignedTransaction, crate::Error>
 	where
 		Self: Sized;
 

--- a/relays/client-wococo/src/lib.rs
+++ b/relays/client-wococo/src/lib.rs
@@ -20,8 +20,8 @@ use bp_messages::MessageNonce;
 use codec::Encode;
 use frame_support::weights::Weight;
 use relay_substrate_client::{
-	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages, SignParam,
-	TransactionSignScheme, UnsignedTransaction,
+	Chain, ChainBase, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
+	Error as SubstrateError, SignParam, TransactionSignScheme, UnsignedTransaction,
 };
 use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
@@ -104,7 +104,7 @@ impl TransactionSignScheme for Wococo {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction = crate::runtime::UncheckedExtrinsic;
 
-	fn sign_transaction(param: SignParam<Self>) -> Self::SignedTransaction {
+	fn sign_transaction(param: SignParam<Self>) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			param.unsigned.call.clone(),
 			bp_wococo::SignedExtensions::new(
@@ -122,12 +122,12 @@ impl TransactionSignScheme for Wococo {
 		let signer: sp_runtime::MultiSigner = param.signer.public().into();
 		let (call, extra, _) = raw_payload.deconstruct();
 
-		bp_wococo::UncheckedExtrinsic::new_signed(
+		Ok(bp_wococo::UncheckedExtrinsic::new_signed(
 			call,
 			sp_runtime::MultiAddress::Id(signer.into_account()),
 			signature.into(),
 			extra,
-		)
+		))
 	}
 
 	fn is_signed(tx: &Self::SignedTransaction) -> bool {

--- a/relays/lib-substrate-relay/src/finality_target.rs
+++ b/relays/lib-substrate-relay/src/finality_target.rs
@@ -123,17 +123,17 @@ where
 			.submit_signed_extrinsic(
 				self.transaction_params.signer.public().into(),
 				move |best_block_id, transaction_nonce| {
-					Bytes(
+					Ok(Bytes(
 						P::TransactionSignScheme::sign_transaction(SignParam {
 							spec_version,
 							transaction_version,
 							genesis_hash,
 							signer: transaction_params.signer.clone(),
 							era: TransactionEra::new(best_block_id, transaction_params.mortality),
-							unsigned: UnsignedTransaction::new(call, transaction_nonce),
-						})
+							unsigned: UnsignedTransaction::new(call.into(), transaction_nonce),
+						})?
 						.encode(),
-					)
+					))
 				},
 			)
 			.await

--- a/relays/lib-substrate-relay/src/headers_initialize.rs
+++ b/relays/lib-substrate-relay/src/headers_initialize.rs
@@ -31,7 +31,9 @@ use bp_header_chain::{
 use codec::Decode;
 use finality_grandpa::voter_set::VoterSet;
 use num_traits::{One, Zero};
-use relay_substrate_client::{BlockNumberOf, Chain, ChainWithGrandpa, Client, HashOf};
+use relay_substrate_client::{
+	BlockNumberOf, Chain, ChainWithGrandpa, Client, Error as SubstrateError, HashOf,
+};
 use sp_core::Bytes;
 use sp_finality_grandpa::AuthorityList as GrandpaAuthoritiesSet;
 use sp_runtime::traits::Header as HeaderT;
@@ -41,7 +43,10 @@ pub async fn initialize<SourceChain: ChainWithGrandpa, TargetChain: Chain>(
 	source_client: Client<SourceChain>,
 	target_client: Client<TargetChain>,
 	target_transactions_signer: TargetChain::AccountId,
-	prepare_initialize_transaction: impl FnOnce(TargetChain::Index, InitializationData<SourceChain::Header>) -> Bytes
+	prepare_initialize_transaction: impl FnOnce(
+			TargetChain::Index,
+			InitializationData<SourceChain::Header>,
+		) -> Result<Bytes, SubstrateError>
 		+ Send
 		+ 'static,
 ) {
@@ -77,7 +82,10 @@ async fn do_initialize<SourceChain: ChainWithGrandpa, TargetChain: Chain>(
 	source_client: Client<SourceChain>,
 	target_client: Client<TargetChain>,
 	target_transactions_signer: TargetChain::AccountId,
-	prepare_initialize_transaction: impl FnOnce(TargetChain::Index, InitializationData<SourceChain::Header>) -> Bytes
+	prepare_initialize_transaction: impl FnOnce(
+			TargetChain::Index,
+			InitializationData<SourceChain::Header>,
+		) -> Result<Bytes, SubstrateError>
 		+ Send
 		+ 'static,
 ) -> Result<


### PR DESCRIPTION
closes #1319 

The main thing here is `EncodedOrDecodedCall`, which has the same encoding as on-chain calls. But it has two variants - the call may be decoded (that's what we have been using previously). Or it may be encoded and only needs to be decoded when it needs to. In terms of relay subcommands, it means that if you're using pre-encoded calls in cli options and specify their dispatch weight, we'll never need to decode this call (this is the main problem from #1319 - we can't decode Rococo/Wococo/Kusama/Polkadot calls, because we have no access to the runtime from the relay).

Examples:
```bash
svyatonik@xwnotebook:~/dev/rococo-wococo.test$ ./bin/substrate-relay encode-message rococo-to-wococo call --sender 5CUXMS6Ja5E8HGa8qq2jumboFKjqpjA8mrdzyANhk7P2mELp --dispatch-weight 10000000000 raw 00010442
INFO bridge Created Message Payload: MessagePayload {
    spec_version: 9140,
    weight: 10000000000,
    origin: CallOrigin::SourceAccount(
        122a87a73f92704a4556131f8c2d14a32dc1d624fc523ba4e528bff3f9dfe55f (5CUXMS6J...),
    ),
    dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
    call: 0x00010442,
}
INFO bridge Encoded Message Payload: 0xb423000000e40b540200000002122a87a73f92704a4556131f8c2d14a32dc1d624fc523ba4e528bff3f9dfe55f001000010442
0xb423000000e40b540200000002122a87a73f92704a4556131f8c2d14a32dc1d624fc523ba4e528bff3f9dfe55f001000010442
svyatonik@xwnotebook:~/dev/rococo-wococo.test$ ./bin/substrate-relay estimate-fee rococo-to-wococo call --sender 5CUXMS6Ja5E8HGa8qq2jumboFKjqpjA8mrdzyANhk7P2mELp --dispatch-weight 0 raw 00010442
INFO bridge Created Message Payload: MessagePayload {
    spec_version: 9140,
    weight: 0,
    origin: CallOrigin::SourceAccount(
        122a87a73f92704a4556131f8c2d14a32dc1d624fc523ba4e528bff3f9dfe55f (5CUXMS6J...),
    ),
    dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
    call: 0x00010442,
}
INFO bridge Encoded Message Payload: 0xb4230000000000000000000002122a87a73f92704a4556131f8c2d14a32dc1d624fc523ba4e528bff3f9dfe55f001000010442
INFO bridge Fee: Balance(293479234556)
293479234556
svyatonik@xwnotebook:~/dev/rococo-wococo.test$ ./bin/substrate-relay send-message rococo-to-wococo --source-signer //Alice --dispatch-weight 100000000000 raw 00010442
INFO bridge Created Message Payload: MessagePayload {
    spec_version: 9140,
    weight: 100000000000,
    origin: CallOrigin::SourceAccount(
        d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d (5GrwvaEF...),
    ),
    dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
    call: 0x00010442,
}
INFO bridge Encoded Message Payload: 0xb423000000e876481700000002d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d001000010442
INFO bridge Sending message to Wococo. Lane: [0, 0, 0, 0]. Size: 177. Dispatch weight: 100000000000. Fee: 1,173,439,257,663
INFO bridge The source account (d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d (5GrwvaEF...)) balance will be reduced by (at most) 1173439257663 (message fee) + 31605393717 (tx fee	) = 1205044651380 Rococo tokens
INFO bridge Signed Rococo Call: 0xc502bd028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0180c4412df47caab679790c7992755661d891bc73ed75b632a46372ab23e2200fafec0946b26eaa091bbd04671261c06c15911e0f4e1a421d6943c66fc9c3ca850008002c0300000000b423000000e876481700000002d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0010000104423f1c6e36110100000000000000000000

```