### PR TITLE
Try fix duplicate header relay

### DIFF
--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -658,6 +658,7 @@ mod tests {
 			}),
 			strategy: BasicStrategy::new(),
 			relay_strategy: MixStrategy::new(RelayerMode::Altruistic),
+			latest_updated_confirm_nonce_at_source: None,
 		};
 
 		race_strategy.strategy.source_nonces_updated(


### PR DESCRIPTION
In our tests, it was found that if multiple bridges are started, many meaningless repeated header relays will be sent. After making this modification, this problem will be alleviated.

Related:
- https://github.com/darwinia-network/parity-bridges-common/pull/12
- https://github.com/darwinia-network/parity-bridges-common/pull/10
- https://github.com/darwinia-network/bridger/issues/344
