### PR TITLE
Increase rate from metric when estimating fee

### DIFF
--- a/relays/bin-substrate/src/cli/estimate_fee.rs
+++ b/relays/bin-substrate/src/cli/estimate_fee.rs
@@ -15,7 +15,11 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	cli::{bridge::FullBridge, Balance, CliChain, HexBytes, HexLaneId, SourceConnectionParams},
+	cli::{
+		bridge::FullBridge,
+		relay_headers_and_messages::CONVERSION_RATE_ALLOWED_DIFFERENCE_RATIO,
+		Balance, CliChain, HexBytes, HexLaneId, SourceConnectionParams,
+	},
 	select_full_bridge,
 };
 use bp_runtime::BalanceOf;
@@ -123,37 +127,68 @@ pub(crate) async fn estimate_message_delivery_and_dispatch_fee<
 	) {
 		(Some(ConversionRateOverride::Explicit(v)), _, _) => {
 			let conversion_rate_override = FixedU128::from_float(v);
-			log::info!(target: "bridge", "{} -> {} conversion rate override: {:?} (explicit)", Target::NAME, Source::NAME, conversion_rate_override.to_float());
+			log::info!(
+				target: "bridge",
+				"{} -> {} conversion rate override: {:?} (explicit)",
+				Target::NAME,
+				Source::NAME,
+				conversion_rate_override.to_float(),
+			);
 			Some(conversion_rate_override)
 		},
 		(Some(ConversionRateOverride::Metric), Some(source_token_id), Some(target_token_id)) => {
-			let conversion_rate_override = FixedU128::from_float(
-				tokens_conversion_rate_from_metrics(target_token_id, source_token_id).await?,
+			let conversion_rate_override = tokens_conversion_rate_from_metrics(target_token_id, source_token_id).await?;
+			// So we have current actual conversion rate and rate that is stored in the runtime.
+			// And we may simply choose the maximal of these. But what if right now there's
+			// rate update transaction on the way, that is updating rate to 10 seconds old actual
+			// rate, which is bigger than the current rate? Then our message will be rejected.
+			//
+			// So let's increase the actual rate by the same value that the conversion rate updater
+			// is using.
+			let increased_conversion_rate_override = FixedU128::from_float(
+				conversion_rate_override * (1.0 + CONVERSION_RATE_ALLOWED_DIFFERENCE_RATIO)
 			);
-			log::info!(target: "bridge", "{} -> {} conversion rate override: {:?} (from metric)", Target::NAME, Source::NAME, conversion_rate_override.to_float());
-			Some(conversion_rate_override)
+			log::info!(
+				target: "bridge",
+				"{} -> {} conversion rate override: {} (value from metric - {})",
+				Target::NAME,
+				Source::NAME,
+				increased_conversion_rate_override.to_float(),
+				conversion_rate_override,
+			);
+			Some(increased_conversion_rate_override)
 		},
 		_ => None,
 	};
 
-	Ok(std::cmp::max(
-		do_estimate_message_delivery_and_dispatch_fee(
-			client,
-			estimate_fee_method,
-			lane,
-			payload.clone(),
-			None,
-		)
-		.await?,
-		do_estimate_message_delivery_and_dispatch_fee(
-			client,
-			estimate_fee_method,
-			lane,
-			payload.clone(),
-			conversion_rate_override,
-		)
-		.await?,
-	))
+	let without_override = do_estimate_message_delivery_and_dispatch_fee(
+		client,
+		estimate_fee_method,
+		lane,
+		payload.clone(),
+		None,
+	)
+	.await?;
+	let with_override = do_estimate_message_delivery_and_dispatch_fee(
+		client,
+		estimate_fee_method,
+		lane,
+		payload.clone(),
+		conversion_rate_override,
+	)
+	.await?;
+	let maximal_fee = std::cmp::max(without_override, with_override);
+
+	log::info!(
+		target: "bridge",
+		"Estimated message fee: {:?} = max of {:?} (without rate override) and {:?} (with override to {:?})",
+		maximal_fee,
+		without_override,
+		with_override,
+		conversion_rate_override,
+	);
+
+	Ok(maximal_fee)
 }
 
 /// Estimate message delivery and dispatch fee with given conversion rate override.

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -50,7 +50,7 @@ use crate::{
 /// stored and real conversion rates. If it is large enough (e.g. > than 10 percents, which is 0.1),
 /// then rational relayers may stop relaying messages because they were submitted using
 /// lesser conversion rate.
-const CONVERSION_RATE_ALLOWED_DIFFERENCE_RATIO: f64 = 0.05;
+pub(crate) const CONVERSION_RATE_ALLOWED_DIFFERENCE_RATIO: f64 = 0.05;
 
 /// Start headers+messages relayer process.
 #[derive(StructOpt)]

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -190,6 +190,7 @@ impl SendMessage {
 				),
 			};
 			let dispatch_weight = payload.weight;
+			let payload_len = payload.encode().len();
 			let send_message_call = Source::encode_call(&encode_call::Call::BridgeSendMessage {
 				bridge_instance_index: self.bridge.bridge_instance_index(),
 				lane: self.lane,
@@ -230,7 +231,7 @@ impl SendMessage {
 						"Sending message to {}. Lane: {:?}. Size: {}. Dispatch weight: {}. Fee: {}",
 						Target::NAME,
 						lane,
-						signed_source_call.len(),
+						payload_len,
 						dispatch_weight,
 						fee,
 					);

--- a/relays/bin-substrate/src/cli/swap_tokens.rs
+++ b/relays/bin-substrate/src/cli/swap_tokens.rs
@@ -363,7 +363,7 @@ impl SwapTokens {
 			//
 
 			if is_transfer_succeeded {
-				log::info!(target: "bridge", "Claiming the swap swap");
+				log::info!(target: "bridge", "Claiming the swap");
 
 				// prepare `claim_swap` message that will be sent over the bridge
 				let claim_swap_call: CallOf<Source> =

--- a/scripts/dump-logs.sh
+++ b/scripts/dump-logs.sh
@@ -28,7 +28,7 @@ SERVICES=(\
 for SVC in ${SERVICES[*]}
 do
 	SHORT_NAME="${SVC//deployments_/}"
-	docker logs $SVC &> $SHORT_NAME.log
+	docker logs $SVC &> $SHORT_NAME.log | true
 done
 
 cd -


### PR DESCRIPTION
Case:
1) conversion rate updater computes conversion rate - e.g. it is `10`;
2) conversion rate updater sends update transaction;
3) message is being sent through the bridge, while rate is dropped to `9`. The fee is obviously lower;
4) update rate transaction is mined;
5) message send transaction is mined and message is rejected, because its fee is lower than required.