### PR TITLE
Update chain versions

### DIFF
--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -36,10 +36,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_version::create_runtime_str!("kusama"),
 	impl_name: sp_version::create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 9140,
+	spec_version: 9180,
 	impl_version: 0,
 	apis: sp_version::create_apis_vec![[]],
-	transaction_version: 8,
+	transaction_version: 11,
 	state_version: 0,
 };
 

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -36,10 +36,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_version::create_runtime_str!("polkadot"),
 	impl_name: sp_version::create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 9140,
+	spec_version: 9180,
 	impl_version: 0,
 	apis: sp_version::create_apis_vec![[]],
-	transaction_version: 9,
+	transaction_version: 12,
 	state_version: 0,
 };
 

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -43,7 +43,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_version::create_runtime_str!("rococo"),
 	impl_name: sp_version::create_runtime_str!("parity-rococo-v2.0"),
 	authoring_version: 0,
-	spec_version: 9140,
+	spec_version: 9180,
 	impl_version: 0,
 	apis: sp_version::create_apis_vec![[]],
 	transaction_version: 0,


### PR DESCRIPTION
Polkadot/Kusama/Rococo

This will probably need an update anyways in the near future, but I'm updating to be able to test Kusama <> Polkadot bridge locally