### PR TITLE
add api data() for inbound_lane

### DIFF
--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -71,6 +71,11 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		InboundLane { storage }
 	}
 
+	/// Get this lane data
+	pub fn data(&self) -> InboundLaneData<S::Relayer> {
+		self.storage.data()
+	}
+
 	/// Receive state of the corresponding outbound lane.
 	pub fn receive_state_update(
 		&mut self,


### PR DESCRIPTION
in outbound lane we have opened the data() api
but in the inbound lane this api is not opened, it's very useful for application using the bridge.