### PR TITLE
Revert "add api data() for inbound_lane (#1373)"

### DIFF
--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -71,11 +71,6 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		InboundLane { storage }
 	}
 
-	/// Get this lane data
-	pub fn data(&self) -> InboundLaneData<S::Relayer> {
-		self.storage.data()
-	}
-
 	/// Receive state of the corresponding outbound lane.
 	pub fn receive_state_update(
 		&mut self,


### PR DESCRIPTION
This reverts commit 82698e3e082cd8f6774a3fb4c15465522091acab. The commit causes warning, since the struct is not public and method isn't used inside the pallet