### PR TITLE
Fix daily gitlab build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,7 +195,8 @@ build:
     - time cargo fetch
     - time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-test-runtime\").manifest_path"`
     - time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-runtime\").manifest_path"`
-    - CARGO_NET_OFFLINE=true time cargo build --release --verbose --workspace
+    - time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"kusama-runtime\").manifest_path"`
+    - CARGO_NET_OFFLINE=true SKIP_POLKADOT_RUNTIME_WASM_BUILD=1 SKIP_KUSAMA_RUNTIME_WASM_BUILD=1 SKIP_POLKADOT_TEST_RUNTIME_WASM_BUILD=1 time cargo build --release --verbose --workspace
   after_script:
     # Prepare artifacts
     - mkdir -p ./artifacts


### PR DESCRIPTION
Our nightly build pipelines are broken (after #1378):
https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/pipelines/191733
https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/pipelines/191755

This should fix the issue - we don't actually need Ksuama/Polkadot runtimes here, so the solution is not to build it here (as I already did for the `cargo test` step)