### PR TITLE
Fix for "`/root` is not writable." during deployments startup

### DIFF
--- a/deployments/monitoring/GrafanaMatrix.Dockerfile
+++ b/deployments/monitoring/GrafanaMatrix.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ruby:alpine
+FROM ROM ruby:alpine3.13
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
Apploies https://github.com/ananace/ruby-grafana-matrix/issues/9#issuecomment-954748808 fix to our test deployments