### PR TITLE
Update spec_version for Rococo

### DIFF
--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -43,7 +43,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: sp_version::create_runtime_str!("rococo"),
 	impl_name: sp_version::create_runtime_str!("parity-rococo-v2.0"),
 	authoring_version: 0,
-	spec_version: 9180,
+	spec_version: 9200,
 	impl_version: 0,
 	apis: sp_version::create_apis_vec![[]],
 	transaction_version: 0,


### PR DESCRIPTION
Update the hardcoded spec_version in the bp_rococo to [current](https://github.com/paritytech/polkadot/blob/d8b8612cb7cd51894b93bd2832165513ed7d58c0/runtime/rococo/src/lib.rs#L103) one, 9200.