### PR TITLE
Generalize error text

### DIFF
--- a/relays/bin-substrate/src/main.rs
+++ b/relays/bin-substrate/src/main.rs
@@ -26,6 +26,6 @@ fn main() {
 	let run = command.run();
 	let result = async_std::task::block_on(run);
 	if let Err(error) = result {
-		log::error!(target: "bridge", "{}", error);
+		log::error!(target: "bridge", "substrate-relay: {}", error);
 	}
 }

--- a/relays/bin-substrate/src/main.rs
+++ b/relays/bin-substrate/src/main.rs
@@ -26,6 +26,6 @@ fn main() {
 	let run = command.run();
 	let result = async_std::task::block_on(run);
 	if let Err(error) = result {
-		log::error!(target: "bridge", "Failed to start relay: {}", error);
+		log::error!(target: "bridge", "{}", error);
 	}
 }


### PR DESCRIPTION
Right now, each time there is an error while executing `substrate-relay`
it will be reported as:

    ERROR bridge Failed to start relay: <Actual cause of error>

This is the case even if the invoked command did not have anything to do
with starting a relayer. Thus this removes this text. Now something like
this would be written:

    ERROR bridge <Actual cause of error>