### PR TITLE
allow(clippy::too_many_arguments) for on-demand relays startup

### DIFF
--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -704,6 +704,7 @@ impl RelayHeadersAndMessages {
 }
 
 /// Start bidirectional on-demand headers <> headers relay.
+#![allow(clippy::too_many_arguments)]
 async fn start_on_demand_relay_to_relay<LC, RC, LR, RL>(
 	left_client: Client<LC>,
 	right_client: Client<RC>,
@@ -762,6 +763,7 @@ where
 }
 
 /// Start bidirectional on-demand headers <> parachains relay.
+#![allow(clippy::too_many_arguments)]
 async fn start_on_demand_relay_to_parachain<LC, RC, RRC, LR, RRF, RL>(
 	left_client: Client<LC>,
 	right_client: Client<RC>,

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -704,7 +704,7 @@ impl RelayHeadersAndMessages {
 }
 
 /// Start bidirectional on-demand headers <> headers relay.
-#![allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)] // TODO: https://github.com/paritytech/parity-bridges-common/issues/1415
 async fn start_on_demand_relay_to_relay<LC, RC, LR, RL>(
 	left_client: Client<LC>,
 	right_client: Client<RC>,
@@ -763,7 +763,7 @@ where
 }
 
 /// Start bidirectional on-demand headers <> parachains relay.
-#![allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)] // TODO: https://github.com/paritytech/parity-bridges-common/issues/1415
 async fn start_on_demand_relay_to_parachain<LC, RC, RRC, LR, RRF, RL>(
 	left_client: Client<LC>,
 	right_client: Client<RC>,


### PR DESCRIPTION
(as a temporary measure - will file an issue for a proper fix)