### PR TITLE
Fix XCM instruction weight in RialtoParachain to match Millau weight

### DIFF
--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -354,10 +354,13 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	XcmPassthrough<Origin>,
 );
 
-pub const BASE_XCM_WEIGHT: Weight = 1_000_000;
+// TODO: until https://github.com/paritytech/parity-bridges-common/issues/1417 is fixed (in either way),
+// the following constant must match the similar constant in the Millau runtime.
+
+/// One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
+pub const BASE_XCM_WEIGHT: Weight = 1_000_000_000;
 
 parameter_types! {
-	// One XCM operation is 1_000_000 weight - almost certainly a conservative estimate.
 	pub UnitWeightCost: Weight = BASE_XCM_WEIGHT;
 	// One UNIT buys 1 second of weight.
 	pub const WeightPrice: (MultiLocation, u128) = (MultiLocation::parent(), UNIT);

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -357,7 +357,7 @@ pub type XcmOriginToTransactDispatchOrigin = (
 // TODO: until https://github.com/paritytech/parity-bridges-common/issues/1417 is fixed (in either way),
 // the following constant must match the similar constant in the Millau runtime.
 
-/// One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
+/// One XCM operation is `1_000_000_000` weight - almost certainly a conservative estimate.
 pub const BASE_XCM_WEIGHT: Weight = 1_000_000_000;
 
 parameter_types! {


### PR DESCRIPTION
see #1417 - it'll probably need some complex fix, but for now this is enough to start RialtoParachain <> Millau bridge