### PR TITLE
Remove excess verbosity from the spellcheck

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,7 +112,7 @@ spellcheck:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - cargo spellcheck check -vvvv --cfg=.config/spellcheck.toml --checkers hunspell -m 1
+    - cargo spellcheck check --cfg=.config/spellcheck.toml --checkers hunspell -m 1
 
 #### stage:                        check
 


### PR DESCRIPTION
see https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/1595784 for example of current output - it's almost impossible to find the actual error there