### PR TITLE
Ensure that the bridge GRANDPA pallet is initialized in the finality relay

### DIFF
--- a/relays/client-substrate/src/error.rs
+++ b/relays/client-substrate/src/error.rs
@@ -54,6 +54,9 @@ pub enum Error {
 	/// The bridge pallet is halted and all transactions will be rejected.
 	#[error("Bridge pallet is halted.")]
 	BridgePalletIsHalted,
+	/// The bridge pallet is not yet initialized and all transactions will be rejected.
+	#[error("Bridge pallet is not initialized.")]
+	BridgePalletIsNotInitialized,
 	/// An error has happened when we have tried to parse storage proof.
 	#[error("Error when parsing storage proof: {0:?}.")]
 	StorageProofError(bp_runtime::StorageProofError),

--- a/relays/lib-substrate-relay/src/finality/initialize.rs
+++ b/relays/lib-substrate-relay/src/finality/initialize.rs
@@ -110,7 +110,11 @@ where
 }
 
 /// Returns `Ok(true)` if bridge has already been initialized.
-async fn is_initialized<E: Engine<SourceChain>, SourceChain: Chain, TargetChain: Chain>(
+pub(crate) async fn is_initialized<
+	E: Engine<SourceChain>,
+	SourceChain: Chain,
+	TargetChain: Chain,
+>(
 	target_client: &Client<TargetChain>,
 ) -> Result<bool, Error<HashOf<SourceChain>, BlockNumberOf<SourceChain>>> {
 	Ok(target_client


### PR DESCRIPTION
There's one inconvenient thing in GRANDPA pallet initialization:
1) the pallet has `IsHalted` flag, which, if set to `true`, means that the pallet will reject (almost) all transactions. If the value of this flag is missing from the runtime storage, it takes default value, which is `false` => pallet is in operational mode;
2) there's another procedure in the pallet, called "initialization", which saves initial header and authorities set in the runtime storage. If pallet is not initialized, it'll reject all incoming headers, waiting for initialization first;
3) finally, there's pallet genesis config, which contains `init_data: Option<InitializationData { is_halted: bool, initial_header: H }>`. So I can't set `IsHalted` to `true` in genesis, without providing initial header.

What it means for the finality relay, is that it shall check both flags during startup - `IsInitialized` and `IsHalted`.