### PR TITLE
Rename CheckBridgedBlockNumber to BridgeRejectObsoleteGrandpaHeader

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -568,7 +568,7 @@ construct_runtime!(
 	}
 );
 
-pallet_bridge_grandpa::declare_check_bridged_block_number_ext! {
+pallet_bridge_grandpa::declare_bridge_reject_obsolete_grandpa_header! {
 	Runtime,
 	Call::BridgeRialtoGrandpa => RialtoGrandpaInstance,
 	Call::BridgeWestendGrandpa => WestendGrandpaInstance
@@ -594,7 +594,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-	CheckBridgedBlockNumber,
+	BridgeRejectObsoleteGrandpaHeader,
 );
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;

--- a/modules/grandpa/src/extension.rs
+++ b/modules/grandpa/src/extension.rs
@@ -14,27 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-/// Declares a runtime-specific `CheckBridgedBlockNumber` signed extension.
+/// Declares a runtime-specific `BridgeRejectObsoleteGrandpaHeader` signed extension.
 ///
 /// ## Example
 ///
 /// ```nocompile
-/// pallet_bridge_grandpa::declare_check_bridged_block_number_ext!{
+/// pallet_bridge_grandpa::declare_bridge_reject_obsolete_grandpa_header!{
 ///     Runtime,
 ///     Call::BridgeRialtoGrandpa => RialtoGrandpaInstance,
 ///     Call::BridgeWestendGrandpa => WestendGrandpaInstance,
 /// }
 /// ```
 #[macro_export]
-macro_rules! declare_check_bridged_block_number_ext {
+macro_rules! declare_bridge_reject_obsolete_grandpa_header {
 	($runtime:ident, $($call:path => $instance:ty),*) => {
 		/// Transaction-with-obsolete-bridged-header check that will reject transaction if
 		/// it submits obsolete bridged header.
 		#[derive(Clone, codec::Decode, codec::Encode, Eq, PartialEq, frame_support::RuntimeDebug, scale_info::TypeInfo)]
-		pub struct CheckBridgedBlockNumber;
+		pub struct BridgeRejectObsoleteGrandpaHeader;
 
-		impl sp_runtime::traits::SignedExtension for CheckBridgedBlockNumber {
-			const IDENTIFIER: &'static str = "CheckBridgedBlockNumber";
+		impl sp_runtime::traits::SignedExtension for BridgeRejectObsoleteGrandpaHeader {
+			const IDENTIFIER: &'static str = "BridgeRejectObsoleteGrandpaHeader";
 			type AccountId = <$runtime as frame_system::Config>::AccountId;
 			type Call = <$runtime as frame_system::Config>::Call;
 			type AdditionalSigned = ();
@@ -114,13 +114,13 @@ mod tests {
 	use frame_support::weights::{DispatchClass, DispatchInfo, Pays};
 	use sp_runtime::traits::SignedExtension;
 
-	declare_check_bridged_block_number_ext! {
+	declare_bridge_reject_obsolete_grandpa_header! {
 		TestRuntime,
 		Call::Grandpa => ()
 	}
 
 	fn validate_block_submit(num: TestNumber) -> bool {
-		CheckBridgedBlockNumber
+		BridgeRejectObsoleteGrandpaHeader
 			.validate(
 				&42,
 				&Call::Grandpa(crate::Call::<TestRuntime, ()>::submit_finality_proof {
@@ -140,7 +140,7 @@ mod tests {
 	}
 
 	#[test]
-	fn check_bridged_block_number_rejects_obsolete_header() {
+	fn extension_rejects_obsolete_header() {
 		run_test(|| {
 			// when current best finalized is #10 and we're trying to import header#5 => tx is
 			// rejected
@@ -150,7 +150,7 @@ mod tests {
 	}
 
 	#[test]
-	fn check_bridged_block_number_rejects_same_header() {
+	fn extension_rejects_same_header() {
 		run_test(|| {
 			// when current best finalized is #10 and we're trying to import header#10 => tx is
 			// rejected
@@ -160,7 +160,7 @@ mod tests {
 	}
 
 	#[test]
-	fn check_bridged_block_number_accepts_new_header() {
+	fn extension_accepts_new_header() {
 		run_test(|| {
 			// when current best finalized is #10 and we're trying to import header#15 => tx is
 			// accepted

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -115,7 +115,7 @@ impl TransactionSignScheme for Millau {
 				frame_system::CheckNonce::<millau_runtime::Runtime>::from(param.unsigned.nonce),
 				frame_system::CheckWeight::<millau_runtime::Runtime>::new(),
 				pallet_transaction_payment::ChargeTransactionPayment::<millau_runtime::Runtime>::from(param.unsigned.tip),
-				millau_runtime::CheckBridgedBlockNumber, // TODO
+				millau_runtime::BridgeRejectObsoleteGrandpaHeader,
 			),
 			(
 				(),


### PR DESCRIPTION
Rationale: I'm working on similar extension for parachains pallet. And the same name (`CheckBridgedBlockNumber`) may be used to identify that new extension as well. So I've changed name to be more specific (mention pallet name) and actually report what it does (so "reject obsolete header" instead of unclear "check block number").