### PR TITLE
Try to generate less invalid XCM messages

### DIFF
--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -70,7 +70,7 @@ do
 		$SEND_MESSAGE \
 			--lane $SECONDARY_MESSAGE_LANE \
 			--conversion-rate-override $CONVERSION_RATE \
-			raw 5678
+			raw 010109030419A8
 	fi
 
 	# every other hour we're sending 3 large (size, weight, size+weight) messages
@@ -94,7 +94,7 @@ do
 			$SEND_MESSAGE \
 				--lane $MESSAGE_LANE \
 				--conversion-rate-override $CONVERSION_RATE \
-				raw deadbeef
+				raw 010109030419A8
 		done
 
 	fi

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -70,7 +70,7 @@ do
 		$SEND_MESSAGE \
 			--lane $SECONDARY_MESSAGE_LANE \
 			--conversion-rate-override $CONVERSION_RATE \
-			raw 5678
+			raw 010109020419A8
 	fi
 
 	# every other hour we're sending 3 large (size, weight, size+weight) messages
@@ -93,7 +93,7 @@ do
 			$SEND_MESSAGE \
 				--lane $MESSAGE_LANE \
 				--conversion-rate-override $CONVERSION_RATE \
-				raw deadbeef
+				raw 010109020419A8
 		done
 
 	fi


### PR DESCRIPTION
closes #1459 

They're only spamming error logs and causing false alarms.