### PR TITLE
Fix on-different-forks metrics during initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ WORKDIR /parity-bridges-common
 
 COPY . .
 
+USER root
+RUN rustup toolchain uninstall stable && \
+    rustup toolchain uninstall nightly && \
+    rustup toolchain install stable && \
+    rustup toolchain install nightly && \
+    rustup target add wasm32-unknown-unknown --toolchain nightly
 ARG PROJECT=substrate-relay
 RUN cargo build --release --verbose -p ${PROJECT} && \
     strip ./target/release/${PROJECT}

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ To run a Rialto node for example, you can use the following command:
 
 ```bash
 docker run -p 30333:30333 -p 9933:9933 -p 9944:9944 \
-  -it paritytech/rialto-bridge-node --dev --tmp \
+  -it local/rialto-bridge-node --dev --tmp \
   --rpc-cors=all --unsafe-rpc-external --unsafe-ws-external
 ```
 

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -683,9 +683,8 @@ impl_runtime_apis! {
 	}
 
 	impl bp_millau::MillauFinalityApi<Block> for Runtime {
-		fn best_finalized() -> (bp_millau::BlockNumber, bp_millau::Hash) {
-			let header = BridgeMillauGrandpa::best_finalized();
-			(header.number, header.hash())
+		fn best_finalized() -> Option<(bp_millau::BlockNumber, bp_millau::Hash)> {
+			BridgeMillauGrandpa::best_finalized().map(|header| (header.number, header.hash()))
 		}
 	}
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -640,9 +640,8 @@ impl_runtime_apis! {
 	}
 
 	impl bp_millau::MillauFinalityApi<Block> for Runtime {
-		fn best_finalized() -> (bp_millau::BlockNumber, bp_millau::Hash) {
-			let header = BridgeMillauGrandpa::best_finalized();
-			(header.number, header.hash())
+		fn best_finalized() -> Option<(bp_millau::BlockNumber, bp_millau::Hash)> {
+			BridgeMillauGrandpa::best_finalized().map(|header| (header.number, header.hash()))
 		}
 	}
 

--- a/deployments/bridges/rialto-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-millau/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       LETSENCRYPT_EMAIL: admin@parity.io
 
   relay-millau-rialto: &sub-bridge-relay
-    image: paritytech/substrate-relay
+    image: local/substrate-relay
     entrypoint: /entrypoints/relay-millau-rialto-entrypoint.sh
     volumes:
       - ./bridges/rialto-millau/entrypoints:/entrypoints

--- a/deployments/bridges/rialto-parachain-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-parachain-millau/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       LETSENCRYPT_EMAIL: admin@parity.io
 
   relay-millau-rialto-parachain: &sub-bridge-relay
-    image: paritytech/substrate-relay
+    image: local/substrate-relay
     entrypoint: /entrypoints/relay-millau-rialto-parachain-entrypoint.sh
     volumes:
       - ./bridges/rialto-parachain-millau/entrypoints:/entrypoints

--- a/deployments/bridges/westend-millau/docker-compose.yml
+++ b/deployments/bridges/westend-millau/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3.5'
 services:
   relay-headers-westend-to-millau-1:
-    image: paritytech/substrate-relay
+    image: local/substrate-relay
     entrypoint: /entrypoints/relay-headers-westend-to-millau-entrypoint.sh
     volumes:
       - ./bridges/westend-millau/entrypoints:/entrypoints
@@ -15,7 +15,7 @@ services:
       - millau-node-alice
 
   relay-headers-westend-to-millau-2:
-    image: paritytech/substrate-relay
+    image: local/substrate-relay
     entrypoint: /entrypoints/relay-headers-westend-to-millau-entrypoint.sh
     volumes:
       - ./bridges/westend-millau/entrypoints:/entrypoints

--- a/deployments/networks/millau.yml
+++ b/deployments/networks/millau.yml
@@ -8,7 +8,7 @@
 version: '3.5'
 services:
   millau-node-alice: &millau-bridge-node
-    image: paritytech/millau-bridge-node
+    image: local/millau-bridge-node
     entrypoint:
       - /home/user/millau-bridge-node
       - --execution=Native

--- a/deployments/networks/rialto-parachain.yml
+++ b/deployments/networks/rialto-parachain.yml
@@ -5,7 +5,7 @@
 version: '3.5'
 services:
   rialto-parachain-collator-alice: &rialto-parachain-collator
-    image: paritytech/rialto-parachain-collator
+    image: local/rialto-parachain-collator
     entrypoint: >
       /home/user/rialto-parachain-collator
       --alice
@@ -77,7 +77,7 @@ services:
       - "20644:9944"
 
   rialto-parachain-registrar:
-    image: paritytech/substrate-relay
+    image: local/substrate-relay
     entrypoint: /entrypoints/rialto-parachain-registrar-entrypoint.sh
     volumes:
       - ./networks/entrypoints:/entrypoints

--- a/deployments/networks/rialto.yml
+++ b/deployments/networks/rialto.yml
@@ -8,7 +8,7 @@
 version: '3.5'
 services:
   rialto-node-alice: &rialto-bridge-node
-    image: paritytech/rialto-bridge-node
+    image: local/rialto-bridge-node
     entrypoint:
       - /home/user/rialto-bridge-node
       - --execution=Native
@@ -94,7 +94,7 @@ services:
       - "10344:9944"
 
   rialto-chainspec-exporter:
-    image: paritytech/rialto-bridge-node
+    image: local/rialto-bridge-node
     entrypoint: /entrypoints/rialto-chainspec-exporter-entrypoint.sh
     volumes:
       - ./networks/entrypoints:/entrypoints

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -537,17 +537,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	///
 	/// Returns a dummy header if there is no best header. This can only happen
 	/// if the pallet has not been initialized yet.
-	pub fn best_finalized() -> BridgedHeader<T, I> {
+	pub fn best_finalized() -> Option<BridgedHeader<T, I>> {
 		let hash = <BestFinalized<T, I>>::get();
-		<ImportedHeaders<T, I>>::get(hash).unwrap_or_else(|| {
-			<BridgedHeader<T, I>>::new(
-				Default::default(),
-				Default::default(),
-				Default::default(),
-				Default::default(),
-				Default::default(),
-			)
-		})
+		<ImportedHeaders<T, I>>::get(hash)
 	}
 
 	/// Check if a particular header is known to the bridge pallet.

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -117,7 +117,7 @@ sp_api::decl_runtime_apis! {
 	/// Kusama runtime itself.
 	pub trait KusamaFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Kusama chain.

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -314,7 +314,7 @@ sp_api::decl_runtime_apis! {
 	/// Millau runtime itself.
 	pub trait MillauFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Millau chain.

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -118,7 +118,7 @@ sp_api::decl_runtime_apis! {
 	/// Polkadot runtime itself.
 	pub trait PolkadotFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Polkadot chain.

--- a/primitives/chain-rialto-parachain/src/lib.rs
+++ b/primitives/chain-rialto-parachain/src/lib.rs
@@ -241,7 +241,7 @@ sp_api::decl_runtime_apis! {
 	/// RialtoParachain runtime itself.
 	pub trait RialtoParachainFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 
 	/// Outbound message lane API for messages that are sent to RialtoParachain chain.

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -262,7 +262,7 @@ sp_api::decl_runtime_apis! {
 	/// Rialto runtime itself.
 	pub trait RialtoFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Rialto chain.

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -113,7 +113,7 @@ sp_api::decl_runtime_apis! {
 	/// Rococo runtime itself.
 	pub trait RococoFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Rococo chain.

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -106,6 +106,6 @@ sp_api::decl_runtime_apis! {
 	/// Westend runtime itself.
 	pub trait WestendFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 }

--- a/primitives/chain-wococo/src/lib.rs
+++ b/primitives/chain-wococo/src/lib.rs
@@ -70,7 +70,7 @@ sp_api::decl_runtime_apis! {
 	/// Wococo runtime itself.
 	pub trait WococoFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> (BlockNumber, Hash);
+		fn best_finalized() -> Option<(BlockNumber, Hash)>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Wococo chain.

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -88,7 +88,7 @@ pub trait InclusionProofVerifier {
 /// A trait for pallets which want to keep track of finalized headers from a bridged chain.
 pub trait HeaderChain<H, E> {
 	/// Get the best finalized header known to the header chain.
-	fn best_finalized() -> H;
+	fn best_finalized() -> Option<H>;
 
 	/// Get the best authority set known to the header chain.
 	fn authority_set() -> AuthoritySet;
@@ -98,8 +98,8 @@ pub trait HeaderChain<H, E> {
 }
 
 impl<H: Default, E> HeaderChain<H, E> for () {
-	fn best_finalized() -> H {
-		H::default()
+	fn best_finalized() -> Option<H> {
+		None
 	}
 
 	fn authority_set() -> AuthoritySet {

--- a/relays/lib-substrate-relay/src/error.rs
+++ b/relays/lib-substrate-relay/src/error.rs
@@ -58,4 +58,9 @@ pub enum Error<Hash: Debug + MaybeDisplay, HeaderNumber: Debug + MaybeDisplay> {
 	/// Failed to retrieve best finalized source header hash from the target chain.
 	#[error("Failed to retrieve best finalized {0} header from the target chain: {1}")]
 	RetrieveBestFinalizedHeaderHash(&'static str, client::Error),
+	/// Failed to submit signed extrinsic from to the target chain.
+	#[error(
+		"Failed to retrieve `is_initialized` flag of the with-{0} finality pallet at {1}: {2:?}"
+	)]
+	IsInitializedRetrieve(&'static str, &'static str, client::Error),
 }

--- a/relays/lib-substrate-relay/src/finality/target.rs
+++ b/relays/lib-substrate-relay/src/finality/target.rs
@@ -51,15 +51,12 @@ impl<P: SubstrateFinalitySyncPipeline> SubstrateFinalityTarget<P> {
 
 	/// Ensure that the bridge pallet at target chain is active.
 	pub async fn ensure_pallet_active(&self) -> Result<(), Error> {
-		let is_halted = self.client.storage_value(P::FinalityEngine::is_halted_key(), None).await?;
-		if is_halted.unwrap_or(false) {
+		let is_halted = P::FinalityEngine::is_halted(&self.client).await?;
+		if is_halted {
 			return Err(Error::BridgePalletIsHalted)
 		}
 
-		let is_initialized =
-			super::initialize::is_initialized::<P::FinalityEngine, P::SourceChain, P::TargetChain>(
-				&self.client,
-			)
+		let is_initialized = P::FinalityEngine::is_initialized(&self.client)
 			.await
 			.map_err(|e| Error::Custom(e.to_string()))?;
 		if !is_initialized {

--- a/relays/lib-substrate-relay/src/messages_target.rs
+++ b/relays/lib-substrate-relay/src/messages_target.rs
@@ -146,8 +146,12 @@ where
 	BalanceOf<P::SourceChain>: TryFrom<BalanceOf<P::TargetChain>>,
 {
 	async fn state(&self) -> Result<TargetClientState<MessageLaneAdapter<P>>, SubstrateError> {
+		// we can't continue to deliver confirmations if source node is out of sync, because
+		// it may have already received confirmations that we're going to deliver
+		//
 		// we can't continue to deliver messages if target node is out of sync, because
 		// it may have already received (some of) messages that we're going to deliver
+		self.source_client.ensure_synced().await?;
 		self.target_client.ensure_synced().await?;
 		// we can't relay messages if messages pallet at target chain is halted
 		self.ensure_pallet_active().await?;

--- a/relays/lib-substrate-relay/src/parachains/target.rs
+++ b/relays/lib-substrate-relay/src/parachains/target.rs
@@ -102,11 +102,13 @@ where
 				Some(at_block.1),
 			)
 			.await?;
-		let decoded_best_finalized_source_block: (
-			BlockNumberOf<P::SourceRelayChain>,
-			HashOf<P::SourceRelayChain>,
-		) = Decode::decode(&mut &encoded_best_finalized_source_block.0[..])
-			.map_err(SubstrateError::ResponseParseFailed)?;
+		let decoded_best_finalized_source_block =
+			Option::<(BlockNumberOf<P::SourceRelayChain>, HashOf<P::SourceRelayChain>)>::decode(
+				&mut &encoded_best_finalized_source_block.0[..],
+			)
+			.map_err(SubstrateError::ResponseParseFailed)?
+			.map(Ok)
+			.unwrap_or(Err(SubstrateError::BridgePalletIsNotInitialized))?;
 		Ok(HeaderId(decoded_best_finalized_source_block.0, decoded_best_finalized_source_block.1))
 	}
 


### PR DESCRIPTION
This PR fixes point (3) from https://github.com/paritytech/parity-bridges-common/pull/1462#issue-1270834540

Currently It breaks RialtoParachain<>Millau relay, since it thinks that with-RialtoParachain finality pallet at Millau. Needs some debugging => draft