### PR TITLE
Change account names to something meaningful

### DIFF
--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -15,7 +15,6 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use beefy_primitives::crypto::AuthorityId as BeefyId;
-use bp_millau::derive_account_from_rialto_id;
 use millau_runtime::{
 	AccountId, AuraConfig, BalancesConfig, BeefyConfig, BridgeRialtoMessagesConfig,
 	BridgeRialtoParachainMessagesConfig, BridgeWestendGrandpaConfig, GenesisConfig, GrandpaConfig,
@@ -87,7 +86,7 @@ impl Alternative {
 				|| {
 					testnet_genesis(
 						vec![get_authority_keys_from_seed("Alice")],
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
+						get_account_id_from_seed::<sr25519::Public>("Sudo"),
 						endowed_accounts(),
 						true,
 					)
@@ -112,7 +111,7 @@ impl Alternative {
 							get_authority_keys_from_seed("Dave"),
 							get_authority_keys_from_seed("Eve"),
 						],
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
+						get_account_id_from_seed::<sr25519::Public>("Sudo"),
 						endowed_accounts(),
 						true,
 					)
@@ -134,54 +133,38 @@ impl Alternative {
 /// purposes), are all available on these chains.
 fn endowed_accounts() -> Vec<AccountId> {
 	vec![
+		// Sudo account
+		get_account_id_from_seed::<sr25519::Public>("Sudo"),
+		// Authorities accounts
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		get_account_id_from_seed::<sr25519::Public>("Bob"),
 		get_account_id_from_seed::<sr25519::Public>("Charlie"),
 		get_account_id_from_seed::<sr25519::Public>("Dave"),
 		get_account_id_from_seed::<sr25519::Public>("Eve"),
-		get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-		get_account_id_from_seed::<sr25519::Public>("George"),
-		get_account_id_from_seed::<sr25519::Public>("Harry"),
-		get_account_id_from_seed::<sr25519::Public>("Iden"),
-		get_account_id_from_seed::<sr25519::Public>("Ken"),
-		get_account_id_from_seed::<sr25519::Public>("Leon"),
-		get_account_id_from_seed::<sr25519::Public>("Mary"),
 		get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+		// Regular (unused) accounts
+		get_account_id_from_seed::<sr25519::Public>("Ferdie"),
 		get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-		get_account_id_from_seed::<sr25519::Public>("George//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Harry//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Iden//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Ken//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Leon//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Mary//stash"),
-		get_account_id_from_seed::<sr25519::Public>("RialtoMessagesOwner"),
-		get_account_id_from_seed::<sr25519::Public>("RialtoParachainMessagesOwner"),
-		pallet_bridge_messages::relayer_fund_account_id::<
-			bp_millau::AccountId,
-			bp_millau::AccountIdConverter,
-		>(),
-		derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Alice"),
-		)),
-		derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Bob"),
-		)),
-		derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Charlie"),
-		)),
-		derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Dave"),
-		)),
-		derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Eve"),
-		)),
-		derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-		)),
+		// Accounts, used by Westend<>Millau bridge
+		get_account_id_from_seed::<sr25519::Public>("Westend.GrandpaOwner"),
+		get_account_id_from_seed::<sr25519::Public>("Westend.HeadersRelay1"),
+		get_account_id_from_seed::<sr25519::Public>("Westend.HeadersRelay2"),
+		get_account_id_from_seed::<sr25519::Public>("Westend.WestmintHeaders"),
+		// Accounts, used by Rialto<>Millau bridge
+		get_account_id_from_seed::<sr25519::Public>("Rialto.MessagesOwner"),
+		get_account_id_from_seed::<sr25519::Public>("Rialto.HeadersAndMessagesRelay"),
+		get_account_id_from_seed::<sr25519::Public>("Rialto.OutboundMessagesRelay.Lane00000001"),
+		get_account_id_from_seed::<sr25519::Public>("Rialto.InboundMessagesRelay.Lane00000001"),
+		get_account_id_from_seed::<sr25519::Public>("Rialto.MessagesSender"),
+		// Accounts, used by RialtoParachain<>Millau bridge
+		get_account_id_from_seed::<sr25519::Public>("RialtoParachain.MessagesOwner"),
+		get_account_id_from_seed::<sr25519::Public>("RialtoParachain.HeadersAndMessagesRelay"),
+		get_account_id_from_seed::<sr25519::Public>("RialtoParachain.RialtoHeadersRelay"),
+		get_account_id_from_seed::<sr25519::Public>("RialtoParachain.MessagesSender"),
 	]
 }
 
@@ -217,28 +200,20 @@ fn testnet_genesis(
 		bridge_westend_grandpa: BridgeWestendGrandpaConfig {
 			// for our deployments to avoid multiple same-nonces transactions:
 			// //Alice is already used to initialize Rialto<->Millau bridge
-			// => let's use //George to initialize Westend->Millau bridge
-			owner: Some(get_account_id_from_seed::<sr25519::Public>("George")),
+			// => let's use //Westend.GrandpaOwner to initialize Westend->Millau bridge
+			owner: Some(get_account_id_from_seed::<sr25519::Public>("Westend.GrandpaOwner")),
 			..Default::default()
 		},
 		bridge_rialto_messages: BridgeRialtoMessagesConfig {
-			owner: Some(get_account_id_from_seed::<sr25519::Public>("RialtoMessagesOwner")),
+			owner: Some(get_account_id_from_seed::<sr25519::Public>("Rialto.MessagesOwner")),
 			..Default::default()
 		},
 		bridge_rialto_parachain_messages: BridgeRialtoParachainMessagesConfig {
 			owner: Some(get_account_id_from_seed::<sr25519::Public>(
-				"RialtoParachainMessagesOwner",
+				"RialtoParachain.MessagesOwner",
 			)),
 			..Default::default()
 		},
 		xcm_pallet: Default::default(),
 	}
-}
-
-#[test]
-fn derived_dave_account_is_as_expected() {
-	let dave = get_account_id_from_seed::<sr25519::Public>("Dave");
-	let derived: AccountId =
-		derive_account_from_rialto_id(bp_runtime::SourceAccount::Account(dave));
-	assert_eq!(derived.to_string(), "5DNW6UVnb7TN6wX5KwXtDYR3Eccecbdzuw89HqjyNfkzce6J".to_string());
 }

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -31,7 +31,7 @@ const LOCAL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = ["Alice", "Bob", "Charlie"
 const DEV_AUTHORITIES_ACCOUNTS: [&'static str; 1] = [LOCAL_AUTHORITIES_ACCOUNTS[0]];
 /// "Names" of all possible authorities accounts.
 const ALL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = LOCAL_AUTHORITIES_ACCOUNTS;
-/// "Name" of the sudo account.
+/// "Name" of the `sudo` account.
 const SUDO_ACCOUNT: &'static str = "Sudo";
 /// "Name" of the account, which owns the with-Westend GRANDPA pallet.
 const WESTEND_GRANDPA_PALLET_OWNER: &'static str = "Westend.GrandpaOwner";

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -100,7 +100,10 @@ impl Alternative {
 				sc_service::ChainType::Development,
 				|| {
 					testnet_genesis(
-						DEV_AUTHORITIES_ACCOUNTS.into_iter().map(get_authority_keys_from_seed).collect(),
+						DEV_AUTHORITIES_ACCOUNTS
+							.into_iter()
+							.map(get_authority_keys_from_seed)
+							.collect(),
 						get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
 						endowed_accounts(),
 						true,
@@ -119,7 +122,10 @@ impl Alternative {
 				sc_service::ChainType::Local,
 				|| {
 					testnet_genesis(
-						LOCAL_AUTHORITIES_ACCOUNTS.into_iter().map(get_authority_keys_from_seed).collect(),
+						LOCAL_AUTHORITIES_ACCOUNTS
+							.into_iter()
+							.map(get_authority_keys_from_seed)
+							.collect(),
 						get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
 						endowed_accounts(),
 						true,
@@ -141,10 +147,12 @@ impl Alternative {
 /// accounts used by relayers in our test deployments, accounts used for demonstration
 /// purposes), are all available on these chains.
 fn endowed_accounts() -> Vec<AccountId> {
-	let all_authorities = ALL_AUTHORITIES_ACCOUNTS.iter().flat_map(|x| [
-		get_account_id_from_seed::<sr25519::Public>(x),
-		get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", x)),
-	]);
+	let all_authorities = ALL_AUTHORITIES_ACCOUNTS.iter().flat_map(|x| {
+		[
+			get_account_id_from_seed::<sr25519::Public>(x),
+			get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", x)),
+		]
+	});
 	vec![
 		// Sudo account
 		get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
@@ -168,7 +176,10 @@ fn endowed_accounts() -> Vec<AccountId> {
 		get_account_id_from_seed::<sr25519::Public>("RialtoParachain.HeadersAndMessagesRelay"),
 		get_account_id_from_seed::<sr25519::Public>("RialtoParachain.RialtoHeadersRelay"),
 		get_account_id_from_seed::<sr25519::Public>("RialtoParachain.MessagesSender"),
-	].into_iter().chain(all_authorities).collect()
+	]
+	.into_iter()
+	.chain(all_authorities)
+	.collect()
 }
 
 fn session_keys(aura: AuraId, beefy: BeefyId, grandpa: GrandpaId) -> SessionKeys {
@@ -212,7 +223,9 @@ fn testnet_genesis(
 			..Default::default()
 		},
 		bridge_rialto_parachain_messages: BridgeRialtoParachainMessagesConfig {
-			owner: Some(get_account_id_from_seed::<sr25519::Public>(RIALTO_PARACHAIN_MESSAGES_PALLET_OWNER)),
+			owner: Some(get_account_id_from_seed::<sr25519::Public>(
+				RIALTO_PARACHAIN_MESSAGES_PALLET_OWNER,
+			)),
 			..Default::default()
 		},
 		xcm_pallet: Default::default(),

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -153,7 +153,8 @@ fn endowed_accounts() -> Vec<AccountId> {
 		get_account_id_from_seed::<sr25519::Public>("Westend.GrandpaOwner"),
 		get_account_id_from_seed::<sr25519::Public>("Westend.HeadersRelay1"),
 		get_account_id_from_seed::<sr25519::Public>("Westend.HeadersRelay2"),
-		get_account_id_from_seed::<sr25519::Public>("Westend.WestmintHeaders"),
+		get_account_id_from_seed::<sr25519::Public>("Westend.WestmintHeaders1"),
+		get_account_id_from_seed::<sr25519::Public>("Westend.WestmintHeaders2"),
 		// Accounts, used by Rialto<>Millau bridge
 		get_account_id_from_seed::<sr25519::Public>("Rialto.MessagesOwner"),
 		get_account_id_from_seed::<sr25519::Public>("Rialto.HeadersAndMessagesRelay"),

--- a/bin/millau/node/src/chain_spec.rs
+++ b/bin/millau/node/src/chain_spec.rs
@@ -26,19 +26,19 @@ use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// "Names" of the authorities accounts at local testnet.
-const LOCAL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = ["Alice", "Bob", "Charlie", "Dave", "Eve"];
+const LOCAL_AUTHORITIES_ACCOUNTS: [&str; 5] = ["Alice", "Bob", "Charlie", "Dave", "Eve"];
 /// "Names" of the authorities accounts at development testnet.
-const DEV_AUTHORITIES_ACCOUNTS: [&'static str; 1] = [LOCAL_AUTHORITIES_ACCOUNTS[0]];
+const DEV_AUTHORITIES_ACCOUNTS: [&str; 1] = [LOCAL_AUTHORITIES_ACCOUNTS[0]];
 /// "Names" of all possible authorities accounts.
-const ALL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = LOCAL_AUTHORITIES_ACCOUNTS;
+const ALL_AUTHORITIES_ACCOUNTS: [&str; 5] = LOCAL_AUTHORITIES_ACCOUNTS;
 /// "Name" of the `sudo` account.
-const SUDO_ACCOUNT: &'static str = "Sudo";
+const SUDO_ACCOUNT: &str = "Sudo";
 /// "Name" of the account, which owns the with-Westend GRANDPA pallet.
-const WESTEND_GRANDPA_PALLET_OWNER: &'static str = "Westend.GrandpaOwner";
+const WESTEND_GRANDPA_PALLET_OWNER: &str = "Westend.GrandpaOwner";
 /// "Name" of the account, which owns the with-Rialto messages pallet.
-const RIALTO_MESSAGES_PALLET_OWNER: &'static str = "Rialto.MessagesOwner";
+const RIALTO_MESSAGES_PALLET_OWNER: &str = "Rialto.MessagesOwner";
 /// "Name" of the account, which owns the with-RialtoParachain messages pallet.
-const RIALTO_PARACHAIN_MESSAGES_PALLET_OWNER: &'static str = "RialtoParachain.MessagesOwner";
+const RIALTO_PARACHAIN_MESSAGES_PALLET_OWNER: &str = "RialtoParachain.MessagesOwner";
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;

--- a/bin/rialto-parachain/node/src/chain_spec.rs
+++ b/bin/rialto-parachain/node/src/chain_spec.rs
@@ -22,6 +22,17 @@ use serde::{Deserialize, Serialize};
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
+/// "Names" of the authorities accounts at local testnet.
+const LOCAL_AUTHORITIES_ACCOUNTS: [&'static str; 2] = ["Alice", "Bob"];
+/// "Names" of the authorities accounts at development testnet.
+const DEV_AUTHORITIES_ACCOUNTS: [&'static str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
+/// "Names" of all possible authorities accounts.
+const ALL_AUTHORITIES_ACCOUNTS: [&'static str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
+/// "Name" of the sudo account.
+const SUDO_ACCOUNT: &'static str = "Sudo";
+/// "Name" of the account, which owns the with-Millau messages pallet.
+const MILLAU_MESSAGES_PALLET_OWNER: &'static str = "Millau.MessagesOwner";
+
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec =
 	sc_service::GenericChainSpec<rialto_parachain_runtime::GenesisConfig, Extensions>;
@@ -67,14 +78,13 @@ where
 /// accounts used by relayers in our test deployments, accounts used for demonstration
 /// purposes), are all available on these chains.
 fn endowed_accounts() -> Vec<AccountId> {
+	let all_authorities = ALL_AUTHORITIES_ACCOUNTS.iter().flat_map(|x| [
+		get_account_id_from_seed::<sr25519::Public>(x),
+		get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", x)),
+	]);
 	vec![
 		// Sudo account
-		get_account_id_from_seed::<sr25519::Public>("Sudo"),
-		// Authorities accounts
-		get_account_id_from_seed::<sr25519::Public>("Alice"),
-		get_account_id_from_seed::<sr25519::Public>("Bob"),
-		get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+		get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
 		// Regular (unused) accounts
 		get_account_id_from_seed::<sr25519::Public>("Charlie"),
 		get_account_id_from_seed::<sr25519::Public>("Dave"),
@@ -85,10 +95,10 @@ fn endowed_accounts() -> Vec<AccountId> {
 		get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 		// Accounts, used by RialtoParachain<>Millau bridge
-		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesOwner"),
+		get_account_id_from_seed::<sr25519::Public>(MILLAU_MESSAGES_PALLET_OWNER),
 		get_account_id_from_seed::<sr25519::Public>("Millau.HeadersAndMessagesRelay"),
 		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesSender"),
-	]
+	].into_iter().chain(all_authorities).collect()
 }
 
 pub fn development_config(id: ParaId) -> ChainSpec {
@@ -105,8 +115,8 @@ pub fn development_config(id: ParaId) -> ChainSpec {
 		ChainType::Local,
 		move || {
 			testnet_genesis(
-				get_account_id_from_seed::<sr25519::Public>("Sudo"),
-				vec![get_from_seed::<AuraId>("Alice"), get_from_seed::<AuraId>("Bob")],
+				get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
+				DEV_AUTHORITIES_ACCOUNTS.into_iter().map(|x| get_from_seed::<AuraId>(x)).collect(),
 				endowed_accounts(),
 				id,
 			)
@@ -137,8 +147,8 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 		ChainType::Local,
 		move || {
 			testnet_genesis(
-				get_account_id_from_seed::<sr25519::Public>("Sudo"),
-				vec![get_from_seed::<AuraId>("Alice"), get_from_seed::<AuraId>("Bob")],
+				get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
+				LOCAL_AUTHORITIES_ACCOUNTS.into_iter().map(|x| get_from_seed::<AuraId>(x)).collect(),
 				endowed_accounts(),
 				id,
 			)
@@ -175,7 +185,7 @@ fn testnet_genesis(
 		aura: rialto_parachain_runtime::AuraConfig { authorities: initial_authorities },
 		aura_ext: Default::default(),
 		bridge_millau_messages: BridgeMillauMessagesConfig {
-			owner: Some(get_account_id_from_seed::<sr25519::Public>("Millau.MessagesOwner")),
+			owner: Some(get_account_id_from_seed::<sr25519::Public>(MILLAU_MESSAGES_PALLET_OWNER)),
 			..Default::default()
 		},
 	}

--- a/bin/rialto-parachain/node/src/chain_spec.rs
+++ b/bin/rialto-parachain/node/src/chain_spec.rs
@@ -105,7 +105,7 @@ pub fn development_config(id: ParaId) -> ChainSpec {
 		ChainType::Local,
 		move || {
 			testnet_genesis(
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				get_account_id_from_seed::<sr25519::Public>("Sudo"),
 				vec![get_from_seed::<AuraId>("Alice"), get_from_seed::<AuraId>("Bob")],
 				endowed_accounts(),
 				id,
@@ -137,7 +137,7 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 		ChainType::Local,
 		move || {
 			testnet_genesis(
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				get_account_id_from_seed::<sr25519::Public>("Sudo"),
 				vec![get_from_seed::<AuraId>("Alice"), get_from_seed::<AuraId>("Bob")],
 				endowed_accounts(),
 				id,

--- a/bin/rialto-parachain/node/src/chain_spec.rs
+++ b/bin/rialto-parachain/node/src/chain_spec.rs
@@ -78,10 +78,12 @@ where
 /// accounts used by relayers in our test deployments, accounts used for demonstration
 /// purposes), are all available on these chains.
 fn endowed_accounts() -> Vec<AccountId> {
-	let all_authorities = ALL_AUTHORITIES_ACCOUNTS.iter().flat_map(|x| [
-		get_account_id_from_seed::<sr25519::Public>(x),
-		get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", x)),
-	]);
+	let all_authorities = ALL_AUTHORITIES_ACCOUNTS.iter().flat_map(|x| {
+		[
+			get_account_id_from_seed::<sr25519::Public>(x),
+			get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", x)),
+		]
+	});
 	vec![
 		// Sudo account
 		get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
@@ -98,7 +100,10 @@ fn endowed_accounts() -> Vec<AccountId> {
 		get_account_id_from_seed::<sr25519::Public>(MILLAU_MESSAGES_PALLET_OWNER),
 		get_account_id_from_seed::<sr25519::Public>("Millau.HeadersAndMessagesRelay"),
 		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesSender"),
-	].into_iter().chain(all_authorities).collect()
+	]
+	.into_iter()
+	.chain(all_authorities)
+	.collect()
 }
 
 pub fn development_config(id: ParaId) -> ChainSpec {
@@ -116,7 +121,10 @@ pub fn development_config(id: ParaId) -> ChainSpec {
 		move || {
 			testnet_genesis(
 				get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
-				DEV_AUTHORITIES_ACCOUNTS.into_iter().map(|x| get_from_seed::<AuraId>(x)).collect(),
+				DEV_AUTHORITIES_ACCOUNTS
+					.into_iter()
+					.map(|x| get_from_seed::<AuraId>(x))
+					.collect(),
 				endowed_accounts(),
 				id,
 			)
@@ -148,7 +156,10 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 		move || {
 			testnet_genesis(
 				get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
-				LOCAL_AUTHORITIES_ACCOUNTS.into_iter().map(|x| get_from_seed::<AuraId>(x)).collect(),
+				LOCAL_AUTHORITIES_ACCOUNTS
+					.into_iter()
+					.map(|x| get_from_seed::<AuraId>(x))
+					.collect(),
 				endowed_accounts(),
 				id,
 			)

--- a/bin/rialto-parachain/node/src/chain_spec.rs
+++ b/bin/rialto-parachain/node/src/chain_spec.rs
@@ -23,15 +23,15 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// "Names" of the authorities accounts at local testnet.
-const LOCAL_AUTHORITIES_ACCOUNTS: [&'static str; 2] = ["Alice", "Bob"];
+const LOCAL_AUTHORITIES_ACCOUNTS: [&str; 2] = ["Alice", "Bob"];
 /// "Names" of the authorities accounts at development testnet.
-const DEV_AUTHORITIES_ACCOUNTS: [&'static str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
+const DEV_AUTHORITIES_ACCOUNTS: [&str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
 /// "Names" of all possible authorities accounts.
-const ALL_AUTHORITIES_ACCOUNTS: [&'static str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
+const ALL_AUTHORITIES_ACCOUNTS: [&str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
 /// "Name" of the `sudo` account.
-const SUDO_ACCOUNT: &'static str = "Sudo";
+const SUDO_ACCOUNT: &str = "Sudo";
 /// "Name" of the account, which owns the with-Millau messages pallet.
-const MILLAU_MESSAGES_PALLET_OWNER: &'static str = "Millau.MessagesOwner";
+const MILLAU_MESSAGES_PALLET_OWNER: &str = "Millau.MessagesOwner";
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec =

--- a/bin/rialto-parachain/node/src/chain_spec.rs
+++ b/bin/rialto-parachain/node/src/chain_spec.rs
@@ -68,25 +68,26 @@ where
 /// purposes), are all available on these chains.
 fn endowed_accounts() -> Vec<AccountId> {
 	vec![
+		// Sudo account
+		get_account_id_from_seed::<sr25519::Public>("Sudo"),
+		// Authorities accounts
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		get_account_id_from_seed::<sr25519::Public>("Bob"),
+		get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+		// Regular (unused) accounts
 		get_account_id_from_seed::<sr25519::Public>("Charlie"),
 		get_account_id_from_seed::<sr25519::Public>("Dave"),
 		get_account_id_from_seed::<sr25519::Public>("Eve"),
 		get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-		get_account_id_from_seed::<sr25519::Public>("George"),
-		get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-		get_account_id_from_seed::<sr25519::Public>("George//stash"),
-		get_account_id_from_seed::<sr25519::Public>("MillauMessagesOwner"),
-		pallet_bridge_messages::relayer_fund_account_id::<
-			bp_rialto_parachain::AccountId,
-			bp_rialto_parachain::AccountIdConverter,
-		>(),
+		// Accounts, used by RialtoParachain<>Millau bridge
+		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesOwner"),
+		get_account_id_from_seed::<sr25519::Public>("Millau.HeadersAndMessagesRelay"),
+		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesSender"),
 	]
 }
 
@@ -174,7 +175,7 @@ fn testnet_genesis(
 		aura: rialto_parachain_runtime::AuraConfig { authorities: initial_authorities },
 		aura_ext: Default::default(),
 		bridge_millau_messages: BridgeMillauMessagesConfig {
-			owner: Some(get_account_id_from_seed::<sr25519::Public>("MillauMessagesOwner")),
+			owner: Some(get_account_id_from_seed::<sr25519::Public>("Millau.MessagesOwner")),
 			..Default::default()
 		},
 	}

--- a/bin/rialto-parachain/node/src/chain_spec.rs
+++ b/bin/rialto-parachain/node/src/chain_spec.rs
@@ -28,7 +28,7 @@ const LOCAL_AUTHORITIES_ACCOUNTS: [&'static str; 2] = ["Alice", "Bob"];
 const DEV_AUTHORITIES_ACCOUNTS: [&'static str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
 /// "Names" of all possible authorities accounts.
 const ALL_AUTHORITIES_ACCOUNTS: [&'static str; 2] = LOCAL_AUTHORITIES_ACCOUNTS;
-/// "Name" of the sudo account.
+/// "Name" of the `sudo` account.
 const SUDO_ACCOUNT: &'static str = "Sudo";
 /// "Name" of the account, which owns the with-Millau messages pallet.
 const MILLAU_MESSAGES_PALLET_OWNER: &'static str = "Millau.MessagesOwner";

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -15,7 +15,6 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use beefy_primitives::crypto::AuthorityId as BeefyId;
-use bp_rialto::derive_account_from_millau_id;
 use polkadot_primitives::v2::{AssignmentId, ValidatorId};
 use rialto_runtime::{
 	AccountId, BabeConfig, BalancesConfig, BeefyConfig, BridgeMillauMessagesConfig,
@@ -274,12 +273,4 @@ fn testnet_genesis(
 		},
 		xcm_pallet: Default::default(),
 	}
-}
-
-#[test]
-fn derived_dave_account_is_as_expected() {
-	let dave = get_account_id_from_seed::<sr25519::Public>("Dave");
-	let derived: AccountId =
-		derive_account_from_millau_id(bp_runtime::SourceAccount::Account(dave));
-	assert_eq!(derived.to_string(), "5HZhdv53gSJmWWtD8XR5Ypu4PgbT5JNWwGw2mkE75cN61w9t".to_string());
 }

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -96,7 +96,7 @@ impl Alternative {
 				|| {
 					testnet_genesis(
 						vec![get_authority_keys_from_seed("Alice")],
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
+						get_account_id_from_seed::<sr25519::Public>("Sudo"),
 						endowed_accounts(),
 						true,
 					)
@@ -121,7 +121,7 @@ impl Alternative {
 							get_authority_keys_from_seed("Dave"),
 							get_authority_keys_from_seed("Eve"),
 						],
-						get_account_id_from_seed::<sr25519::Public>("Alice"),
+						get_account_id_from_seed::<sr25519::Public>("Sudo"),
 						endowed_accounts(),
 						true,
 					)
@@ -143,46 +143,28 @@ impl Alternative {
 /// purposes), are all available on these chains.
 fn endowed_accounts() -> Vec<AccountId> {
 	vec![
+		// Sudo account
+		get_account_id_from_seed::<sr25519::Public>("Sudo"),
+		// Authorities accounts
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		get_account_id_from_seed::<sr25519::Public>("Bob"),
 		get_account_id_from_seed::<sr25519::Public>("Charlie"),
 		get_account_id_from_seed::<sr25519::Public>("Dave"),
 		get_account_id_from_seed::<sr25519::Public>("Eve"),
-		get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-		get_account_id_from_seed::<sr25519::Public>("George"),
-		get_account_id_from_seed::<sr25519::Public>("Harry"),
 		get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
 		get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+		// Regular (unused) accounts
+		get_account_id_from_seed::<sr25519::Public>("Ferdie"),
 		get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-		get_account_id_from_seed::<sr25519::Public>("George//stash"),
-		get_account_id_from_seed::<sr25519::Public>("Harry//stash"),
-		get_account_id_from_seed::<sr25519::Public>("MillauMessagesOwner"),
-		get_account_id_from_seed::<sr25519::Public>("WithMillauTokenSwap"),
-		pallet_bridge_messages::relayer_fund_account_id::<
-			bp_rialto::AccountId,
-			bp_rialto::AccountIdConverter,
-		>(),
-		derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Alice"),
-		)),
-		derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Bob"),
-		)),
-		derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Charlie"),
-		)),
-		derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Dave"),
-		)),
-		derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Eve"),
-		)),
-		derive_account_from_millau_id(bp_runtime::SourceAccount::Account(
-			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-		)),
+		// Accounts, used by Rialto<>Millau bridge
+		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesOwner"),
+		get_account_id_from_seed::<sr25519::Public>("Millau.HeadersAndMessagesRelay"),
+		get_account_id_from_seed::<sr25519::Public>("Millau.OutboundMessagesRelay.Lane00000001"),
+		get_account_id_from_seed::<sr25519::Public>("Millau.InboundMessagesRelay.Lane00000001"),
+		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesSender"),
 	]
 }
 
@@ -287,7 +269,7 @@ fn testnet_genesis(
 		},
 		paras: Default::default(),
 		bridge_millau_messages: BridgeMillauMessagesConfig {
-			owner: Some(get_account_id_from_seed::<sr25519::Public>("MillauMessagesOwner")),
+			owner: Some(get_account_id_from_seed::<sr25519::Public>("Millau.MessagesOwner")),
 			..Default::default()
 		},
 		xcm_pallet: Default::default(),

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -29,15 +29,15 @@ use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// "Names" of the authorities accounts at local testnet.
-const LOCAL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = ["Alice", "Bob", "Charlie", "Dave", "Eve"];
+const LOCAL_AUTHORITIES_ACCOUNTS: [&str; 5] = ["Alice", "Bob", "Charlie", "Dave", "Eve"];
 /// "Names" of the authorities accounts at development testnet.
-const DEV_AUTHORITIES_ACCOUNTS: [&'static str; 1] = [LOCAL_AUTHORITIES_ACCOUNTS[0]];
+const DEV_AUTHORITIES_ACCOUNTS: [&str; 1] = [LOCAL_AUTHORITIES_ACCOUNTS[0]];
 /// "Names" of all possible authorities accounts.
-const ALL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = LOCAL_AUTHORITIES_ACCOUNTS;
+const ALL_AUTHORITIES_ACCOUNTS: [&str; 5] = LOCAL_AUTHORITIES_ACCOUNTS;
 /// "Name" of the `sudo` account.
-const SUDO_ACCOUNT: &'static str = "Sudo";
+const SUDO_ACCOUNT: &str = "Sudo";
 /// "Name" of the account, which owns the with-Millau messages pallet.
-const MILLAU_MESSAGES_PALLET_OWNER: &'static str = "Millau.MessagesOwner";
+const MILLAU_MESSAGES_PALLET_OWNER: &str = "Millau.MessagesOwner";
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec =

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -34,7 +34,7 @@ const LOCAL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = ["Alice", "Bob", "Charlie"
 const DEV_AUTHORITIES_ACCOUNTS: [&'static str; 1] = [LOCAL_AUTHORITIES_ACCOUNTS[0]];
 /// "Names" of all possible authorities accounts.
 const ALL_AUTHORITIES_ACCOUNTS: [&'static str; 5] = LOCAL_AUTHORITIES_ACCOUNTS;
-/// "Name" of the sudo account.
+/// "Name" of the `sudo` account.
 const SUDO_ACCOUNT: &'static str = "Sudo";
 /// "Name" of the account, which owns the with-Millau messages pallet.
 const MILLAU_MESSAGES_PALLET_OWNER: &'static str = "Millau.MessagesOwner";

--- a/bin/rialto/node/src/chain_spec.rs
+++ b/bin/rialto/node/src/chain_spec.rs
@@ -105,7 +105,10 @@ impl Alternative {
 				sc_service::ChainType::Development,
 				|| {
 					testnet_genesis(
-						DEV_AUTHORITIES_ACCOUNTS.into_iter().map(get_authority_keys_from_seed).collect(),
+						DEV_AUTHORITIES_ACCOUNTS
+							.into_iter()
+							.map(get_authority_keys_from_seed)
+							.collect(),
 						get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
 						endowed_accounts(),
 						true,
@@ -124,7 +127,10 @@ impl Alternative {
 				sc_service::ChainType::Local,
 				|| {
 					testnet_genesis(
-						LOCAL_AUTHORITIES_ACCOUNTS.into_iter().map(get_authority_keys_from_seed).collect(),
+						LOCAL_AUTHORITIES_ACCOUNTS
+							.into_iter()
+							.map(get_authority_keys_from_seed)
+							.collect(),
 						get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
 						endowed_accounts(),
 						true,
@@ -146,10 +152,12 @@ impl Alternative {
 /// accounts used by relayers in our test deployments, accounts used for demonstration
 /// purposes), are all available on these chains.
 fn endowed_accounts() -> Vec<AccountId> {
-	let all_authorities = ALL_AUTHORITIES_ACCOUNTS.iter().flat_map(|x| [
-		get_account_id_from_seed::<sr25519::Public>(x),
-		get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", x)),
-	]);
+	let all_authorities = ALL_AUTHORITIES_ACCOUNTS.iter().flat_map(|x| {
+		[
+			get_account_id_from_seed::<sr25519::Public>(x),
+			get_account_id_from_seed::<sr25519::Public>(&format!("{}//stash", x)),
+		]
+	});
 	vec![
 		// Sudo account
 		get_account_id_from_seed::<sr25519::Public>(SUDO_ACCOUNT),
@@ -162,7 +170,10 @@ fn endowed_accounts() -> Vec<AccountId> {
 		get_account_id_from_seed::<sr25519::Public>("Millau.OutboundMessagesRelay.Lane00000001"),
 		get_account_id_from_seed::<sr25519::Public>("Millau.InboundMessagesRelay.Lane00000001"),
 		get_account_id_from_seed::<sr25519::Public>("Millau.MessagesSender"),
-	].into_iter().chain(all_authorities).collect()
+	]
+	.into_iter()
+	.chain(all_authorities)
+	.collect()
 }
 
 fn session_keys(

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -81,11 +81,15 @@ not strictly required.
 
 Rialto authorities are named: `Alice`, `Bob`, `Charlie`, `Dave`, `Eve`.
 Millau authorities are named: `Alice`, `Bob`, `Charlie`, `Dave`, `Eve`.
+RialtoParachain authorities are named: `Alice`, `Bob`.
+
+`Sudo` is a sudo account on all chains.
 
 Both authorities and following accounts have enough funds (for test purposes) on corresponding Substrate chains:
 
-- on Rialto: `Ferdie`, `George`, `Harry`.
-- on Millau: `Ferdie`, `George`, `Harry`.
+- on Rialto: `Ferdie`.
+- on Millau: `Ferdie`.
+- on RialtoParachain: `Charlie`, `Dave`, `Eve`, `Ferdie`.
 
 Names of accounts on Substrate (Rialto and Millau) chains may be prefixed with `//` and used as
 seeds for the `sr25519` keys. This seed may also be used in the signer argument in Substrate relays.
@@ -106,27 +110,29 @@ is not recommended, because this may lead to nonces conflict.
 
 Following accounts are used when `rialto-millau` bridge is running:
 
-- Millau's `Charlie` signs complex headers+messages relay transactions on Millau chain;
-- Rialto's `Charlie` signs complex headers+messages relay transactions on Rialto chain;
-- Millau's `Dave` signs Millau transactions which contain messages for Rialto;
-- Rialto's `Dave` signs Rialto transactions which contain messages for Millau;
-- Millau's `Eve` signs relay transactions with message delivery confirmations (lane 00000001) from Rialto to Millau;
-- Rialto's `Eve` signs relay transactions with messages (lane 00000001) from Millau to Rialto;
-- Millau's `Ferdie` signs relay transactions with messages (lane 00000001) from Rialto to Millau;
-- Rialto's `Ferdie` signs relay transactions with message delivery confirmations (lane 00000001) from Millau to Rialto;
-- Millau's `RialtoMessagesOwner` signs relay transactions with updated Rialto -> Millau conversion rate;
-- Rialto's `MillauMessagesOwner` signs relay transactions with updated Millau -> Rialto conversion rate.
+- Millau's `Rialto.HeadersAndMessagesRelay` signs complex headers+messages relay transactions on Millau chain;
+- Rialto's `Millau.HeadersAndMessagesRelay` signs complex headers+messages relay transactions on Rialto chain;
+- Millau's `Rialto.MessagesSender` signs Millau transactions which contain messages for Rialto;
+- Rialto's `Millau.MessagesSender` signs Rialto transactions which contain messages for Millau;
+- Millau's `Rialto.OutboundMessagesRelay.Lane00000001` signs relay transactions with message delivery confirmations (lane 00000001) from Rialto to Millau;
+- Rialto's `Millau.InboundMessagesRelay.Lane00000001` signs relay transactions with messages (lane 00000001) from Millau to Rialto;
+- Millau's `Millau.OutboundMessagesRelay.Lane00000001` signs relay transactions with messages (lane 00000001) from Rialto to Millau;
+- Rialto's `Rialto.InboundMessagesRelay.Lane00000001` signs relay transactions with message delivery confirmations (lane 00000001) from Millau to Rialto;
+- Millau's `Rialto.MessagesOwner` signs relay transactions with updated Rialto -> Millau conversion rate;
+- Rialto's `Millau.MessagesOwner` signs relay transactions with updated Millau -> Rialto conversion rate.
 
 Following accounts are used when `westend-millau` bridge is running:
 
-- Millau's `George` and `Harry` are signing relay transactions with new Westend headers.
+- Millau's `Westend.GrandpaOwner` is signing with-Westend GRANDPA pallet initialization transaction.
+- Millau's `Westend.HeadersRelay1` and `Westend.HeadersRelay2` are signing transactions with new Westend headers.
+- Millau's `Westend.WestmintHeaders1` and `Westend.WestmintHeaders2` is signing transactions with new Westming headers.
 
 Following accounts are used when `rialto-parachain-millau` bridge is running:
 
-- RialtoParachain's `Bob` signs RialtoParachain transactions which contain messages for Millau;
-- Millau's `Bob` signs Millau transactions which contain messages for RialtoParachain;
-- Millau's `Iden` signs complex headers+parachains+messages relay transactions on Millau chain;
-- RialtoParachain's `George` signs complex headers+messages relay transactions on RialtoParachain chain.
+- RialtoParachain's `Millau.MessagesSender` signs RialtoParachain transactions which contain messages for Millau;
+- Millau's `RialtoParachain.MessagesSender` signs Millau transactions which contain messages for RialtoParachain;
+- Millau's `RialtoParachain.HeadersAndMessagesRelay` signs complex headers+parachains+messages relay transactions on Millau chain;
+- RialtoParachain's `Millau.HeadersAndMessagesRelay` signs complex headers+messages relay transactions on RialtoParachain chain.
 
 ### Docker Usage
 When the network is running you can query logs from individual nodes using:

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -101,7 +101,7 @@ Example:
 	--source-port 9944 \
 	--target-host millau-node-alice \
 	--target-port 9944 \
-	--source-signer //Harry \
+	--source-signer //Ferdie \
 	--prometheus-host=0.0.0.0
 ```
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-millau-to-rialto-entrypoint.sh
@@ -9,8 +9,8 @@ MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 	--lane $MESSAGE_LANE \
 	--source-host millau-node-bob \
 	--source-port 9944 \
-	--source-signer //Eve \
+	--source-signer //Rialto.OutboundMessagesRelay.Lane00000001 \
 	--target-host rialto-node-bob \
 	--target-port 9944 \
-	--target-signer //Eve \
+	--target-signer //Millau.InboundMessagesRelay.Lane00000001 \
 	--prometheus-host=0.0.0.0

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-rialto-to-millau-entrypoint.sh
@@ -9,8 +9,8 @@ MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 	--lane $MESSAGE_LANE \
 	--source-host rialto-node-bob \
 	--source-port 9944 \
-	--source-signer //Ferdie \
+	--source-signer //Millau.OutboundMessagesRelay.Lane00000001 \
 	--target-host millau-node-bob \
 	--target-port 9944 \
-	--target-signer //Ferdie \
+	--target-signer //Rialto.InboundMessagesRelay.Lane00000001 \
 	--prometheus-host=0.0.0.0

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -16,7 +16,7 @@ FERDIE_ADDR=5oSLwptwgySxh5vz1HdvznQJjbQVgwYSvHEpYYeTXu1Ei8j7
 
 SHARED_CMD="/home/user/substrate-relay send-message rialto-to-millau"
 SHARED_HOST="--source-host rialto-node-bob --source-port 9944"
-SOURCE_SIGNER="--source-signer //Millau.MessageSender"
+SOURCE_SIGNER="--source-signer //Millau.MessagesSender"
 
 SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -16,9 +16,9 @@ FERDIE_ADDR=5oSLwptwgySxh5vz1HdvznQJjbQVgwYSvHEpYYeTXu1Ei8j7
 
 SHARED_CMD="/home/user/substrate-relay send-message rialto-to-millau"
 SHARED_HOST="--source-host rialto-node-bob --source-port 9944"
-DAVE_SIGNER="--source-signer //Dave"
+SOURCE_SIGNER="--source-signer //Millau.MessageSender"
 
-SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $DAVE_SIGNER"
+SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
 # Sleep a bit between messages
 rand_sleep() {

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -16,9 +16,9 @@ FERDIE_ADDR=6ztG3jPnJTwgZnnYsgCDXbbQVR82M96hBZtPvkN56A9668ZC
 
 SHARED_CMD=" /home/user/substrate-relay send-message millau-to-rialto"
 SHARED_HOST="--source-host millau-node-bob --source-port 9944"
-DAVE_SIGNER="--source-signer //Dave"
+SOURCE_SIGNER="--source-signer //Rialto.MessagesSender"
 
-SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $DAVE_SIGNER"
+SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
 # Sleep a bit between messages
 rand_sleep() {

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-resubmitter-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-resubmitter-entrypoint.sh
@@ -3,7 +3,7 @@ set -xeu
 
 sleep 15
 
-# //Dave is signing Millau -> Rialto message-send transactions, which are causing problems.
+# //Rialto.MessagesSender is signing Millau -> Rialto message-send transactions, which are causing problems.
 #
 # When large message is being sent from Millau to Rialto AND other transactions are
 # blocking it from being mined, we'll see something like this in logs:
@@ -18,7 +18,7 @@ sleep 15
 /home/user/substrate-relay resubmit-transactions millau \
 	--target-host millau-node-alice \
 	--target-port 9944 \
-	--target-signer //Dave \
+	--target-signer //Rialto.MessagesSender \
 	--stalled-blocks 5 \
 	--tip-limit 1000000000000 \
 	--tip-step 1000000000 \

--- a/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
@@ -8,14 +8,14 @@ sleep 15
 	--source-port 9944 \
 	--target-host rialto-node-alice \
 	--target-port 9944 \
-	--target-signer //Alice
+	--target-signer //Sudo
 
 /home/user/substrate-relay init-bridge rialto-to-millau \
 	--source-host rialto-node-alice \
 	--source-port 9944 \
 	--target-host millau-node-alice \
 	--target-port 9944 \
-	--target-signer //Alice
+	--target-signer //Sudo
 
 # Give chain a little bit of time to process initialization transaction
 sleep 6
@@ -23,13 +23,13 @@ sleep 6
 /home/user/substrate-relay relay-headers-and-messages millau-rialto \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
-	--millau-signer //Charlie \
-	--millau-messages-pallet-owner=//RialtoMessagesOwner \
+	--millau-signer //Rialto.HeadersAndMessagesRelay \
+	--millau-messages-pallet-owner=//Rialto.MessagesOwner \
 	--millau-transactions-mortality=64 \
 	--rialto-host rialto-node-alice \
 	--rialto-port 9944 \
-	--rialto-signer //Charlie \
-	--rialto-messages-pallet-owner=//MillauMessagesOwner \
+	--rialto-signer //Millau.HeadersAndMessagesRelay \
+	--rialto-messages-pallet-owner=//Millau.MessagesOwner \
 	--rialto-transactions-mortality=64 \
 	--lane=00000000 \
 	--lane=73776170 \

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -14,9 +14,9 @@ MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE=1024
 
 SHARED_CMD="/home/user/substrate-relay send-message rialto-parachain-to-millau"
 SHARED_HOST="--source-host rialto-parachain-collator-bob --source-port 9944"
-DAVE_SIGNER="--source-signer //Bob"
+SOURCE_SIGNER="--source-signer //Millau.MessagesSender"
 
-SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $DAVE_SIGNER"
+SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
 # Sleep a bit between messages
 rand_sleep() {

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-generator-entrypoint.sh
@@ -14,9 +14,9 @@ MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE=1024
 
 SHARED_CMD=" /home/user/substrate-relay send-message millau-to-rialto-parachain"
 SHARED_HOST="--source-host millau-node-bob --source-port 9944"
-DAVE_SIGNER="--source-signer //Bob"
+SOURCE_SIGNER="--source-signer //RialtoParachain.MessagesSender"
 
-SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $DAVE_SIGNER"
+SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
 # Sleep a bit between messages
 rand_sleep() {

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-resubmitter-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-resubmitter-entrypoint.sh
@@ -3,7 +3,7 @@ set -xeu
 
 sleep 15
 
-# //Bob is signing Millau -> RialtoParachain message-send transactions, which are causing problems.
+# //RialtoParachain.MessagesSender is signing Millau -> RialtoParachain message-send transactions, which are causing problems.
 #
 # When large message is being sent from Millau to RialtoParachain AND other transactions are
 # blocking it from being mined, we'll see something like this in logs:
@@ -18,7 +18,7 @@ sleep 15
 /home/user/substrate-relay resubmit-transactions millau \
 	--target-host millau-node-alice \
 	--target-port 9944 \
-	--target-signer //Bob \
+	--target-signer //RialtoParachain.MessagesSender \
 	--stalled-blocks 7 \
 	--tip-limit 1000000000000 \
 	--tip-step 1000000000 \

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-millau-rialto-parachain-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-millau-rialto-parachain-entrypoint.sh
@@ -8,14 +8,14 @@ sleep 15
 	--source-port 9944 \
 	--target-host rialto-parachain-collator-alice \
 	--target-port 9944 \
-	--target-signer //Alice
+	--target-signer //Sudo
 
 /home/user/substrate-relay init-bridge rialto-to-millau \
 	--source-host rialto-node-alice \
 	--source-port 9944 \
 	--target-host millau-node-alice \
 	--target-port 9944 \
-	--target-signer //Alice
+	--target-signer //Sudo
 
 # Give chain a little bit of time to process initialization transaction
 sleep 6
@@ -23,14 +23,14 @@ sleep 6
 /home/user/substrate-relay relay-headers-and-messages millau-rialto-parachain \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
-	--millau-signer //Iden \
-	--rialto-headers-to-millau-signer //Ken \
-	--millau-messages-pallet-owner=//RialtoParachainMessagesOwner \
+	--millau-signer //RialtoParachain.HeadersAndMessagesRelay \
+	--rialto-headers-to-millau-signer //RialtoParachain.RialtoHeadersRelay \
+	--millau-messages-pallet-owner=//RialtoParachain.MessagesOwner \
 	--millau-transactions-mortality=64 \
 	--rialto-parachain-host rialto-parachain-collator-charlie \
 	--rialto-parachain-port 9944 \
-	--rialto-parachain-signer //George \
-	--rialto-parachain-messages-pallet-owner=//MillauMessagesOwner \
+	--rialto-parachain-signer //Millau.HeadersAndMessagesRelay \
+	--rialto-parachain-messages-pallet-owner=//Millau.MessagesOwner \
 	--rialto-parachain-transactions-mortality=64 \
 	--rialto-host rialto-node-alice \
 	--rialto-port 9944 \

--- a/deployments/bridges/westend-millau/docker-compose.yml
+++ b/deployments/bridges/westend-millau/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./bridges/westend-millau/entrypoints:/entrypoints
     environment:
       RUST_LOG: rpc=trace,bridge=trace
-      EXT_RELAY_ACCOUNT: //Harry
+      EXT_RELAY_ACCOUNT: //Westend.HeadersRelay2
     ports:
       - "10617:9616"
     depends_on:
@@ -46,7 +46,7 @@ services:
       - ./bridges/westend-millau/entrypoints:/entrypoints
     environment:
       RUST_LOG: rpc=trace,bridge=trace
-      EXT_RELAY_ACCOUNT: //Mary
+      EXT_RELAY_ACCOUNT: //Westend.WestmintHeaders2
     ports:
       - "10619:9616"
     depends_on:

--- a/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
+++ b/deployments/bridges/westend-millau/entrypoints/relay-headers-westend-to-millau-entrypoint.sh
@@ -3,7 +3,7 @@ set -xeu
 
 sleep 15
 
-RELAY_ACCOUNT=${EXT_RELAY_ACCOUNT:-//George}
+RELAY_ACCOUNT=${EXT_RELAY_ACCOUNT:-//Westend.HeadersRelay1}
 
 /home/user/substrate-relay init-bridge westend-to-millau \
 	--source-host westend-rpc.polkadot.io \
@@ -11,7 +11,7 @@ RELAY_ACCOUNT=${EXT_RELAY_ACCOUNT:-//George}
 	--source-secure \
 	--target-host millau-node-alice \
 	--target-port 9944 \
-	--target-signer $RELAY_ACCOUNT
+	--target-signer //Westend.GrandpaOwner
 
 # Give chain a little bit of time to process initialization transaction
 sleep 6

--- a/deployments/bridges/westend-millau/entrypoints/relay-parachains-westend-to-millau-entrypoint.sh
+++ b/deployments/bridges/westend-millau/entrypoints/relay-parachains-westend-to-millau-entrypoint.sh
@@ -3,7 +3,7 @@ set -xeu
 
 sleep 15
 
-RELAY_ACCOUNT=${EXT_RELAY_ACCOUNT:-//Leon}
+RELAY_ACCOUNT=${EXT_RELAY_ACCOUNT:-//Westend.WestmintHeaders1}
 
 /home/user/substrate-relay relay-parachains westend-to-millau \
 	--source-host westend-rpc.polkadot.io \

--- a/deployments/networks/entrypoints/rialto-parachain-registrar-entrypoint.sh
+++ b/deployments/networks/entrypoints/rialto-parachain-registrar-entrypoint.sh
@@ -8,4 +8,4 @@ sleep 15
 	--parachain-port 9944 \
 	--relaychain-host rialto-node-alice \
 	--relaychain-port 9944 \
-	--relaychain-signer //Alice
+	--relaychain-signer //Sudo

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -925,7 +925,9 @@ mod tests {
 						millau_transactions_mortality: Some(64),
 					},
 					left_messages_pallet_owner: MillauMessagesPalletOwnerSigningParams {
-						millau_messages_pallet_owner: Some("//RialtoParachain.MessagesOwner".into()),
+						millau_messages_pallet_owner: Some(
+							"//RialtoParachain.MessagesOwner".into()
+						),
 						millau_messages_pallet_owner_password: None,
 					},
 					left_headers_to_right_sign_override:

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages.rs
@@ -754,7 +754,7 @@ mod tests {
 			"--millau-signer",
 			"//Charlie",
 			"--millau-messages-pallet-owner",
-			"//RialtoMessagesOwner",
+			"//Rialto.MessagesOwner",
 			"--millau-transactions-mortality",
 			"64",
 			"--rialto-host",
@@ -764,7 +764,7 @@ mod tests {
 			"--rialto-signer",
 			"//Charlie",
 			"--rialto-messages-pallet-owner",
-			"//MillauMessagesOwner",
+			"//Millau.MessagesOwner",
 			"--rialto-transactions-mortality",
 			"64",
 			"--lane",
@@ -811,7 +811,7 @@ mod tests {
 					millau_transactions_mortality: Some(64),
 				},
 				left_messages_pallet_owner: MillauMessagesPalletOwnerSigningParams {
-					millau_messages_pallet_owner: Some("//RialtoMessagesOwner".into()),
+					millau_messages_pallet_owner: Some("//Rialto.MessagesOwner".into()),
 					millau_messages_pallet_owner_password: None,
 				},
 				left_headers_to_right_sign_override: MillauHeadersToRialtoSigningParams {
@@ -839,7 +839,7 @@ mod tests {
 					rialto_transactions_mortality: Some(64),
 				},
 				right_messages_pallet_owner: RialtoMessagesPalletOwnerSigningParams {
-					rialto_messages_pallet_owner: Some("//MillauMessagesOwner".into()),
+					rialto_messages_pallet_owner: Some("//Millau.MessagesOwner".into()),
 					rialto_messages_pallet_owner_password: None,
 				},
 				right_headers_to_left_sign_override: RialtoHeadersToMillauSigningParams {
@@ -868,7 +868,7 @@ mod tests {
 			"--rialto-headers-to-millau-signer",
 			"//Ken",
 			"--millau-messages-pallet-owner",
-			"//RialtoParachainMessagesOwner",
+			"//RialtoParachain.MessagesOwner",
 			"--millau-transactions-mortality",
 			"64",
 			"--rialto-parachain-host",
@@ -878,7 +878,7 @@ mod tests {
 			"--rialto-parachain-signer",
 			"//George",
 			"--rialto-parachain-messages-pallet-owner",
-			"//MillauMessagesOwner",
+			"//Millau.MessagesOwner",
 			"--rialto-parachain-transactions-mortality",
 			"64",
 			"--rialto-host",
@@ -925,7 +925,7 @@ mod tests {
 						millau_transactions_mortality: Some(64),
 					},
 					left_messages_pallet_owner: MillauMessagesPalletOwnerSigningParams {
-						millau_messages_pallet_owner: Some("//RialtoParachainMessagesOwner".into()),
+						millau_messages_pallet_owner: Some("//RialtoParachain.MessagesOwner".into()),
 						millau_messages_pallet_owner_password: None,
 					},
 					left_headers_to_right_sign_override:
@@ -955,7 +955,7 @@ mod tests {
 					},
 					right_messages_pallet_owner: RialtoParachainMessagesPalletOwnerSigningParams {
 						rialto_parachain_messages_pallet_owner: Some(
-							"//MillauMessagesOwner".into()
+							"//Millau.MessagesOwner".into()
 						),
 						rialto_parachain_messages_pallet_owner_password: None,
 					},


### PR DESCRIPTION
closes #1428

This PR changes account "names", used on our test deployments from generic (e.g. `//Harry`) to meaningful (`//Millau.MessagesSender`). We had too many issues related to generic names usage - it isn't always clear, which account is already submitting transactions and which is not. Documentation isn't of big help here. This change allows us to understand what account is doing just by looking at its name.

*SIDE INFO*: one account may be used to sign multiple transactions, but every Substrate transaction (in our chains) has so called `nonce`, which is just a "serial number" of transaction. You can't have two transactions with the same number and transactions are always mined in order. If we're using e.g. `//Alice` to sign transactions from different processes (relays), then some transactions may be dropped, because they'll be using the same nonce. We have a inter-process solution for that, but not for multiple processes (and we don't need that).

@serban300 Im summoning you here, because you're also working with codebase. So please let me know what you're thinking about this change and whether names I've choose are understandable. If you think there are better "names" - please suggest.