### PR TITLE
Add another condition to the reject-obsolete-parachain-heads extension

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -1035,6 +1035,7 @@ impl_runtime_apis! {
 					pallet_bridge_parachains::RelayBlockNumber,
 					pallet_bridge_parachains::RelayBlockHash,
 					bp_polkadot_core::parachains::ParaHeadsProof,
+					Vec<(bp_polkadot_core::parachains::ParaId, bp_polkadot_core::parachains::ParaHash)>,
 				) {
 					bridge_runtime_common::parachains_benchmarking::prepare_parachain_heads_proof::<Runtime, WithRialtoParachainsInstance>(
 						parachains,

--- a/bin/runtime-common/src/messages_extension.rs
+++ b/bin/runtime-common/src/messages_extension.rs
@@ -70,6 +70,14 @@ macro_rules! declare_bridge_reject_obsolete_messages {
 
 							let inbound_lane_data = pallet_bridge_messages::InboundLanes::<$runtime, $instance>::get(&proof.lane);
 							if proof.nonces_end <= inbound_lane_data.last_delivered_nonce() {
+								log::trace!(
+									target: pallet_bridge_messages::LOG_TARGET,
+									"Rejecting obsolete messages delivery transaction: lane {:?}, bundled {:?}, best {:?}",
+									proof.lane,
+									proof.nonces_end,
+									inbound_lane_data.last_delivered_nonce(),
+								);
+
 								return sp_runtime::transaction_validity::InvalidTransaction::Stale.into();
 							}
 
@@ -84,6 +92,14 @@ macro_rules! declare_bridge_reject_obsolete_messages {
 
 							let outbound_lane_data = pallet_bridge_messages::OutboundLanes::<$runtime, $instance>::get(&proof.lane);
 							if latest_delivered_nonce <= outbound_lane_data.latest_received_nonce {
+								log::trace!(
+									target: pallet_bridge_messages::LOG_TARGET,
+									"Rejecting obsolete messages confirmation transaction: lane {:?}, bundled {:?}, best {:?}",
+									proof.lane,
+									latest_delivered_nonce,
+									outbound_lane_data.latest_received_nonce,
+								);
+
 								return sp_runtime::transaction_validity::InvalidTransaction::Stale.into();
 							}
 

--- a/modules/grandpa/src/extension.rs
+++ b/modules/grandpa/src/extension.rs
@@ -75,6 +75,13 @@ macro_rules! declare_bridge_reject_obsolete_grandpa_header {
 							if best_finalized_number < bundled_block_number {
 								Ok(sp_runtime::transaction_validity::ValidTransaction::default())
 							} else {
+								log::trace!(
+									target: $crate::LOG_TARGET,
+									"Rejecting obsolete bridged header: bundled {:?}, best {:?}",
+									bundled_block_number,
+									best_finalized_number,
+								);
+
 								sp_runtime::transaction_validity::InvalidTransaction::Stale.into()
 							}
 						},

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -60,7 +60,7 @@ pub use pallet::*;
 pub use weights::WeightInfo;
 
 /// The target that will be used when publishing logs related to this pallet.
-const LOG_TARGET: &str = "runtime::bridge-grandpa";
+pub const LOG_TARGET: &str = "runtime::bridge-grandpa";
 
 /// Block number of the bridged chain.
 pub type BridgedBlockNumber<T, I> = BlockNumberOf<<T as Config<I>>::BridgedChain>;

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -91,7 +91,7 @@ mod mock;
 pub use pallet::*;
 
 /// The target that will be used when publishing logs related to this pallet.
-const LOG_TARGET: &str = "runtime::bridge-messages";
+pub const LOG_TARGET: &str = "runtime::bridge-messages";
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/modules/parachains/src/benchmarking.rs
+++ b/modules/parachains/src/benchmarking.rs
@@ -21,7 +21,7 @@ use crate::{
 	RelayBlockNumber,
 };
 
-use bp_polkadot_core::parachains::{ParaHeadsProof, ParaId};
+use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
 use bp_runtime::StorageProofSize;
 use frame_benchmarking::{account, benchmarks_instance_pallet};
 use frame_system::RawOrigin;
@@ -37,7 +37,7 @@ pub trait Config<I: 'static>: crate::Config<I> {
 		parachains: &[ParaId],
 		parachain_head_size: u32,
 		proof_size: StorageProofSize,
-	) -> (RelayBlockNumber, RelayBlockHash, ParaHeadsProof);
+	) -> (RelayBlockNumber, RelayBlockHash, ParaHeadsProof, Vec<(ParaId, ParaHash)>);
 }
 
 benchmarks_instance_pallet! {
@@ -57,13 +57,13 @@ benchmarks_instance_pallet! {
 
 		let sender = account("sender", 0, 0);
 		let parachains = (1..=p).map(ParaId).collect::<Vec<_>>();
-		let (relay_block_number, relay_block_hash, parachain_heads_proof) = T::prepare_parachain_heads_proof(
+		let (relay_block_number, relay_block_hash, parachain_heads_proof, parachains_heads) = T::prepare_parachain_heads_proof(
 			&parachains,
 			DEFAULT_PARACHAIN_HEAD_SIZE,
 			StorageProofSize::Minimal(0),
 		);
 		let at_relay_block = (relay_block_number, relay_block_hash);
-	}: submit_parachain_heads(RawOrigin::Signed(sender), at_relay_block, parachains.clone(), parachain_heads_proof)
+	}: submit_parachain_heads(RawOrigin::Signed(sender), at_relay_block, parachains_heads, parachain_heads_proof)
 	verify {
 		for parachain in parachains {
 			assert!(crate::Pallet::<T, I>::best_parachain_head(parachain).is_some());
@@ -74,13 +74,13 @@ benchmarks_instance_pallet! {
 	submit_parachain_heads_with_1kb_proof {
 		let sender = account("sender", 0, 0);
 		let parachains = vec![ParaId(1)];
-		let (relay_block_number, relay_block_hash, parachain_heads_proof) = T::prepare_parachain_heads_proof(
+		let (relay_block_number, relay_block_hash, parachain_heads_proof, parachains_heads) = T::prepare_parachain_heads_proof(
 			&parachains,
 			DEFAULT_PARACHAIN_HEAD_SIZE,
 			StorageProofSize::HasExtraNodes(1024),
 		);
 		let at_relay_block = (relay_block_number, relay_block_hash);
-	}: submit_parachain_heads(RawOrigin::Signed(sender), at_relay_block, parachains.clone(), parachain_heads_proof)
+	}: submit_parachain_heads(RawOrigin::Signed(sender), at_relay_block, parachains_heads, parachain_heads_proof)
 	verify {
 		for parachain in parachains {
 			assert!(crate::Pallet::<T, I>::best_parachain_head(parachain).is_some());
@@ -91,13 +91,13 @@ benchmarks_instance_pallet! {
 	submit_parachain_heads_with_16kb_proof {
 		let sender = account("sender", 0, 0);
 		let parachains = vec![ParaId(1)];
-		let (relay_block_number, relay_block_hash, parachain_heads_proof) = T::prepare_parachain_heads_proof(
+		let (relay_block_number, relay_block_hash, parachain_heads_proof, parachains_heads) = T::prepare_parachain_heads_proof(
 			&parachains,
 			DEFAULT_PARACHAIN_HEAD_SIZE,
 			StorageProofSize::HasExtraNodes(16 * 1024),
 		);
 		let at_relay_block = (relay_block_number, relay_block_hash);
-	}: submit_parachain_heads(RawOrigin::Signed(sender), at_relay_block, parachains.clone(), parachain_heads_proof)
+	}: submit_parachain_heads(RawOrigin::Signed(sender), at_relay_block, parachains_heads, parachain_heads_proof)
 	verify {
 		for parachain in parachains {
 			assert!(crate::Pallet::<T, I>::best_parachain_head(parachain).is_some());

--- a/modules/parachains/src/extension.rs
+++ b/modules/parachains/src/extension.rs
@@ -146,7 +146,10 @@ mod tests {
 		Call::Parachains => ()
 	}
 
-	fn validate_submit_parachain_heads(num: RelayBlockNumber, parachains: Vec<(ParaId, ParaHash)>) -> bool {
+	fn validate_submit_parachain_heads(
+		num: RelayBlockNumber,
+		parachains: Vec<(ParaId, ParaHash)>,
+	) -> bool {
 		BridgeRejectObsoleteParachainHeader
 			.validate(
 				&42,
@@ -218,7 +221,10 @@ mod tests {
 			// when current best finalized is #10 and we're trying to import header#5, but another
 			// parachain head is also supplied => tx is accepted
 			sync_to_relay_header_10();
-			assert!(validate_submit_parachain_heads(5, vec![(ParaId(1), [1u8; 32].into()), (ParaId(2), [1u8; 32].into())]));
+			assert!(validate_submit_parachain_heads(
+				5,
+				vec![(ParaId(1), [1u8; 32].into()), (ParaId(2), [1u8; 32].into())]
+			));
 		});
 	}
 }

--- a/modules/parachains/src/extension.rs
+++ b/modules/parachains/src/extension.rs
@@ -166,14 +166,14 @@ mod tests {
 			ParaId(1),
 			BestParaHead {
 				at_relay_block_number: 10,
-				head_hash: Default::default(),
+				head_hash: [1u8; 32].into(),
 				next_imported_hash_position: 0,
 			},
 		);
 	}
 
 	#[test]
-	fn extension_rejects_obsolete_header() {
+	fn extension_rejects_header_from_the_obsolete_relay_block() {
 		run_test(|| {
 			// when current best finalized is #10 and we're trying to import header#5 => tx is
 			// rejected
@@ -183,7 +183,7 @@ mod tests {
 	}
 
 	#[test]
-	fn extension_rejects_same_header() {
+	fn extension_rejects_header_from_the_same_relay_block() {
 		run_test(|| {
 			// when current best finalized is #10 and we're trying to import header#10 => tx is
 			// rejected
@@ -193,12 +193,22 @@ mod tests {
 	}
 
 	#[test]
+	fn extension_rejects_header_from_new_relay_block_with_same_hash() {
+		run_test(|| {
+			// when current best finalized is #10 and we're trying to import header#10 => tx is
+			// rejected
+			sync_to_relay_header_10();
+			assert!(!validate_submit_parachain_heads(20, vec![(ParaId(1), [1u8; 32].into())]));
+		});
+	}
+
+	#[test]
 	fn extension_accepts_new_header() {
 		run_test(|| {
 			// when current best finalized is #10 and we're trying to import header#15 => tx is
 			// accepted
 			sync_to_relay_header_10();
-			assert!(validate_submit_parachain_heads(15, vec![(ParaId(1), [1u8; 32].into())]));
+			assert!(validate_submit_parachain_heads(15, vec![(ParaId(1), [2u8; 32].into())]));
 		});
 	}
 

--- a/modules/parachains/src/extension.rs
+++ b/modules/parachains/src/extension.rs
@@ -208,7 +208,7 @@ mod tests {
 			// when current best finalized is #10 and we're trying to import header#5, but another
 			// parachain head is also supplied => tx is accepted
 			sync_to_relay_header_10();
-			assert!(validate_submit_parachain_heads(5, vec![ParaId(1), ParaId(2)]));
+			assert!(validate_submit_parachain_heads(5, vec![(ParaId(1), [1u8; 32].into()), (ParaId(2), [1u8; 32].into())]));
 		});
 	}
 }

--- a/modules/parachains/src/extension.rs
+++ b/modules/parachains/src/extension.rs
@@ -77,13 +77,29 @@ macro_rules! declare_bridge_reject_obsolete_parachain_header {
 							let bundled_relay_block_number = at_relay_block.0;
 
 							let best_parachain_head = $crate::BestParaHeads::<$runtime, $instance>::get(parachain);
-log::trace!(target: "runtime-bridge", "BridgeRejectObsoleteParachainHeader: Para={:?} Number={:?} Hash={:?} Best={:?}", parachain, bundled_relay_block_number, parachain_head_hash, best_parachain_head);
+
 							match best_parachain_head {
 								Some(best_parachain_head) if best_parachain_head.at_relay_block_number
-									>= bundled_relay_block_number =>
-										sp_runtime::transaction_validity::InvalidTransaction::Stale.into(),
-								Some(best_parachain_head) if best_parachain_head.head_hash == *parachain_head_hash =>
-									sp_runtime::transaction_validity::InvalidTransaction::Stale.into(),
+									>= bundled_relay_block_number => {
+									log::trace!(
+										target: $crate::LOG_TARGET,
+										"Rejecting obsolete parachain-head {:?} transaction: bundled relay block number: \
+										{:?} best relay block number: {:?}",
+										parachain,
+										bundled_relay_block_number,
+										best_parachain_head.at_relay_block_number,
+									);
+									sp_runtime::transaction_validity::InvalidTransaction::Stale.into()
+								}
+								Some(best_parachain_head) if best_parachain_head.head_hash == *parachain_head_hash => {
+									log::trace!(
+										target: $crate::LOG_TARGET,
+										"Rejecting obsolete parachain-head {:?} transaction: head hash {:?}",
+										parachain,
+										best_parachain_head.head_hash,
+									);
+									sp_runtime::transaction_validity::InvalidTransaction::Stale.into()
+								}
 								_ => Ok(sp_runtime::transaction_validity::ValidTransaction::default()),
 							}
 						},
@@ -121,7 +137,7 @@ mod tests {
 		mock::{run_test, Call, TestRuntime},
 		BestParaHead, BestParaHeads, RelayBlockNumber,
 	};
-	use bp_polkadot_core::parachains::{ParaHeadsProof, ParaId};
+	use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
 	use frame_support::weights::{DispatchClass, DispatchInfo, Pays};
 	use sp_runtime::traits::SignedExtension;
 
@@ -130,7 +146,7 @@ mod tests {
 		Call::Parachains => ()
 	}
 
-	fn validate_submit_parachain_heads(num: RelayBlockNumber, parachains: Vec<ParaId>) -> bool {
+	fn validate_submit_parachain_heads(num: RelayBlockNumber, parachains: Vec<(ParaId, ParaHash)>) -> bool {
 		BridgeRejectObsoleteParachainHeader
 			.validate(
 				&42,
@@ -162,7 +178,7 @@ mod tests {
 			// when current best finalized is #10 and we're trying to import header#5 => tx is
 			// rejected
 			sync_to_relay_header_10();
-			assert!(!validate_submit_parachain_heads(5, vec![ParaId(1)]));
+			assert!(!validate_submit_parachain_heads(5, vec![(ParaId(1), [1u8; 32].into())]));
 		});
 	}
 
@@ -172,7 +188,7 @@ mod tests {
 			// when current best finalized is #10 and we're trying to import header#10 => tx is
 			// rejected
 			sync_to_relay_header_10();
-			assert!(!validate_submit_parachain_heads(10, vec![ParaId(1)]));
+			assert!(!validate_submit_parachain_heads(10, vec![(ParaId(1), [1u8; 32].into())]));
 		});
 	}
 
@@ -182,7 +198,7 @@ mod tests {
 			// when current best finalized is #10 and we're trying to import header#15 => tx is
 			// accepted
 			sync_to_relay_header_10();
-			assert!(validate_submit_parachain_heads(15, vec![ParaId(1)]));
+			assert!(validate_submit_parachain_heads(15, vec![(ParaId(1), [1u8; 32].into())]));
 		});
 	}
 

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -613,7 +613,8 @@ mod tests {
 
 	#[test]
 	fn submit_parachain_heads_checks_operating_mode() {
-		let (state_root, proof, parachains) = prepare_parachain_heads_proof(vec![(1, head_data(1, 0))]);
+		let (state_root, proof, parachains) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 0))]);
 
 		run_test(|| {
 			initialize(state_root);
@@ -685,8 +686,10 @@ mod tests {
 
 	#[test]
 	fn imports_parachain_heads_is_able_to_progress() {
-		let (state_root_5, proof_5, parachains_5) = prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
-		let (state_root_10, proof_10, parachains_10) = prepare_parachain_heads_proof(vec![(1, head_data(1, 10))]);
+		let (state_root_5, proof_5, parachains_5) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
+		let (state_root_10, proof_10, parachains_10) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 10))]);
 		run_test(|| {
 			// start with relay block #0 and import head#5 of parachain#1
 			initialize(state_root_5);
@@ -769,7 +772,8 @@ mod tests {
 
 	#[test]
 	fn does_nothing_when_already_imported_this_head_at_previous_relay_header() {
-		let (state_root, proof, parachains) = prepare_parachain_heads_proof(vec![(1, head_data(1, 0))]);
+		let (state_root, proof, parachains) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 0))]);
 		run_test(|| {
 			// import head#0 of parachain#1 at relay block#0
 			initialize(state_root);
@@ -786,8 +790,10 @@ mod tests {
 
 	#[test]
 	fn does_nothing_when_already_imported_head_at_better_relay_header() {
-		let (state_root_5, proof_5, parachains_5) = prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
-		let (state_root_10, proof_10, parachains_10) = prepare_parachain_heads_proof(vec![(1, head_data(1, 10))]);
+		let (state_root_5, proof_5, parachains_5) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
+		let (state_root_10, proof_10, parachains_10) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 10))]);
 		run_test(|| {
 			// start with relay block #0
 			initialize(state_root_5);
@@ -825,7 +831,8 @@ mod tests {
 
 			// import exactly `HeadsToKeep` headers
 			for i in 0..heads_to_keep {
-				let (state_root, proof, parachains) = prepare_parachain_heads_proof(vec![(1, head_data(1, i))]);
+				let (state_root, proof, parachains) =
+					prepare_parachain_heads_proof(vec![(1, head_data(1, i))]);
 				if i == 0 {
 					initialize(state_root);
 				} else {
@@ -866,7 +873,8 @@ mod tests {
 
 	#[test]
 	fn fails_on_unknown_relay_chain_block() {
-		let (state_root, proof, parachains) = prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
+		let (state_root, proof, parachains) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
 		run_test(|| {
 			// start with relay block #0
 			initialize(state_root);
@@ -881,7 +889,8 @@ mod tests {
 
 	#[test]
 	fn fails_on_invalid_storage_proof() {
-		let (_state_root, proof, parachains) = prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
+		let (_state_root, proof, parachains) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
 		run_test(|| {
 			// start with relay block #0
 			initialize(Default::default());
@@ -896,7 +905,8 @@ mod tests {
 
 	#[test]
 	fn is_not_rewriting_existing_head_if_failed_to_read_updated_head() {
-		let (state_root_5, proof_5, parachains_5) = prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
+		let (state_root_5, proof_5, parachains_5) =
+			prepare_parachain_heads_proof(vec![(1, head_data(1, 5))]);
 		let (state_root_10_at_20, proof_10_at_20, parachains_10_at_20) =
 			prepare_parachain_heads_proof(vec![(2, head_data(2, 10))]);
 		let (state_root_10_at_30, proof_10_at_30, parachains_10_at_30) =

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -49,7 +49,7 @@ mod extension;
 mod mock;
 
 /// The target that will be used when publishing logs related to this pallet.
-const LOG_TARGET: &str = "runtime::bridge-parachains";
+pub const LOG_TARGET: &str = "runtime::bridge-parachains";
 
 /// Block hash of the bridged relay chain.
 pub type RelayBlockHash = bp_polkadot_core::Hash;

--- a/relays/lib-substrate-relay/src/parachains/mod.rs
+++ b/relays/lib-substrate-relay/src/parachains/mod.rs
@@ -18,7 +18,7 @@
 //! parachain finality proofs synchronization pipelines.
 
 use async_trait::async_trait;
-use bp_polkadot_core::parachains::{ParaHeadsProof, ParaId};
+use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
 use pallet_bridge_parachains::{
 	Call as BridgeParachainsCall, Config as BridgeParachainsConfig, RelayBlockHash,
 	RelayBlockHasher, RelayBlockNumber,
@@ -71,7 +71,7 @@ pub trait SubmitParachainHeadsCallBuilder<P: SubstrateParachainsPipeline>:
 	/// function of bridge parachains module at the target chain.
 	fn build_submit_parachain_heads_call(
 		at_relay_block: HeaderIdOf<P::SourceRelayChain>,
-		parachains: Vec<ParaId>,
+		parachains: Vec<(ParaId, ParaHash)>,
 		parachain_heads_proof: ParaHeadsProof,
 	) -> CallOf<P::TargetChain>;
 }
@@ -97,7 +97,7 @@ where
 {
 	fn build_submit_parachain_heads_call(
 		at_relay_block: HeaderIdOf<P::SourceRelayChain>,
-		parachains: Vec<ParaId>,
+		parachains: Vec<(ParaId, ParaHash)>,
 		parachain_heads_proof: ParaHeadsProof,
 	) -> CallOf<P::TargetChain> {
 		BridgeParachainsCall::<R, I>::submit_parachain_heads {

--- a/relays/lib-substrate-relay/src/parachains/source.rs
+++ b/relays/lib-substrate-relay/src/parachains/source.rs
@@ -160,23 +160,42 @@ where
 		&self,
 		at_block: HeaderIdOf<P::SourceRelayChain>,
 		parachains: &[ParaId],
-	) -> Result<ParaHeadsProof, Self::Error> {
-		let storage_keys = parachains
-			.iter()
-			.map(|para_id| {
-				parachain_head_storage_key_at_source(
-					P::SourceRelayChain::PARAS_PALLET_NAME,
-					*para_id,
-				)
-			})
-			.collect();
+	) -> Result<(ParaHeadsProof, Vec<ParaHash>), Self::Error> {
+		if parachains.len() != 1 || parachains[0].0 != P::SOURCE_PARACHAIN_PARA_ID {
+			return Err(SubstrateError::Custom(format!(
+				"Trying to prove unexpected parachains {:?}. Expected {:?}",
+				parachains,
+				P::SOURCE_PARACHAIN_PARA_ID,
+			)))
+		}
+		
+		let parachain = parachains[0];
+		let storage_key = parachain_head_storage_key_at_source(
+			P::SourceRelayChain::PARAS_PALLET_NAME,
+			parachain,
+		);
 		let parachain_heads_proof = self
 			.client
-			.prove_storage(storage_keys, at_block.1)
+			.prove_storage(vec![storage_key.clone()], at_block.1)
 			.await?
 			.iter_nodes()
 			.collect();
 
-		Ok(ParaHeadsProof(parachain_heads_proof))
+		// why we're reading parachain head here once again (it has already been read at the `parachain_head`)?
+		// that's because `parachain_head` sometimes returns obsolete parachain head and loop sometimes asks to prove
+		// this obsolete head and gets other (actual) head instead
+		//
+		// => since we want to provide proper hashes in our `submit_parachain_heads` call, we're rereading actual
+		// value here
+		let parachain_head = self
+			.client
+			.raw_storage_value(storage_key, Some(at_block.1))
+			.await?
+			.map(|h| ParaHead::decode(&mut &h.0[..]))
+			.transpose()?
+			.ok_or_else(|| SubstrateError::Custom(format!("Failed to read expected parachain {:?} head at {:?}", parachain, at_block)))?;
+		let parachain_head_hash = parachain_head.hash();
+
+		Ok((ParaHeadsProof(parachain_heads_proof), vec![parachain_head_hash]))
 	}
 }

--- a/relays/lib-substrate-relay/src/parachains/target.rs
+++ b/relays/lib-substrate-relay/src/parachains/target.rs
@@ -28,7 +28,7 @@ use bp_parachains::{
 	best_parachain_head_hash_storage_key_at_target, imported_parachain_head_storage_key_at_target,
 	BestParaHeadHash,
 };
-use bp_polkadot_core::parachains::{ParaHead, ParaHeadsProof, ParaId};
+use bp_polkadot_core::parachains::{ParaHash, ParaHead, ParaHeadsProof, ParaId};
 use codec::{Decode, Encode};
 use parachains_relay::{
 	parachains_loop::TargetClient, parachains_loop_metrics::ParachainsLoopMetrics,
@@ -166,7 +166,7 @@ where
 	async fn submit_parachain_heads_proof(
 		&self,
 		at_relay_block: HeaderIdOf<P::SourceRelayChain>,
-		updated_parachains: Vec<ParaId>,
+		updated_parachains: Vec<(ParaId, ParaHash)>,
 		proof: ParaHeadsProof,
 	) -> Result<(), Self::Error> {
 		let genesis_hash = *self.client.genesis_hash();

--- a/relays/parachains/src/parachains_loop.rs
+++ b/relays/parachains/src/parachains_loop.rs
@@ -697,7 +697,7 @@ mod tests {
 						.ok_or(TestError::MissingParachainHeadProof)?,
 				);
 			}
-			Ok(ParaHeadsProof((proofs, vec![Default::default(); parachains.len()])))
+			Ok((ParaHeadsProof(proofs), vec![Default::default(); parachains.len()]))
 		}
 	}
 
@@ -726,7 +726,7 @@ mod tests {
 		async fn submit_parachain_heads_proof(
 			&self,
 			_at_source_block: HeaderIdOf<TestChain>,
-			_updated_parachains: Vec<ParaId>,
+			_updated_parachains: Vec<(ParaId, ParaHash)>,
 			_proof: ParaHeadsProof,
 		) -> Result<(), Self::Error> {
 			self.data.lock().await.target_submit_result.clone()?;

--- a/relays/parachains/src/parachains_loop.rs
+++ b/relays/parachains/src/parachains_loop.rs
@@ -307,7 +307,11 @@ where
 				P::TargetChain::NAME,
 			);
 
-			assert_eq!(head_hashes.len(), updated_ids.len(), "Incorrect parachains SourceClient implementation");
+			assert_eq!(
+				head_hashes.len(),
+				updated_ids.len(),
+				"Incorrect parachains SourceClient implementation"
+			);
 
 			target_client
 				.submit_parachain_heads_proof(

--- a/relays/parachains/src/parachains_loop.rs
+++ b/relays/parachains/src/parachains_loop.rs
@@ -69,6 +69,16 @@ pub enum ParaHashAtSource {
 	Unavailable,
 }
 
+impl ParaHashAtSource {
+	/// Return parachain head hash, if available.
+	pub fn hash(&self) -> Option<&ParaHash> {
+		match *self {
+			ParaHashAtSource::Some(ref para_hash) => Some(para_hash),
+			_ => None,
+		}
+	}
+}
+
 /// Source client used in parachain heads synchronization loop.
 #[async_trait]
 pub trait SourceClient<P: ParachainsPipeline>: RelayClient {
@@ -87,11 +97,15 @@ pub trait SourceClient<P: ParachainsPipeline>: RelayClient {
 	) -> Result<ParaHashAtSource, Self::Error>;
 
 	/// Get parachain heads proof.
+	///
+	/// The number and order of entries in the resulting parachain head hashes vector must match the
+	/// number and order of parachains in the `parachains` vector. The incorrect implementation will
+	/// result in panic.
 	async fn prove_parachain_heads(
 		&self,
 		at_block: HeaderIdOf<P::SourceChain>,
 		parachains: &[ParaId],
-	) -> Result<ParaHeadsProof, Self::Error>;
+	) -> Result<(ParaHeadsProof, Vec<ParaHash>), Self::Error>;
 }
 
 /// Target client used in parachain heads synchronization loop.
@@ -121,7 +135,7 @@ pub trait TargetClient<P: ParachainsPipeline>: RelayClient {
 	async fn submit_parachain_heads_proof(
 		&self,
 		at_source_block: HeaderIdOf<P::SourceChain>,
-		updated_parachains: Vec<ParaId>,
+		updated_parachains: Vec<(ParaId, ParaHash)>,
 		proof: ParaHeadsProof,
 	) -> Result<(), Self::Error>;
 }
@@ -274,7 +288,7 @@ where
 		);
 
 		if is_update_required {
-			let heads_proofs = source_client
+			let (heads_proofs, head_hashes) = source_client
 				.prove_parachain_heads(best_finalized_relay_block, &updated_ids)
 				.await
 				.map_err(|e| {
@@ -292,10 +306,13 @@ where
 				P::SourceChain::NAME,
 				P::TargetChain::NAME,
 			);
+
+			assert_eq!(head_hashes.len(), updated_ids.len(), "Incorrect parachains SourceClient implementation");
+
 			target_client
 				.submit_parachain_heads_proof(
 					best_finalized_relay_block,
-					updated_ids.clone(),
+					updated_ids.iter().cloned().zip(head_hashes).collect(),
 					heads_proofs,
 				)
 				.await
@@ -394,7 +411,7 @@ where
 
 			needs_update
 		})
-		.map(|((para_id, _), _)| para_id)
+		.map(|((para, _), _)| para)
 		.collect()
 }
 
@@ -666,7 +683,7 @@ mod tests {
 			&self,
 			_at_block: HeaderIdOf<TestChain>,
 			parachains: &[ParaId],
-		) -> Result<ParaHeadsProof, TestError> {
+		) -> Result<(ParaHeadsProof, Vec<ParaHash>), TestError> {
 			let mut proofs = Vec::new();
 			for para_id in parachains {
 				proofs.push(
@@ -680,7 +697,7 @@ mod tests {
 						.ok_or(TestError::MissingParachainHeadProof)?,
 				);
 			}
-			Ok(ParaHeadsProof(proofs))
+			Ok(ParaHeadsProof((proofs, vec![Default::default(); parachains.len()])))
 		}
 	}
 


### PR DESCRIPTION
So currently this extension only rejects transaction if bundled at-relay-chain-block-number is lesser or equal than the existing one. But there's another condition - when parachain head remains the same (i.e. is not updated) in some relay blocks, then the other relay may use different relay chain block to prove it. The extension won't reject the transaction, even though the pallet will ignore the head (since it is the same). This PR handles this situation.

TODOs:
- [x] test it;
- [x] add unit tests;
- [x] cleanup;
- [x] more traces?