### PR TITLE
Follow-up on #1352

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -594,18 +594,14 @@ construct_runtime!(
 	}
 );
 
-bridge_runtime_common::declare_bridge_reject_obsolete_messages! {
-	Runtime,
-	Call::BridgeRialtoMessages => WithRialtoMessagesInstance,
-	Call::BridgeRialtoParachainMessages => WithRialtoParachainMessagesInstance
-}
-
 generate_reject_obsolete_headers_and_messages! {
 	Runtime,
 	// Grandpa
 	BridgeRialtoGrandpa, BridgeWestendGrandpa,
 	// Parachains
-	BridgeRialtoParachains
+	BridgeRialtoParachains,
+	//Messages
+	BridgeRialtoMessages, BridgeRialtoParachainMessages
 }
 
 /// The address format for describing accounts.
@@ -629,7 +625,6 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	RejectObsoleteHeadersAndMessages,
-	BridgeRejectObsoleteMessages,
 );
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -78,7 +78,7 @@ pub use frame_support::{
 		constants::WEIGHT_PER_SECOND, ConstantMultiplier, DispatchClass, IdentityFee,
 		RuntimeDbWeight, Weight,
 	},
-	StorageValue,
+	RuntimeDebug, StorageValue,
 };
 
 pub use frame_system::Call as SystemCall;
@@ -89,6 +89,8 @@ pub use pallet_bridge_parachains::Call as BridgeParachainsCall;
 pub use pallet_sudo::Call as SudoCall;
 pub use pallet_timestamp::Call as TimestampCall;
 
+use bridge_runtime_common::generate_reject_obsolete_headers_and_messages;
+use sp_runtime::traits::DispatchInfoOf;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
@@ -592,12 +594,6 @@ construct_runtime!(
 	}
 );
 
-pallet_bridge_grandpa::declare_bridge_reject_obsolete_grandpa_header! {
-	Runtime,
-	Call::BridgeRialtoGrandpa => RialtoGrandpaInstance,
-	Call::BridgeWestendGrandpa => WestendGrandpaInstance
-}
-
 pallet_bridge_parachains::declare_bridge_reject_obsolete_parachain_header! {
 	Runtime,
 	Call::BridgeRialtoParachains => WithRialtoParachainsInstance
@@ -608,6 +604,8 @@ bridge_runtime_common::declare_bridge_reject_obsolete_messages! {
 	Call::BridgeRialtoMessages => WithRialtoMessagesInstance,
 	Call::BridgeRialtoParachainMessages => WithRialtoParachainMessagesInstance
 }
+
+generate_reject_obsolete_headers_and_messages!(Runtime, BridgeRialtoGrandpa, BridgeWestendGrandpa);
 
 /// The address format for describing accounts.
 pub type Address = AccountId;
@@ -629,7 +627,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-	BridgeRejectObsoleteGrandpaHeader,
+	RejectObsoleteHeadersAndMessages,
 	BridgeRejectObsoleteParachainHeader,
 	BridgeRejectObsoleteMessages,
 );

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -594,18 +594,19 @@ construct_runtime!(
 	}
 );
 
-pallet_bridge_parachains::declare_bridge_reject_obsolete_parachain_header! {
-	Runtime,
-	Call::BridgeRialtoParachains => WithRialtoParachainsInstance
-}
-
 bridge_runtime_common::declare_bridge_reject_obsolete_messages! {
 	Runtime,
 	Call::BridgeRialtoMessages => WithRialtoMessagesInstance,
 	Call::BridgeRialtoParachainMessages => WithRialtoParachainMessagesInstance
 }
 
-generate_reject_obsolete_headers_and_messages!(Runtime, BridgeRialtoGrandpa, BridgeWestendGrandpa);
+generate_reject_obsolete_headers_and_messages! {
+	Runtime,
+	// Grandpa
+	BridgeRialtoGrandpa, BridgeWestendGrandpa,
+	// Parachains
+	BridgeRialtoParachains
+}
 
 /// The address format for describing accounts.
 pub type Address = AccountId;
@@ -628,7 +629,6 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	RejectObsoleteHeadersAndMessages,
-	BridgeRejectObsoleteParachainHeader,
 	BridgeRejectObsoleteMessages,
 );
 /// The payload being signed in transactions.

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -89,8 +89,7 @@ pub use pallet_bridge_parachains::Call as BridgeParachainsCall;
 pub use pallet_sudo::Call as SudoCall;
 pub use pallet_timestamp::Call as TimestampCall;
 
-use bridge_runtime_common::generate_reject_obsolete_headers_and_messages;
-use sp_runtime::traits::DispatchInfoOf;
+use bridge_runtime_common::generate_bridge_reject_obsolete_headers_and_messages;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
@@ -594,8 +593,8 @@ construct_runtime!(
 	}
 );
 
-generate_reject_obsolete_headers_and_messages! {
-	Runtime,
+generate_bridge_reject_obsolete_headers_and_messages! {
+	Call, AccountId,
 	// Grandpa
 	BridgeRialtoGrandpa, BridgeWestendGrandpa,
 	// Parachains
@@ -624,7 +623,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-	RejectObsoleteHeadersAndMessages,
+	BridgeRejectObsoleteHeadersAndMessages,
 );
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;

--- a/bin/runtime-common/src/lib.rs
+++ b/bin/runtime-common/src/lib.rs
@@ -26,3 +26,49 @@ pub mod parachains_benchmarking;
 
 #[cfg(feature = "integrity-test")]
 pub mod integrity;
+
+#[macro_export]
+macro_rules! generate_reject_obsolete_headers_and_messages {
+	($runtime:ident, $($filter_call:ty),*) => {
+		#[derive(Clone, codec::Decode, codec::Encode, Eq, PartialEq, frame_support::RuntimeDebug, scale_info::TypeInfo)]
+		pub struct RejectObsoleteHeadersAndMessages;
+		impl sp_runtime::traits::SignedExtension for RejectObsoleteHeadersAndMessages {
+			const IDENTIFIER: &'static str = "BridgeRejectObsoleteHeadersAndMessages";
+			type AccountId = <$runtime as frame_system::Config>::AccountId;
+			type Call = <$runtime as frame_system::Config>::Call;
+			type AdditionalSigned = ();
+			type Pre = ();
+
+			fn additional_signed(&self) -> sp_std::result::Result<
+				(),
+				sp_runtime::transaction_validity::TransactionValidityError,
+			> {
+				Ok(())
+			}
+
+			fn validate(
+				&self,
+				_who: &Self::AccountId,
+				call: &Self::Call,
+				_info: &DispatchInfoOf<Self::Call>,
+				_len: usize,
+			) -> sp_runtime::transaction_validity::TransactionValidity {
+				use bp_runtime::FilterCall;
+
+				let valid = sp_runtime::transaction_validity::ValidTransaction::default();
+				$(let valid = valid.combine_with(<$filter_call>::validate(call)?);)*
+				Ok(valid)
+			}
+
+			fn pre_dispatch(
+				self,
+				who: &Self::AccountId,
+				call: &Self::Call,
+				info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
+				len: usize,
+			) -> Result<Self::Pre, sp_runtime::transaction_validity::TransactionValidityError> {
+				self.validate(who, call, info, len).map(drop)
+			}
+		}
+	};
+}

--- a/bin/runtime-common/src/lib.rs
+++ b/bin/runtime-common/src/lib.rs
@@ -30,7 +30,12 @@ pub mod parachains_benchmarking;
 #[cfg(feature = "integrity-test")]
 pub mod integrity;
 
+/// A duplication of the `FilterCall` trait.
+///
+/// We need this trait in order to be able to implement it for the messages pallet,
+/// since the implementation is done outside of the pallet crate.
 pub trait BridgeRuntimeFilterCall<Call> {
+	/// Checks if a runtime call is valid.
 	fn validate(call: &Call) -> TransactionValidity;
 }
 
@@ -52,15 +57,30 @@ where
 	}
 }
 
+/// Declares a runtime-specific `BridgeRejectObsoleteHeadersAndMessages` signed extension.
+///
+/// ## Example
+///
+/// ```nocompile
+/// generate_bridge_reject_obsolete_headers_and_messages!{
+///     Call, AccountId
+///     BridgeRialtoGrandpa, BridgeWestendGrandpa,
+///     BridgeRialtoParachains
+/// }
+/// ```
+///
+/// The goal of this extension is to avoid "mining" transactions that provide outdated bridged
+/// headers and messages. Without that extension, even honest relayers may lose their funds if
+/// there are multiple relays running and submitting the same information.
 #[macro_export]
-macro_rules! generate_reject_obsolete_headers_and_messages {
-	($runtime:ident, $($filter_call:ty),*) => {
+macro_rules! generate_bridge_reject_obsolete_headers_and_messages {
+	($call:ty, $account_id:ty, $($filter_call:ty),*) => {
 		#[derive(Clone, codec::Decode, codec::Encode, Eq, PartialEq, frame_support::RuntimeDebug, scale_info::TypeInfo)]
-		pub struct RejectObsoleteHeadersAndMessages;
-		impl sp_runtime::traits::SignedExtension for RejectObsoleteHeadersAndMessages {
+		pub struct BridgeRejectObsoleteHeadersAndMessages;
+		impl sp_runtime::traits::SignedExtension for BridgeRejectObsoleteHeadersAndMessages {
 			const IDENTIFIER: &'static str = "BridgeRejectObsoleteHeadersAndMessages";
-			type AccountId = <$runtime as frame_system::Config>::AccountId;
-			type Call = <$runtime as frame_system::Config>::Call;
+			type AccountId = $account_id;
+			type Call = $call;
 			type AdditionalSigned = ();
 			type Pre = ();
 
@@ -75,13 +95,14 @@ macro_rules! generate_reject_obsolete_headers_and_messages {
 				&self,
 				_who: &Self::AccountId,
 				call: &Self::Call,
-				_info: &DispatchInfoOf<Self::Call>,
+				_info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
 				_len: usize,
 			) -> sp_runtime::transaction_validity::TransactionValidity {
-				use bridge_runtime_common::BridgeRuntimeFilterCall;
-
 				let valid = sp_runtime::transaction_validity::ValidTransaction::default();
-				$(let valid = valid.combine_with(<$filter_call>::validate(call)?);)*
+				$(
+					let valid = valid
+						.combine_with(<$filter_call as $crate::BridgeRuntimeFilterCall<$call>>::validate(call)?);
+				)*
 				Ok(valid)
 			}
 
@@ -96,4 +117,79 @@ macro_rules! generate_reject_obsolete_headers_and_messages {
 			}
 		}
 	};
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::BridgeRuntimeFilterCall;
+	use frame_support::{assert_err, assert_ok};
+	use sp_runtime::{
+		traits::SignedExtension,
+		transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction},
+	};
+
+	pub struct MockCall {
+		data: u32,
+	}
+
+	impl sp_runtime::traits::Dispatchable for MockCall {
+		type Origin = ();
+		type Config = ();
+		type Info = ();
+		type PostInfo = ();
+
+		fn dispatch(
+			self,
+			_origin: Self::Origin,
+		) -> sp_runtime::DispatchResultWithInfo<Self::PostInfo> {
+			unimplemented!()
+		}
+	}
+
+	struct FirstFilterCall;
+	impl BridgeRuntimeFilterCall<MockCall> for FirstFilterCall {
+		fn validate(call: &MockCall) -> TransactionValidity {
+			if call.data <= 1 {
+				return InvalidTransaction::Custom(1).into()
+			}
+
+			Ok(ValidTransaction { priority: 1, ..Default::default() })
+		}
+	}
+
+	struct SecondFilterCall;
+	impl BridgeRuntimeFilterCall<MockCall> for SecondFilterCall {
+		fn validate(call: &MockCall) -> TransactionValidity {
+			if call.data <= 2 {
+				return InvalidTransaction::Custom(2).into()
+			}
+
+			Ok(ValidTransaction { priority: 2, ..Default::default() })
+		}
+	}
+
+	#[test]
+	fn test() {
+		generate_bridge_reject_obsolete_headers_and_messages!(
+			MockCall,
+			(),
+			FirstFilterCall,
+			SecondFilterCall
+		);
+
+		assert_err!(
+			BridgeRejectObsoleteHeadersAndMessages.validate(&(), &MockCall { data: 1 }, &(), 0),
+			InvalidTransaction::Custom(1)
+		);
+
+		assert_err!(
+			BridgeRejectObsoleteHeadersAndMessages.validate(&(), &MockCall { data: 2 }, &(), 0),
+			InvalidTransaction::Custom(2)
+		);
+
+		assert_ok!(
+			BridgeRejectObsoleteHeadersAndMessages.validate(&(), &MockCall { data: 3 }, &(), 0),
+			ValidTransaction { priority: 3, ..Default::default() }
+		)
+	}
 }

--- a/modules/grandpa/src/extension.rs
+++ b/modules/grandpa/src/extension.rs
@@ -14,132 +14,68 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-/// Declares a runtime-specific `BridgeRejectObsoleteGrandpaHeader` signed extension.
-///
-/// ## Example
-///
-/// ```nocompile
-/// pallet_bridge_grandpa::declare_bridge_reject_obsolete_grandpa_header!{
-///     Runtime,
-///     Call::BridgeRialtoGrandpa => RialtoGrandpaInstance,
-///     Call::BridgeWestendGrandpa => WestendGrandpaInstance,
-/// }
-/// ```
-///
-/// The goal of this extension is to avoid "mining" transactions that provide
-/// outdated bridged chain headers. Without that extension, even honest relayers
-/// may lose their funds if there are multiple relays running and submitting the
-/// same information.
-#[macro_export]
-macro_rules! declare_bridge_reject_obsolete_grandpa_header {
-	($runtime:ident, $($call:path => $instance:ty),*) => {
-		/// Transaction-with-obsolete-bridged-header check that will reject transaction if
-		/// it submits obsolete bridged header.
-		#[derive(Clone, codec::Decode, codec::Encode, Eq, PartialEq, frame_support::RuntimeDebug, scale_info::TypeInfo)]
-		pub struct BridgeRejectObsoleteGrandpaHeader;
+use crate::{Config, Pallet};
+use bp_runtime::FilterCall;
+use frame_support::{dispatch::CallableCallFor, traits::IsSubType};
+use sp_runtime::{
+	traits::Header,
+	transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction},
+};
 
-		impl sp_runtime::traits::SignedExtension for BridgeRejectObsoleteGrandpaHeader {
-			const IDENTIFIER: &'static str = "BridgeRejectObsoleteGrandpaHeader";
-			type AccountId = <$runtime as frame_system::Config>::AccountId;
-			type Call = <$runtime as frame_system::Config>::Call;
-			type AdditionalSigned = ();
-			type Pre = ();
+/// Validate Grandpa headers in order to avoid "mining" transactions that provide outdated
+/// bridged chain headers. Without this validation, even honest relayers may lose their funds
+/// if there are multiple relays running and submitting the same information.
+impl<
+		Call: IsSubType<CallableCallFor<Pallet<T, I>, T>>,
+		T: frame_system::Config<Call = Call> + Config<I>,
+		I: 'static,
+	> FilterCall<Call> for Pallet<T, I>
+{
+	fn validate(call: &<T as frame_system::Config>::Call) -> TransactionValidity {
+		let bundled_block_number = match call.is_sub_type() {
+			Some(crate::Call::<T, I>::submit_finality_proof { ref finality_target, .. }) =>
+				*finality_target.number(),
+			_ => return Ok(ValidTransaction::default()),
+		};
 
-			fn additional_signed(&self) -> sp_std::result::Result<
-				(),
-				sp_runtime::transaction_validity::TransactionValidityError,
-			> {
-				Ok(())
-			}
+		let best_finalized = crate::BestFinalized::<T, I>::get();
+		let best_finalized_number = match best_finalized {
+			Some((best_finalized_number, _)) => best_finalized_number,
+			None => return InvalidTransaction::Call.into(),
+		};
 
-			fn validate(
-				&self,
-				_who: &Self::AccountId,
-				call: &Self::Call,
-				_info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
-				_len: usize,
-			) -> sp_runtime::transaction_validity::TransactionValidity {
-				match *call {
-					$(
-						$call($crate::Call::<$runtime, $instance>::submit_finality_proof { ref finality_target, ..}) => {
-							use sp_runtime::traits::Header as HeaderT;
+		if best_finalized_number >= bundled_block_number {
+			log::trace!(
+				target: crate::LOG_TARGET,
+				"Rejecting obsolete bridged header: bundled {:?}, best {:?}",
+				bundled_block_number,
+				best_finalized_number,
+			);
 
-							let bundled_block_number = *finality_target.number();
-
-							let best_finalized = $crate::BestFinalized::<$runtime, $instance>::get();
-							let best_finalized_number = match best_finalized {
-								Some((best_finalized_number, _)) => best_finalized_number,
-								None => return sp_runtime::transaction_validity::InvalidTransaction::Call.into(),
-							};
-
-							if best_finalized_number < bundled_block_number {
-								Ok(sp_runtime::transaction_validity::ValidTransaction::default())
-							} else {
-								log::trace!(
-									target: $crate::LOG_TARGET,
-									"Rejecting obsolete bridged header: bundled {:?}, best {:?}",
-									bundled_block_number,
-									best_finalized_number,
-								);
-
-								sp_runtime::transaction_validity::InvalidTransaction::Stale.into()
-							}
-						},
-					)*
-					_ => Ok(sp_runtime::transaction_validity::ValidTransaction::default()),
-				}
-			}
-
-			fn pre_dispatch(
-				self,
-				who: &Self::AccountId,
-				call: &Self::Call,
-				info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
-				len: usize,
-			) -> Result<Self::Pre, sp_runtime::transaction_validity::TransactionValidityError> {
-				self.validate(who, call, info, len).map(drop)
-			}
-
-			fn post_dispatch(
-				_maybe_pre: Option<Self::Pre>,
-				_info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
-				_post_info: &sp_runtime::traits::PostDispatchInfoOf<Self::Call>,
-				_len: usize,
-				_result: &sp_runtime::DispatchResult,
-			) -> Result<(), sp_runtime::transaction_validity::TransactionValidityError> {
-				Ok(())
-			}
+			return InvalidTransaction::Stale.into()
 		}
-	};
+
+		Ok(ValidTransaction::default())
+	}
 }
 
 #[cfg(test)]
 mod tests {
+	use super::FilterCall;
 	use crate::{
 		mock::{run_test, test_header, Call, TestNumber, TestRuntime},
 		BestFinalized,
 	};
 	use bp_test_utils::make_default_justification;
-	use frame_support::weights::{DispatchClass, DispatchInfo, Pays};
-	use sp_runtime::traits::SignedExtension;
-
-	declare_bridge_reject_obsolete_grandpa_header! {
-		TestRuntime,
-		Call::Grandpa => ()
-	}
 
 	fn validate_block_submit(num: TestNumber) -> bool {
-		BridgeRejectObsoleteGrandpaHeader
-			.validate(
-				&42,
-				&Call::Grandpa(crate::Call::<TestRuntime, ()>::submit_finality_proof {
-					finality_target: Box::new(test_header(num)),
-					justification: make_default_justification(&test_header(num)),
-				}),
-				&DispatchInfo { weight: 0, class: DispatchClass::Operational, pays_fee: Pays::Yes },
-				0,
-			)
-			.is_ok()
+		crate::Pallet::<TestRuntime>::validate(&Call::Grandpa(
+			crate::Call::<TestRuntime, ()>::submit_finality_proof {
+				finality_target: Box::new(test_header(num)),
+				justification: make_default_justification(&test_header(num)),
+			},
+		))
+		.is_ok()
 	}
 
 	fn sync_to_header_10() {

--- a/modules/parachains/src/extension.rs
+++ b/modules/parachains/src/extension.rs
@@ -14,154 +14,98 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-/// Declares a runtime-specific `BridgeRejectObsoleteParachainHeader` signed extension.
-///
-/// ## Example
-///
-/// ```nocompile
-/// pallet_bridge_grandpa::declare_bridge_reject_obsolete_parachain_header!{
-///     Runtime,
-///     Call::BridgeRialtoParachains => RialtoGrandpaInstance,
-///     Call::BridgeWestendParachains => WestendGrandpaInstance,
-/// }
-/// ```
-///
-/// The goal of this extension is to avoid "mining" transactions that provide
-/// outdated bridged parachain heads. Without that extension, even honest relayers
+use crate::{Config, Pallet, RelayBlockHash, RelayBlockHasher, RelayBlockNumber};
+use bp_runtime::FilterCall;
+use frame_support::{dispatch::CallableCallFor, traits::IsSubType};
+use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction};
+
+/// Validate parachain heads in order to avoid "mining" transactions that provide
+/// outdated bridged parachain heads. Without this validation, even honest relayers
 /// may lose their funds if there are multiple relays running and submitting the
 /// same information.
 ///
-/// This extension only works with transactions that are updating single parachain
+/// This validation only works with transactions that are updating single parachain
 /// head. We can't use unbounded validation - it may take too long and either break
 /// block production, or "eat" significant portion of block production time literally
 /// for nothing. In addition, the single-parachain-head-per-transaction is how the
 /// pallet will be used in our environment.
-#[macro_export]
-macro_rules! declare_bridge_reject_obsolete_parachain_header {
-	($runtime:ident, $($call:path => $instance:ty),*) => {
-		/// Transaction-with-obsolete-bridged-parachain-header check that will reject transaction if
-		/// it submits obsolete bridged parachain header.
-		#[derive(Clone, codec::Decode, codec::Encode, Eq, PartialEq, frame_support::RuntimeDebug, scale_info::TypeInfo)]
-		pub struct BridgeRejectObsoleteParachainHeader;
+impl<
+		Call: IsSubType<CallableCallFor<Pallet<T, I>, T>>,
+		T: frame_system::Config<Call = Call> + Config<I>,
+		I: 'static,
+	> FilterCall<Call> for Pallet<T, I>
+where
+	<T as pallet_bridge_grandpa::Config<T::BridgesGrandpaPalletInstance>>::BridgedChain:
+		bp_runtime::Chain<
+			BlockNumber = RelayBlockNumber,
+			Hash = RelayBlockHash,
+			Hasher = RelayBlockHasher,
+		>,
+{
+	fn validate(call: &Call) -> TransactionValidity {
+		let (bundled_relay_block_number, parachains) = match call.is_sub_type() {
+			Some(crate::Call::<T, I>::submit_parachain_heads {
+				ref at_relay_block,
+				ref parachains,
+				..
+			}) if parachains.len() == 1 => (at_relay_block.0, parachains),
+			_ => return Ok(ValidTransaction::default()),
+		};
 
-		impl sp_runtime::traits::SignedExtension for BridgeRejectObsoleteParachainHeader {
-			const IDENTIFIER: &'static str = "BridgeRejectObsoleteParachainHeader";
-			type AccountId = <$runtime as frame_system::Config>::AccountId;
-			type Call = <$runtime as frame_system::Config>::Call;
-			type AdditionalSigned = ();
-			type Pre = ();
+		let (parachain, parachain_head_hash) =
+			parachains.get(0).expect("verified by match condition; qed");
+		let best_parachain_head = crate::BestParaHeads::<T, I>::get(parachain);
 
-			fn additional_signed(&self) -> sp_std::result::Result<
-				(),
-				sp_runtime::transaction_validity::TransactionValidityError,
-			> {
-				Ok(())
-			}
-
-			fn validate(
-				&self,
-				_who: &Self::AccountId,
-				call: &Self::Call,
-				_info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
-				_len: usize,
-			) -> sp_runtime::transaction_validity::TransactionValidity {
-				match *call {
-					$(
-						$call($crate::Call::<$runtime, $instance>::submit_parachain_heads {
-							ref at_relay_block,
-							ref parachains,
-							..
-						}) if parachains.len() == 1 => {
-							let (parachain, parachain_head_hash) = parachains.get(0).expect("verified by match condition; qed");
-
-							let bundled_relay_block_number = at_relay_block.0;
-
-							let best_parachain_head = $crate::BestParaHeads::<$runtime, $instance>::get(parachain);
-
-							match best_parachain_head {
-								Some(best_parachain_head) if best_parachain_head.at_relay_block_number
-									>= bundled_relay_block_number => {
-									log::trace!(
-										target: $crate::LOG_TARGET,
-										"Rejecting obsolete parachain-head {:?} transaction: bundled relay block number: \
-										{:?} best relay block number: {:?}",
-										parachain,
-										bundled_relay_block_number,
-										best_parachain_head.at_relay_block_number,
-									);
-									sp_runtime::transaction_validity::InvalidTransaction::Stale.into()
-								}
-								Some(best_parachain_head) if best_parachain_head.head_hash == *parachain_head_hash => {
-									log::trace!(
-										target: $crate::LOG_TARGET,
-										"Rejecting obsolete parachain-head {:?} transaction: head hash {:?}",
-										parachain,
-										best_parachain_head.head_hash,
-									);
-									sp_runtime::transaction_validity::InvalidTransaction::Stale.into()
-								}
-								_ => Ok(sp_runtime::transaction_validity::ValidTransaction::default()),
-							}
-						},
-					)*
-					_ => Ok(sp_runtime::transaction_validity::ValidTransaction::default()),
-				}
-			}
-
-			fn pre_dispatch(
-				self,
-				who: &Self::AccountId,
-				call: &Self::Call,
-				info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
-				len: usize,
-			) -> Result<Self::Pre, sp_runtime::transaction_validity::TransactionValidityError> {
-				self.validate(who, call, info, len).map(drop)
-			}
-
-			fn post_dispatch(
-				_maybe_pre: Option<Self::Pre>,
-				_info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
-				_post_info: &sp_runtime::traits::PostDispatchInfoOf<Self::Call>,
-				_len: usize,
-				_result: &sp_runtime::DispatchResult,
-			) -> Result<(), sp_runtime::transaction_validity::TransactionValidityError> {
-				Ok(())
-			}
+		match best_parachain_head {
+			Some(best_parachain_head)
+				if best_parachain_head.at_relay_block_number >= bundled_relay_block_number =>
+			{
+				log::trace!(
+					target: crate::LOG_TARGET,
+					"Rejecting obsolete parachain-head {:?} transaction: \
+										bundled relay block number: {:?} \
+										best relay block number: {:?}",
+					parachain,
+					bundled_relay_block_number,
+					best_parachain_head.at_relay_block_number,
+				);
+				InvalidTransaction::Stale.into()
+			},
+			Some(best_parachain_head) if best_parachain_head.head_hash == *parachain_head_hash => {
+				log::trace!(
+					target: crate::LOG_TARGET,
+					"Rejecting obsolete parachain-head {:?} transaction: head hash {:?}",
+					parachain,
+					best_parachain_head.head_hash,
+				);
+				InvalidTransaction::Stale.into()
+			},
+			_ => Ok(ValidTransaction::default()),
 		}
-	};
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use crate::{
+		extension::FilterCall,
 		mock::{run_test, Call, TestRuntime},
 		BestParaHead, BestParaHeads, RelayBlockNumber,
 	};
 	use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
-	use frame_support::weights::{DispatchClass, DispatchInfo, Pays};
-	use sp_runtime::traits::SignedExtension;
-
-	declare_bridge_reject_obsolete_parachain_header! {
-		TestRuntime,
-		Call::Parachains => ()
-	}
 
 	fn validate_submit_parachain_heads(
 		num: RelayBlockNumber,
 		parachains: Vec<(ParaId, ParaHash)>,
 	) -> bool {
-		BridgeRejectObsoleteParachainHeader
-			.validate(
-				&42,
-				&Call::Parachains(crate::Call::<TestRuntime, ()>::submit_parachain_heads {
-					at_relay_block: (num, Default::default()),
-					parachains,
-					parachain_heads_proof: ParaHeadsProof(Vec::new()),
-				}),
-				&DispatchInfo { weight: 0, class: DispatchClass::Operational, pays_fee: Pays::Yes },
-				0,
-			)
-			.is_ok()
+		crate::Pallet::<TestRuntime>::validate(&Call::Parachains(
+			crate::Call::<TestRuntime, ()>::submit_parachain_heads {
+				at_relay_block: (num, Default::default()),
+				parachains,
+				parachain_heads_proof: ParaHeadsProof(Vec::new()),
+			},
+		))
+		.is_ok()
 	}
 
 	fn sync_to_relay_header_10() {

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -35,6 +35,7 @@ pub use chain::{
 };
 pub use frame_support::storage::storage_prefix as storage_value_final_key;
 use num_traits::{CheckedSub, One};
+use sp_runtime::transaction_validity::TransactionValidity;
 pub use storage_proof::{
 	Error as StorageProofError, ProofSize as StorageProofSize, StorageProofChecker,
 };
@@ -398,6 +399,10 @@ pub trait OwnedBridgeModule<T: frame_system::Config> {
 		log::info!(target: Self::LOG_TARGET, "Setting operating mode to {:?}.", operating_mode);
 		Ok(())
 	}
+}
+
+pub trait FilterCall<Call> {
+	fn validate(call: &Call) -> TransactionValidity;
 }
 
 #[cfg(test)]

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -401,7 +401,9 @@ pub trait OwnedBridgeModule<T: frame_system::Config> {
 	}
 }
 
+/// A trait for querying whether a runtime call is valid.
 pub trait FilterCall<Call> {
+	/// Checks if a runtime call is valid.
 	fn validate(call: &Call) -> TransactionValidity;
 }
 

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -114,7 +114,7 @@ impl TransactionSignScheme for Millau {
 				frame_system::CheckNonce::<millau_runtime::Runtime>::from(param.unsigned.nonce),
 				frame_system::CheckWeight::<millau_runtime::Runtime>::new(),
 				pallet_transaction_payment::ChargeTransactionPayment::<millau_runtime::Runtime>::from(param.unsigned.tip),
-				millau_runtime::RejectObsoleteHeadersAndMessages,
+				millau_runtime::BridgeRejectObsoleteHeadersAndMessages,
 			),
 			(
 				(),

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -114,7 +114,7 @@ impl TransactionSignScheme for Millau {
 				frame_system::CheckNonce::<millau_runtime::Runtime>::from(param.unsigned.nonce),
 				frame_system::CheckWeight::<millau_runtime::Runtime>::new(),
 				pallet_transaction_payment::ChargeTransactionPayment::<millau_runtime::Runtime>::from(param.unsigned.tip),
-				millau_runtime::BridgeRejectObsoleteGrandpaHeader,
+				millau_runtime::RejectObsoleteHeadersAndMessages,
 				millau_runtime::BridgeRejectObsoleteParachainHeader,
 				millau_runtime::BridgeRejectObsoleteMessages,
 			),

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -115,7 +115,6 @@ impl TransactionSignScheme for Millau {
 				frame_system::CheckWeight::<millau_runtime::Runtime>::new(),
 				pallet_transaction_payment::ChargeTransactionPayment::<millau_runtime::Runtime>::from(param.unsigned.tip),
 				millau_runtime::RejectObsoleteHeadersAndMessages,
-				millau_runtime::BridgeRejectObsoleteMessages,
 			),
 			(
 				(),
@@ -123,7 +122,6 @@ impl TransactionSignScheme for Millau {
 				param.transaction_version,
 				param.genesis_hash,
 				param.era.signed_payload(param.genesis_hash),
-				(),
 				(),
 				(),
 				(),

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -115,7 +115,6 @@ impl TransactionSignScheme for Millau {
 				frame_system::CheckWeight::<millau_runtime::Runtime>::new(),
 				pallet_transaction_payment::ChargeTransactionPayment::<millau_runtime::Runtime>::from(param.unsigned.tip),
 				millau_runtime::RejectObsoleteHeadersAndMessages,
-				millau_runtime::BridgeRejectObsoleteParachainHeader,
 				millau_runtime::BridgeRejectObsoleteMessages,
 			),
 			(
@@ -124,7 +123,6 @@ impl TransactionSignScheme for Millau {
 				param.transaction_version,
 				param.genesis_hash,
 				param.era.signed_payload(param.genesis_hash),
-				(),
 				(),
 				(),
 				(),


### PR DESCRIPTION
An alternative solution to using macros like `declare_bridge_reject_obsolete_grandpa_header()`.

The current PR implements this approach only for the grandpa headers validation. If the feedback is positive, we can extend this to parachains and messages.

It looks like we don't have enough slots in `SignedPayload` to have a `SignedExtension` implementation for each validator, so I created an aggregated validator that implements `SignedExtension`.

Starting from here we could variate the approach. For example we could have a macro that generates the structures that implement `RejectObsoleteGrandpaHeader` and the `SignedExtension` implementation that aggregates all validations. I think we could also use `impl_for_tuples` as suggested [here](https://github.com/paritytech/parity-bridges-common/pull/1352#issue-1166431293).

Posting this PR to gather feedback on the general idea. I might need to add some comments and do some polishing. 

