### PR TITLE
Followu-up un #1468

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -847,11 +847,10 @@ impl_runtime_apis! {
 		fn best_finalized() -> Option<(bp_rialto::BlockNumber, bp_rialto::Hash)> {
 			// the parachains finality pallet is never decoding parachain heads, so it is
 			// only done in the integration code
-			use bp_rialto_parachain::RIALTO_PARACHAIN_ID;
 			let encoded_head = pallet_bridge_parachains::Pallet::<
 				Runtime,
 				WithRialtoParachainsInstance,
-			>::best_parachain_head(RIALTO_PARACHAIN_ID.into())?;
+			>::best_parachain_head(bp_rialto_parachain::RIALTO_PARACHAIN_ID.into())?;
 			let head = bp_rialto_parachain::Header::decode(&mut &encoded_head.0[..]).ok()?;
 			Some((*head.number(), head.hash()))
 		}

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -49,6 +49,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
+use bp_runtime::{HeaderId, HeaderIdProvider};
 pub use frame_support::{
 	construct_runtime, match_types, parameter_types,
 	traits::{Everything, IsInVec, Nothing, Randomness},
@@ -727,8 +728,8 @@ impl_runtime_apis! {
 	}
 
 	impl bp_millau::MillauFinalityApi<Block> for Runtime {
-		fn best_finalized() -> Option<(bp_millau::BlockNumber, bp_millau::Hash)> {
-			BridgeMillauGrandpa::best_finalized().map(|header| (header.number, header.hash()))
+		fn best_finalized() -> Option<HeaderId<bp_millau::Hash, bp_millau::BlockNumber>> {
+			BridgeMillauGrandpa::best_finalized().map(|header| header.id())
 		}
 	}
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -35,6 +35,7 @@ pub mod xcm_config;
 use crate::millau_messages::{ToMillauMessagePayload, WithMillauMessageBridge};
 
 use beefy_primitives::{crypto::AuthorityId as BeefyId, mmr::MmrLeafVersion, ValidatorSet};
+use bp_runtime::{HeaderId, HeaderIdProvider};
 use bridge_runtime_common::messages::{
 	source::estimate_message_dispatch_and_delivery_fee, MessageBridge,
 };
@@ -653,8 +654,8 @@ impl_runtime_apis! {
 	}
 
 	impl bp_millau::MillauFinalityApi<Block> for Runtime {
-		fn best_finalized() -> Option<(bp_millau::BlockNumber, bp_millau::Hash)> {
-			BridgeMillauGrandpa::best_finalized().map(|header| (header.number, header.hash()))
+		fn best_finalized() -> Option<HeaderId<bp_millau::Hash, bp_millau::BlockNumber>> {
+			BridgeMillauGrandpa::best_finalized().map(|header| header.id())
 		}
 	}
 

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -110,7 +110,7 @@ sp_api::decl_runtime_apis! {
 	/// Kusama runtime itself.
 	pub trait KusamaFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Kusama chain.

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -274,7 +274,7 @@ sp_api::decl_runtime_apis! {
 	/// Millau runtime itself.
 	pub trait MillauFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Millau chain.

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -111,7 +111,7 @@ sp_api::decl_runtime_apis! {
 	/// Polkadot runtime itself.
 	pub trait PolkadotFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Polkadot chain.

--- a/primitives/chain-rialto-parachain/src/lib.rs
+++ b/primitives/chain-rialto-parachain/src/lib.rs
@@ -216,7 +216,7 @@ sp_api::decl_runtime_apis! {
 	/// RialtoParachain runtime itself.
 	pub trait RialtoParachainFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// Outbound message lane API for messages that are sent to RialtoParachain chain.

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -237,7 +237,7 @@ sp_api::decl_runtime_apis! {
 	/// Rialto runtime itself.
 	pub trait RialtoFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Rialto chain.

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -106,7 +106,7 @@ sp_api::decl_runtime_apis! {
 	/// Rococo runtime itself.
 	pub trait RococoFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Rococo chain.

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -104,7 +104,7 @@ sp_api::decl_runtime_apis! {
 	/// Westend runtime itself.
 	pub trait WestendFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// API for querying information about the finalized Westmint headers.
@@ -113,7 +113,7 @@ sp_api::decl_runtime_apis! {
 	/// Westmint runtime itself.
 	pub trait WestmintFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 }
 

--- a/primitives/chain-wococo/src/lib.rs
+++ b/primitives/chain-wococo/src/lib.rs
@@ -63,7 +63,7 @@ sp_api::decl_runtime_apis! {
 	/// Wococo runtime itself.
 	pub trait WococoFinalityApi {
 		/// Returns number and hash of the best finalized header known to the bridge module.
-		fn best_finalized() -> Option<(BlockNumber, Hash)>;
+		fn best_finalized() -> Option<bp_runtime::HeaderId<Hash, BlockNumber>>;
 	}
 
 	/// Outbound message lane API for messages that are sent to Wococo chain.

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/
 pub const ROOT_ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/root";
 
 /// Generic header Id.
-#[derive(RuntimeDebug, Default, Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(RuntimeDebug, Default, Clone, Encode, Decode, Copy, Eq, Hash, PartialEq)]
 pub struct HeaderId<Hash, Number>(pub Number, pub Hash);
 
 /// Generic header id provider.

--- a/relays/lib-substrate-relay/src/messages_source.rs
+++ b/relays/lib-substrate-relay/src/messages_source.rs
@@ -562,17 +562,13 @@ where
 			Some(at_self_hash),
 		)
 		.await?;
-	let decoded_best_finalized_peer_on_self =
-		Option::<(BlockNumberOf<PeerChain>, HashOf<PeerChain>)>::decode(
-			&mut &encoded_best_finalized_peer_on_self.0[..],
-		)
-		.map_err(SubstrateError::ResponseParseFailed)?
-		.map(Ok)
-		.unwrap_or(Err(SubstrateError::BridgePalletIsNotInitialized))?;
-	let peer_on_self_best_finalized_id =
-		HeaderId(decoded_best_finalized_peer_on_self.0, decoded_best_finalized_peer_on_self.1);
 
-	Ok(peer_on_self_best_finalized_id)
+	Option::<HeaderId<HashOf<PeerChain>, BlockNumberOf<PeerChain>>>::decode(
+		&mut &encoded_best_finalized_peer_on_self.0[..],
+	)
+	.map_err(SubstrateError::ResponseParseFailed)?
+	.map(Ok)
+	.unwrap_or(Err(SubstrateError::BridgePalletIsNotInitialized))
 }
 
 fn make_message_details_map<C: Chain>(

--- a/relays/lib-substrate-relay/src/parachains/target.rs
+++ b/relays/lib-substrate-relay/src/parachains/target.rs
@@ -107,14 +107,13 @@ where
 				Some(at_block.1),
 			)
 			.await?;
-		let decoded_best_finalized_source_block =
-			Option::<(BlockNumberOf<P::SourceRelayChain>, HashOf<P::SourceRelayChain>)>::decode(
-				&mut &encoded_best_finalized_source_block.0[..],
-			)
-			.map_err(SubstrateError::ResponseParseFailed)?
-			.map(Ok)
-			.unwrap_or(Err(SubstrateError::BridgePalletIsNotInitialized))?;
-		Ok(HeaderId(decoded_best_finalized_source_block.0, decoded_best_finalized_source_block.1))
+
+		Option::<HeaderId<HashOf<P::SourceRelayChain>, BlockNumberOf<P::SourceRelayChain>>>::decode(
+			&mut &encoded_best_finalized_source_block.0[..],
+		)
+		.map_err(SubstrateError::ResponseParseFailed)?
+		.map(Ok)
+		.unwrap_or(Err(SubstrateError::BridgePalletIsNotInitialized))
 	}
 
 	async fn parachain_head(


### PR DESCRIPTION
Addressing the comments in #1468

This PR breaks existing runtime APIs - `best_finalized()` now returns `Option<HeaderId<BlockHash, BlockNumber>` instead of `Option<(BlockNumber, BlockHash)>`. 

Maybe we should also change the signature of `HeaderId` in the future from `HeaderId<BlockHash, BlockNumber>` to `HeaderId<BlockNumber, BlockHash>`. I find it strange to have `pub struct HeaderId<Hash, Number>(pub Number, pub Hash);`. But for the moment I used it as it is.