### PR TITLE
Refund relayer if parachain head has not been updated

### DIFF
--- a/modules/parachains/src/weights_ext.rs
+++ b/modules/parachains/src/weights_ext.rs
@@ -71,7 +71,7 @@ pub trait WeightInfoExt: WeightInfo {
 	/// Returns weight of single parachain head storage update.
 	///
 	/// This weight only includes db write operations that happens if parachain head is actually
-	/// updated. All extra weights (weight of storage proof validaton, additional checks, ...) is
+	/// updated. All extra weights (weight of storage proof validation, additional checks, ...) is
 	/// not included.
 	fn parachain_head_storage_write_weight(db_weight: RuntimeDbWeight) -> Weight {
 		// it's just a couple of operations - we need to write the hash (`ImportedParaHashes`) and

--- a/modules/parachains/src/weights_ext.rs
+++ b/modules/parachains/src/weights_ext.rs
@@ -68,6 +68,17 @@ pub trait WeightInfoExt: WeightInfo {
 		base_weight.saturating_add(proof_size_overhead).saturating_add(pruning_weight)
 	}
 
+	/// Returns weight of single parachain head storage update.
+	///
+	/// This weight only includes db write operations that happens if parachain head is actually
+	/// updated. All extra weights (weight of storage proof validatons, additional checks, ...) is
+	/// not included.
+	fn parachain_head_storage_write_weight(db_weight: RuntimeDbWeight) -> Weight {
+		// it's just a couple of operations - we need to write the hash (`ImportedParaHashes`) and
+		// the head itself (`ImportedParaHeads`. Pruning is not included here
+		db_weight.writes(2)
+	}
+
 	/// Returns weight of single parachain head pruning.
 	fn parachain_head_pruning_weight(db_weight: RuntimeDbWeight) -> Weight {
 		// it's just one write operation, we don't want any benchmarks for that

--- a/modules/parachains/src/weights_ext.rs
+++ b/modules/parachains/src/weights_ext.rs
@@ -71,7 +71,7 @@ pub trait WeightInfoExt: WeightInfo {
 	/// Returns weight of single parachain head storage update.
 	///
 	/// This weight only includes db write operations that happens if parachain head is actually
-	/// updated. All extra weights (weight of storage proof validatons, additional checks, ...) is
+	/// updated. All extra weights (weight of storage proof validaton, additional checks, ...) is
 	/// not included.
 	fn parachain_head_storage_write_weight(db_weight: RuntimeDbWeight) -> Weight {
 		// it's just a couple of operations - we need to write the hash (`ImportedParaHashes`) and


### PR DESCRIPTION
closes #1440 

I was going to use different approach for that initially, but the logic either becomes too complex (parachain head may be rejected at a different levels) or it is almost impossible to do that (e.g. when we have failed to read parachain head from the proof - shall we even try to refund?). So refunding is done similarly to pruning here - we're only refunding if proof is correct, but someone else has already provided better head.