### PR TITLE
Follow-up on #1419

### DIFF
--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -27,7 +27,7 @@ use scale_info::TypeInfo;
 use sp_core::{hash::H256, storage::StorageKey};
 use sp_io::hashing::blake2_256;
 use sp_runtime::traits::{BadOrigin, Header as HeaderT};
-use sp_std::{cmp::Ordering, convert::TryFrom, fmt::Debug, vec, vec::Vec};
+use sp_std::{convert::TryFrom, fmt::Debug, vec, vec::Vec};
 
 pub use chain::{
 	AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, EncodedOrDecodedCall, HashOf,
@@ -82,20 +82,10 @@ pub const ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/
 pub const ROOT_ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-derivation/root";
 
 /// Generic header Id.
-#[derive(RuntimeDebug, Default, Clone, Encode, Decode, Copy, Eq, Hash, PartialEq)]
+#[derive(
+	RuntimeDebug, Default, Clone, Encode, Decode, Copy, Eq, Hash, PartialEq, PartialOrd, Ord,
+)]
 pub struct HeaderId<Hash, Number>(pub Number, pub Hash);
-
-impl<Hash: PartialEq, Number: PartialOrd> PartialOrd for HeaderId<Hash, Number> {
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		self.0.partial_cmp(&other.0)
-	}
-}
-
-impl<Hash: Eq, Number: Ord> Ord for HeaderId<Hash, Number> {
-	fn cmp(&self, other: &Self) -> Ordering {
-		self.0.cmp(&other.0)
-	}
-}
 
 /// Generic header id provider.
 pub trait HeaderIdProvider<Header: HeaderT> {

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -27,7 +27,7 @@ use scale_info::TypeInfo;
 use sp_core::{hash::H256, storage::StorageKey};
 use sp_io::hashing::blake2_256;
 use sp_runtime::traits::{BadOrigin, Header as HeaderT};
-use sp_std::{convert::TryFrom, fmt::Debug, vec, vec::Vec};
+use sp_std::{cmp::Ordering, convert::TryFrom, fmt::Debug, vec, vec::Vec};
 
 pub use chain::{
 	AccountIdOf, AccountPublicOf, BalanceOf, BlockNumberOf, Chain, EncodedOrDecodedCall, HashOf,
@@ -84,6 +84,18 @@ pub const ROOT_ACCOUNT_DERIVATION_PREFIX: &[u8] = b"pallet-bridge/account-deriva
 /// Generic header Id.
 #[derive(RuntimeDebug, Default, Clone, Encode, Decode, Copy, Eq, Hash, PartialEq)]
 pub struct HeaderId<Hash, Number>(pub Number, pub Hash);
+
+impl<Hash: PartialEq, Number: PartialOrd> PartialOrd for HeaderId<Hash, Number> {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		self.0.partial_cmp(&other.0)
+	}
+}
+
+impl<Hash: Eq, Number: Ord> Ord for HeaderId<Hash, Number> {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.0.cmp(&other.0)
+	}
+}
 
 /// Generic header id provider.
 pub trait HeaderIdProvider<Header: HeaderT> {

--- a/relays/bin-substrate/src/cli/relay_parachains.rs
+++ b/relays/bin-substrate/src/cli/relay_parachains.rs
@@ -18,10 +18,15 @@ use crate::chains::{
 	rialto_parachains_to_millau::RialtoParachainToMillauCliBridge,
 	westend_parachains_to_millau::WestmintToMillauCliBridge,
 };
+use async_std::sync::Mutex;
 use async_trait::async_trait;
 use bp_polkadot_core::parachains::ParaId;
 use parachains_relay::parachains_loop::{ParachainSyncParams, SourceClient, TargetClient};
-use relay_utils::metrics::{GlobalMetrics, StandaloneMetric};
+use relay_utils::{
+	metrics::{GlobalMetrics, StandaloneMetric},
+	NoopOption,
+};
+use std::sync::Arc;
 use structopt::StructOpt;
 use strum::{EnumString, EnumVariantNames, VariantNames};
 use substrate_relay_helper::{
@@ -65,7 +70,10 @@ where
 {
 	async fn relay_headers(data: RelayParachains) -> anyhow::Result<()> {
 		let source_client = data.source.into_client::<Self::SourceRelay>().await?;
-		let source_client = ParachainsSource::<Self::ParachainFinality>::new(source_client, None);
+		let source_client = ParachainsSource::<Self::ParachainFinality>::new(
+			source_client,
+			Arc::new(Mutex::new(NoopOption::None)),
+		);
 
 		let target_transaction_params = TransactionParams {
 			signer: data.target_sign.to_keypair::<Self::Target>()?,

--- a/relays/bin-substrate/src/cli/relay_parachains.rs
+++ b/relays/bin-substrate/src/cli/relay_parachains.rs
@@ -21,11 +21,10 @@ use crate::chains::{
 use async_std::sync::Mutex;
 use async_trait::async_trait;
 use bp_polkadot_core::parachains::ParaId;
-use parachains_relay::parachains_loop::{ParachainSyncParams, SourceClient, TargetClient};
-use relay_utils::{
-	metrics::{GlobalMetrics, StandaloneMetric},
-	NoopOption,
+use parachains_relay::parachains_loop::{
+	AvailableHeader, ParachainSyncParams, SourceClient, TargetClient,
 };
+use relay_utils::metrics::{GlobalMetrics, StandaloneMetric};
 use std::sync::Arc;
 use structopt::StructOpt;
 use strum::{EnumString, EnumVariantNames, VariantNames};
@@ -72,7 +71,7 @@ where
 		let source_client = data.source.into_client::<Self::SourceRelay>().await?;
 		let source_client = ParachainsSource::<Self::ParachainFinality>::new(
 			source_client,
-			Arc::new(Mutex::new(NoopOption::None)),
+			Arc::new(Mutex::new(AvailableHeader::Missing)),
 		);
 
 		let target_transaction_params = TransactionParams {

--- a/relays/lib-substrate-relay/src/finality/source.rs
+++ b/relays/lib-substrate-relay/src/finality/source.rs
@@ -27,7 +27,6 @@ use relay_substrate_client::{
 	BlockNumberOf, BlockWithJustification, Chain, Client, Error, HeaderOf,
 };
 use relay_utils::relay_loop::Client as RelayClient;
-use sp_runtime::traits::Header as HeaderT;
 use std::pin::Pin;
 
 /// Shared updatable reference to the maximal header number that we want to sync from the source.
@@ -76,9 +75,7 @@ impl<P: SubstrateFinalitySyncPipeline> SubstrateFinalitySource<P> {
 	) -> Result<BlockNumberOf<P::SourceChain>, Error> {
 		// we **CAN** continue to relay finality proofs if source node is out of sync, because
 		// target node may be missing proofs that are already available at the source
-		let finalized_header_hash = self.client.best_finalized_header_hash().await?;
-		let finalized_header = self.client.header_by_hash(finalized_header_hash).await?;
-		Ok(*finalized_header.number())
+		self.client.best_finalized_header_number().await
 	}
 }
 

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -389,13 +389,9 @@ where
 		source.client().best_finalized_header().await.map_err(map_source_err)?;
 	let best_finalized_relay_block_id = best_finalized_relay_header.id();
 	let para_header_at_source = source
-		.on_chain_parachain_header(
-			best_finalized_relay_block_id,
-			P::SOURCE_PARACHAIN_PARA_ID.into(),
-		)
+		.on_chain_para_head_id(best_finalized_relay_block_id, P::SOURCE_PARACHAIN_PARA_ID.into())
 		.await
-		.map_err(map_source_err)?
-		.map(|h| h.id());
+		.map_err(map_source_err)?;
 
 	let relay_header_at_source = best_finalized_relay_block_id.0;
 	let relay_header_at_target =
@@ -408,10 +404,9 @@ where
 		.map_err(map_target_err)?;
 
 	let para_header_at_relay_header_at_target = source
-		.on_chain_parachain_header(relay_header_at_target, P::SOURCE_PARACHAIN_PARA_ID.into())
+		.on_chain_para_head_id(relay_header_at_target, P::SOURCE_PARACHAIN_PARA_ID.into())
 		.await
-		.map_err(map_source_err)?
-		.map(|h| h.id());
+		.map_err(map_source_err)?;
 
 	Ok(RelayData {
 		required_para_header: required_header_number,

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -36,13 +36,13 @@ use bp_runtime::HeaderIdProvider;
 use futures::{select, FutureExt};
 use num_traits::Zero;
 use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumber};
-use parachains_relay::parachains_loop::{ParachainSyncParams, TargetClient};
+use parachains_relay::parachains_loop::{AvailableHeader, ParachainSyncParams, TargetClient};
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, BlockNumberOf, Chain, Client, Error as SubstrateError, HashOf,
 	TransactionSignScheme,
 };
 use relay_utils::{
-	metrics::MetricsParams, relay_loop::Client as RelayClient, FailedClient, HeaderId, NoopOption,
+	metrics::MetricsParams, relay_loop::Client as RelayClient, FailedClient, HeaderId,
 };
 use std::fmt::Debug;
 
@@ -143,7 +143,7 @@ async fn background_task<P: SubstrateParachainsPipeline>(
 
 	let mut relay_state = RelayState::Idle;
 	let mut required_parachain_header_number = Zero::zero();
-	let required_para_header_number_ref = Arc::new(Mutex::new(NoopOption::Noop));
+	let required_para_header_number_ref = Arc::new(Mutex::new(AvailableHeader::Unavailable));
 
 	let mut restart_relay = true;
 	let parachains_relay_task = futures::future::Fuse::terminated();
@@ -254,7 +254,7 @@ async fn background_task<P: SubstrateParachainsPipeline>(
 			},
 			RelayState::RelayingParaHeader(required_para_header) => {
 				*required_para_header_number_ref.lock().await =
-					NoopOption::Some(required_para_header);
+					AvailableHeader::Available(required_para_header);
 			},
 		}
 

--- a/relays/parachains/src/parachains_loop.rs
+++ b/relays/parachains/src/parachains_loop.rs
@@ -24,7 +24,9 @@ use bp_polkadot_core::{
 };
 use futures::{future::FutureExt, select};
 use relay_substrate_client::{BlockNumberOf, Chain, HeaderIdOf};
-use relay_utils::{metrics::MetricsParams, relay_loop::Client as RelayClient, FailedClient};
+use relay_utils::{
+	metrics::MetricsParams, relay_loop::Client as RelayClient, FailedClient, NoopOption,
+};
 use std::{
 	collections::{BTreeMap, BTreeSet},
 	future::Future,
@@ -52,33 +54,6 @@ pub enum ParachainSyncStrategy {
 	All,
 }
 
-/// Parachain head hash, available at the source (relay) chain.
-#[derive(Clone, Copy, Debug)]
-pub enum ParaHashAtSource {
-	/// There's no parachain head at the source chain.
-	///
-	/// Normally it means that the parachain is not registered there.
-	None,
-	/// Parachain head with given hash is available at the source chain.
-	Some(ParaHash),
-	/// The source client refuses to report parachain head hash at this moment.
-	///
-	/// It is a "mild" error, which may appear when e.g. on-demand parachains relay is used.
-	/// This variant must be treated as "we don't want to update parachain head value at the
-	/// target chain at this moment".
-	Unavailable,
-}
-
-impl ParaHashAtSource {
-	/// Return parachain head hash, if available.
-	pub fn hash(&self) -> Option<&ParaHash> {
-		match *self {
-			ParaHashAtSource::Some(ref para_hash) => Some(para_hash),
-			_ => None,
-		}
-	}
-}
-
 /// Source client used in parachain heads synchronization loop.
 #[async_trait]
 pub trait SourceClient<P: ParachainsPipeline>: RelayClient {
@@ -94,7 +69,7 @@ pub trait SourceClient<P: ParachainsPipeline>: RelayClient {
 		at_block: HeaderIdOf<P::SourceChain>,
 		metrics: Option<&ParachainsLoopMetrics>,
 		para_id: ParaId,
-	) -> Result<ParaHashAtSource, Self::Error>;
+	) -> Result<NoopOption<ParaHash>, Self::Error>;
 
 	/// Get parachain heads proof.
 	///
@@ -342,7 +317,7 @@ where
 
 /// Given heads at source and target clients, returns set of heads that are out of sync.
 fn select_parachains_to_update<P: ParachainsPipeline>(
-	heads_at_source: BTreeMap<ParaId, ParaHashAtSource>,
+	heads_at_source: BTreeMap<ParaId, NoopOption<ParaHash>>,
 	heads_at_target: BTreeMap<ParaId, Option<BestParaHeadHash>>,
 	best_finalized_relay_block: HeaderIdOf<P::SourceChain>,
 ) -> Vec<ParaId>
@@ -368,12 +343,12 @@ where
 		.zip(heads_at_target.into_iter())
 		.filter(|((para, head_at_source), (_, head_at_target))| {
 			let needs_update = match (head_at_source, head_at_target) {
-				(ParaHashAtSource::Unavailable, _) => {
+				(NoopOption::Noop, _) => {
 					// source client has politely asked us not to update current parachain head
 					// at the target chain
 					false
 				},
-				(ParaHashAtSource::Some(head_at_source), Some(head_at_target))
+				(NoopOption::Some(head_at_source), Some(head_at_target))
 					if head_at_target.at_relay_block_number < best_finalized_relay_block.0 &&
 						head_at_target.head_hash != *head_at_source =>
 				{
@@ -381,22 +356,22 @@ where
 					// client
 					true
 				},
-				(ParaHashAtSource::Some(_), Some(_)) => {
+				(NoopOption::Some(_), Some(_)) => {
 					// this is normal case when relay has recently updated heads, when parachain is
 					// not progressing, or when our source client is still syncing
 					false
 				},
-				(ParaHashAtSource::Some(_), None) => {
+				(NoopOption::Some(_), None) => {
 					// parachain is not yet known to the target client. This is true when parachain
 					// or bridge has been just onboarded/started
 					true
 				},
-				(ParaHashAtSource::None, Some(_)) => {
+				(NoopOption::None, Some(_)) => {
 					// parachain/parathread has been offboarded removed from the system. It needs to
 					// be propageted to the target client
 					true
 				},
-				(ParaHashAtSource::None, None) => {
+				(NoopOption::None, None) => {
 					// all's good - parachain is unknown to both clients
 					false
 				},
@@ -435,7 +410,7 @@ async fn read_heads_at_source<P: ParachainsPipeline>(
 	metrics: Option<&ParachainsLoopMetrics>,
 	at_relay_block: &HeaderIdOf<P::SourceChain>,
 	parachains: &[ParaId],
-) -> Result<BTreeMap<ParaId, ParaHashAtSource>, FailedClient> {
+) -> Result<BTreeMap<ParaId, NoopOption<ParaHash>>, FailedClient> {
 	let mut para_head_hashes = BTreeMap::new();
 	for para in parachains {
 		let para_head = source_client.parachain_head(*at_relay_block, metrics, *para).await;
@@ -612,7 +587,7 @@ mod tests {
 	#[derive(Clone, Debug)]
 	struct TestClientData {
 		source_sync_status: Result<bool, TestError>,
-		source_heads: BTreeMap<u32, Result<ParaHashAtSource, TestError>>,
+		source_heads: BTreeMap<u32, Result<NoopOption<ParaHash>, TestError>>,
 		source_proofs: BTreeMap<u32, Result<Vec<u8>, TestError>>,
 
 		target_best_block: Result<HeaderIdOf<TestChain>, TestError>,
@@ -627,7 +602,7 @@ mod tests {
 		pub fn minimal() -> Self {
 			TestClientData {
 				source_sync_status: Ok(true),
-				source_heads: vec![(PARA_ID, Ok(ParaHashAtSource::Some(PARA_0_HASH)))]
+				source_heads: vec![(PARA_ID, Ok(NoopOption::Some(PARA_0_HASH)))]
 					.into_iter()
 					.collect(),
 				source_proofs: vec![(PARA_ID, Ok(PARA_0_HASH.encode()))].into_iter().collect(),
@@ -676,10 +651,10 @@ mod tests {
 			_at_block: HeaderIdOf<TestChain>,
 			_metrics: Option<&ParachainsLoopMetrics>,
 			para_id: ParaId,
-		) -> Result<ParaHashAtSource, TestError> {
+		) -> Result<NoopOption<ParaHash>, TestError> {
 			match self.data.lock().await.source_heads.get(&para_id.0).cloned() {
 				Some(result) => result,
-				None => Ok(ParaHashAtSource::None),
+				None => Ok(NoopOption::None),
 			}
 		}
 
@@ -988,7 +963,7 @@ mod tests {
 	fn parachain_is_not_updated_if_it_is_unknown_to_both_clients() {
 		assert_eq!(
 			select_parachains_to_update::<TestParachainsPipeline>(
-				vec![(ParaId(PARA_ID), ParaHashAtSource::None)].into_iter().collect(),
+				vec![(ParaId(PARA_ID), NoopOption::None)].into_iter().collect(),
 				vec![(ParaId(PARA_ID), None)].into_iter().collect(),
 				HeaderId(10, Default::default()),
 			),
@@ -1000,9 +975,7 @@ mod tests {
 	fn parachain_is_not_updated_if_it_has_been_updated_at_better_relay_block() {
 		assert_eq!(
 			select_parachains_to_update::<TestParachainsPipeline>(
-				vec![(ParaId(PARA_ID), ParaHashAtSource::Some(PARA_0_HASH))]
-					.into_iter()
-					.collect(),
+				vec![(ParaId(PARA_ID), NoopOption::Some(PARA_0_HASH))].into_iter().collect(),
 				vec![(
 					ParaId(PARA_ID),
 					Some(BestParaHeadHash { at_relay_block_number: 20, head_hash: PARA_1_HASH })
@@ -1019,9 +992,7 @@ mod tests {
 	fn parachain_is_not_updated_if_hash_is_the_same_at_next_relay_block() {
 		assert_eq!(
 			select_parachains_to_update::<TestParachainsPipeline>(
-				vec![(ParaId(PARA_ID), ParaHashAtSource::Some(PARA_0_HASH))]
-					.into_iter()
-					.collect(),
+				vec![(ParaId(PARA_ID), NoopOption::Some(PARA_0_HASH))].into_iter().collect(),
 				vec![(
 					ParaId(PARA_ID),
 					Some(BestParaHeadHash { at_relay_block_number: 0, head_hash: PARA_0_HASH })
@@ -1038,7 +1009,7 @@ mod tests {
 	fn parachain_is_updated_after_offboarding() {
 		assert_eq!(
 			select_parachains_to_update::<TestParachainsPipeline>(
-				vec![(ParaId(PARA_ID), ParaHashAtSource::None)].into_iter().collect(),
+				vec![(ParaId(PARA_ID), NoopOption::None)].into_iter().collect(),
 				vec![(
 					ParaId(PARA_ID),
 					Some(BestParaHeadHash {
@@ -1058,9 +1029,7 @@ mod tests {
 	fn parachain_is_updated_after_onboarding() {
 		assert_eq!(
 			select_parachains_to_update::<TestParachainsPipeline>(
-				vec![(ParaId(PARA_ID), ParaHashAtSource::Some(PARA_0_HASH))]
-					.into_iter()
-					.collect(),
+				vec![(ParaId(PARA_ID), NoopOption::Some(PARA_0_HASH))].into_iter().collect(),
 				vec![(ParaId(PARA_ID), None)].into_iter().collect(),
 				HeaderId(10, Default::default()),
 			),
@@ -1072,9 +1041,7 @@ mod tests {
 	fn parachain_is_updated_if_newer_head_is_known() {
 		assert_eq!(
 			select_parachains_to_update::<TestParachainsPipeline>(
-				vec![(ParaId(PARA_ID), ParaHashAtSource::Some(PARA_1_HASH))]
-					.into_iter()
-					.collect(),
+				vec![(ParaId(PARA_ID), NoopOption::Some(PARA_1_HASH))].into_iter().collect(),
 				vec![(
 					ParaId(PARA_ID),
 					Some(BestParaHeadHash { at_relay_block_number: 0, head_hash: PARA_0_HASH })
@@ -1091,7 +1058,7 @@ mod tests {
 	fn parachain_is_not_updated_if_source_head_is_unavailable() {
 		assert_eq!(
 			select_parachains_to_update::<TestParachainsPipeline>(
-				vec![(ParaId(PARA_ID), ParaHashAtSource::Unavailable)].into_iter().collect(),
+				vec![(ParaId(PARA_ID), NoopOption::Noop)].into_iter().collect(),
 				vec![(
 					ParaId(PARA_ID),
 					Some(BestParaHeadHash { at_relay_block_number: 0, head_hash: PARA_0_HASH })

--- a/relays/utils/src/lib.rs
+++ b/relays/utils/src/lib.rs
@@ -271,3 +271,28 @@ where
 		},
 	}
 }
+
+/// An extension over rust's `Option` that adds an extra possibility: `Noop`.
+#[derive(Clone, Copy, Debug)]
+pub enum NoopOption<T> {
+	/// If any operation depends on this `NoopOption`, we shouldn't perform it.
+	Noop,
+	/// Same as `Option::None`.
+	None,
+	/// Same as `Option::Some`.
+	Some(T),
+}
+
+impl<T> NoopOption<T> {
+	/// Transform contained value.
+	pub fn map<F, U>(self, f: F) -> NoopOption<U>
+	where
+		F: FnOnce(T) -> U,
+	{
+		match self {
+			NoopOption::Noop => NoopOption::Noop,
+			NoopOption::None => NoopOption::None,
+			NoopOption::Some(val) => NoopOption::Some(f(val)),
+		}
+	}
+}

--- a/relays/utils/src/lib.rs
+++ b/relays/utils/src/lib.rs
@@ -271,28 +271,3 @@ where
 		},
 	}
 }
-
-/// An extension over rust's `Option` that adds an extra possibility: `Noop`.
-#[derive(Clone, Copy, Debug)]
-pub enum NoopOption<T> {
-	/// If any operation depends on this `NoopOption`, we shouldn't perform it.
-	Noop,
-	/// Same as `Option::None`.
-	None,
-	/// Same as `Option::Some`.
-	Some(T),
-}
-
-impl<T> NoopOption<T> {
-	/// Transform contained value.
-	pub fn map<F, U>(self, f: F) -> NoopOption<U>
-	where
-		F: FnOnce(T) -> U,
-	{
-		match self {
-			NoopOption::Noop => NoopOption::Noop,
-			NoopOption::None => NoopOption::None,
-			NoopOption::Some(val) => NoopOption::Some(f(val)),
-		}
-	}
-}


### PR DESCRIPTION
Addressing the comments in #1419

I spent a lot of time thinking about naming. `NoopOption` was the best name I could find so far to make `ParaHashAtSource` more generic although it doesn't seem ideal.

Also it would be nice to define `max_head_id` as a `NoopOption` from the start, but I didn't do it since this way we would have to create an `Arc<Mutex<NoopOption>>` and it would be less efficient (because we would have to lock the mutex even if `max_head_id == Noop::None`, which is not needed now). We could have something more efficient using atomic variables, but that would increase the complexity of the code.