### PR TITLE
[Deployments] Deduplicate message sending code

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -43,14 +43,15 @@ and Grafana. We cover these in more details in the [Monitoring](#monitoring) sec
 the monitoring Compose file is _not_ optional, and must be included for bridge deployments.
 
 ### Running and Updating Deployments
-We currently support two bridge deployments
+We currently support three bridge deployments
 1. Rialto Substrate to Millau Substrate
+2. Rialto Parachain Substrate to Millau Substrate
 2. Westend Substrate to Millau Substrate
 
 These bridges can be deployed using our [`./run.sh`](./run.sh) script.
 
-The first argument it takes is the name of the bridge you want to run. Right now we only support two
-bridges: `rialto-millau` and `westend-millau`.
+The first argument it takes is the name of the bridge you want to run. Right now we only support three
+bridges: `rialto-millau`, `rialto-parachain-millau` and `westend-millau`.
 
 ```bash
 ./run.sh rialto-millau
@@ -158,7 +159,7 @@ docker-compose up -d  # Start the nodes in detached mode.
 docker-compose down   # Stop the network.
 ```
 
-Note that for the you'll need to add the appropriate `-f` arguments that were mentioned in the
+Note that you'll also need to add the appropriate `-f` arguments that were mentioned in the
 [Bridges](#bridges) section. You can read more about using multiple Compose files
 [here](https://docs.docker.com/compose/extends/#multiple-compose-files). One thing worth noting is
 that the _order_ the compose files are specified in matters. A different order will result in a
@@ -185,7 +186,7 @@ docker build . -t local/<project_you're_building> --build-arg=PROJECT=<project>
 This will build a local image of a particular component with a tag of
 `local/<project_you're_building>`. This tag can be used in Docker Compose files.
 
-You can configure the build using using Docker
+You can configure the build using Docker
 [build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg).
 Here are the arguments currently supported:
   - `BRIDGE_REPO`: Git repository of the bridge node and relay code
@@ -256,5 +257,5 @@ and import the [`./types.json`](./types.json)
 
 ## Scripts
 
-The are some bash scripts in `scripts` folder that allow testing `Relay`
+There are some bash scripts in `scripts` folder that allow testing `Relay`
 without running the entire network within docker. Use if needed for development.

--- a/deployments/bridges/common/generate_messages.sh
+++ b/deployments/bridges/common/generate_messages.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Script for generating messages from a source chain to a target chain.
+# Prerequisites: mounting the common folder in the docker container (Adding the following volume entry):
+# - ./bridges/common:/common
+# It can be used by executing `source /common/generate_messages.sh` in a different script,
+# after setting the following variables:
+# SOURCE_CHAIN
+# TARGET_CHAIN
+# MAX_SUBMIT_DELAY_S
+# SEND_MESSAGE - the command that is executed to send a message
+# MESSAGE_LANE
+# SECONDARY_MESSAGE_LANE - optional
+# EXTRA_ARGS - for example "--use-xcm-pallet"
+# REGULAR_PAYLOAD
+# BATCH_PAYLOAD
+# MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE
+
+SECONDARY_MESSAGE_LANE=${SECONDARY_MESSAGE_LANE:-""}
+
+# Sleep a bit between messages
+rand_sleep() {
+	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
+	echo "Sleeping $SUBMIT_DELAY_S seconds..."
+	sleep $SUBMIT_DELAY_S
+	NOW=`date "+%Y-%m-%d %H:%M:%S"`
+	echo "Woke up at $NOW"
+}
+
+# last time when we have been asking for conversion rate update
+LAST_CONVERSION_RATE_UPDATE_TIME=0
+# conversion rate override argument
+CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
+
+# start sending large messages immediately
+LARGE_MESSAGES_TIME=0
+# start sending message packs in a hour
+BUNCH_OF_MESSAGES_TIME=3600
+
+while true
+do
+	rand_sleep
+
+	# ask for latest conversion rate. We're doing that because otherwise we'll be facing
+	# bans from the conversion rate provider
+	if [ $SECONDS -ge $LAST_CONVERSION_RATE_UPDATE_TIME ]; then
+		CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
+		CONVERSION_RATE_UPDATE_DELAY=`shuf -i 300-600 -n 1`
+		LAST_CONVERSION_RATE_UPDATE_TIME=$((SECONDS + $CONVERSION_RATE_UPDATE_DELAY))
+	fi
+
+	# send regular message
+	echo "Sending Message from $SOURCE_CHAIN to $TARGET_CHAIN"
+	SEND_MESSAGE_OUTPUT=`$SEND_MESSAGE --lane $MESSAGE_LANE $EXTRA_ARGS $CONVERSION_RATE_OVERRIDE raw $REGULAR_PAYLOAD 2>&1`
+	echo $SEND_MESSAGE_OUTPUT
+	if [ "$CONVERSION_RATE_OVERRIDE" = "--conversion-rate-override metric" ]; then
+		ACTUAL_CONVERSION_RATE_REGEX="conversion rate override: ([0-9\.]+)"
+		if [[ $SEND_MESSAGE_OUTPUT =~ $ACTUAL_CONVERSION_RATE_REGEX ]]; then
+			CONVERSION_RATE=${BASH_REMATCH[1]}
+			echo "Read updated conversion rate: $CONVERSION_RATE"
+			CONVERSION_RATE_OVERRIDE="--conversion-rate-override $CONVERSION_RATE"
+		else
+			echo "Error: unable to find conversion rate in send-message output. Will keep using on-chain rate"
+			CONVERSION_RATE_OVERRIDE=""
+		fi
+	fi
+
+	if [ ! -z $SECONDARY_MESSAGE_LANE ]; then
+		echo "Sending Message from $SOURCE_CHAIN to $TARGET_CHAIN using secondary lane: $SECONDARY_MESSAGE_LANE"
+		$SEND_MESSAGE \
+			--lane $SECONDARY_MESSAGE_LANE \
+			$EXTRA_ARGS \
+			$CONVERSION_RATE_OVERRIDE \
+			raw $REGULAR_PAYLOAD
+	fi
+
+	# every other hour we're sending 3 large (size, weight, size+weight) messages
+	if [ $SECONDS -ge $LARGE_MESSAGES_TIME ]; then
+		LARGE_MESSAGES_TIME=$((SECONDS + 7200))
+
+		rand_sleep
+		echo "Sending Maximal Size Message from $SOURCE_CHAIN to $TARGET_CHAIN"
+		$SEND_MESSAGE \
+			--lane $MESSAGE_LANE \
+			$CONVERSION_RATE_OVERRIDE \
+			sized max
+	fi
+
+	# every other hour we're sending a bunch of small messages
+	if [ $SECONDS -ge $BUNCH_OF_MESSAGES_TIME ]; then
+		BUNCH_OF_MESSAGES_TIME=$((SECONDS + 7200))
+
+		for i in $(seq 0 $MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE);
+		do
+			$SEND_MESSAGE \
+				--lane $MESSAGE_LANE \
+				$EXTRA_ARGS \
+				$CONVERSION_RATE_OVERRIDE \
+				raw $BATCH_PAYLOAD
+		done
+
+	fi
+done

--- a/deployments/bridges/rialto-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-millau/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     image: ${SUBSTRATE_RELAY_IMAGE:-paritytech/substrate-relay}
     entrypoint: /entrypoints/relay-millau-rialto-entrypoint.sh
     volumes:
+      - ./bridges/common:/common
       - ./bridges/rialto-millau/entrypoints:/entrypoints
     environment:
       RUST_LOG: rpc=trace,bridge=trace

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -12,7 +12,6 @@ MAX_SUBMIT_DELAY_S=${MSG_EXCHANGE_GEN_MAX_SUBMIT_DELAY_S:-30}
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 SECONDARY_MESSAGE_LANE=${MSG_EXCHANGE_GEN_SECONDARY_LANE}
 MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE=1024
-FERDIE_ADDR=5oSLwptwgySxh5vz1HdvznQJjbQVgwYSvHEpYYeTXu1Ei8j7
 
 SHARED_CMD="/home/user/substrate-relay send-message rialto-to-millau"
 SHARED_HOST="--source-host rialto-node-bob --source-port 9944"
@@ -20,84 +19,10 @@ SOURCE_SIGNER="--source-signer //Millau.MessagesSender"
 
 SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
-# Sleep a bit between messages
-rand_sleep() {
-	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
-	echo "Sleeping $SUBMIT_DELAY_S seconds..."
-	sleep $SUBMIT_DELAY_S
-	NOW=`date "+%Y-%m-%d %H:%M:%S"`
-	echo "Woke up at $NOW"
-}
+SOURCE_CHAIN="Rialto"
+TARGET_CHAIN="Millau"
+EXTRA_ARGS=""
+REGULAR_PAYLOAD="020419ac"
+BATCH_PAYLOAD="020419ac"
 
-# last time when we have been asking for conversion rate update
-LAST_CONVERSION_RATE_UPDATE_TIME=0
-# conversion rate override argument
-CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-
-# start sending large messages immediately
-LARGE_MESSAGES_TIME=0
-# start sending message packs in a hour
-BUNCH_OF_MESSAGES_TIME=3600
-
-while true
-do
-	rand_sleep
-
-	# ask for latest conversion rate. We're doing that because otherwise we'll be facing
-	# bans from the conversion rate provider
-	if [ $SECONDS -ge $LAST_CONVERSION_RATE_UPDATE_TIME ]; then
-		CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-		CONVERSION_RATE_UPDATE_DELAY=`shuf -i 300-600 -n 1`
-		LAST_CONVERSION_RATE_UPDATE_TIME=$((SECONDS + $CONVERSION_RATE_UPDATE_DELAY))
-	fi
-
-	# send regular message
-	echo "Sending Message from Rialto to Millau"
-	SEND_MESSAGE_OUTPUT=`$SEND_MESSAGE --lane $MESSAGE_LANE $CONVERSION_RATE_OVERRIDE raw 020419ac 2>&1`
-	echo $SEND_MESSAGE_OUTPUT
-	if [ "$CONVERSION_RATE_OVERRIDE" = "--conversion-rate-override metric" ]; then
-		ACTUAL_CONVERSION_RATE_REGEX="conversion rate override: ([0-9\.]+)"
-		if [[ $SEND_MESSAGE_OUTPUT =~ $ACTUAL_CONVERSION_RATE_REGEX ]]; then
-			CONVERSION_RATE=${BASH_REMATCH[1]}
-			echo "Read updated conversion rate: $CONVERSION_RATE"
-			CONVERSION_RATE_OVERRIDE="--conversion-rate-override $CONVERSION_RATE"
-		else
-			echo "Error: unable to find conversion rate in send-message output. Will keep using on-chain rate"
-			CONVERSION_RATE_OVERRIDE=""
-		fi
-	fi
-
-	if [ ! -z $SECONDARY_MESSAGE_LANE ]; then
-		echo "Sending Message from Rialto to Millau using secondary lane: $SECONDARY_MESSAGE_LANE"
-		$SEND_MESSAGE \
-			--lane $SECONDARY_MESSAGE_LANE \
-			$CONVERSION_RATE_OVERRIDE \
-			raw 020419ac
-	fi
-
-	# every other hour we're sending 3 large (size, weight, size+weight) messages
-	if [ $SECONDS -ge $LARGE_MESSAGES_TIME ]; then
-		LARGE_MESSAGES_TIME=$((SECONDS + 7200))
-
-		rand_sleep
-		echo "Sending Maximal Size Message from Rialto to Millau"
-		$SEND_MESSAGE \
-			--lane $MESSAGE_LANE \
-			$CONVERSION_RATE_OVERRIDE \
-			sized max
-	fi
-
-	# every other hour we're sending a bunch of small messages
-	if [ $SECONDS -ge $BUNCH_OF_MESSAGES_TIME ]; then
-		BUNCH_OF_MESSAGES_TIME=$((SECONDS + 7200))
-
-		for i in $(seq 0 $MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE);
-		do
-			$SEND_MESSAGE \
-				--lane $MESSAGE_LANE \
-				$CONVERSION_RATE_OVERRIDE \
-				raw 020419ac
-		done
-
-	fi
-done
+source /common/generate_messages.sh

--- a/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-messages-to-rialto-generator-entrypoint.sh
@@ -12,7 +12,6 @@ MAX_SUBMIT_DELAY_S=${MSG_EXCHANGE_GEN_MAX_SUBMIT_DELAY_S:-30}
 MESSAGE_LANE=${MSG_EXCHANGE_GEN_LANE:-00000000}
 SECONDARY_MESSAGE_LANE=${MSG_EXCHANGE_GEN_SECONDARY_LANE}
 MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE=128
-FERDIE_ADDR=6ztG3jPnJTwgZnnYsgCDXbbQVR82M96hBZtPvkN56A9668ZC
 
 SHARED_CMD=" /home/user/substrate-relay send-message millau-to-rialto"
 SHARED_HOST="--source-host millau-node-bob --source-port 9944"
@@ -20,84 +19,10 @@ SOURCE_SIGNER="--source-signer //Rialto.MessagesSender"
 
 SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
-# Sleep a bit between messages
-rand_sleep() {
-	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
-	echo "Sleeping $SUBMIT_DELAY_S seconds..."
-	sleep $SUBMIT_DELAY_S
-	NOW=`date "+%Y-%m-%d %H:%M:%S"`
-	echo "Woke up at $NOW"
-}
+SOURCE_CHAIN="Millau"
+TARGET_CHAIN="Rialto"
+EXTRA_ARGS="--use-xcm-pallet"
+REGULAR_PAYLOAD="020419ac"
+BATCH_PAYLOAD="020419ac"
 
-# last time when we have been asking for conversion rate update
-LAST_CONVERSION_RATE_UPDATE_TIME=0
-# conversion rate override argument
-CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-
-# start sending large messages immediately
-LARGE_MESSAGES_TIME=0
-# start sending message packs in a hour
-BUNCH_OF_MESSAGES_TIME=3600
-
-while true
-do
-	rand_sleep
-
-	# ask for latest conversion rate. We're doing that because otherwise we'll be facing
-	# bans from the conversion rate provider
-	if [ $SECONDS -ge $LAST_CONVERSION_RATE_UPDATE_TIME ]; then
-		CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-		CONVERSION_RATE_UPDATE_DELAY=`shuf -i 300-600 -n 1`
-		LAST_CONVERSION_RATE_UPDATE_TIME=$((SECONDS + $CONVERSION_RATE_UPDATE_DELAY))
-	fi
-
-	# send regular message
-	echo "Sending Message from Millau to Rialto"
-	SEND_MESSAGE_OUTPUT=`$SEND_MESSAGE --lane $MESSAGE_LANE $CONVERSION_RATE_OVERRIDE --use-xcm-pallet raw 020419ac 2>&1`
-	echo $SEND_MESSAGE_OUTPUT
-	if [ "$CONVERSION_RATE_OVERRIDE" = "--conversion-rate-override metric" ]; then
-		ACTUAL_CONVERSION_RATE_REGEX="conversion rate override: ([0-9\.]+)"
-		if [[ $SEND_MESSAGE_OUTPUT =~ $ACTUAL_CONVERSION_RATE_REGEX ]]; then
-			CONVERSION_RATE=${BASH_REMATCH[1]}
-			echo "Read updated conversion rate: $CONVERSION_RATE"
-			CONVERSION_RATE_OVERRIDE="--conversion-rate-override $CONVERSION_RATE"
-		else
-			echo "Error: unable to find conversion rate in send-message output. Will keep using on-chain rate"
-			CONVERSION_RATE_OVERRIDE=""
-		fi
-	fi
-
-	if [ ! -z $SECONDARY_MESSAGE_LANE ]; then
-		echo "Sending Message from Millau to Rialto using secondary lane: $SECONDARY_MESSAGE_LANE"
-		$SEND_MESSAGE \
-			--lane $SECONDARY_MESSAGE_LANE \
-			$CONVERSION_RATE_OVERRIDE \
-			raw 020419ac
-	fi
-
-	# every other hour we're sending 3 large (size, weight, size+weight) messages
-	if [ $SECONDS -ge $LARGE_MESSAGES_TIME ]; then
-		LARGE_MESSAGES_TIME=$((SECONDS + 7200))
-
-		rand_sleep
-		echo "Sending Maximal Size Message from Millau to Rialto"
-		$SEND_MESSAGE \
-			--lane $MESSAGE_LANE \
-			$CONVERSION_RATE_OVERRIDE \
-			sized max
-	fi
-
-	# every other hour we're sending a bunch of small messages
-	if [ $SECONDS -ge $BUNCH_OF_MESSAGES_TIME ]; then
-		BUNCH_OF_MESSAGES_TIME=$((SECONDS + 7200))
-		for i in $(seq 0 $MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE);
-		do
-			$SEND_MESSAGE \
-				--lane $MESSAGE_LANE \
-				--use-xcm-pallet \
-				$CONVERSION_RATE_OVERRIDE \
-				raw 020419ac
-		done
-
-	fi
-done
+source /common/generate_messages.sh

--- a/deployments/bridges/rialto-parachain-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-parachain-millau/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     image: ${SUBSTRATE_RELAY_IMAGE:-paritytech/substrate-relay}
     entrypoint: /entrypoints/relay-millau-rialto-parachain-entrypoint.sh
     volumes:
+      - ./bridges/common:/common
       - ./bridges/rialto-parachain-millau/entrypoints:/entrypoints
     environment:
       RUST_LOG: rpc=trace,bridge=trace

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-millau-generator-entrypoint.sh
@@ -18,74 +18,10 @@ SOURCE_SIGNER="--source-signer //Millau.MessagesSender"
 
 SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
-# Sleep a bit between messages
-rand_sleep() {
-	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
-	echo "Sleeping $SUBMIT_DELAY_S seconds..."
-	sleep $SUBMIT_DELAY_S
-	NOW=`date "+%Y-%m-%d %H:%M:%S"`
-	echo "Woke up at $NOW"
-}
+SOURCE_CHAIN="RialtoParachain"
+TARGET_CHAIN="Millau"
+EXTRA_ARGS="--use-xcm-pallet"
+REGULAR_PAYLOAD="020419ac"
+BATCH_PAYLOAD="010109020419A8"
 
-# last time when we have been asking for conversion rate update
-LAST_CONVERSION_RATE_UPDATE_TIME=0
-# conversion rate override argument
-CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-
-# start sending large messages immediately
-LARGE_MESSAGES_TIME=0
-# start sending message packs in a hour
-BUNCH_OF_MESSAGES_TIME=3600
-
-while true
-do
-	rand_sleep
-
-	# ask for latest conversion rate. We're doing that because otherwise we'll be facing
-	# bans from the conversion rate provider
-	if [ $SECONDS -ge $LAST_CONVERSION_RATE_UPDATE_TIME ]; then
-		CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-		CONVERSION_RATE_UPDATE_DELAY=`shuf -i 300-600 -n 1`
-		LAST_CONVERSION_RATE_UPDATE_TIME=$((SECONDS + $CONVERSION_RATE_UPDATE_DELAY))
-	fi
-
-	# send regular message
-	echo "Sending Message from RialtoParachain to Millau"
-	SEND_MESSAGE_OUTPUT=`$SEND_MESSAGE --lane $MESSAGE_LANE --use-xcm-pallet $CONVERSION_RATE_OVERRIDE raw 020419ac 2>&1`
-	echo $SEND_MESSAGE_OUTPUT
-	if [ "$CONVERSION_RATE_OVERRIDE" = "--conversion-rate-override metric" ]; then
-		ACTUAL_CONVERSION_RATE_REGEX="conversion rate override: ([0-9\.]+)"
-		if [[ $SEND_MESSAGE_OUTPUT =~ $ACTUAL_CONVERSION_RATE_REGEX ]]; then
-			CONVERSION_RATE=${BASH_REMATCH[1]}
-			CONVERSION_RATE_OVERRIDE="--conversion-rate-override $CONVERSION_RATE"
-		else
-			echo "Error: unable to find conversion rate in send-message output. Will keep using on-chain rate"
-			CONVERSION_RATE_OVERRIDE=""
-		fi
-	fi
-
-	# every other hour we're sending large message
-	if [ $SECONDS -ge $LARGE_MESSAGES_TIME ]; then
-		LARGE_MESSAGES_TIME=$((SECONDS + 7200))
-
-		rand_sleep
-		echo "Sending Maximal Size Message from RialtoParachain to Millau"
-		$SEND_MESSAGE \
-			--lane $MESSAGE_LANE \
-			$CONVERSION_RATE_OVERRIDE \
-			sized max
-	fi
-
-	# every other hour we're sending a bunch of small messages
-	if [ $SECONDS -ge $BUNCH_OF_MESSAGES_TIME ]; then
-		BUNCH_OF_MESSAGES_TIME=$((SECONDS + 7200))
-		for i in $(seq 0 $MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE);
-		do
-			$SEND_MESSAGE \
-				--lane $MESSAGE_LANE \
-				--use-xcm-pallet \
-				$CONVERSION_RATE_OVERRIDE \
-				raw 010109030419A8
-		done
-	fi
-done
+source /common/generate_messages.sh

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-generator-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-generator-entrypoint.sh
@@ -18,75 +18,10 @@ SOURCE_SIGNER="--source-signer //RialtoParachain.MessagesSender"
 
 SEND_MESSAGE="$SHARED_CMD $SHARED_HOST $SOURCE_SIGNER"
 
-# Sleep a bit between messages
-rand_sleep() {
-	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
-	echo "Sleeping $SUBMIT_DELAY_S seconds..."
-	sleep $SUBMIT_DELAY_S
-	NOW=`date "+%Y-%m-%d %H:%M:%S"`
-	echo "Woke up at $NOW"
-}
+SOURCE_CHAIN="Millau"
+TARGET_CHAIN="RialtoParachain"
+EXTRA_ARGS="--use-xcm-pallet"
+REGULAR_PAYLOAD="020419ac"
+BATCH_PAYLOAD="010109020419A8"
 
-# last time when we have been asking for conversion rate update
-LAST_CONVERSION_RATE_UPDATE_TIME=0
-# conversion rate override argument
-CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-
-# start sending large messages immediately
-LARGE_MESSAGES_TIME=0
-# start sending message packs in a hour
-BUNCH_OF_MESSAGES_TIME=3600
-
-while true
-do
-	rand_sleep
-
-	# ask for latest conversion rate. We're doing that because otherwise we'll be facing
-	# bans from the conversion rate provider
-	if [ $SECONDS -ge $LAST_CONVERSION_RATE_UPDATE_TIME ]; then
-		CONVERSION_RATE_OVERRIDE="--conversion-rate-override metric"
-		CONVERSION_RATE_UPDATE_DELAY=`shuf -i 300-600 -n 1`
-		LAST_CONVERSION_RATE_UPDATE_TIME=$((SECONDS + $CONVERSION_RATE_UPDATE_DELAY))
-	fi
-
-	# send regular message
-	echo "Sending Message from Millau to RialtoParachain"
-	SEND_MESSAGE_OUTPUT=`$SEND_MESSAGE --lane $MESSAGE_LANE --use-xcm-pallet $CONVERSION_RATE_OVERRIDE raw 020419ac 2>&1`
-	echo $SEND_MESSAGE_OUTPUT
-	if [ "$CONVERSION_RATE_OVERRIDE" = "--conversion-rate-override metric" ]; then
-		ACTUAL_CONVERSION_RATE_REGEX="conversion rate override: ([0-9\.]+)"
-		if [[ $SEND_MESSAGE_OUTPUT =~ $ACTUAL_CONVERSION_RATE_REGEX ]]; then
-			CONVERSION_RATE=${BASH_REMATCH[1]}
-			echo "Read updated conversion rate: $CONVERSION_RATE"
-			CONVERSION_RATE_OVERRIDE="--conversion-rate-override $CONVERSION_RATE"
-		else
-			echo "Error: unable to find conversion rate in send-message output. Will keep using on-chain rate"
-			CONVERSION_RATE_OVERRIDE=""
-		fi
-	fi
-
-	# every other hour we're sending large message
-	if [ $SECONDS -ge $LARGE_MESSAGES_TIME ]; then
-		LARGE_MESSAGES_TIME=$((SECONDS + 7200))
-
-		rand_sleep
-		echo "Sending Maximal Size Message from RialtoParachain to Millau"
-		$SEND_MESSAGE \
-			--lane $MESSAGE_LANE \
-			$CONVERSION_RATE_OVERRIDE \
-			sized max
-	fi
-
-	# every other hour we're sending a bunch of small messages
-	if [ $SECONDS -ge $BUNCH_OF_MESSAGES_TIME ]; then
-		BUNCH_OF_MESSAGES_TIME=$((SECONDS + 7200))
-		for i in $(seq 0 $MAX_UNCONFIRMED_MESSAGES_AT_INBOUND_LANE);
-		do
-			$SEND_MESSAGE \
-				--lane $MESSAGE_LANE \
-				--use-xcm-pallet \
-				$CONVERSION_RATE_OVERRIDE \
-				raw 010109020419A8
-		done
-	fi
-done
+source /common/generate_messages.sh


### PR DESCRIPTION
Fixes #1526

I was playing with the deployments while reviewing #1412 and since I got here I thought it would be an useful exercise for me to also play with some code and address #1526. The approach might not be ideal (it might be nicer to have a script that receives CLI parameters, but it's harder to do from bash). But anyway, it deduplicates some code.