### PR TITLE
Increase grafana start delay to 10m

### DIFF
--- a/deployments/monitoring/docker-compose.yml
+++ b/deployments/monitoring/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus-metrics
-    entrypoint: sh -c "echo 'sleeping for 240s' && sleep 240 && /run.sh"
+    entrypoint: sh -c "echo 'sleeping for 10m' && sleep 600 && /run.sh"
 
   grafana-matrix-notifier:
     build:

--- a/deployments/monitoring/grafana/dashboards/nodes.json
+++ b/deployments/monitoring/grafana/dashboards/nodes.json
@@ -43,7 +43,7 @@
             "query": {
               "params": [
                 "A",
-                "10m",
+                "15m",
                 "now"
               ]
             },
@@ -55,7 +55,7 @@
           }
         ],
         "executionErrorState": "alerting",
-        "for": "5m",
+        "for": "3m",
         "frequency": "1m",
         "handler": 1,
         "name": "Nodes are not running",


### PR DESCRIPTION
Fixes #1369 

Increase grafana start delay to 10m to make sure we don't receive any
[No Data] messages.