### PR TITLE
restart relay loop when proof genration fails

### DIFF
--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -395,7 +395,7 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>, TC: TargetClient<P>>(
 					&mut source_go_offline_future,
 					async_std::task::sleep,
 					|| format!("Error generating proof at {}", P::source_name()),
-				).fail_if_connection_error(FailedClient::Source)?;
+				).fail_if_error(FailedClient::Source).map(|_| true)?;
 			},
 			proof_submit_result = target_submit_proof => {
 				target_client_is_online = process_future_result(


### PR DESCRIPTION
closes #1583 

This PR shall change the "stalled" semantics to (almost) what've been before work on #1464 has started (see e.g. commit https://github.com/paritytech/parity-bridges-common/tree/9a433f25da2ab0968faafcbfb6011c228f42e207 for comparison):
- [x] for finality relay - the semantics is the same - the `stall_timeout` was starting after transaction has been submitted, as it is now;
- [x] for parachains relay - this loop holds no (almost) internal state, so every error there is a connection error, so nothing changes in practice;
- [x] for messages relay the stall timeout was restarted after best target nonces were read + after transaction has been submitted. Now the stall is detected only when transaction has been submitted and it is missing for the `stall_timeout`. But imo this difference shall not cause any issues - why would we need to restart if we have not even submitted any transaction?.