### PR TITLE
Run RialtoParachain<>Millau relay in altruistic mode

### DIFF
--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-millau-rialto-parachain-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-millau-rialto-parachain-entrypoint.sh
@@ -38,5 +38,6 @@ sleep 6
 	--rialto-parachain-transactions-mortality=64 \
 	--rialto-host rialto-node-alice \
 	--rialto-port 9944 \
+	--relayer-mode=altruistic \
 	--lane=00000000 \
 	--prometheus-host=0.0.0.0


### PR DESCRIPTION
After migration to XCM, our relayers are supposed to run in altruistic mode - Rialto<>Millau is already running in this mode. This PR is switching RialtoParachain<>Millau to the same mode