### PR TITLE
Increase max header size of Rialto and Millau (512 -> 1024)

### DIFF
--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -113,7 +113,7 @@ pub const SESSION_LENGTH: BlockNumber = 5 * time_units::MINUTES;
 pub const MAX_AUTHORITIES_COUNT: u32 = 5;
 
 /// Maximal SCALE-encoded header size (in bytes) at Millau.
-pub const MAX_HEADER_SIZE: u32 = 512;
+pub const MAX_HEADER_SIZE: u32 = 1024;
 
 /// Re-export `time_units` to make usage easier.
 pub use time_units::*;

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -104,7 +104,7 @@ pub const SESSION_LENGTH: BlockNumber = 4;
 pub const MAX_AUTHORITIES_COUNT: u32 = 5;
 
 /// Maximal SCALE-encoded header size (in bytes) at Rialto.
-pub const MAX_HEADER_SIZE: u32 = 512;
+pub const MAX_HEADER_SIZE: u32 = 1024;
 
 /// Maximal SCALE-encoded size of parachains headers that are stored at Rialto `Paras` pallet.
 pub const MAX_NESTED_PARACHAIN_HEAD_SIZE: u32 = MAX_HEADER_SIZE;


### PR DESCRIPTION
closes #1602 

Normally we have `3` authorities in the digest, but there's first session with `5` authorities, so the sync has been broken