### PR TITLE
Ignore clippy or_fun_call lint (try to unblock CI again)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ clippy-nightly:
     RUSTFLAGS:                     "-D warnings"
   script:
     # clippy currently is raising `derive-partial-eq-without-eq` warning even if `Eq` is actually derived
-    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq
+    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq -A clippy::or_fun_call
 
 fmt:
   stage:                           lint


### PR DESCRIPTION
On bridges-ci staging: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/1965536
On bridges-ci production: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/1961605

We want to finally upgrade our production to staging, but clippy currently blocks us from doing that.