### PR TITLE
Fix parachains_loop::tests::minimal_working_case

### DIFF
--- a/relays/parachains/src/parachains_loop.rs
+++ b/relays/parachains/src/parachains_loop.rs
@@ -24,7 +24,7 @@ use bp_polkadot_core::{
 };
 use futures::{
 	future::{FutureExt, Shared},
-	poll, select,
+	poll, select_biased,
 };
 use relay_substrate_client::{BlockNumberOf, Chain, HeaderIdOf};
 use relay_utils::{
@@ -217,9 +217,9 @@ where
 
 	loop {
 		// either wait for new block, or exit signal
-		select! {
-			_ = async_std::task::sleep(min_block_interval).fuse() => {},
+		select_biased! {
 			_ = exit_signal => return Ok(()),
+			_ = async_std::task::sleep(min_block_interval).fuse() => {},
 		}
 
 		// if source client is not yet synced, we'll need to sleep. Otherwise we risk submitting too

--- a/relays/parachains/src/parachains_loop.rs
+++ b/relays/parachains/src/parachains_loop.rs
@@ -216,7 +216,9 @@ where
 	// regular errors.
 
 	loop {
-		// either wait for new block, or exit signal
+		// Either wait for new block, or exit signal.
+		// Please note that we are prioritizing the exit signal since if both events happen at once
+		// it doesn't make sense to perform one more loop iteration.
 		select_biased! {
 			_ = exit_signal => return Ok(()),
 			_ = async_std::task::sleep(min_block_interval).fuse() => {},


### PR DESCRIPTION
Fixes #1610 

The parachains loop waits for new block or exit signal before performing the actual relaying logic:

```
		select! {
			_ = async_std::task::sleep(min_block_interval).fuse() => {},
			_ = exit_signal => return Ok(()),
		}
```

The problem is that when the `min_block_interval` is 0 and an an exit signal was also received, both branches will complete at the same time. In this case `select!` doesn't guarantee which branch will be chosen. When the new block branch is chosen, the test fails.

I changed this to use `select_biased` which chooses the first defined branch of the completed ones, and defined the branch for the exit signal before the branch for new block in order to prioritize it.