### PR TITLE
Second iteration of weights v1.5

### DIFF
--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -407,7 +407,7 @@ pub mod source {
 		let delivery_transaction = BridgedChain::<B>::estimate_delivery_transaction(
 			&payload.encode(),
 			true,
-			Weight::from_ref_time(0),
+			Weight::zero(),
 		);
 		let delivery_transaction_fee = BridgedChain::<B>::transaction_payment(delivery_transaction);
 
@@ -733,7 +733,7 @@ pub mod target {
 					payload.weight = Some(weight);
 					weight
 				},
-				_ => Weight::from_ref_time(0),
+				_ => Weight::zero(),
 			}
 		}
 
@@ -762,17 +762,22 @@ pub mod target {
 					location,
 					xcm,
 					hash,
-					weight_limit.unwrap_or(Weight::from_ref_time(0)).ref_time(),
+					weight_limit.unwrap_or_else(Weight::zero).ref_time(),
 					weight_credit.ref_time(),
 				);
 				Ok(xcm_outcome)
 			};
 
 			let xcm_outcome = do_dispatch();
-			log::trace!(target: "runtime::bridge-dispatch", "Incoming message {:?} dispatched with result: {:?}", message_id, xcm_outcome);
+			log::trace!(
+				target: "runtime::bridge-dispatch",
+				"Incoming message {:?} dispatched with result: {:?}",
+				message_id,
+				xcm_outcome,
+			);
 			MessageDispatchResult {
 				dispatch_result: true,
-				unspent_weight: Weight::from_ref_time(0),
+				unspent_weight: Weight::zero(),
 				dispatch_fee_paid_during_dispatch: false,
 			}
 		}

--- a/bin/runtime-common/src/messages_api.rs
+++ b/bin/runtime-common/src/messages_api.rs
@@ -39,7 +39,7 @@ where
 				nonce,
 				// dispatch message weight is always zero at the source chain, since we're paying for
 				// dispatch at the target chain
-				dispatch_weight: frame_support::weights::Weight::from_ref_time(0),
+				dispatch_weight: frame_support::weights::Weight::zero(),
 				size: message_data.payload.len() as _,
 				delivery_and_dispatch_fee: message_data.fee,
 				// we're delivering XCM messages here, so fee is always paid at the target chain

--- a/bin/runtime-common/src/messages_benchmarking.rs
+++ b/bin/runtime-common/src/messages_benchmarking.rs
@@ -94,7 +94,7 @@ where
 			nonces_start: *params.message_nonces.start(),
 			nonces_end: *params.message_nonces.end(),
 		},
-		Weight::from_ref_time(0),
+		Weight::zero(),
 	)
 }
 

--- a/bin/runtime-common/src/messages_extension.rs
+++ b/bin/runtime-common/src/messages_extension.rs
@@ -125,7 +125,7 @@ mod tests {
 				pallet_bridge_messages::Call::<Runtime, ()>::receive_messages_proof {
 					relayer_id_at_bridged_chain: [0u8; 32].into(),
 					messages_count: (nonces_end - nonces_start + 1) as u32,
-					dispatch_weight: frame_support::weights::Weight::from_ref_time(0),
+					dispatch_weight: frame_support::weights::Weight::zero(),
 					proof: FromBridgedChainMessagesProof {
 						bridged_header_hash: Default::default(),
 						storage_proof: vec![],

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -135,9 +135,7 @@ pub mod pallet {
 		fn on_initialize(_n: T::BlockNumber) -> frame_support::weights::Weight {
 			<RequestCount<T, I>>::mutate(|count| *count = count.saturating_sub(1));
 
-			Weight::from_ref_time(0)
-				.saturating_add(T::DbWeight::get().reads(1))
-				.saturating_add(T::DbWeight::get().writes(1))
+			T::DbWeight::get().reads_writes(1, 1)
 		}
 	}
 

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -748,7 +748,7 @@ mod tests {
 		let db_weight = <TestRuntime as frame_system::Config>::DbWeight::get();
 		WeightInfoOf::<TestRuntime, ()>::submit_parachain_heads_weight(db_weight, proof, 1)
 			.saturating_sub(if prune_expected {
-				Weight::from_ref_time(0)
+				Weight::zero()
 			} else {
 				WeightInfoOf::<TestRuntime, ()>::parachain_head_pruning_weight(db_weight)
 			})

--- a/primitives/messages/src/source_chain.rs
+++ b/primitives/messages/src/source_chain.rs
@@ -212,7 +212,7 @@ impl<SenderOrigin, Balance, Payload> MessagesBridge<SenderOrigin, Balance, Paylo
 		_message: Payload,
 		_delivery_and_dispatch_fee: Balance,
 	) -> Result<SendMessageArtifacts, Self::Error> {
-		Ok(SendMessageArtifacts { nonce: 0, weight: Weight::from_ref_time(0) })
+		Ok(SendMessageArtifacts { nonce: 0, weight: Weight::zero() })
 	}
 }
 
@@ -237,7 +237,7 @@ pub trait OnDeliveryConfirmed {
 #[impl_trait_for_tuples::impl_for_tuples(30)]
 impl OnDeliveryConfirmed for Tuple {
 	fn on_messages_delivered(lane: &LaneId, messages: &DeliveredMessages) -> Weight {
-		let mut total_weight = Weight::from_ref_time(0);
+		let mut total_weight = Weight::zero();
 		for_tuples!(
 			#(
 				total_weight = total_weight.saturating_add(Tuple::on_messages_delivered(lane, messages));
@@ -255,7 +255,7 @@ pub trait OnMessageAccepted {
 
 impl OnMessageAccepted for () {
 	fn on_messages_accepted(_lane: &LaneId, _message: &MessageNonce) -> Weight {
-		Weight::from_ref_time(0)
+		Weight::zero()
 	}
 }
 

--- a/primitives/messages/src/target_chain.rs
+++ b/primitives/messages/src/target_chain.rs
@@ -167,7 +167,7 @@ impl<AccountId, Fee> MessageDispatch<AccountId, Fee> for ForbidInboundMessages {
 	) -> MessageDispatchResult {
 		MessageDispatchResult {
 			dispatch_result: false,
-			unspent_weight: Weight::from_ref_time(0),
+			unspent_weight: Weight::zero(),
 			dispatch_fee_paid_during_dispatch: false,
 		}
 	}

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -20,7 +20,8 @@
 
 use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
 use frame_support::{
-	log, pallet_prelude::DispatchResult, PalletError, RuntimeDebug, StorageHasher, StorageValue,
+	log, pallet_prelude::DispatchResult, weights::Weight, PalletError, RuntimeDebug, StorageHasher,
+	StorageValue,
 };
 use frame_system::RawOrigin;
 use scale_info::TypeInfo;
@@ -454,6 +455,24 @@ pub trait OwnedBridgeModule<T: frame_system::Config> {
 pub trait FilterCall<Call> {
 	/// Checks if a runtime call is valid.
 	fn validate(call: &Call) -> TransactionValidity;
+}
+
+/// All extra operations with weights that we need in bridges.
+pub trait WeightExtraOps {
+	/// Checked division of individual components of two weights.
+	///
+	/// Divides components and returns minimal division result. Returns `None` if one
+	/// of `other` weight components is zero.
+	fn min_components_checked_div(&self, other: Weight) -> Option<u64>;
+}
+
+impl WeightExtraOps for Weight {
+	fn min_components_checked_div(&self, other: Weight) -> Option<u64> {
+		Some(sp_std::cmp::min(
+			self.ref_time().checked_div(other.ref_time())?,
+			self.proof_size().checked_div(other.proof_size())?,
+		))
+	}
 }
 
 #[cfg(test)]

--- a/relays/lib-substrate-relay/src/messages_source.rs
+++ b/relays/lib-substrate-relay/src/messages_source.rs
@@ -653,7 +653,7 @@ mod tests {
 			.into_iter()
 			.map(|nonce| bp_messages::OutboundMessageDetails {
 				nonce,
-				dispatch_weight: Weight::from_ref_time(0),
+				dispatch_weight: Weight::zero(),
 				size: 0,
 				delivery_and_dispatch_fee: 0,
 				dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
@@ -730,7 +730,7 @@ mod tests {
 		for (idx, _) in payload_sizes.iter().enumerate() {
 			out_msgs_details.push(OutboundMessageDetails::<BalanceOf<Rialto>> {
 				nonce: idx as MessageNonce,
-				dispatch_weight: Weight::from_ref_time(0),
+				dispatch_weight: Weight::zero(),
 				size: 0,
 				delivery_and_dispatch_fee: 0,
 				dispatch_fee_payment: DispatchFeePayment::AtTargetChain,

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -295,7 +295,7 @@ impl<P: MessageLane, Strategy: RelayStrategy, SC, TC> MessageDeliveryStrategy<P,
 			.source_queue()
 			.iter()
 			.flat_map(|(_, range)| range.values().map(|details| details.dispatch_weight))
-			.fold(Weight::from_ref_time(0), |total, weight| total.saturating_add(weight))
+			.fold(Weight::zero(), |total, weight| total.saturating_add(weight))
 	}
 }
 

--- a/relays/messages/src/relay_strategy/enforcement_strategy.rs
+++ b/relays/messages/src/relay_strategy/enforcement_strategy.rs
@@ -55,7 +55,7 @@ impl<Strategy: RelayStrategy> EnforcementStrategy<Strategy> {
 		let mut hard_selected_count = 0;
 		let mut soft_selected_count = 0;
 
-		let mut selected_weight = Weight::from_ref_time(0);
+		let mut selected_weight = Weight::zero();
 		let mut selected_count: MessageNonce = 0;
 
 		let hard_selected_begin_nonce =
@@ -77,12 +77,12 @@ impl<Strategy: RelayStrategy> EnforcementStrategy<Strategy> {
 
 			hard_selected_begin_nonce,
 			selected_prepaid_nonces: 0,
-			selected_unpaid_weight: Weight::from_ref_time(0),
+			selected_unpaid_weight: Weight::zero(),
 
 			index: 0,
 			nonce: 0,
 			details: MessageDetails {
-				dispatch_weight: Weight::from_ref_time(0),
+				dispatch_weight: Weight::zero(),
 				size: 0,
 				reward: P::SourceChainBalance::zero(),
 				dispatch_fee_payment: DispatchFeePayment::AtSourceChain,
@@ -107,8 +107,8 @@ impl<Strategy: RelayStrategy> EnforcementStrategy<Strategy> {
 			// limit messages in the batch by weight
 			let new_selected_weight = match selected_weight.checked_add(&details.dispatch_weight) {
 				Some(new_selected_weight)
-					if new_selected_weight.ref_time() <=
-						reference.max_messages_weight_in_single_batch.ref_time() =>
+					if new_selected_weight
+						.all_lte(reference.max_messages_weight_in_single_batch) =>
 					new_selected_weight,
 				new_selected_weight if selected_count == 0 => {
 					log::warn!(


### PR DESCRIPTION
What has been done here:
- [x] replaced `Weight::from_ref_time(0)` with `Weight::zero()` where I'm sure we don't need non-zero value of the second component;
- [x] replaced `min_by` + `ref_time()` with `Weight::min` where appropriate;
- [x] replaced `ref_time() == 0` with `Weight::is_zer()` call where appropriate;
- [x] replaced `w1.ref_time() <comparison-op> w2.ref_time` with `all_lte`/`all_gte`/... calls where appropriate;
- [x] added `WeightExtraOps` trait for the `min_components_checked_div` fn that is missing from the `Weight` struct. We need it to compute number of messages that are fit into the delivery transaction.

Next iteration will be after v2 weights will become available - we'll need to deal with refund, weight formulae, benchmarks, ...