### PR TITLE
Prune messages from on-idle callback

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -469,6 +469,8 @@ parameter_types! {
 	pub const RootAccountForPayments: Option<AccountId> = None;
 	pub const RialtoChainId: bp_runtime::ChainId = bp_runtime::RIALTO_CHAIN_ID;
 	pub const RialtoParachainChainId: bp_runtime::ChainId = bp_runtime::RIALTO_PARACHAIN_CHAIN_ID;
+	pub RialtoActiveOutboundLanes: &'static [bp_messages::LaneId] = &[rialto_messages::XCM_LANE];
+	pub RialtoParachainActiveOutboundLanes: &'static [bp_messages::LaneId] = &[rialto_parachain_messages::XCM_LANE];
 }
 
 /// Instance of the messages pallet used to relay messages to/from Rialto chain.
@@ -477,7 +479,7 @@ pub type WithRialtoMessagesInstance = ();
 impl pallet_bridge_messages::Config<WithRialtoMessagesInstance> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_bridge_messages::weights::BridgeWeight<Runtime>;
-	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
+	type ActiveOutboundLanes = RialtoActiveOutboundLanes;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
 
@@ -508,7 +510,7 @@ pub type WithRialtoParachainMessagesInstance = pallet_bridge_messages::Instance1
 impl pallet_bridge_messages::Config<WithRialtoParachainMessagesInstance> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_bridge_messages::weights::BridgeWeight<Runtime>;
-	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
+	type ActiveOutboundLanes = RialtoParachainActiveOutboundLanes;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
 

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -16,7 +16,7 @@
 
 //! Everything required to serve Millau <-> Rialto messages.
 
-use crate::{OriginCaller, RialtoGrandpaInstance, Runtime, RuntimeCall, RuntimeOrigin};
+use crate::{RialtoGrandpaInstance, Runtime, RuntimeCall, RuntimeOrigin};
 
 use bp_messages::{
 	source_chain::TargetHeaderChain,
@@ -98,24 +98,8 @@ impl messages::ThisChainWithMessages for Millau {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 
-	fn is_message_accepted(send_origin: &Self::RuntimeOrigin, lane: &LaneId) -> bool {
-		let here_location =
-			xcm::v3::MultiLocation::from(crate::xcm_config::UniversalLocation::get());
-		match send_origin.caller {
-			OriginCaller::XcmPallet(pallet_xcm::Origin::Xcm(ref location))
-				if *location == here_location =>
-			{
-				log::trace!(target: "runtime::bridge", "Verifying message sent using XCM pallet to Rialto");
-			},
-			_ => {
-				// keep in mind that in this case all messages are free (in term of fees)
-				// => it's just to keep testing bridge on our test deployments until we'll have a
-				// better option
-				log::trace!(target: "runtime::bridge", "Verifying message sent using messages pallet to Rialto");
-			},
-		}
-
-		*lane == XCM_LANE
+	fn is_message_accepted(_send_origin: &Self::RuntimeOrigin, _lane: &LaneId) -> bool {
+		true
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -28,7 +28,7 @@ use bridge_runtime_common::messages::{self, MessageBridge};
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
 
 /// Default lane that is used to send messages to Rialto.
-pub const DEFAULT_XCM_LANE_TO_RIALTO: LaneId = [0, 0, 0, 0];
+pub const XCM_LANE: LaneId = [0, 0, 0, 0];
 /// Weight of 2 XCM instructions is for simple `Trap(42)` program, coming through bridge
 /// (it is prepended with `UniversalOrigin` instruction). It is used just for simplest manual
 /// tests, confirming that we don't break encoding somewhere between.
@@ -115,7 +115,7 @@ impl messages::ThisChainWithMessages for Millau {
 			},
 		}
 
-		*lane == DEFAULT_XCM_LANE_TO_RIALTO || *lane == [0, 0, 0, 1]
+		*lane == XCM_LANE || *lane == [0, 0, 0, 1]
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -115,7 +115,7 @@ impl messages::ThisChainWithMessages for Millau {
 			},
 		}
 
-		*lane == XCM_LANE || *lane == [0, 0, 0, 1]
+		*lane == XCM_LANE
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/millau/runtime/src/rialto_parachain_messages.rs
+++ b/bin/millau/runtime/src/rialto_parachain_messages.rs
@@ -103,8 +103,8 @@ impl messages::ThisChainWithMessages for Millau {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeOrigin = RuntimeOrigin;
 
-	fn is_message_accepted(_send_origin: &Self::RuntimeOrigin, lane: &LaneId) -> bool {
-		*lane == XCM_LANE
+	fn is_message_accepted(_send_origin: &Self::RuntimeOrigin, _lane: &LaneId) -> bool {
+		true
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/millau/runtime/src/rialto_parachain_messages.rs
+++ b/bin/millau/runtime/src/rialto_parachain_messages.rs
@@ -104,7 +104,7 @@ impl messages::ThisChainWithMessages for Millau {
 	type RuntimeOrigin = RuntimeOrigin;
 
 	fn is_message_accepted(_send_origin: &Self::RuntimeOrigin, lane: &LaneId) -> bool {
-		*lane == XCM_LANE || *lane == [0, 0, 0, 1]
+		*lane == XCM_LANE
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/millau/runtime/src/rialto_parachain_messages.rs
+++ b/bin/millau/runtime/src/rialto_parachain_messages.rs
@@ -28,7 +28,7 @@ use bridge_runtime_common::messages::{self, MessageBridge};
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
 
 /// Default lane that is used to send messages to Rialto parachain.
-pub const DEFAULT_XCM_LANE_TO_RIALTO_PARACHAIN: LaneId = [0, 0, 0, 0];
+pub const XCM_LANE: LaneId = [0, 0, 0, 0];
 /// Weight of 2 XCM instructions is for simple `Trap(42)` program, coming through bridge
 /// (it is prepended with `UniversalOrigin` instruction). It is used just for simplest manual
 /// tests, confirming that we don't break encoding somewhere between.
@@ -104,7 +104,7 @@ impl messages::ThisChainWithMessages for Millau {
 	type RuntimeOrigin = RuntimeOrigin;
 
 	fn is_message_accepted(_send_origin: &Self::RuntimeOrigin, lane: &LaneId) -> bool {
-		*lane == DEFAULT_XCM_LANE_TO_RIALTO_PARACHAIN || *lane == [0, 0, 0, 1]
+		*lane == XCM_LANE || *lane == [0, 0, 0, 1]
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/millau/runtime/src/xcm_config.rs
+++ b/bin/millau/runtime/src/xcm_config.rs
@@ -17,10 +17,8 @@
 //! XCM configurations for the Millau runtime.
 
 use super::{
-	rialto_messages::{WithRialtoMessageBridge, DEFAULT_XCM_LANE_TO_RIALTO},
-	rialto_parachain_messages::{
-		WithRialtoParachainMessageBridge, DEFAULT_XCM_LANE_TO_RIALTO_PARACHAIN,
-	},
+	rialto_messages::{WithRialtoMessageBridge, XCM_LANE},
+	rialto_parachain_messages::{WithRialtoParachainMessageBridge, XCM_LANE as XCM_LANE_PARACHAIN},
 	AccountId, AllPalletsWithSystem, Balances, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 	WithRialtoMessagesInstance, WithRialtoParachainMessagesInstance, XcmPallet,
 };
@@ -218,7 +216,7 @@ impl XcmBridge for ToRialtoBridge {
 	}
 
 	fn xcm_lane() -> LaneId {
-		DEFAULT_XCM_LANE_TO_RIALTO
+		XCM_LANE
 	}
 }
 
@@ -245,7 +243,7 @@ impl XcmBridge for ToRialtoParachainBridge {
 	}
 
 	fn xcm_lane() -> LaneId {
-		DEFAULT_XCM_LANE_TO_RIALTO_PARACHAIN
+		XCM_LANE_PARACHAIN
 	}
 }
 

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -26,7 +26,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use crate::millau_messages::{WithMillauMessageBridge, DEFAULT_XCM_LANE_TO_MILLAU};
+use crate::millau_messages::{WithMillauMessageBridge, XCM_LANE};
 
 use bridge_runtime_common::messages::source::{XcmBridge, XcmBridgeAdapter};
 use cumulus_pallet_parachain_system::AnyRelayNumber;
@@ -455,7 +455,7 @@ impl XcmBridge for ToMillauBridge {
 	}
 
 	fn xcm_lane() -> bp_messages::LaneId {
-		DEFAULT_XCM_LANE_TO_MILLAU
+		XCM_LANE
 	}
 }
 
@@ -554,6 +554,7 @@ parameter_types! {
 		bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 	pub const RootAccountForPayments: Option<AccountId> = None;
 	pub const BridgedChainId: bp_runtime::ChainId = bp_runtime::MILLAU_CHAIN_ID;
+	pub ActiveOutboundLanes: &'static [bp_messages::LaneId] = &[millau_messages::XCM_LANE];
 }
 
 /// Instance of the messages pallet used to relay messages to/from Millau chain.
@@ -562,7 +563,7 @@ pub type WithMillauMessagesInstance = ();
 impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_bridge_messages::weights::BridgeWeight<Runtime>;
-	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
+	type ActiveOutboundLanes = ActiveOutboundLanes;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
 

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -31,7 +31,7 @@ use bridge_runtime_common::messages::{self, MessageBridge};
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
 
 /// Default lane that is used to send messages to Millau.
-pub const DEFAULT_XCM_LANE_TO_MILLAU: LaneId = [0, 0, 0, 0];
+pub const XCM_LANE: LaneId = [0, 0, 0, 0];
 /// Weight of 2 XCM instructions is for simple `Trap(42)` program, coming through bridge
 /// (it is prepended with `UniversalOrigin` instruction). It is used just for simplest manual
 /// tests, confirming that we don't break encoding somewhere between.

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -19,7 +19,7 @@
 // TODO: this is almost exact copy of `millau_messages.rs` from Rialto runtime.
 // Should be extracted to a separate crate and reused here.
 
-use crate::{MillauGrandpaInstance, OriginCaller, Runtime, RuntimeCall, RuntimeOrigin};
+use crate::{MillauGrandpaInstance, Runtime, RuntimeCall, RuntimeOrigin};
 
 use bp_messages::{
 	source_chain::TargetHeaderChain,
@@ -102,23 +102,8 @@ impl messages::ThisChainWithMessages for RialtoParachain {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeOrigin = RuntimeOrigin;
 
-	fn is_message_accepted(send_origin: &Self::RuntimeOrigin, lane: &LaneId) -> bool {
-		let here_location = xcm::v3::MultiLocation::from(crate::UniversalLocation::get());
-		match send_origin.caller {
-			OriginCaller::PolkadotXcm(pallet_xcm::Origin::Xcm(ref location))
-				if *location == here_location =>
-			{
-				log::trace!(target: "runtime::bridge", "Verifying message sent using XCM pallet to Millau");
-			},
-			_ => {
-				// keep in mind that in this case all messages are free (in term of fees)
-				// => it's just to keep testing bridge on our test deployments until we'll have a
-				// better option
-				log::trace!(target: "runtime::bridge", "Verifying message sent using messages pallet to Millau");
-			},
-		}
-
-		*lane == XCM_LANE
+	fn is_message_accepted(_send_origin: &Self::RuntimeOrigin, _lane: &LaneId) -> bool {
+		true
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -118,7 +118,7 @@ impl messages::ThisChainWithMessages for RialtoParachain {
 			},
 		}
 
-		*lane == [0, 0, 0, 0] || *lane == [0, 0, 0, 1]
+		*lane == XCM_LANE
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -442,6 +442,7 @@ parameter_types! {
 		bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 	pub const RootAccountForPayments: Option<AccountId> = None;
 	pub const BridgedChainId: bp_runtime::ChainId = bp_runtime::MILLAU_CHAIN_ID;
+	pub ActiveOutboundLanes: &'static [bp_messages::LaneId] = &[millau_messages::XCM_LANE];
 }
 
 /// Instance of the messages pallet used to relay messages to/from Millau chain.
@@ -450,7 +451,7 @@ pub type WithMillauMessagesInstance = ();
 impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_bridge_messages::weights::BridgeWeight<Runtime>;
-	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
+	type ActiveOutboundLanes = ActiveOutboundLanes;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
 

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -27,6 +27,8 @@ use bp_runtime::{ChainId, MILLAU_CHAIN_ID, RIALTO_CHAIN_ID};
 use bridge_runtime_common::messages::{self, MessageBridge};
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
 
+/// Lane that is used for XCM messages exchange.
+pub const XCM_LANE: LaneId = [0, 0, 0, 0];
 /// Weight of 2 XCM instructions is for simple `Trap(42)` program, coming through bridge
 /// (it is prepended with `UniversalOrigin` instruction). It is used just for simplest manual
 /// tests, confirming that we don't break encoding somewhere between.
@@ -113,7 +115,7 @@ impl messages::ThisChainWithMessages for Rialto {
 			},
 		}
 
-		*lane == [0, 0, 0, 0] || *lane == [0, 0, 0, 1]
+		*lane == XCM_LANE
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -16,7 +16,7 @@
 
 //! Everything required to serve Millau <-> Rialto messages.
 
-use crate::{MillauGrandpaInstance, OriginCaller, Runtime, RuntimeCall, RuntimeOrigin};
+use crate::{MillauGrandpaInstance, Runtime, RuntimeCall, RuntimeOrigin};
 
 use bp_messages::{
 	source_chain::TargetHeaderChain,
@@ -98,24 +98,8 @@ impl messages::ThisChainWithMessages for Rialto {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 
-	fn is_message_accepted(send_origin: &Self::RuntimeOrigin, lane: &LaneId) -> bool {
-		let here_location =
-			xcm::v3::MultiLocation::from(crate::xcm_config::UniversalLocation::get());
-		match send_origin.caller {
-			OriginCaller::XcmPallet(pallet_xcm::Origin::Xcm(ref location))
-				if *location == here_location =>
-			{
-				log::trace!(target: "runtime::bridge", "Verifying message sent using XCM pallet to Millau");
-			},
-			_ => {
-				// keep in mind that in this case all messages are free (in term of fees)
-				// => it's just to keep testing bridge on our test deployments until we'll have a
-				// better option
-				log::trace!(target: "runtime::bridge", "Verifying message sent using messages pallet to Millau");
-			},
-		}
-
-		*lane == XCM_LANE
+	fn is_message_accepted(_send_origin: &Self::RuntimeOrigin, _lane: &LaneId) -> bool {
+		true
 	}
 
 	fn maximal_pending_messages_at_outbound_lane() -> MessageNonce {

--- a/bin/runtime-common/src/integrity.rs
+++ b/bin/runtime-common/src/integrity.rs
@@ -204,9 +204,9 @@ where
 	MI: 'static,
 {
 	assert!(
-		R::MaxMessagesToPruneAtOnce::get() > 0,
-		"MaxMessagesToPruneAtOnce ({}) must be larger than zero",
-		R::MaxMessagesToPruneAtOnce::get(),
+		R::ActiveOutboundLanes::get().len() > 0,
+		"ActiveOutboundLanes ({:?}) must not be empty",
+		R::ActiveOutboundLanes::get(),
 	);
 	assert!(
 		R::MaxUnrewardedRelayerEntriesAtInboundLane::get() <= params.max_unrewarded_relayers_in_bridged_confirmation_tx,

--- a/bin/runtime-common/src/integrity.rs
+++ b/bin/runtime-common/src/integrity.rs
@@ -204,7 +204,7 @@ where
 	MI: 'static,
 {
 	assert!(
-		R::ActiveOutboundLanes::get().len() > 0,
+		!R::ActiveOutboundLanes::get().is_empty(),
 		"ActiveOutboundLanes ({:?}) must not be empty",
 		R::ActiveOutboundLanes::get(),
 	);

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -217,7 +217,7 @@ pub mod pallet {
 			let mut active_lane = outbound_lane::<T, I>(active_lane_id);
 			let mut used_weight = db_weight.reads(1);
 			// and here we'll have writes
-			used_weight -= active_lane.prune_messages(db_weight, remaining_weight);
+			used_weight += active_lane.prune_messages(db_weight, remaining_weight);
 
 			// we already checked we have enough `remaining_weight` to cover this `used_weight`
 			used_weight

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -1760,28 +1760,41 @@ mod tests {
 			System::<TestRuntime>::set_block_number(2);
 
 			// if passed wight is too low to do anything
-			Pallet::<TestRuntime, ()>::on_idle(0, DbWeight::get().reads_writes(1, 1));
+			let dbw = DbWeight::get();
+			assert_eq!(
+				Pallet::<TestRuntime, ()>::on_idle(0, dbw.reads_writes(1, 1)),
+				Weight::zero(),
+			);
 			assert_eq!(
 				outbound_lane::<TestRuntime, ()>(TEST_LANE_ID).data().oldest_unpruned_nonce,
 				1
 			);
 
 			// if passed wight is enough to prune single message
-			Pallet::<TestRuntime, ()>::on_idle(0, DbWeight::get().reads_writes(1, 2));
+			assert_eq!(
+				Pallet::<TestRuntime, ()>::on_idle(0, dbw.reads_writes(1, 2)),
+				dbw.reads_writes(1, 2),
+			);
 			assert_eq!(
 				outbound_lane::<TestRuntime, ()>(TEST_LANE_ID).data().oldest_unpruned_nonce,
 				2
 			);
 
 			// if passed wight is enough to prune two more messages
-			Pallet::<TestRuntime, ()>::on_idle(0, DbWeight::get().reads_writes(1, 3));
+			assert_eq!(
+				Pallet::<TestRuntime, ()>::on_idle(0, dbw.reads_writes(1, 3)),
+				dbw.reads_writes(1, 3),
+			);
 			assert_eq!(
 				outbound_lane::<TestRuntime, ()>(TEST_LANE_ID).data().oldest_unpruned_nonce,
 				4
 			);
 
 			// if passed wight is enough to prune many messages
-			Pallet::<TestRuntime, ()>::on_idle(0, DbWeight::get().reads_writes(100, 100));
+			assert_eq!(
+				Pallet::<TestRuntime, ()>::on_idle(0, dbw.reads_writes(100, 100)),
+				dbw.reads_writes(1, 2),
+			);
 			assert_eq!(
 				outbound_lane::<TestRuntime, ()>(TEST_LANE_ID).data().oldest_unpruned_nonce,
 				5
@@ -1839,8 +1852,12 @@ mod tests {
 			);
 
 			// in block#2.on_idle lane messages of lane 1 are pruned
+			let dbw = DbWeight::get();
 			System::<TestRuntime>::set_block_number(2);
-			Pallet::<TestRuntime, ()>::on_idle(0, DbWeight::get().reads_writes(100, 100));
+			assert_eq!(
+				Pallet::<TestRuntime, ()>::on_idle(0, dbw.reads_writes(100, 100)),
+				dbw.reads_writes(1, 2),
+			);
 			assert_eq!(
 				outbound_lane::<TestRuntime, ()>(TEST_LANE_ID).data().oldest_unpruned_nonce,
 				2
@@ -1852,7 +1869,11 @@ mod tests {
 
 			// in block#3.on_idle lane messages of lane 2 are pruned
 			System::<TestRuntime>::set_block_number(3);
-			Pallet::<TestRuntime, ()>::on_idle(0, DbWeight::get().reads_writes(100, 100));
+
+			assert_eq!(
+				Pallet::<TestRuntime, ()>::on_idle(0, dbw.reads_writes(100, 100)),
+				dbw.reads_writes(1, 2),
+			);
 			assert_eq!(
 				outbound_lane::<TestRuntime, ()>(TEST_LANE_ID).data().oldest_unpruned_nonce,
 				2

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -215,14 +215,12 @@ pub mod pallet {
 
 			// first db read - outbound lane state
 			let mut active_lane = outbound_lane::<T, I>(active_lane_id);
-			let original_remaining_weight = remaining_weight;
-			remaining_weight -= db_weight.reads(1);
-			// and here we'll have writes. It is safe to do regular subtraction, since
-			// `prune_messages` respects the `remaining_weight`
-			remaining_weight -= active_lane.prune_messages(db_weight, remaining_weight);
+			let mut used_weight = db_weight.reads(1);
+			// and here we'll have writes
+			used_weight -= active_lane.prune_messages(db_weight, remaining_weight);
 
-			// safe to use regular subtraction, since we respect the `remaining_weight`
-			original_remaining_weight - remaining_weight
+			// we already checked we have enough `remaining_weight` to cover this `used_weight`
+			used_weight
 		}
 	}
 

--- a/modules/messages/src/mock.rs
+++ b/modules/messages/src/mock.rs
@@ -196,6 +196,9 @@ pub const TEST_LANE_ID: LaneId = [0, 0, 0, 1];
 /// Secondary lane that we're using in tests.
 pub const TEST_LANE_ID_2: LaneId = [0, 0, 0, 2];
 
+/// Inactive outbound lane.
+pub const TEST_LANE_ID_3: LaneId = [0, 0, 0, 3];
+
 /// Regular message payload.
 pub const REGULAR_PAYLOAD: TestPayload = message_payload(0, 50);
 

--- a/modules/messages/src/mock.rs
+++ b/modules/messages/src/mock.rs
@@ -144,12 +144,13 @@ parameter_types! {
 	pub const MaxUnrewardedRelayerEntriesAtInboundLane: u64 = 16;
 	pub const MaxUnconfirmedMessagesAtInboundLane: u64 = 32;
 	pub const TestBridgedChainId: bp_runtime::ChainId = *b"test";
+	pub const ActiveOutboundLanes: &'static [LaneId] = &[TEST_LANE_ID, TEST_LANE_ID_2];
 }
 
 impl Config for TestRuntime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
-	type MaxMessagesToPruneAtOnce = MaxMessagesToPruneAtOnce;
+	type ActiveOutboundLanes = ActiveOutboundLanes;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = MaxUnrewardedRelayerEntriesAtInboundLane;
 	type MaxUnconfirmedMessagesAtInboundLane = MaxUnconfirmedMessagesAtInboundLane;
 
@@ -196,6 +197,9 @@ pub const TEST_ERROR: &str = "Test error";
 
 /// Lane that we're using in tests.
 pub const TEST_LANE_ID: LaneId = [0, 0, 0, 1];
+
+/// Secondary lane that we're using in tests.
+pub const TEST_LANE_ID_2: LaneId = [0, 0, 0, 2];
 
 /// Regular message payload.
 pub const REGULAR_PAYLOAD: TestPayload = message_payload(0, 50);

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -91,13 +91,14 @@ impl pallet_balances::Config for TestRuntime {
 
 parameter_types! {
 	pub const TestBridgedChainId: bp_runtime::ChainId = *b"test";
+	pub ActiveOutboundLanes: &'static [bp_messages::LaneId] = &[[0, 0, 0, 0]];
 }
 
 // we're not testing messages pallet here, so values in this config might be crazy
 impl pallet_bridge_messages::Config for TestRuntime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = ();
-	type MaxMessagesToPruneAtOnce = frame_support::traits::ConstU64<0>;
+	type ActiveOutboundLanes = ActiveOutboundLanes;
 	type MaxUnrewardedRelayerEntriesAtInboundLane = frame_support::traits::ConstU64<8>;
 	type MaxUnconfirmedMessagesAtInboundLane = frame_support::traits::ConstU64<8>;
 


### PR DESCRIPTION
part of #1647

Pruning from on-idle isn't that easy, since we support multiple lanes and (I believe) we may actually use other lanes in the future - e.g. to prioritize some bridge over others or to increase bridge bandwidth. But then to prune messages we need to iterate all lanes and check if those have unpruned messages. Iterating = db read and if we'll be reading lane state it at every on-idle call, we may run out of remaining weight without doing any actual work. So instead I've added `ActiveOutboundLanes` to the messages pallet configuration and we're pruning only one lane per block (`block_number % lanes_len`). This still may cause troubles in the future, but for our start it is fine