### PR TITLE
Added event `MessagesReceived` for better visibility on receiving side

### DIFF
--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -20,10 +20,9 @@ use crate::Config;
 
 use bp_messages::{
 	target_chain::{DispatchMessage, DispatchMessageData, MessageDispatch},
-	DeliveredMessages, InboundLaneData, LaneId, MessageKey, MessageNonce, NotDispatchedReason,
-	OutboundLaneData, ReceivedMessageResult, UnrewardedRelayer,
+	DeliveredMessages, InboundLaneData, LaneId, MessageKey, MessageNonce, OutboundLaneData,
+	ReceivalResult, UnrewardedRelayer,
 };
-use bp_runtime::messages::MessageDispatchResult;
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
 use frame_support::{traits::Get, RuntimeDebug};
 use scale_info::{Type, TypeInfo};
@@ -105,35 +104,6 @@ impl<T: Config<I>, I: 'static> MaxEncodedLen for StoredInboundLaneData<T, I> {
 			T::MaxUnconfirmedMessagesAtInboundLane::get() as usize,
 		)
 		.unwrap_or(usize::MAX)
-	}
-}
-
-/// Result of single message receival.
-#[derive(RuntimeDebug, PartialEq, Eq)]
-pub enum ReceivalResult {
-	/// Message has been received and dispatched. Note that we don't care whether dispatch has
-	/// been successful or not - in both case message falls into this category.
-	///
-	/// The message dispatch result is also returned.
-	Dispatched(MessageDispatchResult),
-	/// Message has invalid nonce and lane has rejected to accept this message.
-	InvalidNonce,
-	/// There are too many unrewarded relayer entries at the lane.
-	TooManyUnrewardedRelayers,
-	/// There are too many unconfirmed messages at the lane.
-	TooManyUnconfirmedMessages,
-}
-
-impl From<ReceivalResult> for ReceivedMessageResult {
-	fn from(value: ReceivalResult) -> Self {
-		match value {
-			ReceivalResult::Dispatched(_) => ReceivedMessageResult::Dispatched,
-			ReceivalResult::InvalidNonce => NotDispatchedReason::InvalidNonce.into(),
-			ReceivalResult::TooManyUnrewardedRelayers =>
-				NotDispatchedReason::TooManyUnrewardedRelayers.into(),
-			ReceivalResult::TooManyUnconfirmedMessages =>
-				NotDispatchedReason::TooManyUnconfirmedMessages.into(),
-		}
 	}
 }
 

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -20,8 +20,8 @@ use crate::Config;
 
 use bp_messages::{
 	target_chain::{DispatchMessage, DispatchMessageData, MessageDispatch},
-	DeliveredMessages, InboundLaneData, LaneId, MessageKey, MessageNonce, OutboundLaneData,
-	UnrewardedRelayer,
+	DeliveredMessages, InboundLaneData, LaneId, MessageKey, MessageNonce, NotDispatchedReason,
+	OutboundLaneData, ReceivedMessageResult, UnrewardedRelayer,
 };
 use bp_runtime::messages::MessageDispatchResult;
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
@@ -122,6 +122,19 @@ pub enum ReceivalResult {
 	TooManyUnrewardedRelayers,
 	/// There are too many unconfirmed messages at the lane.
 	TooManyUnconfirmedMessages,
+}
+
+impl From<ReceivalResult> for ReceivedMessageResult {
+	fn from(value: ReceivalResult) -> Self {
+		match value {
+			ReceivalResult::Dispatched(_) => ReceivedMessageResult::Dispatched,
+			ReceivalResult::InvalidNonce => NotDispatchedReason::InvalidNonce.into(),
+			ReceivalResult::TooManyUnrewardedRelayers =>
+				NotDispatchedReason::TooManyUnrewardedRelayers.into(),
+			ReceivalResult::TooManyUnconfirmedMessages =>
+				NotDispatchedReason::TooManyUnconfirmedMessages.into(),
+		}
+	}
 }
 
 /// Inbound messages lane.

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -181,12 +181,12 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 	}
 
 	/// Receive new message.
-	pub fn receive_message<P: MessageDispatch<AccountId>, AccountId>(
+	pub fn receive_message<Dispatch: MessageDispatch<AccountId>, AccountId>(
 		&mut self,
 		relayer_at_bridged_chain: &S::Relayer,
 		relayer_at_this_chain: &AccountId,
 		nonce: MessageNonce,
-		message_data: DispatchMessageData<P::DispatchPayload>,
+		message_data: DispatchMessageData<Dispatch::DispatchPayload>,
 	) -> ReceivalResult {
 		let mut data = self.storage.data();
 		let is_correct_message = nonce == data.last_delivered_nonce() + 1;
@@ -206,7 +206,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		}
 
 		// then, dispatch message
-		let dispatch_result = P::dispatch(
+		let dispatch_result = Dispatch::dispatch(
 			relayer_at_this_chain,
 			DispatchMessage {
 				key: MessageKey { lane_id: self.storage.id(), nonce },

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -91,6 +91,7 @@ pub const LOG_TARGET: &str = "runtime::bridge-messages";
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
+	use bp_messages::{NotDispatchedReason, ReceivedMessageResult, ReceivedMessages};
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 
@@ -298,6 +299,7 @@ pub mod pallet {
 			// dispatch messages and (optionally) update lane(s) state(s)
 			let mut total_messages = 0;
 			let mut valid_messages = 0;
+			let mut messages_received_status = Vec::with_capacity(messages.len());
 			let mut dispatch_weight_left = dispatch_weight;
 			for (lane_id, lane_data) in messages {
 				let mut lane = inbound_lane::<T, I>(lane_id);
@@ -314,24 +316,41 @@ pub mod pallet {
 					}
 				}
 
+				let mut lane_messages_received_status =
+					Vec::with_capacity(lane_data.messages.len());
+				let mut is_lane_processing_stopped_no_weight_left = false;
+
 				for mut message in lane_data.messages {
 					debug_assert_eq!(message.key.lane_id, lane_id);
+					total_messages += 1;
+
+					if is_lane_processing_stopped_no_weight_left {
+						lane_messages_received_status.push((
+							message.key.nonce,
+							NotDispatchedReason::NotEnoughWeightForLane.into(),
+						));
+						continue
+					}
 
 					// ensure that relayer has declared enough weight for dispatching next message
 					// on this lane. We can't dispatch lane messages out-of-order, so if declared
 					// weight is not enough, let's move to next lane
-					let dispatch_weight = T::MessageDispatch::dispatch_weight(&mut message);
-					if dispatch_weight.any_gt(dispatch_weight_left) {
+					let message_dispatch_weight = T::MessageDispatch::dispatch_weight(&mut message);
+					if message_dispatch_weight.any_gt(dispatch_weight_left) {
 						log::trace!(
 							target: LOG_TARGET,
 							"Cannot dispatch any more messages on lane {:?}. Weight: declared={}, left={}",
 							lane_id,
-							dispatch_weight,
+							message_dispatch_weight,
 							dispatch_weight_left,
 						);
-						break
+						lane_messages_received_status.push((
+							message.key.nonce,
+							NotDispatchedReason::NotEnoughWeightForLane.into(),
+						));
+						is_lane_processing_stopped_no_weight_left = true;
+						continue
 					}
-					total_messages += 1;
 
 					let receival_result = lane.receive_message::<T::MessageDispatch, T::AccountId>(
 						&relayer_id_at_bridged_chain,
@@ -349,18 +368,38 @@ pub mod pallet {
 					let (unspent_weight, refund_pay_dispatch_fee) = match receival_result {
 						ReceivalResult::Dispatched(dispatch_result) => {
 							valid_messages += 1;
+							lane_messages_received_status
+								.push((message.key.nonce, ReceivedMessageResult::Dispatched));
 							(
 								dispatch_result.unspent_weight,
 								!dispatch_result.dispatch_fee_paid_during_dispatch,
 							)
 						},
-						ReceivalResult::InvalidNonce |
-						ReceivalResult::TooManyUnrewardedRelayers |
-						ReceivalResult::TooManyUnconfirmedMessages => (dispatch_weight, true),
+						ReceivalResult::InvalidNonce => {
+							lane_messages_received_status.push((
+								message.key.nonce,
+								NotDispatchedReason::InvalidNonce.into(),
+							));
+							(message_dispatch_weight, true)
+						},
+						ReceivalResult::TooManyUnrewardedRelayers => {
+							lane_messages_received_status.push((
+								message.key.nonce,
+								NotDispatchedReason::TooManyUnrewardedRelayers.into(),
+							));
+							(message_dispatch_weight, true)
+						},
+						ReceivalResult::TooManyUnconfirmedMessages => {
+							lane_messages_received_status.push((
+								message.key.nonce,
+								NotDispatchedReason::TooManyUnconfirmedMessages.into(),
+							));
+							(message_dispatch_weight, true)
+						},
 					};
 
-					let unspent_weight = unspent_weight.min(dispatch_weight);
-					dispatch_weight_left -= dispatch_weight - unspent_weight;
+					let unspent_weight = unspent_weight.min(message_dispatch_weight);
+					dispatch_weight_left -= message_dispatch_weight - unspent_weight;
 					actual_weight = actual_weight.saturating_sub(unspent_weight).saturating_sub(
 						// delivery call weight formula assumes that the fee is paid at
 						// this (target) chain. If the message is prepaid at the source
@@ -372,9 +411,12 @@ pub mod pallet {
 						},
 					);
 				}
+
+				messages_received_status
+					.push(ReceivedMessages::new(lane_id, lane_messages_received_status));
 			}
 
-			log::trace!(
+			log::debug!(
 				target: LOG_TARGET,
 				"Received messages: total={}, valid={}. Weight used: {}/{}",
 				total_messages,
@@ -382,6 +424,8 @@ pub mod pallet {
 				actual_weight,
 				declared_weight,
 			);
+
+			Self::deposit_event(Event::MessagesReceived(messages_received_status));
 
 			Ok(PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee: Pays::Yes })
 		}
@@ -494,6 +538,8 @@ pub mod pallet {
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// Message has been accepted and is waiting to be delivered.
 		MessageAccepted { lane_id: LaneId, nonce: MessageNonce },
+		/// Messages have been received from the bridged chain.
+		MessagesReceived(Vec<ReceivedMessages<ReceivedMessageResult>>),
 		/// Messages in the inclusive range have been delivered to the bridged chain.
 		MessagesDelivered { lane_id: LaneId, messages: DeliveredMessages },
 	}

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -221,13 +221,25 @@ pub struct UnrewardedRelayer<RelayerId> {
 /// Received messages with their dispatch result.
 #[derive(Clone, Default, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo)]
 pub struct ReceivedMessages<Result> {
+	/// Id of the lane which is receiving messages.
 	pub lane: LaneId,
+	/// Result of messages which we tried to dispatch
 	pub receive_results: Vec<(MessageNonce, Result)>,
+	/// Messages which were skipped and never dispatched
+	pub skipped_for_not_enough_weight: Vec<MessageNonce>,
 }
 
 impl<Result> ReceivedMessages<Result> {
 	pub fn new(lane: LaneId, receive_results: Vec<(MessageNonce, Result)>) -> Self {
-		ReceivedMessages { lane, receive_results }
+		ReceivedMessages { lane, receive_results, skipped_for_not_enough_weight: Vec::new() }
+	}
+
+	pub fn push(&mut self, message: MessageNonce, result: Result) {
+		self.receive_results.push((message, result));
+	}
+
+	pub fn push_skipped_for_not_enough_weight(&mut self, message: MessageNonce) {
+		self.skipped_for_not_enough_weight.push(message);
 	}
 }
 
@@ -252,8 +264,6 @@ pub enum NotDispatchedReason {
 	TooManyUnrewardedRelayers,
 	/// There are too many unconfirmed messages at the lane.
 	TooManyUnconfirmedMessages,
-	/// There are too many unconfirmed messages at the lane.
-	NotEnoughWeightForLane,
 }
 
 impl From<NotDispatchedReason> for ReceivedMessageResult {

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -32,6 +32,7 @@ pub mod storage_keys;
 pub mod target_chain;
 
 // Weight is reexported to avoid additional frame-support dependencies in related crates.
+use bp_runtime::messages::MessageDispatchResult;
 pub use frame_support::weights::Weight;
 
 /// Messages pallet operating mode.
@@ -245,31 +246,18 @@ impl<Result> ReceivedMessages<Result> {
 
 /// Result of single message receival.
 #[derive(RuntimeDebug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo)]
-pub enum ReceivedMessageResult {
+pub enum ReceivalResult {
 	/// Message has been received and dispatched. Note that we don't care whether dispatch has
 	/// been successful or not - in both case message falls into this category.
 	///
 	/// The message dispatch result is also returned.
-	Dispatched,
-	/// Reason why messages was not dispatched
-	NotDispatched(NotDispatchedReason),
-}
-
-/// Result of single message receival.
-#[derive(RuntimeDebug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo)]
-pub enum NotDispatchedReason {
+	Dispatched(MessageDispatchResult),
 	/// Message has invalid nonce and lane has rejected to accept this message.
 	InvalidNonce,
 	/// There are too many unrewarded relayer entries at the lane.
 	TooManyUnrewardedRelayers,
 	/// There are too many unconfirmed messages at the lane.
 	TooManyUnconfirmedMessages,
-}
-
-impl From<NotDispatchedReason> for ReceivedMessageResult {
-	fn from(value: NotDispatchedReason) -> Self {
-		ReceivedMessageResult::NotDispatched(value)
-	}
 }
 
 /// Delivered messages with their dispatch result.

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -218,6 +218,50 @@ pub struct UnrewardedRelayer<RelayerId> {
 	pub messages: DeliveredMessages,
 }
 
+/// Received messages with their dispatch result.
+#[derive(Clone, Default, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo)]
+pub struct ReceivedMessages<Result> {
+	pub lane: LaneId,
+	pub receive_results: Vec<(MessageNonce, Result)>,
+}
+
+impl<Result> ReceivedMessages<Result> {
+	pub fn new(lane: LaneId, receive_results: Vec<(MessageNonce, Result)>) -> Self {
+		ReceivedMessages { lane, receive_results }
+	}
+}
+
+/// Result of single message receival.
+#[derive(RuntimeDebug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo)]
+pub enum ReceivedMessageResult {
+	/// Message has been received and dispatched. Note that we don't care whether dispatch has
+	/// been successful or not - in both case message falls into this category.
+	///
+	/// The message dispatch result is also returned.
+	Dispatched,
+	/// Reason why messages was not dispatched
+	NotDispatched(NotDispatchedReason),
+}
+
+/// Result of single message receival.
+#[derive(RuntimeDebug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo)]
+pub enum NotDispatchedReason {
+	/// Message has invalid nonce and lane has rejected to accept this message.
+	InvalidNonce,
+	/// There are too many unrewarded relayer entries at the lane.
+	TooManyUnrewardedRelayers,
+	/// There are too many unconfirmed messages at the lane.
+	TooManyUnconfirmedMessages,
+	/// There are too many unconfirmed messages at the lane.
+	NotEnoughWeightForLane,
+}
+
+impl From<NotDispatchedReason> for ReceivedMessageResult {
+	fn from(value: NotDispatchedReason) -> Self {
+		ReceivedMessageResult::NotDispatched(value)
+	}
+}
+
 /// Delivered messages with their dispatch result.
 #[derive(Clone, Default, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo)]
 pub struct DeliveredMessages {

--- a/scripts/send-message-from-millau-rialto.sh
+++ b/scripts/send-message-from-millau-rialto.sh
@@ -6,6 +6,8 @@
 # we have (to make sure the message relays are running), but remove the message
 # generator service. From there you may submit messages manually using this script.
 
+# TODO: Fix demeo scripts https://github.com/paritytech/parity-bridges-common/issues/1406
+
 MILLAU_PORT="${RIALTO_PORT:-9945}"
 
 case "$1" in

--- a/scripts/send-message-from-millau-rialto.sh
+++ b/scripts/send-message-from-millau-rialto.sh
@@ -15,10 +15,7 @@ case "$1" in
 			--source-host localhost \
 			--source-port $MILLAU_PORT \
 			--source-signer //Alice \
-			--target-signer //Bob \
-			--lane 00000000 \
-			--origin Target \
-			remark \
+			raw 020419ac
 		;;
 	transfer)
 		RUST_LOG=runtime=trace,substrate-relay=trace,bridge=trace \
@@ -26,9 +23,6 @@ case "$1" in
 			--source-host localhost \
 			--source-port $MILLAU_PORT \
 			--source-signer //Alice \
-			--target-signer //Bob \
-			--lane 00000000 \
-			--origin Target \
 			transfer \
 			--amount 100000000000000 \
 			--recipient 5DZvVvd1udr61vL7Xks17TFQ4fi9NiagYLaBobnbPCP14ewA \

--- a/scripts/send-message-from-rialto-millau.sh
+++ b/scripts/send-message-from-rialto-millau.sh
@@ -14,21 +14,15 @@ case "$1" in
 		./target/debug/substrate-relay send-message rialto-to-millau \
 			--source-host localhost \
 			--source-port $RIALTO_PORT \
-			--target-signer //Alice \
 			--source-signer //Bob \
-			--lane 00000000 \
-			--origin Target \
-			remark \
+			raw 020419ac
 		;;
 	transfer)
 		RUST_LOG=runtime=trace,substrate-relay=trace,bridge=trace \
 		./target/debug/substrate-relay send-message rialto-to-millau \
 			--source-host localhost \
 			--source-port $RIALTO_PORT \
-			--target-signer //Alice \
 			--source-signer //Bob \
-			--lane 00000000 \
-			--origin Target \
 			transfer \
 			--amount 100000000000000 \
 			--recipient 5DZvVvd1udr61vL7Xks17TFQ4fi9NiagYLaBobnbPCP14ewA \

--- a/scripts/send-message-from-rialto-millau.sh
+++ b/scripts/send-message-from-rialto-millau.sh
@@ -6,6 +6,8 @@
 # we have (to make sure the message relays are running), but remove the message
 # generator service. From there you may submit messages manually using this script.
 
+# TODO: Fix demeo scripts https://github.com/paritytech/parity-bridges-common/issues/1406
+
 RIALTO_PORT="${RIALTO_PORT:-9944}"
 
 case "$1" in


### PR DESCRIPTION
We generate (messages) events only on source chain, so this adds event on target chain, it could help better understand and see and anaylze what is going on, better visibility, e.g. at least, we could see easily in polkadot.js in what block messages were received.
If this will be too much overhead, later we could remove that or just add there only some counters.


plus trying to fix https://substrate.stackexchange.com/questions/5901/failed-to-run-parity-bridges-common-message-realy-demo/5906?noredirect=1#comment5781_5906