### PR TITLE
`dry-run` mode for init bridge command

### DIFF
--- a/primitives/messages/src/target_chain.rs
+++ b/primitives/messages/src/target_chain.rs
@@ -90,7 +90,7 @@ pub trait MessageDispatch<AccountId> {
 	type DispatchPayload: Decode;
 
 	/// Fine-grained result of single message dispatch (for better diagnostic purposes)
-	type DispatchLevelResult: Clone + Decode + sp_std::fmt::Debug + Eq;
+	type DispatchLevelResult: Clone + sp_std::fmt::Debug + Eq;
 
 	/// Estimate dispatch weight.
 	///

--- a/relays/bin-substrate/src/cli/init_bridge.rs
+++ b/relays/bin-substrate/src/cli/init_bridge.rs
@@ -99,7 +99,7 @@ where
 				log::info!(
 					target: "bridge",
 					"Initialize bridge call encoded as hex string: {:?}",
-					format!("0x{}", hex::encode(&call.encode()))
+					format!("0x{}", hex::encode(call.encode()))
 				);
 				Ok(UnsignedTransaction::new(call.into(), transaction_nonce))
 			},

--- a/relays/bin-substrate/src/cli/init_bridge.rs
+++ b/relays/bin-substrate/src/cli/init_bridge.rs
@@ -15,6 +15,7 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use async_trait::async_trait;
+use codec::Encode;
 
 use crate::{
 	chains::{
@@ -46,6 +47,9 @@ pub struct InitBridge {
 	target: TargetConnectionParams,
 	#[structopt(flatten)]
 	target_sign: TargetSigningParams,
+	/// Generates all required data, but does not submit extrinsic
+	#[structopt(long)]
+	dry_run: bool,
 }
 
 #[derive(Debug, EnumString, EnumVariantNames)]
@@ -77,6 +81,7 @@ where
 		let source_client = data.source.into_client::<Self::Source>().await?;
 		let target_client = data.target.into_client::<Self::Target>().await?;
 		let target_sign = data.target_sign.to_keypair::<Self::Target>()?;
+		let dry_run = data.dry_run;
 
 		let (spec_version, transaction_version) = target_client.simple_runtime_version().await?;
 		substrate_relay_helper::finality::initialize::initialize::<Self::Engine, _, _, _>(
@@ -90,11 +95,15 @@ where
 				signer: target_sign,
 			},
 			move |transaction_nonce, initialization_data| {
-				Ok(UnsignedTransaction::new(
-					Self::encode_init_bridge(initialization_data).into(),
-					transaction_nonce,
-				))
+				let call = Self::encode_init_bridge(initialization_data);
+				log::info!(
+					target: "bridge",
+					"Initialize bridge call encoded as hex string: {:?}",
+					format!("0x{}", hex::encode(&call.encode()))
+				);
+				Ok(UnsignedTransaction::new(call.into(), transaction_nonce))
 			},
+			dry_run,
 		)
 		.await;
 

--- a/relays/lib-substrate-relay/src/finality/initialize.rs
+++ b/relays/lib-substrate-relay/src/finality/initialize.rs
@@ -134,9 +134,9 @@ where
 			move |_, transaction_nonce| {
 				let tx = prepare_initialize_transaction(transaction_nonce, initialization_data);
 				if dry_run {
-					Err(SubstrateError::Custom(format!(
-						"Not submitting extrinsic in `dry-run` mode!"
-					)))
+					Err(SubstrateError::Custom(
+						"Not submitting extrinsic in `dry-run` mode!".to_string(),
+					))
 				} else {
 					tx
 				}

--- a/relays/lib-substrate-relay/src/finality/initialize.rs
+++ b/relays/lib-substrate-relay/src/finality/initialize.rs
@@ -40,6 +40,7 @@ pub async fn initialize<
 	target_transactions_signer: TargetChain::AccountId,
 	target_signing_data: SignParam<TargetChain>,
 	prepare_initialize_transaction: F,
+	dry_run: bool,
 ) where
 	F: FnOnce(
 			TargetChain::Index,
@@ -54,6 +55,7 @@ pub async fn initialize<
 		target_transactions_signer,
 		target_signing_data,
 		prepare_initialize_transaction,
+		dry_run,
 	)
 	.await;
 
@@ -88,6 +90,7 @@ async fn do_initialize<
 	target_transactions_signer: TargetChain::AccountId,
 	target_signing_data: SignParam<TargetChain>,
 	prepare_initialize_transaction: F,
+	dry_run: bool,
 ) -> Result<
 	Option<TargetChain::Hash>,
 	Error<SourceChain::Hash, <SourceChain::Header as HeaderT>::Number>,
@@ -110,7 +113,9 @@ where
 			SourceChain::NAME,
 			TargetChain::NAME,
 		);
-		return Ok(None)
+		if !dry_run {
+			return Ok(None)
+		}
 	}
 
 	let initialization_data = E::prepare_initialization_data(source_client).await?;
@@ -127,7 +132,14 @@ where
 			target_transactions_signer,
 			target_signing_data,
 			move |_, transaction_nonce| {
-				prepare_initialize_transaction(transaction_nonce, initialization_data)
+				let tx = prepare_initialize_transaction(transaction_nonce, initialization_data);
+				if dry_run {
+					Err(SubstrateError::Custom(format!(
+						"Not submitting extrinsic in `dry-run` mode!"
+					)))
+				} else {
+					tx
+				}
 			},
 		)
 		.await


### PR DESCRIPTION
this logs encoded call, which can be decoded with: `https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/extrinsics/decode`

```
2022-12-01 13:18:05 +00 INFO bridge Connecting to Millau node at ws://localhost:9945
2022-12-01 13:18:05 +00 INFO bridge Connecting to Rialto node at ws://localhost:9944
2022-12-01 13:18:05 +00 INFO bridge Millau-headers bridge at Rialto is already initialized. Skipping
2022-12-01 13:18:06 +00 INFO bridge Prepared initialization data for Millau-headers bridge at Rialto: InitializationData { header: Header { parent_hash: 0x706da343a66a7418a5da14f0c73b0954057d9c204eef51666457d1c26a73fff5e1229b75db928c363ca907b01d332fd1cf7a1b0a1972147169b961cecdcc7cd2, number: 367, state_root: 0xcf087713bce805f36c875b5a8e36cc7becda55f0e6164364b67c52f5646d862f22df29ae6be5a29fc70b8fbe3689f60848bd8b1e8fe6c876b6694b62210787c1, extrinsics_root: 0x879e2c3f57009eb6e588155a7d8734c91633fa80947e0eadcaa6fdf47d9a2cdf2cee18c0d6e18697a77b88373558fe82a3b42be74f18295c664faa109409751d, digest: Digest { logs: [DigestItem::PreRuntime([97, 117, 114, 97], [235, 198, 150, 16, 0, 0, 0, 0]), DigestItem::Consensus([66, 69, 69, 70], [3, 67, 241, 226, 32, 0, 48, 31, 116, 246, 36, 233, 133, 105, 90, 91, 39, 102, 115, 164, 43, 247, 172, 130, 208, 235, 110, 12, 193, 255, 232, 213, 248]), DigestItem::Seal([97, 117, 114, 97], [120, 114, 152, 244, 122, 30, 200, 107, 184, 228, 36, 100, 74, 70, 234, 146, 164, 211, 83, 110, 242, 187, 153, 185, 43, 208, 162, 229, 156, 197, 102, 21, 79, 100, 17, 196, 30, 240, 147, 25, 167, 182, 42, 214, 204, 12, 58, 137, 186, 105, 60, 171, 90, 31, 235, 58, 45, 74, 225, 141, 228, 101, 81, 137])] } }, authority_list: [(Public(88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee (5FA9nQDV...)), 1)], set_id: 6, operating_mode: BasicOperatingMode::Normal }
2022-12-01 13:18:06 +00 INFO bridge Initialize bridge call encoded as hex string: "0x01000e01706da343a66a7418a5da14f0c73b0954057d9c204eef51666457d1c26a73fff5e1229b75db928c363ca907b01d332fd1cf7a1b0a1972147169b961cecdcc7cd2bd05cf087713bce805f36c875b5a8e36cc7becda55f0e6164364b67c52f5646d862f22df29ae6be5a29fc70b8fbe3689f60848bd8b1e8fe6c876b6694b62210787c1879e2c3f57009eb6e588155a7d8734c91633fa80947e0eadcaa6fdf47d9a2cdf2cee18c0d6e18697a77b88373558fe82a3b42be74f18295c664faa109409751d0c066175726120ebc69610000000000442454546840343f1e22000301f74f624e985695a5b276673a42bf7ac82d0eb6e0cc1ffe8d5f805617572610101787298f47a1ec86bb8e424644a46ea92a4d3536ef2bb99b92bd0a2e59cc566154f6411c41ef09319a7b62ad6cc0c3a89ba693cab5a1feb3a2d4ae18de46551890488dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee0100000000000000060000000000000000"
2022-12-01 13:18:06 +00 ERROR bridge Failed to submit Millau-headers bridge initialization transaction to Rialto: SubmitTransaction("Rialto", Custom("Not submitting extrinsic in `dry-run` mode!"))
```