### PR TITLE
added version guards to RBH<>WBH GRANDPA finality (and complex) relay

### DIFF
--- a/relays/bin-substrate/src/chains/rococo_headers_to_bridge_hub_wococo.rs
+++ b/relays/bin-substrate/src/chains/rococo_headers_to_bridge_hub_wococo.rs
@@ -17,8 +17,12 @@
 //! Rococo-to-Wococo bridge hubs headers sync entrypoint.
 
 use crate::cli::bridge::{CliBridgeBase, RelayToRelayHeadersCliBridge};
-use substrate_relay_helper::finality::{
-	engine::Grandpa as GrandpaFinalityEngine, SubstrateFinalitySyncPipeline,
+
+use async_trait::async_trait;
+use relay_substrate_client::{AccountKeyPairOf, Client};
+use substrate_relay_helper::{
+	finality::{engine::Grandpa as GrandpaFinalityEngine, SubstrateFinalitySyncPipeline},
+	TransactionParams,
 };
 
 /// Description of Rococo -> Wococo finalized headers bridge.
@@ -32,12 +36,27 @@ substrate_relay_helper::generate_mocked_submit_finality_proof_call_builder!(
 	relay_bridge_hub_wococo_client::runtime::BridgeGrandpaRococoCall::submit_finality_proof
 );
 
+#[async_trait]
 impl SubstrateFinalitySyncPipeline for RococoFinalityToBridgeHubWococo {
 	type SourceChain = relay_rococo_client::Rococo;
 	type TargetChain = relay_bridge_hub_wococo_client::BridgeHubWococo;
 
 	type FinalityEngine = GrandpaFinalityEngine<Self::SourceChain>;
 	type SubmitFinalityProofCallBuilder = RococoFinalityToBridgeHubWococoCallBuilder;
+
+	async fn start_relay_guards(
+		target_client: &Client<Self::TargetChain>,
+		_transaction_params: &TransactionParams<AccountKeyPairOf<Self::TargetChain>>,
+		enable_version_guard: bool,
+	) -> relay_substrate_client::Result<()> {
+		if enable_version_guard {
+			relay_substrate_client::guard::abort_on_spec_version_change(
+				target_client.clone(),
+				target_client.simple_runtime_version().await?.0,
+			);
+		}
+		Ok(())
+	}
 }
 
 /// `Rococo` to BridgeHub `Wococo` bridge definition.


### PR DESCRIPTION
closes #1629 

https://github.com/paritytech/parity-bridges-common/issues/1629#issuecomment-1331950764 . @bkontur what it means is that if `*-version-mode` is set to `Bundle` (default) or `Custom`, the complex relay will abort when the runtime version of chain changes (after runtime upgrade). An alternative for Rococo<>Wococo would be to set version mode to `Auto` (so it'll read version from the node it is connected) or to release relay version every time we do runtime upgrade.

For Kusama<>Polkadot we shall use `Bundle` and release relay version every time it is upgraded (we may discuss it later). For testnets the `Auto`option is easier (we don't care about losing test tokens). 