### PR TITLE
Handle `SIGTERM` for the docker containers + relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10472,12 +10472,24 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-async-std"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4aa94397e2023af5b7cff5b8d4785e935cfb77f0e4aab0cae3b26258ace556"
+dependencies = [
+ "async-io",
+ "futures-lite",
+ "libc",
+ "signal-hook",
 ]
 
 [[package]]
@@ -11653,6 +11665,8 @@ dependencies = [
  "relay-wococo-client",
  "rialto-parachain-runtime",
  "rialto-runtime",
+ "signal-hook",
+ "signal-hook-async-std",
  "sp-core",
  "sp-keyring",
  "sp-runtime",

--- a/deployments/bridges/common/generate_messages.sh
+++ b/deployments/bridges/common/generate_messages.sh
@@ -17,11 +17,13 @@
 
 SECONDARY_EXTRA_ARGS=${SECONDARY_EXTRA_ARGS:-""}
 
+trap "echo Exiting... TERM; exit $?" TERM
+
 # Sleep a bit between messages
 rand_sleep() {
 	SUBMIT_DELAY_S=`shuf -i 0-$MAX_SUBMIT_DELAY_S -n 1`
 	echo "Sleeping $SUBMIT_DELAY_S seconds..."
-	sleep $SUBMIT_DELAY_S
+	sleep $SUBMIT_DELAY_S & wait $!
 	NOW=`date "+%Y-%m-%d %H:%M:%S"`
 	echo "Woke up at $NOW"
 }

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-resubmitter-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-messages-to-rialto-parachain-resubmitter-entrypoint.sh
@@ -15,7 +15,7 @@ sleep 15
 # we need tip around `526186677695 - 17800827994 = 508_385_849_701`. Let's round it
 # up to `1_000_000_000_000`.
 
-/home/user/substrate-relay resubmit-transactions millau \
+exec /home/user/substrate-relay resubmit-transactions millau \
 	--target-host millau-node-alice \
 	--target-port 9944 \
 	--target-signer //RialtoParachain.MessagesSender \

--- a/deployments/bridges/rialto-parachain-millau/entrypoints/relay-millau-rialto-parachain-entrypoint.sh
+++ b/deployments/bridges/rialto-parachain-millau/entrypoints/relay-millau-rialto-parachain-entrypoint.sh
@@ -24,7 +24,7 @@ RIALTO_PARACHAIN_RELAY_ACCOUNT=${EXT_RIALTO_PARACHAIN_RELAY_ACCOUNT:-//Millau.He
 # Give chain a little bit of time to process initialization transaction
 sleep 6
 
-/home/user/substrate-relay relay-headers-and-messages millau-rialto-parachain \
+exec /home/user/substrate-relay relay-headers-and-messages millau-rialto-parachain \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
 	--millau-signer $MILLAU_RELAY_ACCOUNT \

--- a/deployments/monitoring/docker-compose.yml
+++ b/deployments/monitoring/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus-metrics
+    # SIGTERM won't work because of our custom entrypoint. Should be ok to use SIGKILL.
+    stop_signal: SIGKILL
     entrypoint: sh -c "echo 'sleeping for 10m' && sleep 600 && /run.sh"
 
   grafana-matrix-notifier:

--- a/deployments/networks/entrypoints/rialto-chainspec-exporter-entrypoint.sh
+++ b/deployments/networks/entrypoints/rialto-chainspec-exporter-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -xeu
 
+trap "echo Exiting... TERM; exit $?" TERM
+
 /home/user/rialto-bridge-node build-spec \
 	--chain local \
 	--raw \
@@ -11,4 +13,4 @@ set -xeu
 # by the container running this script. If this script ends, the volume will be detached
 # and our chain spec will be lost when it'll go online again. Hence the never-ending
 # script which keeps volume online until container is stopped.
-tail -f /dev/null
+tail -f /dev/null & wait $!

--- a/deployments/networks/entrypoints/rialto-parachain-registrar-entrypoint.sh
+++ b/deployments/networks/entrypoints/rialto-parachain-registrar-entrypoint.sh
@@ -3,7 +3,7 @@ set -xeu
 
 sleep 15
 
-/home/user/substrate-relay register-parachain rialto-parachain \
+exec /home/user/substrate-relay register-parachain rialto-parachain \
 	--parachain-host rialto-parachain-collator-alice \
 	--parachain-port 9944 \
 	--relaychain-host rialto-node-alice \

--- a/deployments/ui/docker-compose.yml
+++ b/deployments/ui/docker-compose.yml
@@ -9,5 +9,6 @@ services:
       LETSENCRYPT_EMAIL: admin@parity.io
       CHAIN_1_SUBSTRATE_PROVIDER: ${UI_CHAIN_1:-ws://localhost:9944}
       CHAIN_2_SUBSTRATE_PROVIDER: ${UI_CHAIN_2:-ws://localhost:19944}
+    stop_signal: SIGKILL
     ports:
       - "8080:80"

--- a/relays/bin-substrate/Cargo.toml
+++ b/relays/bin-substrate/Cargo.toml
@@ -16,6 +16,8 @@ log = "0.4.17"
 num-format = "0.4"
 num-traits = "0.2"
 structopt = "0.3"
+signal-hook = "0.3.14"
+signal-hook-async-std = "0.2.2"
 strum = { version = "0.21.0", features = ["derive"] }
 
 # Bridge dependencies

--- a/relays/bin-substrate/src/main.rs
+++ b/relays/bin-substrate/src/main.rs
@@ -24,8 +24,5 @@ mod cli;
 fn main() {
 	let command = cli::parse_args();
 	let run = command.run();
-	let result = async_std::task::block_on(run);
-	if let Err(error) = result {
-		log::error!(target: "bridge", "substrate-relay: {}", error);
-	}
+	async_std::task::block_on(run);
 }


### PR DESCRIPTION
Fixes #505 

Not sure if we want to handle `SIGTERM` for the relay. If we don't, there are other alternatives for fixing the mentioned issue.