### PR TITLE
Expose metrics of on-demand relay chain headers sync from with-parachain complex relays

### DIFF
--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
@@ -240,6 +240,7 @@ trait Full2WayBridgeBase: Sized + Send + Sync {
 	/// Start on-demand headers relays.
 	async fn start_on_demand_headers_relayers(
 		&mut self,
+		metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,
@@ -317,8 +318,9 @@ where
 		}
 
 		// start on-demand header relays
+		let metrics_params = self.base().common().metrics_params.clone();
 		let (left_to_right_on_demand_headers, right_to_left_on_demand_headers) =
-			self.mut_base().start_on_demand_headers_relayers().await?;
+			self.mut_base().start_on_demand_headers_relayers(&metrics_params).await?;
 
 		// add balance-related metrics
 		{

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
@@ -240,7 +240,6 @@ trait Full2WayBridgeBase: Sized + Send + Sync {
 	/// Start on-demand headers relays.
 	async fn start_on_demand_headers_relayers(
 		&mut self,
-		metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,
@@ -318,9 +317,8 @@ where
 		}
 
 		// start on-demand header relays
-		let metrics_params = self.base().common().metrics_params.clone();
 		let (left_to_right_on_demand_headers, right_to_left_on_demand_headers) =
-			self.mut_base().start_on_demand_headers_relayers(&metrics_params).await?;
+			self.mut_base().start_on_demand_headers_relayers().await?;
 
 		// add balance-related metrics
 		{

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/parachain_to_parachain.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/parachain_to_parachain.rs
@@ -27,7 +27,6 @@ use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumbe
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, Parachain,
 };
-use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
 use substrate_relay_helper::{
 	finality::SubstrateFinalitySyncPipeline,
@@ -206,7 +205,6 @@ where
 
 	async fn start_on_demand_headers_relayers(
 		&mut self,
-		metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,
@@ -247,7 +245,7 @@ where
 				self.common.right.client.clone(),
 				self.left_headers_to_right_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
-				Some(metrics_params.clone()),
+				Some(self.common.metrics_params.clone()),
 			);
 		let right_relay_to_left_on_demand_headers =
 			OnDemandHeadersRelay::<<R2L as ParachainToRelayHeadersCliBridge>::RelayFinality>::new(
@@ -255,7 +253,7 @@ where
 				self.common.left.client.clone(),
 				self.right_headers_to_left_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
-				Some(metrics_params.clone()),
+				Some(self.common.metrics_params.clone()),
 			);
 
 		let left_to_right_on_demand_parachains = OnDemandParachainsRelay::<

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/parachain_to_parachain.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/parachain_to_parachain.rs
@@ -27,6 +27,7 @@ use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumbe
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, Parachain,
 };
+use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
 use substrate_relay_helper::{
 	finality::SubstrateFinalitySyncPipeline,
@@ -205,6 +206,7 @@ where
 
 	async fn start_on_demand_headers_relayers(
 		&mut self,
+		metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,
@@ -245,6 +247,7 @@ where
 				self.common.right.client.clone(),
 				self.left_headers_to_right_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
+				Some(metrics_params.clone()),
 			);
 		let right_relay_to_left_on_demand_headers =
 			OnDemandHeadersRelay::<<R2L as ParachainToRelayHeadersCliBridge>::RelayFinality>::new(
@@ -252,6 +255,7 @@ where
 				self.common.left.client.clone(),
 				self.right_headers_to_left_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
+				Some(metrics_params.clone()),
 			);
 
 		let left_to_right_on_demand_parachains = OnDemandParachainsRelay::<

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_parachain.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_parachain.rs
@@ -30,7 +30,6 @@ use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumbe
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, Parachain,
 };
-use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
 use substrate_relay_helper::{
 	finality::SubstrateFinalitySyncPipeline,
@@ -189,7 +188,6 @@ where
 
 	async fn start_on_demand_headers_relayers(
 		&mut self,
-		metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,
@@ -234,7 +232,7 @@ where
 				self.common.left.client.clone(),
 				self.right_headers_to_left_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
-				Some(metrics_params.clone()),
+				Some(self.common.metrics_params.clone()),
 			);
 		let right_to_left_on_demand_parachains = OnDemandParachainsRelay::<
 			<R2L as ParachainToRelayHeadersCliBridge>::ParachainFinality,

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_parachain.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_parachain.rs
@@ -30,6 +30,7 @@ use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumbe
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, Parachain,
 };
+use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
 use substrate_relay_helper::{
 	finality::SubstrateFinalitySyncPipeline,
@@ -188,6 +189,7 @@ where
 
 	async fn start_on_demand_headers_relayers(
 		&mut self,
+		metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,
@@ -224,6 +226,7 @@ where
 				self.common.right.client.clone(),
 				self.left_headers_to_right_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
+				None,
 			);
 		let right_relay_to_left_on_demand_headers =
 			OnDemandHeadersRelay::<<R2L as ParachainToRelayHeadersCliBridge>::RelayFinality>::new(
@@ -231,6 +234,7 @@ where
 				self.common.left.client.clone(),
 				self.right_headers_to_left_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
+				Some(metrics_params.clone()),
 			);
 		let right_to_left_on_demand_parachains = OnDemandParachainsRelay::<
 			<R2L as ParachainToRelayHeadersCliBridge>::ParachainFinality,

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_relay.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_relay.rs
@@ -23,6 +23,7 @@ use crate::cli::{
 	CliChain,
 };
 use relay_substrate_client::{AccountIdOf, AccountKeyPairOf, ChainWithTransactions};
+use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
 use substrate_relay_helper::{
 	finality::SubstrateFinalitySyncPipeline,
@@ -141,6 +142,7 @@ where
 
 	async fn start_on_demand_headers_relayers(
 		&mut self,
+		_metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,
@@ -173,6 +175,7 @@ where
 				self.common.right.client.clone(),
 				self.left_to_right_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
+				None,
 			);
 		let right_to_left_on_demand_headers =
 			OnDemandHeadersRelay::<<R2L as RelayToRelayHeadersCliBridge>::Finality>::new(
@@ -180,6 +183,7 @@ where
 				self.common.left.client.clone(),
 				self.right_to_left_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
+				None,
 			);
 
 		Ok((Arc::new(left_to_right_on_demand_headers), Arc::new(right_to_left_on_demand_headers)))

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_relay.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_relay.rs
@@ -23,7 +23,6 @@ use crate::cli::{
 	CliChain,
 };
 use relay_substrate_client::{AccountIdOf, AccountKeyPairOf, ChainWithTransactions};
-use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
 use substrate_relay_helper::{
 	finality::SubstrateFinalitySyncPipeline,
@@ -142,7 +141,6 @@ where
 
 	async fn start_on_demand_headers_relayers(
 		&mut self,
-		_metrics_params: &MetricsParams,
 	) -> anyhow::Result<(
 		Arc<dyn OnDemandRelay<Self::Left, Self::Right>>,
 		Arc<dyn OnDemandRelay<Self::Right, Self::Left>>,

--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -64,11 +64,15 @@ pub struct OnDemandHeadersRelay<P: SubstrateFinalitySyncPipeline> {
 
 impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
 	/// Create new on-demand headers relay.
+	///
+	/// If `metrics_params` is `Some(_)`, the metrics of the finalty relay are registered.
+	/// Otherwise, all required metrics must be exposed outside of this method.
 	pub fn new(
 		source_client: Client<P::SourceChain>,
 		target_client: Client<P::TargetChain>,
 		target_transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 		only_mandatory_headers: bool,
+		metrics_params: Option<MetricsParams>,
 	) -> Self
 	where
 		AccountIdOf<P::TargetChain>:
@@ -87,6 +91,7 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
 				target_transaction_params,
 				only_mandatory_headers,
 				required_header_number,
+				metrics_params,
 			)
 			.await;
 		});
@@ -148,6 +153,7 @@ async fn background_task<P: SubstrateFinalitySyncPipeline>(
 	target_transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 	only_mandatory_headers: bool,
 	required_header_number: RequiredHeaderNumberRef<P::SourceChain>,
+	metrics_params: Option<MetricsParams>,
 ) where
 	AccountIdOf<P::TargetChain>: From<<AccountKeyPairOf<P::TargetChain> as sp_core::Pair>::Public>,
 {
@@ -310,7 +316,7 @@ async fn background_task<P: SubstrateFinalitySyncPipeline>(
 						stall_timeout,
 						only_mandatory_headers,
 					},
-					MetricsParams::disabled(),
+					metrics_params.clone().unwrap_or_else(|| MetricsParams::disabled()),
 					futures::future::pending(),
 				)
 				.fuse(),

--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -65,7 +65,7 @@ pub struct OnDemandHeadersRelay<P: SubstrateFinalitySyncPipeline> {
 impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
 	/// Create new on-demand headers relay.
 	///
-	/// If `metrics_params` is `Some(_)`, the metrics of the finalty relay are registered.
+	/// If `metrics_params` is `Some(_)`, the metrics of the finality relay are registered.
 	/// Otherwise, all required metrics must be exposed outside of this method.
 	pub fn new(
 		source_client: Client<P::SourceChain>,


### PR DESCRIPTION
closes #1736 

Right now we only expose best blocks (known to relay) of source and target chains - e.g. best finalized `RococoBridgeHub` and best finalized `RococoBridgeHub`, known to `WococoBridgeHub`. However, for some dashboards and alerts we also need to know best blocks of corresponding relay chains - e.g. `Rococo` and `Wococo`.