### PR TITLE
Make debug display of LaneId compatible with its previous version

### DIFF
--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -78,11 +78,30 @@ impl OperatingMode for MessagesOperatingMode {
 	Ord,
 	PartialOrd,
 	PartialEq,
-	RuntimeDebug,
 	TypeInfo,
 	MaxEncodedLen,
 )]
 pub struct LaneId(pub [u8; 4]);
+
+pub use lane_id_debug_impl::*;
+
+#[cfg(not(feature = "std"))]
+mod lane_id_debug_impl {
+	impl core::fmt::Debug for super::LaneId {
+		fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+			fmt.write_str("<stripped>")
+		}
+	}
+}
+
+#[cfg(feature = "std")]
+mod lane_id_debug_impl {
+	impl std::fmt::Debug for super::LaneId {
+		fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+			self.0.fmt(fmt)
+		}
+	}
+}
 
 impl AsRef<[u8]> for LaneId {
 	fn as_ref(&self) -> &[u8] {
@@ -457,5 +476,13 @@ mod tests {
 		assert!(delivered_messages.contains_message(100));
 		assert!(delivered_messages.contains_message(150));
 		assert!(!delivered_messages.contains_message(151));
+	}
+
+	#[test]
+	fn lane_id_debug_format_works_as_before() {
+		assert_eq!(
+			format!("{:?}", LaneId([0, 0, 0, 0])),
+			format!("{:?}", [0, 0, 0, 0]),
+		);
 	}
 }

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -69,17 +69,7 @@ impl OperatingMode for MessagesOperatingMode {
 
 /// Lane id which implements `TypeId`.
 #[derive(
-	Clone,
-	Copy,
-	Decode,
-	Default,
-	Encode,
-	Eq,
-	Ord,
-	PartialOrd,
-	PartialEq,
-	TypeInfo,
-	MaxEncodedLen,
+	Clone, Copy, Decode, Default, Encode, Eq, Ord, PartialOrd, PartialEq, TypeInfo, MaxEncodedLen,
 )]
 pub struct LaneId(pub [u8; 4]);
 
@@ -480,9 +470,6 @@ mod tests {
 
 	#[test]
 	fn lane_id_debug_format_works_as_before() {
-		assert_eq!(
-			format!("{:?}", LaneId([0, 0, 0, 0])),
-			format!("{:?}", [0, 0, 0, 0]),
-		);
+		assert_eq!(format!("{:?}", LaneId([0, 0, 0, 0])), format!("{:?}", [0, 0, 0, 0]),);
 	}
 }

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -73,23 +73,9 @@ impl OperatingMode for MessagesOperatingMode {
 )]
 pub struct LaneId(pub [u8; 4]);
 
-pub use lane_id_debug_impl::*;
-
-#[cfg(not(feature = "std"))]
-mod lane_id_debug_impl {
-	impl core::fmt::Debug for super::LaneId {
-		fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
-			fmt.write_str("<stripped>")
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-mod lane_id_debug_impl {
-	impl std::fmt::Debug for super::LaneId {
-		fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-			self.0.fmt(fmt)
-		}
+impl core::fmt::Debug for LaneId {
+	fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.0.fmt(fmt)
 	}
 }
 
@@ -469,7 +455,7 @@ mod tests {
 	}
 
 	#[test]
-	fn lane_id_debug_format_works_as_before() {
+	fn lane_id_debug_format_matches_inner_array_format() {
 		assert_eq!(format!("{:?}", LaneId([0, 0, 0, 0])), format!("{:?}", [0, 0, 0, 0]),);
 	}
 }


### PR DESCRIPTION
follow up of #1738

We're using formatted version in logs, would be good to keep it shorter (as before)