### PR TITLE
no-grafana-startup-delay option in run.sh

### DIFF
--- a/deployments/monitoring/docker-compose.yml
+++ b/deployments/monitoring/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - prometheus-metrics
     # SIGTERM won't work because of our custom entrypoint. Should be ok to use SIGKILL.
     stop_signal: SIGKILL
-    entrypoint: sh -c "echo 'sleeping for 10m' && sleep 600 && /run.sh"
+    entrypoint: sh -c "${NO_GRAFANA_STARTUP_DELAY:-echo 'sleeping for 10m' && sleep 600} && /run.sh"
 
   grafana-matrix-notifier:
     build:

--- a/deployments/run.sh
+++ b/deployments/run.sh
@@ -43,6 +43,7 @@ function show_help () {
   echo "  --local-rialto                             Use prebuilt local/rialto-bridge-node image when starting nodes"
   echo "  --local-rialto-parachain                   Use prebuilt local/rialto-parachain-collator image when starting nodes"
   echo "  --local-millau                             Use prebuilt local/millau-bridge-node image when starting nodes"
+  echo "  --no-grafana-startup-delay                 Start Grafana without any delay (you may see some false alerts during startup)"
   echo " "
   echo "You can start multiple bridges at once by passing several bridge names:"
   echo "  ./run.sh rialto-millau rialto-parachain-millau westend-millau [stop|update]"
@@ -81,6 +82,7 @@ do
       export RIALTO_BRIDGE_NODE_IMAGE=local/rialto-bridge-node
       export RIALTO_PARACHAIN_COLLATOR_IMAGE=local/rialto-parachain-collator
       export MILLAU_BRIDGE_NODE_IMAGE=local/millau-bridge-node
+      export IMMEDIATE_
       shift
       continue
       ;;
@@ -101,6 +103,11 @@ do
       ;;
     --local-millau)
       export MILLAU_BRIDGE_NODE_IMAGE=local/millau-bridge-node
+      shift
+      continue
+      ;;
+    --no-grafana-startup-delay)
+      export NO_GRAFANA_STARTUP_DELAY="echo 'No Grafana startup delay'"
       shift
       continue
       ;;


### PR DESCRIPTION
It is useful sometimes for local tests, when you just need to check some metric fast, without waiting `10m` before Grafana start.