### PR TITLE
Expose `EXTRA_STORAGE_PROOF_SIZE` in `bp-bridge-hub-cumulus`

### DIFF
--- a/primitives/chain-bridge-hub-cumulus/src/lib.rs
+++ b/primitives/chain-bridge-hub-cumulus/src/lib.rs
@@ -20,7 +20,7 @@ use bp_messages::*;
 pub use bp_polkadot_core::{
 	AccountId, AccountInfoStorageMapKeyProvider, AccountPublic, Balance, BlockNumber, Hash, Hasher,
 	Hashing, Header, Index, Nonce, Perbill, PolkadotSignedExtension, Signature, SignedBlock,
-	UncheckedExtrinsic, TX_EXTRA_BYTES,
+	UncheckedExtrinsic, EXTRA_STORAGE_PROOF_SIZE, TX_EXTRA_BYTES,
 };
 use frame_support::{
 	dispatch::DispatchClass,


### PR DESCRIPTION
We need this for the integrity tests in cumulus.