### PR TITLE
Use wss to connect to the Rialto node in test deployments

### DIFF
--- a/deployments/bridges/rialto-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-millau/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ./bridges/common:/common
       - ./bridges/rialto-millau/entrypoints:/entrypoints
     environment:
-      RUST_LOG: rpc=trace,bridge=trace
+      RUST_LOG: rpc=trace,bridge=trace,jsonrpsee=trace,jsonrpsee_core=trace,jsonrpsee_ws_client=trace,rustls=trace,soketto=trace
     ports:
       - "10016:9616"
     depends_on: &all-nodes

--- a/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
@@ -25,8 +25,9 @@ sleep 6
 	--millau-port 9944 \
 	--millau-signer //Rialto.HeadersAndMessagesRelay \
 	--millau-transactions-mortality=64 \
-	--rialto-host rialto-node-alice \
-	--rialto-port 9944 \
+	--rialto-host wss.rialto.brucke.link \
+	--rialto-port 443 \
+	--rialto-secure \
 	--rialto-signer //Millau.HeadersAndMessagesRelay \
 	--rialto-transactions-mortality=64 \
 	--lane=00000000 \

--- a/deployments/networks/rialto.yml
+++ b/deployments/networks/rialto.yml
@@ -56,6 +56,8 @@ services:
       - --unsafe-rpc-external
       - --unsafe-ws-external
       - --prometheus-external
+    environment:
+      RUST_LOG: runtime=trace,rpc=debug,txpool=trace,runtime::bridge=trace,beefy=debug,jsonrpsee=trace,jsonrpsee_core=trace,jsonrpsee_server=trace,rustls=trace,soketto=trace
     ports:
       - "10133:9933"
       - "10144:9944"


### PR DESCRIPTION
prototype of #1805 
related to #1785 

Millau<>Rialto relay now connects to Rialto node using wss. I've also enabled some additional logs for relay and for the wss RPC node. We'll revert this PR after problem is solved.