### PR TITLE
Functions to benchmark messages pallet with linked to parachain

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -983,7 +983,7 @@ impl_runtime_apis! {
 			let mut batches = Vec::<BenchmarkBatch>::new();
 			let params = (&config, &whitelist);
 
-			use bridge_runtime_common::messages_benchmarking::{prepare_message_delivery_proof, prepare_message_proof};
+			use bridge_runtime_common::messages_benchmarking::{prepare_message_delivery_proof_from_grandpa_chain, prepare_message_proof_from_grandpa_chain};
 			use pallet_bridge_messages::benchmarking::{
 				Pallet as MessagesBench,
 				Config as MessagesConfig,
@@ -1004,7 +1004,7 @@ impl_runtime_apis! {
 				fn prepare_message_proof(
 					params: MessageProofParams,
 				) -> (rialto_messages::FromRialtoMessagesProof, Weight) {
-					prepare_message_proof::<Runtime, (), (), WithRialtoMessageBridge, bp_rialto::Header, bp_rialto::Hasher>(
+					prepare_message_proof_from_grandpa_chain::<Runtime, RialtoGrandpaInstance, WithRialtoMessageBridge>(
 						params,
 					)
 				}
@@ -1012,7 +1012,7 @@ impl_runtime_apis! {
 				fn prepare_message_delivery_proof(
 					params: MessageDeliveryProofParams<Self::AccountId>,
 				) -> rialto_messages::ToRialtoMessagesDeliveryProof {
-					prepare_message_delivery_proof::<Runtime, (), WithRialtoMessageBridge, bp_rialto::Header, bp_rialto::Hasher>(
+					prepare_message_delivery_proof_from_grandpa_chain::<Runtime, RialtoGrandpaInstance, WithRialtoMessageBridge>(
 						params,
 					)
 				}

--- a/bin/runtime-common/Cargo.toml
+++ b/bin/runtime-common/Cargo.toml
@@ -82,6 +82,7 @@ std = [
 runtime-benchmarks = [
 	"pallet-bridge-grandpa/runtime-benchmarks",
 	"pallet-bridge-messages/runtime-benchmarks",
+	"pallet-bridge-parachains/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 ]
 integrity-test = [

--- a/bin/runtime-common/src/messages_benchmarking.rs
+++ b/bin/runtime-common/src/messages_benchmarking.rs
@@ -22,7 +22,7 @@
 use crate::{
 	messages::{
 		source::FromBridgedChainMessagesDeliveryProof, target::FromBridgedChainMessagesProof,
-		AccountIdOf, BalanceOf, BridgedChain, CallOf, HashOf, MessageBridge, ThisChain,
+		AccountIdOf, BridgedChain, HashOf, HasherOf, MessageBridge, RawStorageProof, ThisChain,
 	},
 	messages_generation::{
 		encode_all_messages, encode_lane_data, grow_trie, prepare_messages_storage_proof,
@@ -30,52 +30,46 @@ use crate::{
 };
 
 use bp_messages::storage_keys;
-use bp_runtime::{record_all_trie_keys, StorageProofSize};
+use bp_polkadot_core::parachains::ParaHash;
+use bp_runtime::{record_all_trie_keys, Chain, Parachain, StorageProofSize, UnderlyingChainOf};
 use codec::Encode;
-use frame_support::{dispatch::GetDispatchInfo, weights::Weight};
+use frame_support::weights::Weight;
 use pallet_bridge_messages::benchmarking::{MessageDeliveryProofParams, MessageProofParams};
-use sp_core::Hasher;
-use sp_runtime::traits::{Header, MaybeSerializeDeserialize, Zero};
-use sp_std::{fmt::Debug, prelude::*};
+use sp_runtime::traits::{Header, Zero};
+use sp_std::prelude::*;
 use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, Recorder, TrieMut};
 
 /// Prepare proof of messages for the `receive_messages_proof` call.
 ///
 /// In addition to returning valid messages proof, environment is prepared to verify this message
 /// proof.
-pub fn prepare_message_proof<R, BI, FI, B, BH, BHH>(
+///
+/// This method is intended to be used when benchmarking pallet, linked to the chain that
+/// uses GRANDPA finality. For parachains, please use the `prepare_message_proof_from_parachain`
+/// function.
+pub fn prepare_message_proof_from_grandpa_chain<R, FI, B>(
 	params: MessageProofParams,
 ) -> (FromBridgedChainMessagesProof<HashOf<BridgedChain<B>>>, Weight)
 where
-	R: frame_system::Config<AccountId = AccountIdOf<ThisChain<B>>>
-		+ pallet_bridge_grandpa::Config<FI>,
-	R::BridgedChain: bp_runtime::Chain<Hash = HashOf<BridgedChain<B>>, Header = BH>,
-	B: MessageBridge,
-	BI: 'static,
+	R: pallet_bridge_grandpa::Config<FI, BridgedChain = UnderlyingChainOf<BridgedChain<B>>>,
 	FI: 'static,
-	BH: Header<Hash = HashOf<BridgedChain<B>>>,
-	BHH: Hasher<Out = HashOf<BridgedChain<B>>>,
-	AccountIdOf<ThisChain<B>>: PartialEq + sp_std::fmt::Debug,
-	AccountIdOf<BridgedChain<B>>: From<[u8; 32]>,
-	BalanceOf<ThisChain<B>>: Debug + MaybeSerializeDeserialize,
-	CallOf<ThisChain<B>>: From<frame_system::Call<R>> + GetDispatchInfo,
-	HashOf<BridgedChain<B>>: Copy + Default,
+	B: MessageBridge,
 {
-	let message_payload = match params.size {
-		StorageProofSize::Minimal(ref size) => vec![0u8; *size as _],
-		_ => vec![],
-	};
-
-	// finally - prepare storage proof and update environment
+	// prepare storage proof
 	let (state_root, storage_proof) = prepare_messages_storage_proof::<B>(
 		params.lane,
 		params.message_nonces.clone(),
 		params.outbound_lane_data,
 		params.size,
-		message_payload,
+		match params.size {
+			StorageProofSize::Minimal(ref size) => vec![0u8; *size as _],
+			_ => vec![],
+		},
 		encode_all_messages,
 		encode_lane_data,
 	);
+
+	// update runtime storage
 	let (_, bridged_header_hash) = insert_header_to_grandpa_pallet::<R, FI>(state_root);
 
 	(
@@ -90,18 +84,115 @@ where
 	)
 }
 
+/// Prepare proof of messages for the `receive_messages_proof` call.
+///
+/// In addition to returning valid messages proof, environment is prepared to verify this message
+/// proof.
+///
+/// This method is intended to be used when benchmarking pallet, linked to the chain that
+/// uses parachain finality. For GRANDPA chains, please use the
+/// `prepare_message_proof_from_grandpa_chain` function.
+pub fn prepare_message_proof_from_parachain<R, PI, B>(
+	params: MessageProofParams,
+) -> (FromBridgedChainMessagesProof<HashOf<BridgedChain<B>>>, Weight)
+where
+	R: pallet_bridge_parachains::Config<PI>,
+	PI: 'static,
+	B: MessageBridge,
+	UnderlyingChainOf<BridgedChain<B>>: Chain<Hash = ParaHash> + Parachain,
+{
+	// prepare storage proof
+	let (state_root, storage_proof) = prepare_messages_storage_proof::<B>(
+		params.lane,
+		params.message_nonces.clone(),
+		params.outbound_lane_data,
+		params.size,
+		match params.size {
+			StorageProofSize::Minimal(ref size) => vec![0u8; *size as _],
+			_ => vec![],
+		},
+		encode_all_messages,
+		encode_lane_data,
+	);
+
+	// update runtime storage
+	let (_, bridged_header_hash) =
+		insert_header_to_parachains_pallet::<R, PI, UnderlyingChainOf<BridgedChain<B>>>(state_root);
+
+	(
+		FromBridgedChainMessagesProof {
+			bridged_header_hash,
+			storage_proof,
+			lane: params.lane,
+			nonces_start: *params.message_nonces.start(),
+			nonces_end: *params.message_nonces.end(),
+		},
+		Weight::zero(),
+	)
+}
+
 /// Prepare proof of messages delivery for the `receive_messages_delivery_proof` call.
-pub fn prepare_message_delivery_proof<R, FI, B, BH, BHH>(
+///
+/// This method is intended to be used when benchmarking pallet, linked to the chain that
+/// uses GRANDPA finality. For parachains, please use the
+/// `prepare_message_delivery_proof_from_parachain` function.
+pub fn prepare_message_delivery_proof_from_grandpa_chain<R, FI, B>(
 	params: MessageDeliveryProofParams<AccountIdOf<ThisChain<B>>>,
 ) -> FromBridgedChainMessagesDeliveryProof<HashOf<BridgedChain<B>>>
 where
-	R: pallet_bridge_grandpa::Config<FI>,
-	R::BridgedChain: bp_runtime::Chain<Hash = HashOf<BridgedChain<B>>, Header = BH>,
+	R: pallet_bridge_grandpa::Config<FI, BridgedChain = UnderlyingChainOf<BridgedChain<B>>>,
 	FI: 'static,
 	B: MessageBridge,
-	BH: Header<Hash = HashOf<BridgedChain<B>>>,
-	BHH: Hasher<Out = HashOf<BridgedChain<B>>>,
-	HashOf<BridgedChain<B>>: Copy + Default,
+{
+	// prepare storage proof
+	let lane = params.lane;
+	let (state_root, storage_proof) = prepare_message_delivery_proof::<B>(params);
+
+	// update runtime storage
+	let (_, bridged_header_hash) = insert_header_to_grandpa_pallet::<R, FI>(state_root);
+
+	FromBridgedChainMessagesDeliveryProof {
+		bridged_header_hash: bridged_header_hash.into(),
+		storage_proof,
+		lane,
+	}
+}
+
+/// Prepare proof of messages delivery for the `receive_messages_delivery_proof` call.
+///
+/// This method is intended to be used when benchmarking pallet, linked to the chain that
+/// uses parachain finality. For GRANDPA chains, please use the
+/// `prepare_message_delivery_proof_from_grandpa_chain` function.
+pub fn prepare_message_delivery_proof_from_parachain<R, PI, B>(
+	params: MessageDeliveryProofParams<AccountIdOf<ThisChain<B>>>,
+) -> FromBridgedChainMessagesDeliveryProof<HashOf<BridgedChain<B>>>
+where
+	R: pallet_bridge_parachains::Config<PI>,
+	PI: 'static,
+	B: MessageBridge,
+	UnderlyingChainOf<BridgedChain<B>>: Chain<Hash = ParaHash> + Parachain,
+{
+	// prepare storage proof
+	let lane = params.lane;
+	let (state_root, storage_proof) = prepare_message_delivery_proof::<B>(params);
+
+	// update runtime storage
+	let (_, bridged_header_hash) =
+		insert_header_to_parachains_pallet::<R, PI, UnderlyingChainOf<BridgedChain<B>>>(state_root);
+
+	FromBridgedChainMessagesDeliveryProof {
+		bridged_header_hash: bridged_header_hash.into(),
+		storage_proof,
+		lane,
+	}
+}
+
+/// Prepare in-memory message delivery proof, without inserting anything to the runtime storage.
+fn prepare_message_delivery_proof<B>(
+	params: MessageDeliveryProofParams<AccountIdOf<ThisChain<B>>>,
+) -> (HashOf<BridgedChain<B>>, RawStorageProof)
+where
+	B: MessageBridge,
 {
 	// prepare Bridged chain storage with inbound lane state
 	let storage_key =
@@ -109,7 +200,8 @@ where
 	let mut root = Default::default();
 	let mut mdb = MemoryDB::default();
 	{
-		let mut trie = TrieDBMutBuilderV1::<BHH>::new(&mut mdb, &mut root).build();
+		let mut trie =
+			TrieDBMutBuilderV1::<HasherOf<BridgedChain<B>>>::new(&mut mdb, &mut root).build();
 		trie.insert(&storage_key, &params.inbound_lane_data.encode())
 			.map_err(|_| "TrieMut::insert has failed")
 			.expect("TrieMut::insert should not fail in benchmarks");
@@ -117,20 +209,17 @@ where
 	root = grow_trie(root, &mut mdb, params.size);
 
 	// generate storage proof to be delivered to This chain
-	let mut proof_recorder = Recorder::<LayoutV1<BHH>>::new();
-	record_all_trie_keys::<LayoutV1<BHH>, _>(&mdb, &root, &mut proof_recorder)
-		.map_err(|_| "record_all_trie_keys has failed")
-		.expect("record_all_trie_keys should not fail in benchmarks");
+	let mut proof_recorder = Recorder::<LayoutV1<HasherOf<BridgedChain<B>>>>::new();
+	record_all_trie_keys::<LayoutV1<HasherOf<BridgedChain<B>>>, _>(
+		&mdb,
+		&root,
+		&mut proof_recorder,
+	)
+	.map_err(|_| "record_all_trie_keys has failed")
+	.expect("record_all_trie_keys should not fail in benchmarks");
 	let storage_proof = proof_recorder.drain().into_iter().map(|n| n.data.to_vec()).collect();
 
-	// finally insert header with given state root to our storage
-	let (_, bridged_header_hash) = insert_header_to_grandpa_pallet::<R, FI>(root);
-
-	FromBridgedChainMessagesDeliveryProof {
-		bridged_header_hash: bridged_header_hash.into(),
-		storage_proof,
-		lane: params.lane,
-	}
+	(root, storage_proof)
 }
 
 /// Insert header to the bridge GRANDPA pallet.
@@ -152,5 +241,27 @@ where
 	);
 	let bridged_header_hash = bridged_header.hash();
 	pallet_bridge_grandpa::initialize_for_benchmarks::<R, GI>(bridged_header);
+	(bridged_block_number, bridged_header_hash)
+}
+
+/// Insert header to the bridge parachains pallet.
+pub(crate) fn insert_header_to_parachains_pallet<R, PI, PC>(
+	state_root: bp_runtime::HashOf<PC>,
+) -> (bp_runtime::BlockNumberOf<PC>, bp_runtime::HashOf<PC>)
+where
+	R: pallet_bridge_parachains::Config<PI>,
+	PI: 'static,
+	PC: Chain<Hash = ParaHash> + Parachain,
+{
+	let bridged_block_number = Zero::zero();
+	let bridged_header = bp_runtime::HeaderOf::<PC>::new(
+		bridged_block_number,
+		Default::default(),
+		state_root,
+		Default::default(),
+		Default::default(),
+	);
+	let bridged_header_hash = bridged_header.hash();
+	pallet_bridge_parachains::initialize_for_benchmarks::<R, PI, PC>(bridged_header);
 	(bridged_block_number, bridged_header_hash)
 }

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -29,7 +29,7 @@ pub use weights_ext::WeightInfoExt;
 use bp_header_chain::HeaderChain;
 use bp_parachains::{parachain_head_storage_key_at_source, ParaInfo, ParaStoredHeaderData};
 use bp_polkadot_core::parachains::{ParaHash, ParaHead, ParaHeadsProof, ParaId};
-use bp_runtime::{Chain, HashOf, HeaderId, HeaderIdOf, HeaderOf, Parachain, StorageProofError};
+use bp_runtime::{Chain, HashOf, HeaderId, HeaderIdOf, Parachain, StorageProofError};
 use frame_support::dispatch::PostDispatchInfo;
 use sp_std::{marker::PhantomData, vec::Vec};
 

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -27,15 +27,19 @@ pub use weights::WeightInfo;
 pub use weights_ext::WeightInfoExt;
 
 use bp_header_chain::HeaderChain;
-use bp_parachains::{
-	parachain_head_storage_key_at_source, ParaInfo, ParaStoredHeaderData,
-	ParaStoredHeaderDataBuilder,
-};
+use bp_parachains::{parachain_head_storage_key_at_source, ParaInfo, ParaStoredHeaderData};
 use bp_polkadot_core::parachains::{ParaHash, ParaHead, ParaHeadsProof, ParaId};
 use bp_runtime::{Chain, HashOf, HeaderId, HeaderIdOf, HeaderOf, Parachain, StorageProofError};
-use codec::Encode;
 use frame_support::dispatch::PostDispatchInfo;
 use sp_std::{marker::PhantomData, vec::Vec};
+
+#[cfg(feature = "runtime-benchmarks")]
+use bp_parachains::ParaStoredHeaderDataBuilder;
+#[cfg(feature = "runtime-benchmarks")]
+use bp_runtime::HeaderOf;
+#[cfg(feature = "runtime-benchmarks")]
+use codec::Encode;
+
 
 // Re-export in crate namespace for `construct_runtime!`.
 pub use pallet::*;

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -40,7 +40,6 @@ use bp_runtime::HeaderOf;
 #[cfg(feature = "runtime-benchmarks")]
 use codec::Encode;
 
-
 // Re-export in crate namespace for `construct_runtime!`.
 pub use pallet::*;
 


### PR DESCRIPTION
Required for https://github.com/paritytech/cumulus/pull/2107

All current helpers are inserting headers to the `pallet_bridge_grandpa`, which isn't used by messages pallet when it is bridged with the parachain. Also some cleanup