### PR TITLE
Use named parameters for indirect calls

### DIFF
--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -1178,7 +1178,7 @@ mod tests {
 
 		let direct_initialize_call =
 			Call::<TestRuntime>::initialize { init_data: init_data.clone() };
-		let indirect_initialize_call = BridgeGrandpaCall::<TestHeader>::initialize(init_data);
+		let indirect_initialize_call = BridgeGrandpaCall::<TestHeader>::initialize { init_data };
 		assert_eq!(direct_initialize_call.encode(), indirect_initialize_call.encode());
 
 		let direct_submit_finality_proof_call = Call::<TestRuntime>::submit_finality_proof {
@@ -1186,7 +1186,10 @@ mod tests {
 			justification: justification.clone(),
 		};
 		let indirect_submit_finality_proof_call =
-			BridgeGrandpaCall::<TestHeader>::submit_finality_proof(Box::new(header), justification);
+			BridgeGrandpaCall::<TestHeader>::submit_finality_proof {
+				finality_target: Box::new(header),
+				justification,
+			};
 		assert_eq!(
 			direct_submit_finality_proof_call.encode(),
 			indirect_submit_finality_proof_call.encode()

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -1928,12 +1928,12 @@ mod tests {
 			AccountId,
 			TestMessagesProof,
 			TestMessagesDeliveryProof,
-		>::receive_messages_proof(
-			account_id,
-			message_proof,
-			1,
-			REGULAR_PAYLOAD.declared_weight,
-		);
+		>::receive_messages_proof {
+			relayer_id_at_bridged_chain: account_id,
+			proof: message_proof,
+			messages_count: 1,
+			dispatch_weight: REGULAR_PAYLOAD.declared_weight,
+		};
 		assert_eq!(
 			direct_receive_messages_proof_call.encode(),
 			indirect_receive_messages_proof_call.encode()
@@ -1948,10 +1948,10 @@ mod tests {
 			AccountId,
 			TestMessagesProof,
 			TestMessagesDeliveryProof,
-		>::receive_messages_delivery_proof(
-			message_delivery_proof,
-			unrewarded_relayer_state,
-		);
+		>::receive_messages_delivery_proof {
+			proof: message_delivery_proof,
+			relayers_state: unrewarded_relayer_state,
+		};
 		assert_eq!(
 			direct_receive_messages_delivery_proof_call.encode(),
 			indirect_receive_messages_delivery_proof_call.encode()

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -1513,8 +1513,11 @@ mod tests {
 			parachains: parachains.clone(),
 			parachain_heads_proof: proof.clone(),
 		};
-		let indirect_submit_parachain_heads_call =
-			BridgeParachainCall::submit_parachain_heads(relay_header_id, parachains, proof);
+		let indirect_submit_parachain_heads_call = BridgeParachainCall::submit_parachain_heads {
+			at_relay_block: relay_header_id,
+			parachains,
+			parachain_heads_proof: proof,
+		};
 		assert_eq!(
 			direct_submit_parachain_heads_call.encode(),
 			indirect_submit_parachain_heads_call.encode()

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -176,10 +176,13 @@ impl<Number: Codec> ConsensusLogReader for GrandpaConsensusLogReader<Number> {
 pub enum BridgeGrandpaCall<Header: HeaderT> {
 	/// `pallet-bridge-grandpa::Call::submit_finality_proof`
 	#[codec(index = 0)]
-	submit_finality_proof(Box<Header>, justification::GrandpaJustification<Header>),
+	submit_finality_proof {
+		finality_target: Box<Header>,
+		justification: justification::GrandpaJustification<Header>,
+	},
 	/// `pallet-bridge-grandpa::Call::initialize`
 	#[codec(index = 1)]
-	initialize(InitializationData<Header>),
+	initialize { init_data: InitializationData<Header> },
 }
 
 /// The `BridgeGrandpaCall` used by a chain.

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -397,10 +397,18 @@ where
 pub enum BridgeMessagesCall<AccountId, MessagesProof, MessagesDeliveryProof> {
 	/// `pallet-bridge-messages::Call::receive_messages_proof`
 	#[codec(index = 2)]
-	receive_messages_proof(AccountId, MessagesProof, u32, Weight),
+	receive_messages_proof {
+		relayer_id_at_bridged_chain: AccountId,
+		proof: MessagesProof,
+		messages_count: u32,
+		dispatch_weight: Weight,
+	},
 	/// `pallet-bridge-messages::Call::receive_messages_delivery_proof`
 	#[codec(index = 3)]
-	receive_messages_delivery_proof(MessagesDeliveryProof, UnrewardedRelayersState),
+	receive_messages_delivery_proof {
+		proof: MessagesDeliveryProof,
+		relayers_state: UnrewardedRelayersState,
+	},
 }
 
 #[cfg(test)]

--- a/primitives/parachains/src/lib.rs
+++ b/primitives/parachains/src/lib.rs
@@ -157,9 +157,9 @@ impl ParaStoredHeaderDataBuilder for C {
 pub enum BridgeParachainCall {
 	/// `pallet-bridge-parachains::Call::submit_parachain_heads`
 	#[codec(index = 0)]
-	submit_parachain_heads(
-		(RelayBlockNumber, RelayBlockHash),
-		Vec<(ParaId, ParaHash)>,
-		ParaHeadsProof,
-	),
+	submit_parachain_heads {
+		at_relay_block: (RelayBlockNumber, RelayBlockHash),
+		parachains: Vec<(ParaId, ParaHash)>,
+		parachain_heads_proof: ParaHeadsProof,
+	},
 }

--- a/relays/bin-substrate/src/chains/rococo_parachains_to_bridge_hub_wococo.rs
+++ b/relays/bin-substrate/src/chains/rococo_parachains_to_bridge_hub_wococo.rs
@@ -51,11 +51,11 @@ impl SubmitParachainHeadsCallBuilder<BridgeHubRococoToBridgeHubWococo>
 		parachain_heads_proof: ParaHeadsProof,
 	) -> CallOf<relay_bridge_hub_wococo_client::BridgeHubWococo> {
 		relay_bridge_hub_wococo_client::runtime::Call::BridgeRococoParachain(
-			relay_bridge_hub_wococo_client::runtime::BridgeParachainCall::submit_parachain_heads(
-				(at_relay_block.0, at_relay_block.1),
+			relay_bridge_hub_wococo_client::runtime::BridgeParachainCall::submit_parachain_heads {
+				at_relay_block: (at_relay_block.0, at_relay_block.1),
 				parachains,
 				parachain_heads_proof,
-			),
+			},
 		)
 	}
 }

--- a/relays/bin-substrate/src/chains/wococo_parachains_to_bridge_hub_rococo.rs
+++ b/relays/bin-substrate/src/chains/wococo_parachains_to_bridge_hub_rococo.rs
@@ -51,11 +51,11 @@ impl SubmitParachainHeadsCallBuilder<BridgeHubWococoToBridgeHubRococo>
 		parachain_heads_proof: ParaHeadsProof,
 	) -> CallOf<relay_bridge_hub_rococo_client::BridgeHubRococo> {
 		relay_bridge_hub_rococo_client::runtime::Call::BridgeWococoParachain(
-			bp_parachains::BridgeParachainCall::submit_parachain_heads(
-				(at_relay_block.0, at_relay_block.1),
+			bp_parachains::BridgeParachainCall::submit_parachain_heads {
+				at_relay_block: (at_relay_block.0, at_relay_block.1),
 				parachains,
 				parachain_heads_proof,
-			),
+			},
 		)
 	}
 }

--- a/relays/bin-substrate/src/cli/init_bridge.rs
+++ b/relays/bin-substrate/src/cli/init_bridge.rs
@@ -125,9 +125,10 @@ impl BridgeInitializer for MillauToRialtoParachainCliBridge {
 	) -> <Self::Target as Chain>::Call {
 		use relay_rialto_parachain_client::runtime;
 
-		let initialize_call = runtime::Call::BridgeMillauGrandpa(
-			runtime::BridgeMillauGrandpaCall::initialize(init_data),
-		);
+		let initialize_call =
+			runtime::Call::BridgeMillauGrandpa(runtime::BridgeMillauGrandpaCall::initialize {
+				init_data,
+			});
 		let sudo_call = SudoCall::sudo(Box::new(initialize_call));
 		runtime::Call::Sudo(sudo_call)
 	}
@@ -176,7 +177,9 @@ impl BridgeInitializer for RococoToBridgeHubWococoCliBridge {
 		init_data: <Self::Engine as Engine<Self::Source>>::InitializationData,
 	) -> <Self::Target as Chain>::Call {
 		relay_bridge_hub_wococo_client::runtime::Call::BridgeRococoGrandpa(
-			relay_bridge_hub_wococo_client::runtime::BridgeRococoGrandpaCall::initialize(init_data),
+			relay_bridge_hub_wococo_client::runtime::BridgeRococoGrandpaCall::initialize {
+				init_data,
+			},
 		)
 	}
 }
@@ -188,7 +191,9 @@ impl BridgeInitializer for WococoToBridgeHubRococoCliBridge {
 		init_data: <Self::Engine as Engine<Self::Source>>::InitializationData,
 	) -> <Self::Target as Chain>::Call {
 		relay_bridge_hub_rococo_client::runtime::Call::BridgeWococoGrandpa(
-			relay_bridge_hub_rococo_client::runtime::BridgeWococoGrandpaCall::initialize(init_data),
+			relay_bridge_hub_rococo_client::runtime::BridgeWococoGrandpaCall::initialize {
+				init_data,
+			},
 		)
 	}
 }

--- a/relays/client-bridge-hub-wococo/src/runtime_wrapper.rs
+++ b/relays/client-bridge-hub-wococo/src/runtime_wrapper.rs
@@ -96,7 +96,7 @@ mod tests {
 			set_id: 6,
 			operating_mode: BasicOperatingMode::Normal,
 		};
-		let call = BridgeRococoGrandpaCall::initialize(init_data);
+		let call = BridgeRococoGrandpaCall::initialize { init_data };
 		let tx = Call::BridgeRococoGrandpa(call);
 
 		// encode call as hex string

--- a/relays/lib-substrate-relay/src/finality/mod.rs
+++ b/relays/lib-substrate-relay/src/finality/mod.rs
@@ -156,7 +156,12 @@ macro_rules! generate_mocked_submit_finality_proof_call_builder {
 			) -> relay_substrate_client::CallOf<
 				<$pipeline as $crate::finality::SubstrateFinalitySyncPipeline>::TargetChain
 			> {
-				$bridge_grandpa($submit_finality_proof(Box::new(header.into_inner()), proof))
+				bp_runtime::paste::item! {
+					$bridge_grandpa($submit_finality_proof {
+						finality_target: Box::new(header.into_inner()),
+						justification: proof
+					})
+				}
 			}
 		}
 	};

--- a/relays/lib-substrate-relay/src/messages_lane.rs
+++ b/relays/lib-substrate-relay/src/messages_lane.rs
@@ -335,12 +335,14 @@ macro_rules! generate_mocked_receive_message_proof_call_builder {
 			) -> relay_substrate_client::CallOf<
 				<$pipeline as $crate::messages_lane::SubstrateMessageLane>::TargetChain
 			> {
-				$bridge_messages($receive_messages_proof(
-					relayer_id_at_source,
-					proof.1,
-					messages_count,
-					dispatch_weight,
-				))
+				bp_runtime::paste::item! {
+					$bridge_messages($receive_messages_proof {
+						relayer_id_at_bridged_chain: relayer_id_at_source,
+						proof: proof.1,
+						messages_count: messages_count,
+						dispatch_weight: dispatch_weight,
+					})
+				}
 			}
 		}
 	};
@@ -424,7 +426,12 @@ macro_rules! generate_mocked_receive_message_delivery_proof_call_builder {
 			) -> relay_substrate_client::CallOf<
 				<$pipeline as $crate::messages_lane::SubstrateMessageLane>::SourceChain
 			> {
-				$bridge_messages($receive_messages_delivery_proof(proof.1, proof.0))
+				bp_runtime::paste::item! {
+					$bridge_messages($receive_messages_delivery_proof {
+						proof: proof.1,
+						relayers_state: proof.0
+					})
+				}
 			}
 		}
 	};


### PR DESCRIPTION
We will need this in order to use the following macros with the calls in the autogenerated runtimes:

`generate_mocked_submit_finality_proof_call_builder`
`generate_mocked_receive_message_proof_call_builder`
`generate_mocked_receive_message_delivery_proof_call_builder`