### PR TITLE
Use specific error for case when para head is missing from the bridge pallet

### DIFF
--- a/relays/client-substrate/src/error.rs
+++ b/relays/client-substrate/src/error.rs
@@ -61,6 +61,9 @@ pub enum Error {
 	/// The bridge pallet is not yet initialized and all transactions will be rejected.
 	#[error("Bridge pallet is not initialized.")]
 	BridgePalletIsNotInitialized,
+	/// There's no best head of the parachain at the `pallet-bridge-parachains` at the target side.
+	#[error("No head of the ParaId({0}) at the bridge parachains pallet at {1}.")]
+	NoParachainHeadAtTarget(u32, String),
 	/// An error has happened when we have tried to parse storage proof.
 	#[error("Error when parsing storage proof: {0:?}.")]
 	StorageProofError(bp_runtime::StorageProofError),

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -473,12 +473,12 @@ where
 		P::SourceParachain,
 	>(target.client(), best_target_block_hash)
 	.await;
-	// if there are no parachain heads at the target (`BridgePalletIsNotInitialized`), we'll need
-	// to submit at least one. Otherwise the pallet will be treated as uninitialized and messages
+	// if there are no parachain heads at the target (`NoParachainHeadAtTarget`), we'll need to
+	// submit at least one. Otherwise the pallet will be treated as uninitialized and messages
 	// sync will stall.
 	let para_header_at_target = match para_header_at_target {
 		Ok(para_header_at_target) => Some(para_header_at_target.0),
-		Err(SubstrateError::BridgePalletIsNotInitialized) => None,
+		Err(SubstrateError::NoParachainHeadAtTarget(_, _)) => None,
 		Err(e) => return Err(map_target_err(e)),
 	};
 

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -478,6 +478,7 @@ where
 	// sync will stall.
 	let para_header_at_target = match para_header_at_target {
 		Ok(para_header_at_target) => Some(para_header_at_target.0),
+		Err(SubstrateError::BridgePalletIsNotInitialized) |
 		Err(SubstrateError::NoParachainHeadAtTarget(_, _)) => None,
 		Err(e) => return Err(map_target_err(e)),
 	};

--- a/relays/lib-substrate-relay/src/parachains/target.rs
+++ b/relays/lib-substrate-relay/src/parachains/target.rs
@@ -33,7 +33,7 @@ use parachains_relay::{
 };
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, BlockNumberOf, Chain, Client, Error as SubstrateError, HashOf,
-	HeaderIdOf, RelayChain, TransactionEra, TransactionTracker, UnsignedTransaction,
+	HeaderIdOf, ParachainBase, RelayChain, TransactionEra, TransactionTracker, UnsignedTransaction,
 };
 use relay_utils::{relay_loop::Client as RelayClient, HeaderId};
 use sp_core::{Bytes, Pair};
@@ -110,7 +110,10 @@ where
 		)
 		.map_err(SubstrateError::ResponseParseFailed)?
 		.map(Ok)
-		.unwrap_or(Err(SubstrateError::BridgePalletIsNotInitialized))
+		.unwrap_or(Err(SubstrateError::NoParachainHeadAtTarget(
+			P::SourceParachain::PARACHAIN_ID,
+			P::TargetChain::NAME.into(),
+		)))
 	}
 
 	async fn parachain_head(


### PR DESCRIPTION
It is strange to see `BridgePalletIsNotInitialized` in relay logs, even though the parachains pallet do not have this "initialization" step.