### PR TITLE
Fix on demand parachains relay when no parachain head at target

### DIFF
--- a/relays/lib-substrate-relay/src/finality/target.rs
+++ b/relays/lib-substrate-relay/src/finality/target.rs
@@ -102,7 +102,8 @@ where
 			None,
 		)
 		.await?
-		.best_finalized_peer_at_best_self)
+		.best_finalized_peer_at_best_self
+		.ok_or(Error::BridgePalletIsNotInitialized)?)
 	}
 
 	async fn submit_finality_proof(

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -422,11 +422,14 @@ struct RelayData<ParaHash, ParaNumber, RelayNumber> {
 	pub para_header_at_source: Option<HeaderId<ParaHash, ParaNumber>>,
 	/// Parachain header, that is available at the source relay chain at `relay_header_at_target`
 	/// block.
+	///
+	/// May be `None` if there's no `relay_header_at_target` yet, or if the
+	/// `relay_header_at_target` is too old and we think its state has been pruned.
 	pub para_header_at_relay_header_at_target: Option<HeaderId<ParaHash, ParaNumber>>,
 	/// Relay header number at the source chain.
 	pub relay_header_at_source: RelayNumber,
 	/// Relay header number at the target chain.
-	pub relay_header_at_target: RelayNumber,
+	pub relay_header_at_target: Option<RelayNumber>,
 }
 
 /// Read required data from source and target clients.
@@ -477,9 +480,8 @@ where
 	// submit at least one. Otherwise the pallet will be treated as uninitialized and messages
 	// sync will stall.
 	let para_header_at_target = match para_header_at_target {
-		Ok(para_header_at_target) => Some(para_header_at_target.0),
-		Err(SubstrateError::BridgePalletIsNotInitialized) |
-		Err(SubstrateError::NoParachainHeadAtTarget(_, _)) => None,
+		Ok(Some(para_header_at_target)) => Some(para_header_at_target.0),
+		Ok(None) => None,
 		Err(e) => return Err(map_target_err(e)),
 	};
 
@@ -502,25 +504,34 @@ where
 	.await
 	.map_err(map_target_err)?;
 
-	// if relay header at target is too old, then its state may already be discarded at the source
+	// if relay header at target is too old then its state may already be discarded at the source
 	// => just use `None` in this case
-	let is_relay_header_at_target_ancient =
-		is_ancient_block(relay_header_at_target.number(), relay_header_at_source);
-	let para_header_at_relay_header_at_target = if is_relay_header_at_target_ancient {
-		None
-	} else {
-		source
-			.on_chain_para_head_id(relay_header_at_target, P::SourceParachain::PARACHAIN_ID.into())
-			.await
-			.map_err(map_source_err)?
-	};
+	//
+	// the same is for case when there's no relay header at target at all
+	let available_relay_header_at_target =
+		relay_header_at_target.filter(|relay_header_at_target| {
+			!is_ancient_block(relay_header_at_target.number(), relay_header_at_source)
+		});
+	let para_header_at_relay_header_at_target =
+		if let Some(available_relay_header_at_target) = available_relay_header_at_target {
+			source
+				.on_chain_para_head_id(
+					available_relay_header_at_target,
+					P::SourceParachain::PARACHAIN_ID.into(),
+				)
+				.await
+				.map_err(map_source_err)?
+		} else {
+			None
+		};
 
 	Ok(RelayData {
 		required_para_header: required_header_number,
 		para_header_at_target,
 		para_header_at_source,
 		relay_header_at_source,
-		relay_header_at_target: relay_header_at_target.0,
+		relay_header_at_target: relay_header_at_target
+			.map(|relay_header_at_target| relay_header_at_target.0),
 		para_header_at_relay_header_at_target,
 	})
 }
@@ -535,18 +546,28 @@ where
 	ParaNumber: Copy + PartialOrd + Zero,
 	RelayNumber: Copy + Debug + Ord,
 {
+	// we can't do anything until **relay chain** bridge GRANDPA pallet is not initialized at the
+	// target chain
+	let relay_header_at_target = match data.relay_header_at_target {
+		Some(relay_header_at_target) => relay_header_at_target,
+		None => return RelayState::Idle,
+	};
+
 	// Process the `RelayingRelayHeader` state.
 	if let &RelayState::RelayingRelayHeader(relay_header_number) = &state {
-		if data.relay_header_at_target < relay_header_number {
+		if relay_header_at_target < relay_header_number {
 			// The required relay header hasn't yet been relayed. Ask / wait for it.
 			return state
 		}
 
 		// We may switch to `RelayingParaHeader` if parachain head is available.
-		state = data
-			.para_header_at_relay_header_at_target
-			.clone()
-			.map_or(RelayState::Idle, RelayState::RelayingParaHeader);
+		if let Some(para_header_at_relay_header_at_target) =
+			data.para_header_at_relay_header_at_target.clone()
+		{
+			return RelayState::RelayingParaHeader(para_header_at_relay_header_at_target)
+		}
+
+		// else use the regular process - e.g. we may require to deliver new relay header first
 	}
 
 	// Process the `RelayingParaHeader` state.
@@ -585,7 +606,7 @@ where
 	// its ancestor
 
 	// we need relay chain header first
-	if data.relay_header_at_target < data.relay_header_at_source {
+	if relay_header_at_target < data.relay_header_at_source {
 		return RelayState::RelayingRelayHeader(data.relay_header_at_source)
 	}
 
@@ -640,7 +661,8 @@ impl<'a, P: SubstrateParachainsPipeline>
 			None,
 		)
 		.await?
-		.best_finalized_peer_at_best_self)
+		.best_finalized_peer_at_best_self
+		.ok_or(SubstrateError::BridgePalletIsNotInitialized)?)
 	}
 
 	async fn best_finalized_para_block_at_source(
@@ -726,7 +748,7 @@ mod tests {
 					para_header_at_target: Some(50),
 					para_header_at_source: Some(HeaderId(110, 110)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 700,
+					relay_header_at_target: Some(700),
 					para_header_at_relay_header_at_target: Some(HeaderId(100, 100)),
 				},
 				RelayState::RelayingRelayHeader(750),
@@ -744,7 +766,7 @@ mod tests {
 					para_header_at_target: Some(50),
 					para_header_at_source: Some(HeaderId(110, 110)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 750,
+					relay_header_at_target: Some(750),
 					para_header_at_relay_header_at_target: Some(HeaderId(100, 100)),
 				},
 				RelayState::RelayingRelayHeader(750),
@@ -762,7 +784,7 @@ mod tests {
 					para_header_at_target: Some(50),
 					para_header_at_source: Some(HeaderId(110, 110)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 780,
+					relay_header_at_target: Some(780),
 					para_header_at_relay_header_at_target: Some(HeaderId(105, 105)),
 				},
 				RelayState::RelayingRelayHeader(750),
@@ -779,7 +801,7 @@ mod tests {
 					para_header_at_target: Some(50),
 					para_header_at_source: Some(HeaderId(110, 110)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 780,
+					relay_header_at_target: Some(780),
 					para_header_at_relay_header_at_target: Some(HeaderId(105, 105)),
 				},
 				RelayState::RelayingParaHeader(HeaderId(105, 105)),
@@ -797,7 +819,7 @@ mod tests {
 					para_header_at_target: Some(105),
 					para_header_at_source: Some(HeaderId(110, 110)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 780,
+					relay_header_at_target: Some(780),
 					para_header_at_relay_header_at_target: Some(HeaderId(105, 105)),
 				},
 				RelayState::Idle,
@@ -815,7 +837,7 @@ mod tests {
 					para_header_at_target: Some(105),
 					para_header_at_source: None,
 					relay_header_at_source: 800,
-					relay_header_at_target: 780,
+					relay_header_at_target: Some(780),
 					para_header_at_relay_header_at_target: Some(HeaderId(105, 105)),
 				},
 				RelayState::Idle,
@@ -833,7 +855,7 @@ mod tests {
 					para_header_at_target: Some(105),
 					para_header_at_source: Some(HeaderId(110, 110)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 780,
+					relay_header_at_target: Some(780),
 					para_header_at_relay_header_at_target: Some(HeaderId(105, 105)),
 				},
 				RelayState::Idle,
@@ -851,7 +873,7 @@ mod tests {
 					para_header_at_target: Some(105),
 					para_header_at_source: Some(HeaderId(125, 125)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 780,
+					relay_header_at_target: Some(780),
 					para_header_at_relay_header_at_target: Some(HeaderId(105, 105)),
 				},
 				RelayState::Idle,
@@ -869,7 +891,7 @@ mod tests {
 					para_header_at_target: Some(105),
 					para_header_at_source: Some(HeaderId(125, 125)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 800,
+					relay_header_at_target: Some(800),
 					para_header_at_relay_header_at_target: Some(HeaderId(125, 125)),
 				},
 				RelayState::Idle,
@@ -887,7 +909,7 @@ mod tests {
 					para_header_at_target: Some(105),
 					para_header_at_source: None,
 					relay_header_at_source: 800,
-					relay_header_at_target: 800,
+					relay_header_at_target: Some(800),
 					para_header_at_relay_header_at_target: None,
 				},
 				RelayState::RelayingRelayHeader(800),
@@ -905,7 +927,7 @@ mod tests {
 					para_header_at_target: None,
 					para_header_at_source: Some(HeaderId(125, 125)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 800,
+					relay_header_at_target: Some(800),
 					para_header_at_relay_header_at_target: Some(HeaderId(125, 125)),
 				},
 				RelayState::Idle,
@@ -923,7 +945,7 @@ mod tests {
 					para_header_at_target: None,
 					para_header_at_source: Some(HeaderId(125, 125)),
 					relay_header_at_source: 800,
-					relay_header_at_target: 700,
+					relay_header_at_target: Some(700),
 					para_header_at_relay_header_at_target: Some(HeaderId(125, 125)),
 				},
 				RelayState::Idle,

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -561,10 +561,8 @@ where
 		}
 
 		// We may switch to `RelayingParaHeader` if parachain head is available.
-		if let Some(para_header_at_relay_header_at_target) =
-			data.para_header_at_relay_header_at_target.clone()
-		{
-			return RelayState::RelayingParaHeader(para_header_at_relay_header_at_target)
+		if let Some(para_header_at_relay_header_at_target) = data.para_header_at_relay_header_at_target.as_ref() {
+			return RelayState::RelayingParaHeader(para_header_at_relay_header_at_target.clone())
 		}
 
 		// else use the regular process - e.g. we may require to deliver new relay header first

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -561,7 +561,9 @@ where
 		}
 
 		// We may switch to `RelayingParaHeader` if parachain head is available.
-		if let Some(para_header_at_relay_header_at_target) = data.para_header_at_relay_header_at_target.as_ref() {
+		if let Some(para_header_at_relay_header_at_target) =
+			data.para_header_at_relay_header_at_target.as_ref()
+		{
 			return RelayState::RelayingParaHeader(para_header_at_relay_header_at_target.clone())
 		}
 

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -539,7 +539,7 @@ where
 /// Select relay and parachain headers that need to be relayed.
 fn select_headers_to_relay<ParaHash, ParaNumber, RelayNumber>(
 	data: &RelayData<ParaHash, ParaNumber, RelayNumber>,
-	mut state: RelayState<ParaHash, ParaNumber, RelayNumber>,
+	state: RelayState<ParaHash, ParaNumber, RelayNumber>,
 ) -> RelayState<ParaHash, ParaNumber, RelayNumber>
 where
 	ParaHash: Clone,

--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -308,7 +308,7 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>, TC: TargetClient<P>>(
 						target_best_nonces_required = true;
 						race_state.best_target_header_id = Some(target_state.best_self);
 						race_state.best_finalized_source_header_id_at_best_target
-							= Some(target_state.best_finalized_peer_at_best_self);
+							= target_state.best_finalized_peer_at_best_self;
 					}
 
 					let is_target_finalized_state_updated = race_state.best_finalized_target_header_id.as_ref()

--- a/relays/messages/src/metrics.rs
+++ b/relays/messages/src/metrics.rs
@@ -66,24 +66,38 @@ impl MessageLaneLoopMetrics {
 	pub fn update_source_state<P: MessageLane>(&self, source_client_state: SourceClientState<P>) {
 		self.source_to_target_finality_metrics
 			.update_best_block_at_source(source_client_state.best_self.0);
-		self.target_to_source_finality_metrics
-			.update_best_block_at_target(source_client_state.best_finalized_peer_at_best_self.0);
-		self.target_to_source_finality_metrics.update_using_same_fork(
-			source_client_state.best_finalized_peer_at_best_self.1 ==
-				source_client_state.actual_best_finalized_peer_at_best_self.1,
-		);
+		if let Some(best_finalized_peer_at_best_self) =
+			source_client_state.best_finalized_peer_at_best_self
+		{
+			self.target_to_source_finality_metrics
+				.update_best_block_at_target(best_finalized_peer_at_best_self.0);
+			if let Some(actual_best_finalized_peer_at_best_self) =
+				source_client_state.actual_best_finalized_peer_at_best_self
+			{
+				self.target_to_source_finality_metrics.update_using_same_fork(
+					best_finalized_peer_at_best_self.1 == actual_best_finalized_peer_at_best_self.1,
+				);
+			}
+		}
 	}
 
 	/// Update target client state metrics.
 	pub fn update_target_state<P: MessageLane>(&self, target_client_state: TargetClientState<P>) {
 		self.target_to_source_finality_metrics
 			.update_best_block_at_source(target_client_state.best_self.0);
-		self.source_to_target_finality_metrics
-			.update_best_block_at_target(target_client_state.best_finalized_peer_at_best_self.0);
-		self.source_to_target_finality_metrics.update_using_same_fork(
-			target_client_state.best_finalized_peer_at_best_self.1 ==
-				target_client_state.actual_best_finalized_peer_at_best_self.1,
-		);
+		if let Some(best_finalized_peer_at_best_self) =
+			target_client_state.best_finalized_peer_at_best_self
+		{
+			self.source_to_target_finality_metrics
+				.update_best_block_at_target(best_finalized_peer_at_best_self.0);
+			if let Some(actual_best_finalized_peer_at_best_self) =
+				target_client_state.actual_best_finalized_peer_at_best_self
+			{
+				self.source_to_target_finality_metrics.update_using_same_fork(
+					best_finalized_peer_at_best_self.1 == actual_best_finalized_peer_at_best_self.1,
+				);
+			}
+		}
 	}
 
 	/// Update latest generated nonce at source.


### PR DESCRIPTION
follow up on #1829 (actually I was thinking that the #1829) would fix the issue, but it has not

The main issue is that the messages relay needs to read "client state" first to understand if he wants to deliver something or not. But if there were no parachain head in the bridge parachains pallet at the target chain, it was treated as an error => the messages relay was unable to decide that it needs some parachain header to be relayed => it wasn't relayed "normally".