### PR TITLE
Only connect using wss on actual test deployments

### DIFF
--- a/deployments/bridges/rialto-millau/docker-compose.yml
+++ b/deployments/bridges/rialto-millau/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ./bridges/rialto-millau/entrypoints:/entrypoints
     environment:
       RUST_LOG: rpc=trace,bridge=trace
+      GLOBAL_DEPLOYMENTS: $GLOBAL_DEPLOYMENTS
     ports:
       - "10016:9616"
     depends_on: &all-nodes

--- a/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
+++ b/deployments/bridges/rialto-millau/entrypoints/relay-millau-rialto-entrypoint.sh
@@ -20,14 +20,17 @@ sleep 15
 # Give chain a little bit of time to process initialization transaction
 sleep 6
 
+RIALTO_NODE_CONNECTION_PARAMS=$([ -z ${GLOBAL_DEPLOYMENTS} ] && \
+	echo "--rialto-host rialto-node-alice --rialto-port 9944" \
+	|| \
+	echo "--rialto-host wss.rialto.brucke.link --rialto-port 443 --rialto-secure" )
+
 /home/user/substrate-relay relay-headers-and-messages millau-rialto \
 	--millau-host millau-node-alice \
 	--millau-port 9944 \
 	--millau-signer //Rialto.HeadersAndMessagesRelay \
 	--millau-transactions-mortality=64 \
-	--rialto-host wss.rialto.brucke.link \
-	--rialto-port 443 \
-	--rialto-secure \
+	$RIALTO_NODE_CONNECTION_PARAMS \
 	--rialto-signer //Millau.HeadersAndMessagesRelay \
 	--rialto-transactions-mortality=64 \
 	--lane=00000000 \


### PR DESCRIPTION
The other part of #1809, which I want to keep, but under some flag. Otherwise when I start it locally, it tries to connnect to our node from test deployments