### PR TITLE
Run partial-repo-build-test on every PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,7 @@ benchmarks-test:
 partial-repo-build-test:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *nightly-test
+  <<:                              *test-refs
   script:
     - ./scripts/verify-pallets-build.sh --no-revert
   # we may live with failing partial repo build, it is just a signal for us

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,8 +197,6 @@ partial-repo-build-test:
   <<:                              *test-refs
   script:
     - ./scripts/verify-pallets-build.sh --no-revert
-  # we may live with failing partial repo build, it is just a signal for us
-  allow_failure:                   true
 
 #### stage:                        build
 


### PR DESCRIPTION
@bkontur That's for your request here: https://github.com/paritytech/parity-bridges-common/issues/1774#issuecomment-1422831767 . My thoughts were:
- it is just a helper to leave minimal set of code in the Cumuls repo;
- if something goes wrong, we may leave additional code in Cumuls repo, until it is fixed;
- running this on every PR slows down CI a bit;
- some PRs may be more important than leaving repo in partial-compilable-state, so we may defer this fix until better times.

But if you think we need it here, let's do that - just press Approve :)