### PR TITLE
Reject storage proofs with unused nodes: begin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,7 +863,6 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-runtime 7.0.0",
  "sp-std 5.0.0",
- "sp-trie 7.0.0",
 ]
 
 [[package]]

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -942,42 +942,34 @@ mod tests {
 				);
 				target::verify_messages_proof::<OnThisChainBridge>(proof, 10)
 			}),
-			Err(target::MessageProofError::HeaderChain(HeaderChainError::StorageProof(StorageProofError::StorageRootMismatch))),
+			Err(target::MessageProofError::HeaderChain(HeaderChainError::StorageProof(
+				StorageProofError::StorageRootMismatch
+			))),
 		);
 	}
 
 	#[test]
 	fn message_proof_is_rejected_if_it_has_duplicate_trie_nodes() {
 		assert_eq!(
-			using_messages_proof(
-				10,
-				None,
-				encode_all_messages,
-				encode_lane_data,
-				|mut proof| {
-					let node = proof.storage_proof.pop().unwrap();
-					proof.storage_proof.push(node.clone());
-					proof.storage_proof.push(node);
-					target::verify_messages_proof::<OnThisChainBridge>(proof, 10)
-				},
-			),
-			Err(target::MessageProofError::HeaderChain(HeaderChainError::StorageProof(StorageProofError::DuplicateNodesInProof))),
+			using_messages_proof(10, None, encode_all_messages, encode_lane_data, |mut proof| {
+				let node = proof.storage_proof.pop().unwrap();
+				proof.storage_proof.push(node.clone());
+				proof.storage_proof.push(node);
+				target::verify_messages_proof::<OnThisChainBridge>(proof, 10)
+			},),
+			Err(target::MessageProofError::HeaderChain(HeaderChainError::StorageProof(
+				StorageProofError::DuplicateNodesInProof
+			))),
 		);
 	}
 
 	#[test]
 	fn message_proof_is_rejected_if_it_has_unused_trie_nodes() {
 		assert_eq!(
-			using_messages_proof(
-				10,
-				None,
-				encode_all_messages,
-				encode_lane_data,
-				|mut proof| {
-					proof.storage_proof.push(vec![42]);
-					target::verify_messages_proof::<OnThisChainBridge>(proof, 10)
-				},
-			),
+			using_messages_proof(10, None, encode_all_messages, encode_lane_data, |mut proof| {
+				proof.storage_proof.push(vec![42]);
+				target::verify_messages_proof::<OnThisChainBridge>(proof, 10)
+			},),
 			Err(target::MessageProofError::StorageProof(StorageProofError::UnusedNodesInTheProof)),
 		);
 	}

--- a/bin/runtime-common/src/messages_benchmarking.rs
+++ b/bin/runtime-common/src/messages_benchmarking.rs
@@ -209,15 +209,9 @@ where
 	root = grow_trie(root, &mut mdb, params.size);
 
 	// generate storage proof to be delivered to This chain
-	let mut proof_recorder = Recorder::<LayoutV1<HasherOf<BridgedChain<B>>>>::new();
-	record_all_trie_keys::<LayoutV1<HasherOf<BridgedChain<B>>>, _>(
-		&mdb,
-		&root,
-		&mut proof_recorder,
-	)
-	.map_err(|_| "record_all_trie_keys has failed")
-	.expect("record_all_trie_keys should not fail in benchmarks");
-	let storage_proof = proof_recorder.drain().into_iter().map(|n| n.data.to_vec()).collect();
+	let storage_proof = record_all_trie_keys::<LayoutV1<HasherOf<BridgedChain<B>>>, _>(&mdb, &root)
+		.map_err(|_| "record_all_trie_keys has failed")
+		.expect("record_all_trie_keys should not fail in benchmarks");
 
 	(root, storage_proof)
 }

--- a/bin/runtime-common/src/messages_benchmarking.rs
+++ b/bin/runtime-common/src/messages_benchmarking.rs
@@ -22,7 +22,7 @@
 use crate::{
 	messages::{
 		source::FromBridgedChainMessagesDeliveryProof, target::FromBridgedChainMessagesProof,
-		AccountIdOf, BridgedChain, HashOf, HasherOf, MessageBridge, RawStorageProof, ThisChain,
+		AccountIdOf, BridgedChain, HashOf, HasherOf, MessageBridge, ThisChain,
 	},
 	messages_generation::{
 		encode_all_messages, encode_lane_data, grow_trie, prepare_messages_storage_proof,
@@ -31,13 +31,15 @@ use crate::{
 
 use bp_messages::storage_keys;
 use bp_polkadot_core::parachains::ParaHash;
-use bp_runtime::{record_all_trie_keys, Chain, Parachain, StorageProofSize, UnderlyingChainOf};
+use bp_runtime::{
+	record_all_trie_keys, Chain, Parachain, RawStorageProof, StorageProofSize, UnderlyingChainOf,
+};
 use codec::Encode;
 use frame_support::weights::Weight;
 use pallet_bridge_messages::benchmarking::{MessageDeliveryProofParams, MessageProofParams};
 use sp_runtime::traits::{Header, Zero};
 use sp_std::prelude::*;
-use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, Recorder, TrieMut};
+use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, TrieMut};
 
 /// Prepare proof of messages for the `receive_messages_proof` call.
 ///

--- a/bin/runtime-common/src/parachains_benchmarking.rs
+++ b/bin/runtime-common/src/parachains_benchmarking.rs
@@ -72,11 +72,9 @@ where
 	state_root = grow_trie(state_root, &mut mdb, size);
 
 	// generate heads storage proof
-	let mut proof_recorder = Recorder::<LayoutV1<RelayBlockHasher>>::new();
-	record_all_trie_keys::<LayoutV1<RelayBlockHasher>, _>(&mdb, &state_root, &mut proof_recorder)
+	let proof = record_all_trie_keys::<LayoutV1<RelayBlockHasher>, _>(&mdb, &state_root)
 		.map_err(|_| "record_all_trie_keys has failed")
 		.expect("record_all_trie_keys should not fail in benchmarks");
-	let proof = proof_recorder.drain().into_iter().map(|n| n.data.to_vec()).collect();
 
 	let (relay_block_number, relay_block_hash) =
 		insert_header_to_grandpa_pallet::<R, R::BridgesGrandpaPalletInstance>(state_root);

--- a/bin/runtime-common/src/parachains_benchmarking.rs
+++ b/bin/runtime-common/src/parachains_benchmarking.rs
@@ -29,7 +29,7 @@ use codec::Encode;
 use frame_support::traits::Get;
 use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumber};
 use sp_std::prelude::*;
-use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, Recorder, TrieMut};
+use sp_trie::{trie_types::TrieDBMutBuilderV1, LayoutV1, MemoryDB, TrieMut};
 
 /// Prepare proof of messages for the `receive_messages_proof` call.
 ///

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -1064,7 +1064,7 @@ mod tests {
 			assert_noop!(
 				Pallet::<TestRuntime>::parse_finalized_storage_proof(
 					Default::default(),
-					sp_trie::StorageProof::new(vec![]),
+					vec![],
 					|_| (),
 				),
 				bp_header_chain::HeaderChainError::UnknownHeader,

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -1500,7 +1500,7 @@ mod tests {
 
 	#[test]
 	fn ignores_parachain_head_if_it_is_missing_from_storage_proof() {
-		let (state_root, proof, _) = prepare_parachain_heads_proof(vec![(1, head_data(1, 0))]);
+		let (state_root, proof, _) = prepare_parachain_heads_proof(vec![]);
 		let parachains = vec![(ParaId(2), Default::default())];
 		run_test(|| {
 			initialize(state_root);

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -417,12 +417,9 @@ pub mod pallet {
 					storage.ensure_no_unused_nodes()
 				},
 			)
+			.and_then(|r| r.map_err(bp_header_chain::HeaderChainError::StorageProof))
 			.map_err(|e| {
-				log::trace!(target: LOG_TARGET, "Failed to read parachain heads. Storage proof is invalid: {:?}", e);
-				Error::<T, I>::InvalidStorageProof
-			})?
-			.map_err(|e| {
-				log::trace!(target: LOG_TARGET, "Failed to read parachain heads: {:?}", e);
+				log::trace!(target: LOG_TARGET, "Parachain heads storage proof is invalid: {:?}", e);
 				Error::<T, I>::InvalidStorageProof
 			})?;
 

--- a/primitives/header-chain/Cargo.toml
+++ b/primitives/header-chain/Cargo.toml
@@ -23,7 +23,6 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", 
 sp-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [dev-dependencies]
 bp-test-utils = { path = "../test-utils" }
@@ -43,5 +42,4 @@ std = [
 	"sp-finality-grandpa/std",
 	"sp-runtime/std",
 	"sp-std/std",
-	"sp-trie/std",
 ]

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -48,11 +48,7 @@ impl From<HeaderChainError> for &'static str {
 	fn from(err: HeaderChainError) -> &'static str {
 		match err {
 			HeaderChainError::UnknownHeader => "UnknownHeader",
-			HeaderChainError::StorageProof(StorageProofError::DuplicateNodesInProof) =>
-				"Storage proof contains duplicate nodes",
-			HeaderChainError::StorageProof(StorageProofError::UnusedNodesInTheProof) =>
-				"Storage proof contains unused nodes",
-			HeaderChainError::StorageProof(_) => "StorageProofError",
+			HeaderChainError::StorageProof(e) => e.into(),
 		}
 	}
 }

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -93,8 +93,8 @@ pub trait HeaderChain<C: Chain> {
 	) -> Result<R, HeaderChainError> {
 		let state_root = Self::finalized_header_state_root(header_hash)
 			.ok_or(HeaderChainError::UnknownHeader)?;
-		let storage_proof_checker =
-			bp_runtime::StorageProofChecker::new(state_root, storage_proof).map_err(HeaderChainError::StorageProof)?;
+		let storage_proof_checker = bp_runtime::StorageProofChecker::new(state_root, storage_proof)
+			.map_err(HeaderChainError::StorageProof)?;
 
 		Ok(parse(storage_proof_checker))
 	}

--- a/primitives/polkadot-core/src/parachains.rs
+++ b/primitives/polkadot-core/src/parachains.rs
@@ -22,7 +22,7 @@
 //! chains. Having pallets that are referencing polkadot, would mean that there may
 //! be two versions of polkadot crates included in the runtime. Which is bad.
 
-use bp_runtime::Size;
+use bp_runtime::{RawStorageProof, Size};
 use codec::{CompactAs, Decode, Encode, MaxEncodedLen};
 use frame_support::RuntimeDebug;
 use scale_info::TypeInfo;
@@ -88,7 +88,7 @@ pub type ParaHasher = crate::Hasher;
 
 /// Raw storage proof of parachain heads, stored in polkadot-like chain runtime.
 #[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
-pub struct ParaHeadsProof(pub Vec<Vec<u8>>);
+pub struct ParaHeadsProof(pub RawStorageProof);
 
 impl Size for ParaHeadsProof {
 	fn size(&self) -> u32 {

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -40,7 +40,7 @@ use num_traits::{CheckedSub, One};
 use sp_runtime::transaction_validity::TransactionValidity;
 pub use storage_proof::{
 	record_all_keys as record_all_trie_keys, Error as StorageProofError,
-	ProofSize as StorageProofSize, StorageProofChecker,
+	ProofSize as StorageProofSize, RawStorageProof, StorageProofChecker,
 };
 pub use storage_types::BoundedStorageValue;
 

--- a/primitives/runtime/src/storage_proof.rs
+++ b/primitives/runtime/src/storage_proof.rs
@@ -16,7 +16,7 @@
 
 //! Logic for checking Substrate storage proofs.
 
-use codec::Decode;
+use codec::{Decode, Encode};
 use hash_db::{HashDB, Hasher, EMPTY_PREFIX};
 use sp_runtime::RuntimeDebug;
 use sp_std::{boxed::Box, collections::btree_set::BTreeSet, vec::Vec};
@@ -125,7 +125,7 @@ where
 }
 
 /// Storage proof related errors.
-#[derive(Eq, RuntimeDebug, PartialEq)]
+#[derive(Clone, Eq, PartialEq, RuntimeDebug)]
 pub enum Error {
 	/// Duplicate trie nodes are found in the proof.
 	DuplicateNodesInProof,
@@ -144,7 +144,6 @@ pub enum Error {
 /// NOTE: This should only be used for **testing**.
 #[cfg(feature = "std")]
 pub fn craft_valid_storage_proof() -> (sp_core::H256, RawStorageProof) {
-	use codec::Encode;
 	use sp_state_machine::{backend::Backend, prove_read, InMemoryBackend};
 
 	let state_version = sp_runtime::StateVersion::default();

--- a/primitives/runtime/src/storage_proof.rs
+++ b/primitives/runtime/src/storage_proof.rs
@@ -142,14 +142,10 @@ pub enum Error {
 impl From<Error> for &'static str {
 	fn from(err: Error) -> &'static str {
 		match err {
-			Error::DuplicateNodesInProof =>
-				"Storage proof contains duplicate nodes",
-			Error::UnusedNodesInTheProof =>
-				"Storage proof contains unused nodes",
-			Error::StorageRootMismatch =>
-				"Storage root is missing from the storage proof",
-			Error::StorageValueUnavailable =>
-				"Storage value is missing from the storage proof",
+			Error::DuplicateNodesInProof => "Storage proof contains duplicate nodes",
+			Error::UnusedNodesInTheProof => "Storage proof contains unused nodes",
+			Error::StorageRootMismatch => "Storage root is missing from the storage proof",
+			Error::StorageValueUnavailable => "Storage value is missing from the storage proof",
 			Error::StorageValueDecodeFailed(_) =>
 				"Failed to decode storage value from the storage proof",
 		}

--- a/primitives/runtime/src/storage_proof.rs
+++ b/primitives/runtime/src/storage_proof.rs
@@ -224,7 +224,7 @@ pub mod tests {
 	#[test]
 	fn proof_with_duplicate_items_is_rejected() {
 		let (root, mut proof) = craft_valid_storage_proof();
-		proof.push(proof.iter().next().unwrap().clone());
+		proof.push(proof.first().unwrap().clone());
 
 		assert_eq!(
 			StorageProofChecker::<sp_core::Blake2Hasher>::new(root, proof).map(drop),

--- a/primitives/runtime/src/storage_proof.rs
+++ b/primitives/runtime/src/storage_proof.rs
@@ -195,11 +195,13 @@ where
 		trie.get(&key)?;
 	}
 
+	// recorder may record the same trie node multiple times and we don't want duplicate nodes
+	// in our proofs => let's deduplicate it by collecting to the BTreeSet first
 	Ok(recorder
 		.drain()
 		.into_iter()
 		.map(|n| n.data.to_vec())
-		.collect::<BTreeSet<_>>() // deduplicate
+		.collect::<BTreeSet<_>>()
 		.into_iter()
 		.collect())
 }

--- a/primitives/runtime/src/storage_proof.rs
+++ b/primitives/runtime/src/storage_proof.rs
@@ -223,11 +223,28 @@ pub mod tests {
 
 	#[test]
 	fn proof_with_duplicate_items_is_rejected() {
-		// TODO
+		let (root, mut proof) = craft_valid_storage_proof();
+		proof.push(proof.iter().next().unwrap().clone());
+
+		assert_eq!(
+			StorageProofChecker::<sp_core::Blake2Hasher>::new(root, proof).map(drop),
+			Err(Error::DuplicateNodesInProof),
+		);
 	}
 
 	#[test]
 	fn proof_with_unused_items_is_rejected() {
-		// TODO
+		let (root, proof) = craft_valid_storage_proof();
+
+		let mut checker =
+			StorageProofChecker::<sp_core::Blake2Hasher>::new(root, proof.clone()).unwrap();
+		checker.read_value(b"key1").unwrap();
+		checker.read_value(b"key2").unwrap();
+		checker.read_value(b"key4").unwrap();
+		checker.read_value(b"key22").unwrap();
+		assert_eq!(checker.ensure_no_unused_nodes(), Ok(()));
+
+		let checker = StorageProofChecker::<sp_core::Blake2Hasher>::new(root, proof).unwrap();
+		assert_eq!(checker.ensure_no_unused_nodes(), Err(Error::UnusedNodesInTheProof));
 	}
 }

--- a/primitives/runtime/src/storage_proof.rs
+++ b/primitives/runtime/src/storage_proof.rs
@@ -139,6 +139,23 @@ pub enum Error {
 	StorageValueDecodeFailed(codec::Error),
 }
 
+impl From<Error> for &'static str {
+	fn from(err: Error) -> &'static str {
+		match err {
+			Error::DuplicateNodesInProof =>
+				"Storage proof contains duplicate nodes",
+			Error::UnusedNodesInTheProof =>
+				"Storage proof contains unused nodes",
+			Error::StorageRootMismatch =>
+				"Storage root is missing from the storage proof",
+			Error::StorageValueUnavailable =>
+				"Storage value is missing from the storage proof",
+			Error::StorageValueDecodeFailed(_) =>
+				"Failed to decode storage value from the storage proof",
+		}
+	}
+}
+
 /// Return valid storage proof and state root.
 ///
 /// NOTE: This should only be used for **testing**.


### PR DESCRIPTION
related https://github.com/paritytech/srlabs_findings/issues/266

The goal of this PR is to:
- [x] reject messages proof if there are duplicate/unused trie nodes in the storage proof;
- [x] reject message delivery confirmations if there are duplicate/unused trie nodes in the storage proof;
- [x] reject parachain heads update transaction if there are duplicate/unused trie nodes in the storage proof;
- [x] test that it that actually works with our relay.

The outcome is that any transaction with duplicate/unused trie nodes in the storage proof (we have `3` transactions that accept storage proofs) will be invalid AND we won't refund relayer for submitting such transaction.