### PR TITLE
Fix clippy issues

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ clippy-nightly:
     RUSTFLAGS:                     "-D warnings"
   script:
     # clippy currently is raising `derive-partial-eq-without-eq` warning even if `Eq` is actually derived
-    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq -A clippy::or_fun_call -A clippy::extra_unused_type_parameters
+    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq -A clippy::or_fun_call -A clippy::extra-unused-type-parameters
 
 fmt:
   stage:                           lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ clippy-nightly:
     RUSTFLAGS:                     "-D warnings"
   script:
     # clippy currently is raising `derive-partial-eq-without-eq` warning even if `Eq` is actually derived
-    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq -A clippy::or_fun_call
+    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq -A clippy::or_fun_call -A clippy::extra_unused_type_parameters
 
 fmt:
   stage:                           lint

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,7 @@ clippy-nightly:
     RUSTFLAGS:                     "-D warnings"
   script:
     # clippy currently is raising `derive-partial-eq-without-eq` warning even if `Eq` is actually derived
-    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq -A clippy::or_fun_call -A clippy::extra-unused-type-parameters
+    - SKIP_WASM_BUILD=1 cargo +nightly clippy --all-targets -- -A clippy::redundant_closure -A clippy::derive-partial-eq-without-eq -A clippy::or_fun_call
 
 fmt:
   stage:                           lint

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -162,7 +162,6 @@ mod tests {
 			RialtoGrandpaInstance,
 			WithRialtoMessagesInstance,
 			WithRialtoMessageBridge,
-			bp_millau::Millau,
 		>(AssertCompleteBridgeConstants {
 			this_chain_constants: AssertChainConstants {
 				block_length: bp_millau::BlockLength::get(),

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -161,7 +161,6 @@ mod tests {
 			MillauGrandpaInstance,
 			WithMillauMessagesInstance,
 			WithMillauMessageBridge,
-			bp_rialto::Rialto,
 		>(AssertCompleteBridgeConstants {
 			this_chain_constants: AssertChainConstants {
 				block_length: bp_rialto::BlockLength::get(),

--- a/bin/runtime-common/src/integrity.rs
+++ b/bin/runtime-common/src/integrity.rs
@@ -141,10 +141,9 @@ pub struct AssertChainConstants {
 ///
 /// 1) block weight limits are matching;
 /// 2) block size limits are matching.
-pub fn assert_chain_constants<R, C>(params: AssertChainConstants)
+pub fn assert_chain_constants<R>(params: AssertChainConstants)
 where
 	R: frame_system::Config,
-	C: Chain,
 {
 	// we don't check runtime version here, because in our case we'll be building relay from one
 	// repo and runtime will live in another repo, along with outdated relay version. To avoid
@@ -274,7 +273,7 @@ pub struct AssertCompleteBridgeConstants<'a> {
 
 /// All bridge-related constants tests for the complete standard messages bridge (i.e. with bridge
 /// GRANDPA and messages pallets deployed).
-pub fn assert_complete_bridge_constants<R, GI, MI, B, This>(params: AssertCompleteBridgeConstants)
+pub fn assert_complete_bridge_constants<R, GI, MI, B>(params: AssertCompleteBridgeConstants)
 where
 	R: frame_system::Config
 		+ pallet_bridge_grandpa::Config<GI>
@@ -282,9 +281,8 @@ where
 	GI: 'static,
 	MI: 'static,
 	B: MessageBridge,
-	This: Chain,
 {
-	assert_chain_constants::<R, This>(params.this_chain_constants);
+	assert_chain_constants::<R>(params.this_chain_constants);
 	assert_bridge_grandpa_pallet_constants::<R, GI>();
 	assert_bridge_messages_pallet_constants::<R, MI>(params.messages_pallet_constants);
 	assert_bridge_pallet_names::<B, R, GI, MI>(params.pallet_names);
@@ -325,6 +323,7 @@ pub fn check_message_lane_weights<C: Chain, T: frame_system::Config>(
 ///
 /// This method doesn't perform any `assert`. If the condition is not true it will generate a
 /// compile-time error.
+#[allow(clippy::extra_unused_type_parameters)]
 pub fn check_additional_signed<SignedExt, IndirectSignedExt: SignedExtension>()
 where
 	SignedExt: SignedExtension,

--- a/bin/runtime-common/src/integrity.rs
+++ b/bin/runtime-common/src/integrity.rs
@@ -323,7 +323,6 @@ pub fn check_message_lane_weights<C: Chain, T: frame_system::Config>(
 ///
 /// This method doesn't perform any `assert`. If the condition is not true it will generate a
 /// compile-time error.
-#[allow(clippy::extra_unused_type_parameters)]
 pub fn check_additional_signed<SignedExt, IndirectSignedExt: SignedExtension>()
 where
 	SignedExt: SignedExtension,

--- a/modules/beefy/src/utils.rs
+++ b/modules/beefy/src/utils.rs
@@ -52,7 +52,7 @@ fn verify_authority_set<T: Config<I>, I: 'static>(
 ///
 /// We're using 'conservative' approach here, where signatures of `2/3+1` validators are
 /// required..
-pub(crate) fn signatures_required<T: Config<I>, I: 'static>(validators_len: usize) -> usize {
+pub(crate) fn signatures_required(validators_len: usize) -> usize {
 	validators_len - validators_len.saturating_sub(1) / 3
 }
 
@@ -67,7 +67,7 @@ fn verify_signatures<T: Config<I>, I: 'static>(
 
 	// Ensure that the commitment was signed by enough authorities.
 	let msg = commitment.commitment.encode();
-	let mut missing_signatures = signatures_required::<T, I>(authority_set.len());
+	let mut missing_signatures = signatures_required(authority_set.len());
 	for (idx, (authority, maybe_sig)) in
 		authority_set.validators().iter().zip(commitment.signatures.iter()).enumerate()
 	{


### PR DESCRIPTION
https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/2399714 + couple of others

I had to disable `extra_unused_type_parameters` clippy check, because it causes  false alerts in current version. Actually - we need to revisit all currently disabled checks later - maybe some are fixed already. But let's do that later :