### PR TITLE
ChainWithGrandpa in primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,8 +869,10 @@ dependencies = [
 name = "bp-kusama"
 version = "0.1.0"
 dependencies = [
+ "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
+ "frame-support",
  "sp-api",
 ]
 
@@ -894,6 +896,7 @@ name = "bp-millau"
 version = "0.1.0"
 dependencies = [
  "bp-beefy",
+ "bp-header-chain",
  "bp-messages",
  "bp-runtime",
  "fixed-hash",
@@ -933,8 +936,10 @@ dependencies = [
 name = "bp-polkadot"
 version = "0.1.0"
 dependencies = [
+ "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
+ "frame-support",
  "sp-api",
 ]
 
@@ -973,6 +978,7 @@ dependencies = [
 name = "bp-rialto"
 version = "0.1.0"
 dependencies = [
+ "bp-header-chain",
  "bp-messages",
  "bp-runtime",
  "frame-support",
@@ -1002,6 +1008,7 @@ dependencies = [
 name = "bp-rococo"
 version = "0.1.0"
 dependencies = [
+ "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
@@ -1048,6 +1055,7 @@ dependencies = [
 name = "bp-westend"
 version = "0.1.0"
 dependencies = [
+ "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
@@ -1058,9 +1066,11 @@ dependencies = [
 name = "bp-wococo"
 version = "0.1.0"
 dependencies = [
+ "bp-header-chain",
  "bp-polkadot-core",
  "bp-rococo",
  "bp-runtime",
+ "frame-support",
  "sp-api",
 ]
 

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -387,21 +387,6 @@ impl pallet_bridge_relayers::Config for Runtime {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	/// Number of headers to keep.
-	///
-	/// Assuming the worst case of every header being finalized, we will keep headers at least for a
-	/// day.
-	pub const HeadersToKeep: u32 = bp_rialto::DAYS;
-	/// Maximal number of authorities at Rialto.
-	pub const MaxAuthoritiesAtRialto: u32 = bp_rialto::MAX_AUTHORITIES_COUNT;
-}
-
-parameter_types! {
-	/// Maximal number of authorities at Westend.
-	pub const MaxAuthoritiesAtWestend: u32 = bp_westend::MAX_AUTHORITIES_COUNT;
-}
-
 pub type RialtoGrandpaInstance = ();
 impl pallet_bridge_grandpa::Config for Runtime {
 	type BridgedChain = bp_rialto::Rialto;
@@ -410,9 +395,7 @@ impl pallet_bridge_grandpa::Config for Runtime {
 	// Note that once this is hit the pallet will essentially throttle incoming requests down to one
 	// call per block.
 	type MaxRequests = ConstU32<50>;
-	type HeadersToKeep = HeadersToKeep;
-	type MaxBridgedAuthorities = MaxAuthoritiesAtRialto;
-
+	type HeadersToKeep = ConstU32<{ bp_rialto::DAYS as u32 }>;
 	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
 }
 
@@ -420,9 +403,7 @@ pub type WestendGrandpaInstance = pallet_bridge_grandpa::Instance1;
 impl pallet_bridge_grandpa::Config<WestendGrandpaInstance> for Runtime {
 	type BridgedChain = bp_westend::Westend;
 	type MaxRequests = ConstU32<50>;
-	type HeadersToKeep = HeadersToKeep;
-	type MaxBridgedAuthorities = MaxAuthoritiesAtWestend;
-
+	type HeadersToKeep = ConstU32<{ bp_westend::DAYS as u32 }>;
 	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
 }
 
@@ -521,7 +502,7 @@ impl pallet_bridge_parachains::Config<WithRialtoParachainsInstance> for Runtime 
 	type ParasPalletName = RialtoParasPalletName;
 	type ParaStoredHeaderDataBuilder =
 		SingleParaStoredHeaderDataBuilder<bp_rialto_parachain::RialtoParachain>;
-	type HeadsToKeep = HeadersToKeep;
+	type HeadsToKeep = ConstU32<1024>;
 	type MaxParaHeadDataSize = MaxRialtoParaHeadDataSize;
 }
 
@@ -534,7 +515,7 @@ impl pallet_bridge_parachains::Config<WithWestendParachainsInstance> for Runtime
 	type BridgesGrandpaPalletInstance = WestendGrandpaInstance;
 	type ParasPalletName = WestendParasPalletName;
 	type ParaStoredHeaderDataBuilder = SingleParaStoredHeaderDataBuilder<bp_westend::Westmint>;
-	type HeadsToKeep = HeadersToKeep;
+	type HeadsToKeep = ConstU32<1024>;
 	type MaxParaHeadDataSize = MaxWestendParaHeadDataSize;
 }
 

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -525,17 +525,6 @@ impl pallet_bridge_relayers::Config for Runtime {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	/// Number of headers to keep.
-	///
-	/// Assuming the worst case of every header being finalized, we will keep headers at least for a
-	/// day.
-	pub const HeadersToKeep: u32 = bp_millau::DAYS as u32;
-
-	/// Maximal number of authorities at Millau.
-	pub const MaxAuthoritiesAtMillau: u32 = bp_millau::MAX_AUTHORITIES_COUNT;
-}
-
 pub type MillauGrandpaInstance = ();
 impl pallet_bridge_grandpa::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
@@ -544,8 +533,7 @@ impl pallet_bridge_grandpa::Config for Runtime {
 	/// Note that once this is hit the pallet will essentially throttle incoming requests down to
 	/// one call per block.
 	type MaxRequests = ConstU32<50>;
-	type HeadersToKeep = HeadersToKeep;
-	type MaxBridgedAuthorities = MaxAuthoritiesAtMillau;
+	type HeadersToKeep = ConstU32<{ bp_millau::DAYS as u32 }>;
 	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
 }
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -397,17 +397,6 @@ impl pallet_bridge_relayers::Config for Runtime {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	/// Number of headers to keep.
-	///
-	/// Assuming the worst case of every header being finalized, we will keep headers at least for a
-	/// day.
-	pub const HeadersToKeep: u32 = bp_rialto::DAYS;
-
-	/// Maximal number of authorities at Millau.
-	pub const MaxAuthoritiesAtMillau: u32 = bp_millau::MAX_AUTHORITIES_COUNT;
-}
-
 pub type MillauGrandpaInstance = ();
 impl pallet_bridge_grandpa::Config for Runtime {
 	type BridgedChain = bp_millau::Millau;
@@ -416,8 +405,7 @@ impl pallet_bridge_grandpa::Config for Runtime {
 	/// Note that once this is hit the pallet will essentially throttle incoming requests down to
 	/// one call per block.
 	type MaxRequests = ConstU32<50>;
-	type HeadersToKeep = HeadersToKeep;
-	type MaxBridgedAuthorities = MaxAuthoritiesAtMillau;
+	type HeadersToKeep = ConstU32<{ bp_millau::DAYS as u32 }>;
 	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<Runtime>;
 }
 

--- a/bin/runtime-common/src/mock.rs
+++ b/bin/runtime-common/src/mock.rs
@@ -32,7 +32,7 @@ use crate::messages::{
 	BridgedChainWithMessages, HashOf, MessageBridge, ThisChainWithMessages,
 };
 
-use bp_header_chain::HeaderChain;
+use bp_header_chain::{ChainWithGrandpa, HeaderChain};
 use bp_messages::{target_chain::ForbidInboundMessages, LaneId, MessageNonce};
 use bp_parachains::SingleParaStoredHeaderDataBuilder;
 use bp_runtime::{Chain, ChainId, Parachain, UnderlyingChainProvider};
@@ -195,7 +195,6 @@ impl pallet_bridge_grandpa::Config for TestRuntime {
 	type BridgedChain = BridgedUnderlyingChain;
 	type MaxRequests = ConstU32<50>;
 	type HeadersToKeep = ConstU32<8>;
-	type MaxBridgedAuthorities = ConstU32<1024>;
 	type WeightInfo = pallet_bridge_grandpa::weights::BridgeWeight<TestRuntime>;
 }
 
@@ -370,6 +369,14 @@ impl Chain for BridgedUnderlyingChain {
 	fn max_extrinsic_weight() -> Weight {
 		Weight::zero()
 	}
+}
+
+impl ChainWithGrandpa for BridgedUnderlyingChain {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = "";
+	const MAX_AUTHORITIES_COUNT: u32 = 16;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 = 8;
+	const MAX_HEADER_SIZE: u32 = 256;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = 64;
 }
 
 impl Chain for BridgedUnderlyingParachain {

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -39,10 +39,10 @@
 use storage_types::StoredAuthoritySet;
 
 use bp_header_chain::{
-	justification::GrandpaJustification, HeaderChain, InitializationData, StoredHeaderData,
-	StoredHeaderDataBuilder,
+	justification::GrandpaJustification, ChainWithGrandpa, HeaderChain, InitializationData,
+	StoredHeaderData, StoredHeaderDataBuilder,
 };
-use bp_runtime::{BlockNumberOf, Chain, HashOf, HasherOf, HeaderId, HeaderOf, OwnedBridgeModule};
+use bp_runtime::{BlockNumberOf, HashOf, HasherOf, HeaderId, HeaderOf, OwnedBridgeModule};
 use finality_grandpa::voter_set::VoterSet;
 use frame_support::{dispatch::PostDispatchInfo, ensure};
 use sp_finality_grandpa::{ConsensusLog, GRANDPA_ENGINE_ID};
@@ -97,7 +97,7 @@ pub mod pallet {
 	#[pallet::config]
 	pub trait Config<I: 'static = ()>: frame_system::Config {
 		/// The chain we are bridging to here.
-		type BridgedChain: Chain;
+		type BridgedChain: ChainWithGrandpa;
 
 		/// The upper bound on the number of requests allowed by the pallet.
 		///
@@ -117,10 +117,6 @@ pub mod pallet {
 		/// Incautious change of this constant may lead to orphan entries in the runtime storage.
 		#[pallet::constant]
 		type HeadersToKeep: Get<u32>;
-
-		/// Max number of authorities at the bridged chain.
-		#[pallet::constant]
-		type MaxBridgedAuthorities: Get<u32>;
 
 		/// Weights gathered through benchmarking.
 		type WeightInfo: WeightInfo;
@@ -513,7 +509,7 @@ pub mod pallet {
 					target: LOG_TARGET,
 					"Failed to initialize bridge. Number of authorities in the set {} is larger than the configured value {}",
 					authority_set_length,
-					T::MaxBridgedAuthorities::get(),
+					T::BridgedChain::MAX_AUTHORITIES_COUNT,
 				);
 
 				Error::TooManyAuthoritiesInSet

--- a/modules/grandpa/src/mock.rs
+++ b/modules/grandpa/src/mock.rs
@@ -17,8 +17,13 @@
 // From construct_runtime macro
 #![allow(clippy::from_over_into)]
 
+use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::Chain;
-use frame_support::{construct_runtime, parameter_types, traits::ConstU64, weights::Weight};
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{ConstU32, ConstU64},
+	weights::Weight,
+};
 use sp_core::sr25519::Signature;
 use sp_runtime::{
 	testing::{Header, H256},
@@ -78,7 +83,7 @@ impl frame_system::Config for TestRuntime {
 	type BlockLength = ();
 	type SS58Prefix = ();
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = ConstU32<16>;
 }
 
 parameter_types! {
@@ -92,7 +97,6 @@ impl grandpa::Config for TestRuntime {
 	type BridgedChain = TestBridgedChain;
 	type MaxRequests = MaxRequests;
 	type HeadersToKeep = HeadersToKeep;
-	type MaxBridgedAuthorities = frame_support::traits::ConstU32<MAX_BRIDGED_AUTHORITIES>;
 	type WeightInfo = ();
 }
 
@@ -116,6 +120,14 @@ impl Chain for TestBridgedChain {
 	fn max_extrinsic_weight() -> Weight {
 		unreachable!()
 	}
+}
+
+impl ChainWithGrandpa for TestBridgedChain {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = "";
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_BRIDGED_AUTHORITIES;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 = 8;
+	const MAX_HEADER_SIZE: u32 = 256;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = 64;
 }
 
 pub fn run_test<T>(test: impl FnOnce() -> T) -> T {

--- a/modules/parachains/src/mock.rs
+++ b/modules/parachains/src/mock.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
+use bp_header_chain::ChainWithGrandpa;
 use bp_polkadot_core::parachains::ParaId;
 use bp_runtime::{Chain, Parachain};
 use frame_support::{construct_runtime, parameter_types, traits::ConstU32, weights::Weight};
@@ -199,7 +200,6 @@ impl pallet_bridge_grandpa::Config<pallet_bridge_grandpa::Instance1> for TestRun
 	type BridgedChain = TestBridgedChain;
 	type MaxRequests = ConstU32<2>;
 	type HeadersToKeep = HeadersToKeep;
-	type MaxBridgedAuthorities = frame_support::traits::ConstU32<5>;
 	type WeightInfo = ();
 }
 
@@ -207,7 +207,6 @@ impl pallet_bridge_grandpa::Config<pallet_bridge_grandpa::Instance2> for TestRun
 	type BridgedChain = TestBridgedChain;
 	type MaxRequests = ConstU32<2>;
 	type HeadersToKeep = HeadersToKeep;
-	type MaxBridgedAuthorities = frame_support::traits::ConstU32<5>;
 	type WeightInfo = ();
 }
 
@@ -250,6 +249,14 @@ impl Chain for TestBridgedChain {
 	}
 }
 
+impl ChainWithGrandpa for TestBridgedChain {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = "";
+	const MAX_AUTHORITIES_COUNT: u32 = 16;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 = 8;
+	const MAX_HEADER_SIZE: u32 = 256;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = 64;
+}
+
 #[derive(Debug)]
 pub struct OtherBridgedChain;
 
@@ -271,6 +278,14 @@ impl Chain for OtherBridgedChain {
 	fn max_extrinsic_weight() -> Weight {
 		unreachable!()
 	}
+}
+
+impl ChainWithGrandpa for OtherBridgedChain {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = "";
+	const MAX_AUTHORITIES_COUNT: u32 = 16;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 = 8;
+	const MAX_HEADER_SIZE: u32 = 256;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = 64;
 }
 
 pub fn run_test<T>(test: impl FnOnce() -> T) -> T {

--- a/primitives/chain-kusama/Cargo.toml
+++ b/primitives/chain-kusama/Cargo.toml
@@ -10,17 +10,21 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 # Bridge Dependencies
 
+bp-header-chain = { path = "../header-chain", default-features = false }
 bp-polkadot-core = { path = "../polkadot-core", default-features = false }
 bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
 
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"bp-header-chain/std",
 	"bp-polkadot-core/std",
 	"bp-runtime/std",
+	"frame-support/std",
 	"sp-api/std",
 ]

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -19,10 +19,42 @@
 #![allow(clippy::too_many_arguments)]
 
 pub use bp_polkadot_core::*;
-use bp_runtime::decl_bridge_finality_runtime_apis;
+
+use bp_header_chain::ChainWithGrandpa;
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use frame_support::weights::Weight;
 
 /// Kusama Chain
-pub type Kusama = PolkadotLike;
+pub struct Kusama;
+
+impl Chain for Kusama {
+	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
+	type Hash = <PolkadotLike as Chain>::Hash;
+	type Hasher = <PolkadotLike as Chain>::Hasher;
+	type Header = <PolkadotLike as Chain>::Header;
+
+	type AccountId = <PolkadotLike as Chain>::AccountId;
+	type Balance = <PolkadotLike as Chain>::Balance;
+	type Index = <PolkadotLike as Chain>::Index;
+	type Signature = <PolkadotLike as Chain>::Signature;
+
+	fn max_extrinsic_size() -> u32 {
+		PolkadotLike::max_extrinsic_size()
+	}
+
+	fn max_extrinsic_weight() -> Weight {
+		PolkadotLike::max_extrinsic_weight()
+	}
+}
+
+impl ChainWithGrandpa for Kusama {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_KUSAMA_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
 
 /// Name of the With-Kusama GRANDPA pallet instance that is deployed at bridged chains.
 pub const WITH_KUSAMA_GRANDPA_PALLET_NAME: &str = "BridgeKusamaGrandpa";

--- a/primitives/chain-millau/Cargo.toml
+++ b/primitives/chain-millau/Cargo.toml
@@ -8,11 +8,6 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 
-# Bridge Dependencies
-
-bp-beefy = { path = "../beefy", default-features = false }
-bp-messages = { path = "../messages", default-features = false }
-bp-runtime = { path = "../runtime", default-features = false }
 fixed-hash = { version = "0.8.0", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 impl-codec = { version = "0.6", default-features = false }
@@ -20,6 +15,13 @@ impl-serde = { version = "0.4.0", optional = true }
 parity-util-mem = { version = "0.12.0", default-features = false, features = ["primitive-types"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+
+# Bridge Dependencies
+
+bp-beefy = { path = "../beefy", default-features = false }
+bp-header-chain = { path = "../header-chain", default-features = false }
+bp-messages = { path = "../messages", default-features = false }
+bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
 
@@ -36,6 +38,7 @@ sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master", 
 default = ["std"]
 std = [
 	"bp-beefy/std",
+	"bp-header-chain/std",
 	"bp-messages/std",
 	"bp-runtime/std",
 	"fixed-hash/std",

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -21,6 +21,7 @@
 mod millau_hash;
 
 use bp_beefy::ChainWithBeefy;
+use bp_header_chain::ChainWithGrandpa;
 use bp_messages::{
 	InboundMessageDetails, LaneId, MessageNonce, MessagePayload, OutboundMessageDetails,
 };
@@ -82,6 +83,27 @@ pub const SESSION_LENGTH: BlockNumber = 5 * time_units::MINUTES;
 
 /// Maximal number of GRANDPA authorities at Millau.
 pub const MAX_AUTHORITIES_COUNT: u32 = 5;
+
+/// Reasonable number of headers in the `votes_ancestries` on Millau chain.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 = 8;
+
+/// Approximate average header size in `votes_ancestries` field of justification on Millau chain.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = 256;
+
+/// Approximate maximal header size on Millau chain.
+///
+/// We expect maximal header to have digest item with the new authorities set for every consensus
+/// engine (GRANDPA, Babe, BEEFY, ...) - so we multiply it by 3. And also
+/// `AVERAGE_HEADER_SIZE_IN_JUSTIFICATION` bytes for other stuff.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const MAX_HEADER_SIZE: u32 = MAX_AUTHORITIES_COUNT
+	.saturating_mul(3)
+	.saturating_add(AVERAGE_HEADER_SIZE_IN_JUSTIFICATION);
 
 /// Re-export `time_units` to make usage easier.
 pub use time_units::*;
@@ -154,6 +176,15 @@ impl Chain for Millau {
 			.max_extrinsic
 			.unwrap_or(Weight::MAX)
 	}
+}
+
+impl ChainWithGrandpa for Millau {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_MILLAU_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
 }
 
 impl ChainWithBeefy for Millau {

--- a/primitives/chain-polkadot/Cargo.toml
+++ b/primitives/chain-polkadot/Cargo.toml
@@ -7,19 +7,24 @@ edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+
 # Bridge Dependencies
 
+bp-header-chain = { path = "../header-chain", default-features = false }
 bp-polkadot-core = { path = "../polkadot-core", default-features = false }
 bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
 
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"bp-header-chain/std",
 	"bp-polkadot-core/std",
 	"bp-runtime/std",
+	"frame-support/std",
 	"sp-api/std",
 ]

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -19,10 +19,42 @@
 #![allow(clippy::too_many_arguments)]
 
 pub use bp_polkadot_core::*;
-use bp_runtime::decl_bridge_finality_runtime_apis;
+
+use bp_header_chain::ChainWithGrandpa;
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use frame_support::weights::Weight;
 
 /// Polkadot Chain
-pub type Polkadot = PolkadotLike;
+pub struct Polkadot;
+
+impl Chain for Polkadot {
+	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
+	type Hash = <PolkadotLike as Chain>::Hash;
+	type Hasher = <PolkadotLike as Chain>::Hasher;
+	type Header = <PolkadotLike as Chain>::Header;
+
+	type AccountId = <PolkadotLike as Chain>::AccountId;
+	type Balance = <PolkadotLike as Chain>::Balance;
+	type Index = <PolkadotLike as Chain>::Index;
+	type Signature = <PolkadotLike as Chain>::Signature;
+
+	fn max_extrinsic_size() -> u32 {
+		PolkadotLike::max_extrinsic_size()
+	}
+
+	fn max_extrinsic_weight() -> Weight {
+		PolkadotLike::max_extrinsic_weight()
+	}
+}
+
+impl ChainWithGrandpa for Polkadot {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_POLKADOT_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
 
 /// Name of the With-Polkadot GRANDPA pallet instance that is deployed at bridged chains.
 pub const WITH_POLKADOT_GRANDPA_PALLET_NAME: &str = "BridgePolkadotGrandpa";

--- a/primitives/chain-rialto/Cargo.toml
+++ b/primitives/chain-rialto/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 # Bridge Dependencies
 
+bp-header-chain = { path = "../header-chain", default-features = false }
 bp-messages = { path = "../messages", default-features = false }
 bp-runtime = { path = "../runtime", default-features = false }
 
@@ -25,6 +26,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", d
 [features]
 default = ["std"]
 std = [
+	"bp-header-chain/std",
 	"bp-messages/std",
 	"bp-runtime/std",
 	"frame-support/std",

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -18,6 +18,7 @@
 // RuntimeApi generated functions
 #![allow(clippy::too_many_arguments)]
 
+use bp_header_chain::ChainWithGrandpa;
 use bp_messages::{
 	InboundMessageDetails, LaneId, MessageNonce, MessagePayload, OutboundMessageDetails,
 };
@@ -71,6 +72,27 @@ pub const SESSION_LENGTH: BlockNumber = 4;
 
 /// Maximal number of GRANDPA authorities at Rialto.
 pub const MAX_AUTHORITIES_COUNT: u32 = 5;
+
+/// Reasonable number of headers in the `votes_ancestries` on Rialto chain.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 = 8;
+
+/// Approximate average header size in `votes_ancestries` field of justification on Rialto chain.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = 256;
+
+/// Approximate maximal header size on Rialto chain.
+///
+/// We expect maximal header to have digest item with the new authorities set for every consensus
+/// engine (GRANDPA, Babe, BEEFY, ...) - so we multiply it by 3. And also
+/// `AVERAGE_HEADER_SIZE_IN_JUSTIFICATION` bytes for other stuff.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const MAX_HEADER_SIZE: u32 = MAX_AUTHORITIES_COUNT
+	.saturating_mul(3)
+	.saturating_add(AVERAGE_HEADER_SIZE_IN_JUSTIFICATION);
 
 /// Maximal size of encoded `bp_parachains::ParaStoredHeaderData` structure among all Rialto
 /// parachains.
@@ -158,6 +180,15 @@ impl Chain for Rialto {
 			.max_extrinsic
 			.unwrap_or(Weight::MAX)
 	}
+}
+
+impl ChainWithGrandpa for Rialto {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_RIALTO_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
 }
 
 frame_support::parameter_types! {

--- a/primitives/chain-rococo/Cargo.toml
+++ b/primitives/chain-rococo/Cargo.toml
@@ -9,18 +9,22 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 
 # Bridge Dependencies
+
+bp-header-chain = { path = "../header-chain", default-features = false }
 bp-polkadot-core = { path = "../polkadot-core", default-features = false }
 bp-runtime = { path = "../runtime", default-features = false }
 
 # Substrate Based Dependencies
+
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"bp-header-chain/std",
 	"bp-polkadot-core/std",
 	"bp-runtime/std",
-	"sp-api/std",
 	"frame-support/std",
+	"sp-api/std",
 ]

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -19,11 +19,42 @@
 #![allow(clippy::too_many_arguments)]
 
 pub use bp_polkadot_core::*;
-use bp_runtime::decl_bridge_finality_runtime_apis;
-use frame_support::parameter_types;
+
+use bp_header_chain::ChainWithGrandpa;
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use frame_support::{parameter_types, weights::Weight};
 
 /// Rococo Chain
-pub type Rococo = PolkadotLike;
+pub struct Rococo;
+
+impl Chain for Rococo {
+	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
+	type Hash = <PolkadotLike as Chain>::Hash;
+	type Hasher = <PolkadotLike as Chain>::Hasher;
+	type Header = <PolkadotLike as Chain>::Header;
+
+	type AccountId = <PolkadotLike as Chain>::AccountId;
+	type Balance = <PolkadotLike as Chain>::Balance;
+	type Index = <PolkadotLike as Chain>::Index;
+	type Signature = <PolkadotLike as Chain>::Signature;
+
+	fn max_extrinsic_size() -> u32 {
+		PolkadotLike::max_extrinsic_size()
+	}
+
+	fn max_extrinsic_weight() -> Weight {
+		PolkadotLike::max_extrinsic_weight()
+	}
+}
+
+impl ChainWithGrandpa for Rococo {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_ROCOCO_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
 
 parameter_types! {
 	pub const SS58Prefix: u8 = 42;

--- a/primitives/chain-westend/Cargo.toml
+++ b/primitives/chain-westend/Cargo.toml
@@ -10,6 +10,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 # Bridge Dependencies
 
+bp-header-chain = { path = "../header-chain", default-features = false }
 bp-polkadot-core = { path = "../polkadot-core", default-features = false }
 bp-runtime = { path = "../runtime", default-features = false }
 
@@ -21,6 +22,7 @@ sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", d
 [features]
 default = ["std"]
 std = [
+	"bp-header-chain/std",
 	"bp-polkadot-core/std",
 	"bp-runtime/std",
 	"frame-support/std",

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -19,11 +19,42 @@
 #![allow(clippy::too_many_arguments)]
 
 pub use bp_polkadot_core::*;
+
+use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, Parachain};
 use frame_support::weights::Weight;
 
 /// Westend Chain
-pub type Westend = PolkadotLike;
+pub struct Westend;
+
+impl Chain for Westend {
+	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
+	type Hash = <PolkadotLike as Chain>::Hash;
+	type Hasher = <PolkadotLike as Chain>::Hasher;
+	type Header = <PolkadotLike as Chain>::Header;
+
+	type AccountId = <PolkadotLike as Chain>::AccountId;
+	type Balance = <PolkadotLike as Chain>::Balance;
+	type Index = <PolkadotLike as Chain>::Index;
+	type Signature = <PolkadotLike as Chain>::Signature;
+
+	fn max_extrinsic_size() -> u32 {
+		PolkadotLike::max_extrinsic_size()
+	}
+
+	fn max_extrinsic_weight() -> Weight {
+		PolkadotLike::max_extrinsic_weight()
+	}
+}
+
+impl ChainWithGrandpa for Westend {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_WESTEND_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
 
 /// Westmint parachain definition
 #[derive(Debug, Clone, Copy)]

--- a/primitives/chain-wococo/Cargo.toml
+++ b/primitives/chain-wococo/Cargo.toml
@@ -9,18 +9,24 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 
 # Bridge Dependencies
+
+bp-header-chain = { path = "../header-chain", default-features = false }
 bp-polkadot-core = { path = "../polkadot-core", default-features = false }
 bp-runtime = { path = "../runtime", default-features = false }
 bp-rococo = { path = "../chain-rococo", default-features = false }
 
 # Substrate Based Dependencies
+
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"bp-header-chain/std",
 	"bp-polkadot-core/std",
 	"bp-runtime/std",
 	"bp-rococo/std",
+	"frame-support/std",
 	"sp-api/std",
 ]

--- a/primitives/chain-wococo/src/lib.rs
+++ b/primitives/chain-wococo/src/lib.rs
@@ -22,10 +22,42 @@ pub use bp_polkadot_core::*;
 pub use bp_rococo::{
 	SS58Prefix, MAX_AUTHORITIES_COUNT, MAX_NESTED_PARACHAIN_HEAD_DATA_SIZE, PARAS_PALLET_NAME,
 };
-use bp_runtime::decl_bridge_finality_runtime_apis;
+
+use bp_header_chain::ChainWithGrandpa;
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use frame_support::weights::Weight;
 
 /// Wococo Chain
-pub type Wococo = PolkadotLike;
+pub struct Wococo;
+
+impl Chain for Wococo {
+	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
+	type Hash = <PolkadotLike as Chain>::Hash;
+	type Hasher = <PolkadotLike as Chain>::Hasher;
+	type Header = <PolkadotLike as Chain>::Header;
+
+	type AccountId = <PolkadotLike as Chain>::AccountId;
+	type Balance = <PolkadotLike as Chain>::Balance;
+	type Index = <PolkadotLike as Chain>::Index;
+	type Signature = <PolkadotLike as Chain>::Signature;
+
+	fn max_extrinsic_size() -> u32 {
+		PolkadotLike::max_extrinsic_size()
+	}
+
+	fn max_extrinsic_weight() -> Weight {
+		PolkadotLike::max_extrinsic_weight()
+	}
+}
+
+impl ChainWithGrandpa for Wococo {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_WOCOCO_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
 
 /// Name of the With-Wococo GRANDPA pallet instance that is deployed at bridged chains.
 pub const WITH_WOCOCO_GRANDPA_PALLET_NAME: &str = "BridgeWococoGrandpa";

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -119,7 +119,7 @@ impl AuthoritySet {
 	}
 }
 
-/// Data required for initializing the bridge pallet.
+/// Data required for initializing the GRANDPA bridge pallet.
 ///
 /// The bridge needs to know where to start its sync from, and this provides that initial context.
 #[derive(Default, Encode, Decode, RuntimeDebug, PartialEq, Eq, Clone, TypeInfo)]
@@ -188,3 +188,48 @@ pub enum BridgeGrandpaCall<Header: HeaderT> {
 
 /// The `BridgeGrandpaCall` used by a chain.
 pub type BridgeGrandpaCallOf<C> = BridgeGrandpaCall<HeaderOf<C>>;
+
+/// Substrate-based chain that is using direct GRANDPA finality.
+///
+/// Keep in mind that parachains are relying on relay chain GRANDPA, so they should not implement
+/// this trait.
+pub trait ChainWithGrandpa: Chain {
+	/// Name of the bridge GRANDPA pallet (used in `construct_runtime` macro call) that is deployed
+	/// at some other chain to bridge with this `ChainWithGrandpa`.
+	///
+	/// We assume that all chains that are bridging with this `ChainWithGrandpa` are using
+	/// the same name.
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str;
+
+	/// Max number of GRANDPA authorities at the chain.
+	///
+	/// This is a strict constant. If bridged chain will have more authorities than that,
+	/// the GRANDPA bridge pallet may halt.
+	const MAX_AUTHORITIES_COUNT: u32;
+
+	/// Max reasonable number of headers in `votes_ancestries` vector of the GRANDPA justification.
+	///
+	/// This isn't a strict limit. The relay may submit justifications with more headers in its
+	/// ancestry and the pallet will accept such justification. The limit is only used to compute
+	/// maximal refund amount and submitting justifications which exceed the limit, may be costly
+	/// to submitter.
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32;
+
+	/// Maximal size of the chain header. The header may be the header that enacts new GRANDPA
+	/// authorities set (so it has large digest inside).
+	///
+	/// This isn't a strict limit. The relay may submit larger headers and the pallet will accept
+	/// the call. The limit is only used to compute maximal refund amount and doing calls which
+	/// exceed the limit, may be costly to submitter.
+	const MAX_HEADER_SIZE: u32;
+
+	/// Average size of the chain header from justification ancestry. We don't expect to see there
+	/// heders that change GRANDPA authorities set (GRANDPA will probably be able to finalize at
+	/// least one additional header per session on non test chains), so this is average size of
+	/// headers that aren't changing the set.
+	///
+	/// This isn't a strict limit. The relay may submit justifications with larger headers in its
+	/// ancestry and the pallet will accept the call. The limit is only used to compute maximal
+	/// refund amount and doing calls which exceed the limit, may be costly to submitter.
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32;
+}

--- a/primitives/polkadot-core/src/lib.rs
+++ b/primitives/polkadot-core/src/lib.rs
@@ -53,6 +53,28 @@ pub mod parachains;
 /// take twice as much here.
 pub const MAX_AUTHORITIES_COUNT: u32 = 2_048;
 
+/// Reasonable number of headers in the `votes_ancestries` on Polkadot-like chains.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 = 8;
+
+/// Approximate average header size in `votes_ancestries` field of justification on Polkadot-like
+/// chains.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = 256;
+
+/// Approximate maximal header size on Polkadot-like chains.
+///
+/// We expect maximal header to have digest item with the new authorities set for every consensus
+/// engine (GRANDPA, Babe, BEEFY, ...) - so we multiply it by 3. And also
+/// `AVERAGE_HEADER_SIZE_IN_JUSTIFICATION` bytes for other stuff.
+///
+/// See [`bp_header_chain::ChainWithGrandpa`] for more details.
+pub const MAX_HEADER_SIZE: u32 = MAX_AUTHORITIES_COUNT
+	.saturating_mul(3)
+	.saturating_add(AVERAGE_HEADER_SIZE_IN_JUSTIFICATION);
+
 /// Number of extra bytes (excluding size of storage value itself) of storage proof, built at
 /// Polkadot-like chain. This mostly depends on number of entries in the storage trie.
 /// Some reserve is reserved to account future chain growth.

--- a/relays/client-kusama/src/lib.rs
+++ b/relays/client-kusama/src/lib.rs
@@ -17,7 +17,7 @@
 //! Types used to connect to the Kusama chain.
 
 use bp_kusama::AccountInfoStorageMapKeyProvider;
-use relay_substrate_client::{Chain, ChainWithBalances, ChainWithGrandpa, UnderlyingChainProvider};
+use relay_substrate_client::{Chain, ChainWithBalances, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
 
@@ -41,10 +41,6 @@ impl Chain for Kusama {
 
 	type SignedBlock = bp_kusama::SignedBlock;
 	type Call = ();
-}
-
-impl ChainWithGrandpa for Kusama {
-	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = bp_kusama::WITH_KUSAMA_GRANDPA_PALLET_NAME;
 }
 
 impl ChainWithBalances for Kusama {

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -19,9 +19,9 @@
 use bp_messages::MessageNonce;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
-	BalanceOf, Chain, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
-	ChainWithTransactions, ChainWithUtilityPallet, Error as SubstrateError,
-	FullRuntimeUtilityPallet, IndexOf, SignParam, UnderlyingChainProvider, UnsignedTransaction,
+	BalanceOf, Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions,
+	ChainWithUtilityPallet, Error as SubstrateError, FullRuntimeUtilityPallet, IndexOf, SignParam,
+	UnderlyingChainProvider, UnsignedTransaction,
 };
 use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
@@ -36,10 +36,6 @@ pub struct Millau;
 
 impl UnderlyingChainProvider for Millau {
 	type Chain = bp_millau::Millau;
-}
-
-impl ChainWithGrandpa for Millau {
-	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = bp_millau::WITH_MILLAU_GRANDPA_PALLET_NAME;
 }
 
 impl ChainWithMessages for Millau {

--- a/relays/client-polkadot/src/lib.rs
+++ b/relays/client-polkadot/src/lib.rs
@@ -17,7 +17,7 @@
 //! Types used to connect to the Polkadot chain.
 
 use bp_polkadot::AccountInfoStorageMapKeyProvider;
-use relay_substrate_client::{Chain, ChainWithBalances, ChainWithGrandpa, UnderlyingChainProvider};
+use relay_substrate_client::{Chain, ChainWithBalances, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
 
@@ -41,11 +41,6 @@ impl Chain for Polkadot {
 
 	type SignedBlock = bp_polkadot::SignedBlock;
 	type Call = ();
-}
-
-impl ChainWithGrandpa for Polkadot {
-	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str =
-		bp_polkadot::WITH_POLKADOT_GRANDPA_PALLET_NAME;
 }
 
 impl ChainWithBalances for Polkadot {

--- a/relays/client-rialto/src/lib.rs
+++ b/relays/client-rialto/src/lib.rs
@@ -19,9 +19,9 @@
 use bp_messages::MessageNonce;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
-	BalanceOf, Chain, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
-	ChainWithTransactions, Error as SubstrateError, IndexOf, RelayChain, SignParam,
-	UnderlyingChainProvider, UnsignedTransaction,
+	BalanceOf, Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions,
+	Error as SubstrateError, IndexOf, RelayChain, SignParam, UnderlyingChainProvider,
+	UnsignedTransaction,
 };
 use sp_core::{storage::StorageKey, Pair};
 use sp_runtime::{generic::SignedPayload, traits::IdentifyAccount};
@@ -54,10 +54,6 @@ impl RelayChain for Rialto {
 	const PARAS_PALLET_NAME: &'static str = bp_rialto::PARAS_PALLET_NAME;
 	const PARACHAINS_FINALITY_PALLET_NAME: &'static str =
 		bp_rialto::WITH_RIALTO_BRIDGE_PARAS_PALLET_NAME;
-}
-
-impl ChainWithGrandpa for Rialto {
-	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = bp_rialto::WITH_RIALTO_GRANDPA_PALLET_NAME;
 }
 
 impl ChainWithMessages for Rialto {

--- a/relays/client-rococo/src/lib.rs
+++ b/relays/client-rococo/src/lib.rs
@@ -16,9 +16,7 @@
 
 //! Types used to connect to the Rococo-Substrate chain.
 
-use relay_substrate_client::{
-	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
-};
+use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
 
@@ -45,10 +43,6 @@ impl Chain for Rococo {
 
 	type SignedBlock = bp_rococo::SignedBlock;
 	type Call = ();
-}
-
-impl ChainWithGrandpa for Rococo {
-	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = bp_rococo::WITH_ROCOCO_GRANDPA_PALLET_NAME;
 }
 
 impl ChainWithBalances for Rococo {

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -73,11 +73,6 @@ pub trait RelayChain: Chain {
 	const PARACHAINS_FINALITY_PALLET_NAME: &'static str;
 }
 
-/// Substrate-based parachain from minimal relay-client point of view.
-pub trait Parachain: Chain + ParachainBase {}
-
-impl<T> Parachain for T where T: UnderlyingChainProvider + Chain + ParachainBase {}
-
 /// Substrate-based chain that is using direct GRANDPA finality from minimal relay-client point of
 /// view.
 ///
@@ -91,6 +86,20 @@ pub trait ChainWithGrandpa: Chain {
 	/// the same name.
 	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str;
 }
+
+impl<T> ChainWithGrandpa for T
+where
+	T: Chain + UnderlyingChainProvider,
+	T::Chain: bp_header_chain::ChainWithGrandpa,
+{
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str =
+		<T::Chain as bp_header_chain::ChainWithGrandpa>::WITH_CHAIN_GRANDPA_PALLET_NAME;
+}
+
+/// Substrate-based parachain from minimal relay-client point of view.
+pub trait Parachain: Chain + ParachainBase {}
+
+impl<T> Parachain for T where T: UnderlyingChainProvider + Chain + ParachainBase {}
 
 /// Substrate-based chain with messaging support from minimal relay-client point of view.
 pub trait ChainWithMessages: Chain {

--- a/relays/client-westend/src/lib.rs
+++ b/relays/client-westend/src/lib.rs
@@ -16,9 +16,7 @@
 
 //! Types used to connect to the Westend chain.
 
-use relay_substrate_client::{
-	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
-};
+use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
 
@@ -51,11 +49,6 @@ impl RelayChain for Westend {
 	const PARAS_PALLET_NAME: &'static str = bp_westend::PARAS_PALLET_NAME;
 	const PARACHAINS_FINALITY_PALLET_NAME: &'static str =
 		bp_westend::WITH_WESTEND_BRIDGE_PARAS_PALLET_NAME;
-}
-
-impl ChainWithGrandpa for Westend {
-	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str =
-		bp_westend::WITH_WESTEND_GRANDPA_PALLET_NAME;
 }
 
 impl ChainWithBalances for Westend {

--- a/relays/client-wococo/src/lib.rs
+++ b/relays/client-wococo/src/lib.rs
@@ -16,9 +16,7 @@
 
 //! Types used to connect to the Wococo-Substrate chain.
 
-use relay_substrate_client::{
-	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
-};
+use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
 
@@ -45,10 +43,6 @@ impl Chain for Wococo {
 
 	type SignedBlock = bp_wococo::SignedBlock;
 	type Call = ();
-}
-
-impl ChainWithGrandpa for Wococo {
-	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = bp_wococo::WITH_WOCOCO_GRANDPA_PALLET_NAME;
 }
 
 impl ChainWithBalances for Wococo {


### PR DESCRIPTION
A non-essential part of #1882, which has a lot of changes, so I've decided to extract it to the separate PR. The idea is to use `type BridgedChain: ChainWithGrandpa` instead of `type BridgedChain: Chain` in `pallet_bridge_grandpa::Config` and add/move some GRANDPA-related constants in that new trait. So I need it on primitives level. At the same time, we need `ChainWithGrandpa: relay_substrate_client::Chain` in relays, so the `ChainWithGrandpa` in `relay_substrate_client` also stays there.