### PR TITLE
Do not stall on lost transaction

### DIFF
--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -211,7 +211,7 @@ pub trait RaceStrategy<SourceHeaderId, TargetHeaderId, Proof>: Debug {
 	/// data) from source to target node.
 	/// Additionally, parameters required to generate proof are returned.
 	async fn select_nonces_to_deliver(
-		&mut self,
+		&self,
 		race_state: RaceState<SourceHeaderId, TargetHeaderId, Proof>,
 	) -> Option<(RangeInclusive<MessageNonce>, Self::ProofParameters)>;
 }
@@ -665,7 +665,7 @@ where
 
 async fn select_nonces_to_deliver<SourceHeaderId, TargetHeaderId, Proof, Strategy>(
 	race_state: RaceState<SourceHeaderId, TargetHeaderId, Proof>,
-	strategy: &mut Strategy,
+	strategy: &Strategy,
 ) -> Option<(SourceHeaderId, RangeInclusive<MessageNonce>, Strategy::ProofParameters)>
 where
 	SourceHeaderId: Clone,

--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -539,7 +539,7 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>, TC: TargetClient<P>>(
 				};
 
 			let nonces_to_deliver =
-				select_nonces_to_deliver(expected_race_state, &mut strategy).await;
+				select_nonces_to_deliver(expected_race_state, &strategy).await;
 			let best_at_source = strategy.best_at_source();
 
 			if let Some((at_block, nonces_range, proof_parameters)) = nonces_to_deliver {
@@ -730,7 +730,7 @@ mod tests {
 
 		// the proof will be generated on source, but using BEST_AT_TARGET block
 		assert_eq!(
-			select_nonces_to_deliver(race_state, &mut strategy).await,
+			select_nonces_to_deliver(race_state, &strategy).await,
 			Some((HeaderId(BEST_AT_TARGET, BEST_AT_TARGET), 6..=10, (),))
 		);
 	}

--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -538,8 +538,7 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>, TC: TargetClient<P>>(
 					race_state.clone()
 				};
 
-			let nonces_to_deliver =
-				select_nonces_to_deliver(expected_race_state, &strategy).await;
+			let nonces_to_deliver = select_nonces_to_deliver(expected_race_state, &strategy).await;
 			let best_at_source = strategy.best_at_source();
 
 			if let Some((at_block, nonces_range, proof_parameters)) = nonces_to_deliver {


### PR DESCRIPTION
closes #1901

So the issue happens when we have an extensively used bidirectional bridge (read: our test deployments). Then several relayers are submitting complex (finality + messages) transactions in both directions => update relay chain/parachain finality. So some of complex transactions are failing because of obsolete finality proofs. Our message races are considering themselves "stalled" when their transactions are rejected. Stall means that all in-memory data is dropped and the race restarts. But when it restarts, it sees that the messages/confirmation are queued at some new block, say `100`, even if they were really queued at block `90`. So relayers submit complex transactions with block `100` and it fails again (sometimes) => everything repeats.

The proposed fix is not to "stall" on lost transaction. So we don't drop in-memory data and we may use existing block `90` finality to deliver messages/confirmations.