### PR TITLE
CI add jobs to publish Docker images description to hub.docker.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   - test
   - build
   - publish
+  - publish-docker-description
 
 variables:
   GIT_STRATEGY:                    fetch
@@ -314,5 +315,49 @@ bridges-common-relay:
     <<:                            *image-variables
     BRIDGES_PROJECT:               substrate-relay
     DOCKER_IMAGE_NAME:             bridges-common-relay
+
+# Publish Docker images description to hub.docker.com
+
+.publish-docker-image-description: &publish-docker-image-description
+  stage:                           publish-docker-description
+  image:                           paritytech/dockerhub-description
+  variables:
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/docs/${CI_JOB_NAME}.README.md
+  rules:
+  - if: $CI_COMMIT_REF_NAME == "master"
+    changes:
+    - docs/${CI_JOB_NAME}.README.md
+  script:
+    - export DOCKERHUB_REPOSITORY="paritytech/${CI_JOB_NAME:10}"
+    - cd / && sh entrypoint.sh
+  tags:
+    - kubernetes-parity-build
+
+dockerhub-rialto-bridge-node:
+  extends:                .publish-docker-image-description
+  variables:
+    SHORT_DESCRIPTION:    "rialto-bridge-node"
+
+dockerhub-rialto-parachain-collator:
+  extends:                .publish-docker-image-description
+  variables:
+    SHORT_DESCRIPTION:    "rialto-parachain-collator"
+
+dockerhub-millau-bridge-node:
+  extends:                .publish-docker-image-description
+  variables:
+    SHORT_DESCRIPTION:    "millau-bridge-node"
+
+dockerhub-substrate-relay:
+  extends:                .publish-docker-image-description
+  variables:
+    SHORT_DESCRIPTION:    "substrate-relay"
+
+dockerhub-bridges-common-relay:
+  extends:                .publish-docker-image-description
+  variables:
+    SHORT_DESCRIPTION:    "bridges-common-relay"
 
 # FIXME: publish binaries

--- a/docs/dockerhub-bridges-common-relay.README.md
+++ b/docs/dockerhub-bridges-common-relay.README.md
@@ -1,0 +1,1 @@
+# bridges-common-relay

--- a/docs/dockerhub-millau-bridge-node.README.md
+++ b/docs/dockerhub-millau-bridge-node.README.md
@@ -1,0 +1,1 @@
+# millau-bridge-node

--- a/docs/dockerhub-rialto-bridge-node.README.md
+++ b/docs/dockerhub-rialto-bridge-node.README.md
@@ -1,0 +1,1 @@
+# rialto-bridge-node

--- a/docs/dockerhub-rialto-parachain-collator.README.md
+++ b/docs/dockerhub-rialto-parachain-collator.README.md
@@ -1,0 +1,1 @@
+# rialto-parachain-collator

--- a/docs/dockerhub-substrate-relay.README.md
+++ b/docs/dockerhub-substrate-relay.README.md
@@ -1,0 +1,1 @@
+# substrate-relay


### PR DESCRIPTION
This PR add CI jobs to publish Docker images description to hub.docker.com

Also created stub files in the `/docs` folder where description should be updated.

Related to https://github.com/paritytech/ci_cd/issues/741