### PR TITLE
Reconnect on-demand clients from MessagesSource::reconnect and MessagesTarget::reconnect

### DIFF
--- a/relays/lib-substrate-relay/src/messages_source.rs
+++ b/relays/lib-substrate-relay/src/messages_source.rs
@@ -139,7 +139,7 @@ impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesSource<P> {
 		//
 		// this may lead to multiple reconnects to the same node during the same call and it
 		// needs to be addressed in the future
-		// TODO: add issue reference here!!!!!!!!!!!!!!!!!!!!
+		// TODO: https://github.com/paritytech/parity-bridges-common/issues/1928
 		if let Some(ref mut target_to_source_headers_relay) = self.target_to_source_headers_relay {
 			target_to_source_headers_relay.reconnect().await?;
 		}

--- a/relays/lib-substrate-relay/src/messages_source.rs
+++ b/relays/lib-substrate-relay/src/messages_source.rs
@@ -129,8 +129,22 @@ impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesSource<P> {
 	type Error = SubstrateError;
 
 	async fn reconnect(&mut self) -> Result<(), SubstrateError> {
+		// since the client calls RPC methods on both sides, we need to reconnect both
 		self.source_client.reconnect().await?;
-		self.target_client.reconnect().await
+		self.target_client.reconnect().await?;
+
+		// call reconnect on on-demand headers relay, because we may use different chains there
+		// and the error that has lead to reconnect may have came from those other chains
+		// (see `require_target_header_on_source`)
+		//
+		// this may lead to multiple reconnects to the same node during the same call and it
+		// needs to be addressed in the future
+		// TODO: add issue reference here!!!!!!!!!!!!!!!!!!!!
+		if let Some(ref mut target_to_source_headers_relay) = self.target_to_source_headers_relay {
+			target_to_source_headers_relay.reconnect().await?;
+		}
+
+		Ok(())
 	}
 }
 

--- a/relays/lib-substrate-relay/src/messages_target.rs
+++ b/relays/lib-substrate-relay/src/messages_target.rs
@@ -123,8 +123,22 @@ impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesTarget<P> {
 	type Error = SubstrateError;
 
 	async fn reconnect(&mut self) -> Result<(), SubstrateError> {
+		// since the client calls RPC methods on both sides, we need to reconnect both
 		self.target_client.reconnect().await?;
-		self.source_client.reconnect().await
+		self.source_client.reconnect().await?;
+
+		// call reconnect on on-demand headers relay, because we may use different chains there
+		// and the error that has lead to reconnect may have came from those other chains
+		// (see `require_source_header_on_target`)
+		//
+		// this may lead to multiple reconnects to the same node during the same call and it
+		// needs to be addressed in the future
+		// TODO: add issue reference here!!!!!!!!!!!!!!!!!!!!
+		if let Some(ref mut source_to_target_headers_relay) = self.source_to_target_headers_relay {
+			source_to_target_headers_relay.reconnect().await?;
+		}
+
+		Ok(())
 	}
 }
 

--- a/relays/lib-substrate-relay/src/messages_target.rs
+++ b/relays/lib-substrate-relay/src/messages_target.rs
@@ -133,7 +133,7 @@ impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesTarget<P> {
 		//
 		// this may lead to multiple reconnects to the same node during the same call and it
 		// needs to be addressed in the future
-		// TODO: add issue reference here!!!!!!!!!!!!!!!!!!!!
+		// TODO: https://github.com/paritytech/parity-bridges-common/issues/1928
 		if let Some(ref mut source_to_target_headers_relay) = self.source_to_target_headers_relay {
 			source_to_target_headers_relay.reconnect().await?;
 		}

--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -108,7 +108,8 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 	for OnDemandHeadersRelay<P>
 {
 	async fn reconnect(&self) -> Result<(), SubstrateError> {
-		// using clone is fine here (to avoid mut requirement), because clone on Client clones internal references
+		// using clone is fine here (to avoid mut requirement), because clone on Client clones
+		// internal references
 		self.source_client.clone().reconnect().await?;
 		self.target_client.clone().reconnect().await
 	}

--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -60,6 +60,8 @@ pub struct OnDemandHeadersRelay<P: SubstrateFinalitySyncPipeline> {
 	required_header_number: RequiredHeaderNumberRef<P::SourceChain>,
 	/// Client of the source chain.
 	source_client: Client<P::SourceChain>,
+	/// Client of the target chain.
+	target_client: Client<P::TargetChain>,
 }
 
 impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
@@ -83,6 +85,7 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
 			relay_task_name: on_demand_headers_relay_name::<P::SourceChain, P::TargetChain>(),
 			required_header_number: required_header_number.clone(),
 			source_client: source_client.clone(),
+			target_client: target_client.clone(),
 		};
 		async_std::task::spawn(async move {
 			background_task::<P>(
@@ -104,6 +107,12 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
 impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetChain>
 	for OnDemandHeadersRelay<P>
 {
+	async fn reconnect(&self) -> Result<(), SubstrateError> {
+		// using clone is fine here (to avoid mut requirement), because clone on Client clones internal references
+		self.source_client.clone().reconnect().await?;
+		self.target_client.clone().reconnect().await
+	}
+
 	async fn require_more_headers(&self, required_header: BlockNumberOf<P::SourceChain>) {
 		let mut required_header_number = self.required_header_number.lock().await;
 		if required_header > *required_header_number {

--- a/relays/lib-substrate-relay/src/on_demand/mod.rs
+++ b/relays/lib-substrate-relay/src/on_demand/mod.rs
@@ -44,4 +44,5 @@ pub trait OnDemandRelay<SourceChain: Chain, TargetChain: Chain>: Send + Sync {
 	async fn prove_header(
 		&self,
 		required_header: BlockNumberOf<SourceChain>,
-	) -> Result<(HeaderIdOf<SourceChain>, Vec<CallOf<TargetChain>>), SubstrateError>;}
+	) -> Result<(HeaderIdOf<SourceChain>, Vec<CallOf<TargetChain>>), SubstrateError>;
+}

--- a/relays/lib-substrate-relay/src/on_demand/mod.rs
+++ b/relays/lib-substrate-relay/src/on_demand/mod.rs
@@ -26,6 +26,9 @@ pub mod parachains;
 /// On-demand headers relay that is relaying finalizing headers only when requested.
 #[async_trait]
 pub trait OnDemandRelay<SourceChain: Chain, TargetChain: Chain>: Send + Sync {
+	/// Reconnect to source and target nodes.
+	async fn reconnect(&self) -> Result<(), SubstrateError>;
+
 	/// Ask relay to relay source header with given number  to the target chain.
 	///
 	/// Depending on implementation, on-demand relay may also relay `required_header` ancestors
@@ -41,5 +44,4 @@ pub trait OnDemandRelay<SourceChain: Chain, TargetChain: Chain>: Send + Sync {
 	async fn prove_header(
 		&self,
 		required_header: BlockNumberOf<SourceChain>,
-	) -> Result<(HeaderIdOf<SourceChain>, Vec<CallOf<TargetChain>>), SubstrateError>;
-}
+	) -> Result<(HeaderIdOf<SourceChain>, Vec<CallOf<TargetChain>>), SubstrateError>;}

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -119,6 +119,14 @@ impl<P: SubstrateParachainsPipeline> OnDemandRelay<P::SourceParachain, P::Target
 where
 	P::SourceParachain: Chain<Hash = ParaHash>,
 {
+	async fn reconnect(&self) -> Result<(), SubstrateError> {
+		// using clone is fine here (to avoid mut requirement), because clone on Client clones internal references
+		self.source_relay_client.clone().reconnect().await?;
+		self.target_client.clone().reconnect().await?;
+		// we'll probably need to reconnect relay chain relayer clients also 
+		self.on_demand_source_relay_to_target_headers.reconnect().await
+	}
+
 	async fn require_more_headers(&self, required_header: BlockNumberOf<P::SourceParachain>) {
 		if let Err(e) = self.required_header_number_sender.send(required_header).await {
 			log::trace!(

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -120,10 +120,11 @@ where
 	P::SourceParachain: Chain<Hash = ParaHash>,
 {
 	async fn reconnect(&self) -> Result<(), SubstrateError> {
-		// using clone is fine here (to avoid mut requirement), because clone on Client clones internal references
+		// using clone is fine here (to avoid mut requirement), because clone on Client clones
+		// internal references
 		self.source_relay_client.clone().reconnect().await?;
 		self.target_client.clone().reconnect().await?;
-		// we'll probably need to reconnect relay chain relayer clients also 
+		// we'll probably need to reconnect relay chain relayer clients also
 		self.on_demand_source_relay_to_target_headers.reconnect().await
 	}
 


### PR DESCRIPTION
closes #1785 

It looks that the issue in #1785 happens because of following:
- messages relay sees new messages at RBH header 100 (example);
- messages relay asks for RBH header 100 at WBH;
- we're using batch transactions in RBH<>WBH bridge, so instead of simply signal to on-demand header relays, we are trying to prove RBH header 100 by reading state of some Rococo header, say 200;
- Rococo client fails (it is normal when interacting with this particular RPC node and sometimes with other RPC nodes as well) and error is propagated back to the messages relay;
- messages relay calls `MessageTarget::reconnect()` and we are reconnecting to RBH and WBH nodes. But the actual problem is with the Rococo client, which does not reconnects in this case. So it happens again and again.

The proposed solution is to call `reconnect` for all clients, used by underlying on-demand headers relay. Hope it'l help

No test, until we have something similar to what is described in #1820 :(