### PR TITLE
Optimize justifications before they're included into complex transaction

### DIFF
--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -138,6 +138,9 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 		let (header, proof) = finality_source.prove_block_finality(required_header).await?;
 		let header_id = header.id();
 
+		// optimize justification before including it into the call
+		let proof = P::FinalityEngine::optimize_proof(&self.target_client, &header, proof).await?;
+
 		log::debug!(
 			target: "bridge",
 			"[{}] Requested to prove {} head {:?}. Selected to prove {} head {:?}",


### PR DESCRIPTION
So we now have GRANDPA justification optimization and it is required for the call to be successful. So far it has been done for the: standalone finality relay calls (https://github.com/paritytech/parity-bridges-common/pull/1887), init-bridge calls (https://github.com/paritytech/parity-bridges-common/pull/1900). And this PR adds optimization to the last one (I hope) submit-justification-call - that's the our brand new complex call (grandpa finality ++ parachains finality ++ messages delivery/confirmation).