### PR TITLE
Removed deprecated `#[pallet::generate_store(pub(super) trait Store)]` according to latest Cumulus

### DIFF
--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -178,7 +178,6 @@ pub mod pallet {
 		>>::MessagesDeliveryProof;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	impl<T: Config<I>, I: 'static> OwnedBridgeModule<T> for Pallet<T, I> {

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -277,7 +277,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
 	impl<T: Config<I>, I: 'static> OwnedBridgeModule<T> for Pallet<T, I> {

--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -63,7 +63,6 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	#[pallet::call]

--- a/modules/shift-session-manager/src/lib.rs
+++ b/modules/shift-session-manager/src/lib.rs
@@ -35,7 +35,6 @@ pub mod pallet {
 	pub trait Config: pallet_session::Config {}
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 


### PR DESCRIPTION
```
Checking pallet-bridge-grandpa v0.1.0 (/home/bparity/parity/cumulus/cumulus/bridges/modules/grandpa)
warning: use of deprecated struct `pallet::_::Store`: 
                 Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed soon.
                 Check https://github.com/paritytech/substrate/pull/13535 for more details.
   --> bridges/modules/messages/src/lib.rs:181:3
    |
181 |     #[pallet::generate_store(pub(super) trait Store)]
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

    Checking bp-parachains v0.1.0 (/home/bparity/parity/cumulus/cumulus/bridges/primitives/parachains)
warning: `pallet-bridge-messages` (lib) generated 1 warning
    Checking pallet-bridge-relayers v0.1.0 (/home/bparity/parity/cumulus/cumulus/bridges/modules/relayers)
    Checking pallet-bridge-parachains v0.1.0 (/home/bparity/parity/cumulus/cumulus/bridges/modules/parachains)
warning: use of deprecated struct `pallet::_::Store`: 
                 Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed soon.
                 Check https://github.com/paritytech/substrate/pull/13535 for more details.
  --> bridges/modules/relayers/src/lib.rs:66:3
   |
66 |     #[pallet::generate_store(pub(super) trait Store)]
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated struct `pallet::_::Store`: 
                 Use of `#[pallet::generate_store(pub(super) trait Store)]` will be removed soon.
                 Check https://github.com/paritytech/substrate/pull/13535 for more details.
   --> bridges/modules/parachains/src/lib.rs:280:3
    |
280 |     #[pallet::generate_store(pub(super) trait Store)]
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `pallet-bridge-relayers` (lib) generated 1 warning
warning: `pallet-bridge-parachains` (lib) generated 1 warning
    Checking xcm-builder v0.9.37 (https://github.com/paritytech/polkadot?branch=master#70598a19)

```