### PR TITLE
Dependabot: ignore binary-merkle-tree

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
   - dependency-name: try-runtime-cli
     versions:
     - ">= 0"
+  - dependency-name: binary-merkle-tree
+    versions:
+    - ">= 0"
   # Polkadot dependencies
   - dependency-name: kusama-*
     versions:


### PR DESCRIPTION
that's a dependency from Substrate codebase and we want manual control over it