### PR TITLE
Run tests for `runtime-benchmarks` feature only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,6 +152,7 @@ test:
 #    RUSTFLAGS:                     "-D warnings"
   script:                          &test-script
     - time cargo fetch
+    - time cargo fetch --target wasm32-unknown-unknown
     # Enable this, when you see: "`cargo metadata` can not fail on project `Cargo.toml`"
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-runtime\").manifest_path"`
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"kusama-runtime\").manifest_path"`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,11 +152,10 @@ test:
 #    RUSTFLAGS:                     "-D warnings"
   script:                          &test-script
     - time cargo fetch
-    - time cargo fetch --target wasm32-unknown-unknown
     # Enable this, when you see: "`cargo metadata` can not fail on project `Cargo.toml`"
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-runtime\").manifest_path"`
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"kusama-runtime\").manifest_path"`
-    - CARGO_NET_OFFLINE=true SKIP_POLKADOT_RUNTIME_WASM_BUILD=1 SKIP_KUSAMA_RUNTIME_WASM_BUILD=1 SKIP_POLKADOT_TEST_RUNTIME_WASM_BUILD=1 time cargo test --verbose --workspace --all-features
+    - CARGO_NET_OFFLINE=true SKIP_POLKADOT_RUNTIME_WASM_BUILD=1 SKIP_KUSAMA_RUNTIME_WASM_BUILD=1 SKIP_POLKADOT_TEST_RUNTIME_WASM_BUILD=1 time cargo test --verbose --workspace --features runtime-benchmarks
 
 test-nightly:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,11 +151,7 @@ test:
 #  variables:
 #    RUSTFLAGS:                     "-D warnings"
   script:                          &test-script
-    - time cargo fetch
-    # Enable this, when you see: "`cargo metadata` can not fail on project `Cargo.toml`"
-    #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-runtime\").manifest_path"`
-    #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"kusama-runtime\").manifest_path"`
-    - CARGO_NET_OFFLINE=true SKIP_POLKADOT_RUNTIME_WASM_BUILD=1 SKIP_KUSAMA_RUNTIME_WASM_BUILD=1 SKIP_POLKADOT_TEST_RUNTIME_WASM_BUILD=1 time cargo test --verbose --workspace --all-features
+    - time cargo test --verbose --workspace --all-features
 
 test-nightly:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,11 @@ test:
 #  variables:
 #    RUSTFLAGS:                     "-D warnings"
   script:                          &test-script
-    - time cargo test --verbose --workspace --all-features
+    - time cargo fetch
+    # Enable this, when you see: "`cargo metadata` can not fail on project `Cargo.toml`"
+    #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-runtime\").manifest_path"`
+    #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"kusama-runtime\").manifest_path"`
+    - CARGO_NET_OFFLINE=true SKIP_POLKADOT_RUNTIME_WASM_BUILD=1 SKIP_KUSAMA_RUNTIME_WASM_BUILD=1 SKIP_POLKADOT_TEST_RUNTIME_WASM_BUILD=1 time cargo test --verbose --workspace --all-features
 
 test-nightly:
   stage:                           test


### PR DESCRIPTION
There are two failures tonight:
- [x] in regular cargo test: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/2599503
- [ ] in benchmarks testing: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/2599507

The first is because I've changed `cargo test` to `cargo test --all-features` yesterday, which obviously is a bad idea, because it'll enable tests for `no-std` feature where it is available => fail. So I've changed it to `cargo test --features runtime-benchmarks`. It should be fixed

Re second issue - not sure if that is an outcome of first issue or something else (there's some strange `warning: Git command failed with status: exit status: 128`) - let's see tomorrow.