### PR TITLE
Cleanup removed lane traces

### DIFF
--- a/deployments/bridges/rialto-millau/dashboard/prometheus/targets.yml
+++ b/deployments/bridges/rialto-millau/dashboard/prometheus/targets.yml
@@ -1,4 +1,2 @@
 - targets:
   - relay-millau-rialto:9616
-  - relay-messages-millau-to-rialto-lane-00000001:9616
-  - relay-messages-rialto-to-millau-lane-00000001:9616

--- a/scripts/dump-logs.sh
+++ b/scripts/dump-logs.sh
@@ -15,8 +15,6 @@ cd $LOGS_DIR
 SERVICES=(\
 	deployments_relay-messages-millau-to-rialto-generator_1 \
 	deployments_relay-messages-rialto-to-millau-generator_1 \
-	deployments_relay-messages-millau-to-rialto-lane-00000001_1 \
-	deployments_relay-messages-rialto-to-millau-lane-00000001_1 \
 	deployments_relay-millau-rialto_1 \
 	deployments_relay-headers-westend-to-millau-1_1 \
 	deployments_relay-headers-westend-to-millau-2_1 \


### PR DESCRIPTION
I've removed all lanes except 0x00000000 recently and there are still traces of other lanes in Prometheus/Grafana, which cause "Nodes are not running" alerts.