### PR TITLE
Relay node down alert

### DIFF
--- a/deployments/bridges/rococo-wococo/dashboard/grafana/bridges-alerts.json
+++ b/deployments/bridges/rococo-wococo/dashboard/grafana/bridges-alerts.json
@@ -1,0 +1,1994 @@
+{
+    "Bridges": [
+      {
+        "name": "Bridges",
+        "interval": "1m",
+        "rules": [
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "tkgc6_bnk",
+              "__panelId__": "12",
+              "summary": "Messages from RococoBridgeHub to WococoBridgeHub (00000001) are either not delivered, or are delivered with lags"
+            },
+            "grafana_alert": {
+              "id": 51,
+              "orgId": 1,
+              "title": "RococoBridgeHub -> WococoBridgeHub delivery lags (00000001)",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "scalar(max_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_generated\"}[2m]) OR on() vector(0)) - scalar(max_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Undelivered messages",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            0
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "min"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 90,
+              "uid": "r41otJp4k",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "zqjpgXxnk",
+              "__panelId__": "14",
+              "summary": "Messages from WococoBridgeHub to RococoBridgeHub (00000001) are either not delivered, or are delivered with lags"
+            },
+            "grafana_alert": {
+              "id": 55,
+              "orgId": 1,
+              "title": "WococoBridgeHub -> RococoBridgeHub delivery lags (00000001)",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_generated\"}[2m]) OR on() vector(0)) - scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Undelivered messages",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            0
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "min"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 88,
+              "uid": "wqmPtJpVz",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "tkgc6_bnk",
+              "__panelId__": "14",
+              "summary": "Messages from RococoBridgeHub to WococoBridgeHub (00000001) are either not confirmed, or are confirmed with lags"
+            },
+            "grafana_alert": {
+              "id": 56,
+              "orgId": 1,
+              "title": "RococoBridgeHub -> WococoBridgeHub confirmation lags (00000001)",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "scalar(max_over_time(RococoBridgeHub_to_WococoBridgeHub_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0)) - scalar(max_over_time(RococoBridgeHub_to_WococoBridgeHub_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_confirmed\"}[2m]) OR on() vector(0))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Unconfirmed messages",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            50
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "min"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 84,
+              "uid": "z4h3pJtVz",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "zqjpgXxnk",
+              "__panelId__": "16",
+              "summary": "Messages from WococoBridgeHub to RococoBridgeHub (00000001) are either not confirmed, or are confirmed with lags"
+            },
+            "grafana_alert": {
+              "id": 57,
+              "orgId": 1,
+              "title": "WococoBridgeHub -> RococoBridgeHub confirmation lags (00000001)",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0)) - scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_confirmed\"}[2m]) OR on() vector(0))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Unconfirmed messages",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            50
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "min"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 83,
+              "uid": "Kj_z21t4k",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "zqjpgXxnk",
+              "__panelId__": "18",
+              "summary": "Rewards for messages from WococoBridgeHub to RococoBridgeHub (00000001) are either not confirmed, or are confirmed with lags"
+            },
+            "grafana_alert": {
+              "id": 58,
+              "orgId": 1,
+              "title": "WococoBridgeHub -> RococoBridgeHub reward lags (00000001)",
+              "condition": "C",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_confirmed\"}[2m]) OR on() vector(0)) - scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_confirmed\"}[2m]) OR on() vector(0))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Unconfirmed rewards",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "(scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_confirmed\"}[2m]) OR on() vector(0)) - scalar(max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_confirmed\"}[2m]) OR on() vector(0))) * (max_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0) > bool min_over_time(BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0))",
+                    "hide": true,
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "__auto",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "B"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            10
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "B"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "min"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "C",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 78,
+              "uid": "hw_a21pVk",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "tkgc6_bnk",
+              "__panelId__": "15",
+              "summary": "Rewards for messages from RococoBridgeHub to WococoBridgeHub (00000001) are either not confirmed, or are confirmed with lags"
+            },
+            "grafana_alert": {
+              "id": 59,
+              "orgId": 1,
+              "title": "RococoBridgeHub -> WococoBridgeHub reward lags (00000001)",
+              "condition": "C",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "scalar(max_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_confirmed\"}[2m]) OR on() vector(0)) - scalar(max_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_confirmed\"}[2m]) OR on() vector(0))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Unconfirmed rewards",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "(scalar(max_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"source_latest_confirmed\"}[2m]) OR on() vector(0)) - scalar(max_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_confirmed\"}[2m]) OR on() vector(0))) * (max_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0) > bool min_over_time(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\",type=\"target_latest_received\"}[2m]) OR on() vector(0))",
+                    "hide": true,
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "__auto",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "B"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            10
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "min"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "C",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 77,
+              "uid": "daN62Jt4z",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "2",
+              "summary": "Best BridgeHubRococo header at BridgeHubWococo (00000001) doesn't match the same header at BridgeHubRococo"
+            },
+            "grafana_alert": {
+              "id": 60,
+              "orgId": 1,
+              "title": "BridgeHubRococo header mismatch (00000001)",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            0
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "max"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 74,
+              "uid": "BzBDb1pVz",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "3",
+              "summary": "Best BridgeHubWococo header at BridgeHubRococo (00000001) doesn't match the same header at BridgeHubWococo"
+            },
+            "grafana_alert": {
+              "id": 61,
+              "orgId": 1,
+              "title": "BridgeHubWococo header mismatch (00000001)",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            0
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "max"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 73,
+              "uid": "1W6lb1p4z",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "5",
+              "summary": "With-WococoBridgeHub messages relay balance at RococoBridgeHub (00000001) is too low"
+            },
+            "grafana_alert": {
+              "id": 62,
+              "orgId": 1,
+              "title": "With-WococoBridgeHub messages relay balance at RococoBridgeHub (00000001) is too low",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "last_over_time(at_BridgeHubRococo_relay_BridgeHubWococoMessages_balance{domain=\"parity-testnet\"}[1h])",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Messages Relay Balance",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            10
+                          ],
+                          "type": "lt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 72,
+              "uid": "Y5Dm-1tVz",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "6",
+              "summary": "With-RococoBridgeHub messages relay balance at WococoBridgeHub (00000001) is too low"
+            },
+            "grafana_alert": {
+              "id": 63,
+              "orgId": 1,
+              "title": "With-RococoBridgeHub messages relay balance at WococoBridgeHub (00000001) is too low",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "last_over_time(at_BridgeHubWococo_relay_BridgeHubRococoMessages_balance{domain=\"parity-testnet\"}[1h])",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Messages Relay Balance",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 300,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            10
+                          ],
+                          "type": "lt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "A"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "B",
+                    "type": "classic_conditions"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 71,
+              "uid": "yUl4a1tVz",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "5m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "tkgc6_bnk",
+              "__panelId__": "6",
+              "summary": "Less than 500 Rococo headers have been synced to WococoBridgeHub in last 120 minutes. Relay is not running?"
+            },
+            "grafana_alert": {
+              "id": 65,
+              "orgId": 1,
+              "title": "Rococo -> WococoBridgeHub finality sync lags (00000001)",
+              "condition": "D",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(increase(Rococo_to_BridgeHubWococo_Sync_best_source_at_target_block_number{domain=\"parity-testnet\"}[120m]))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "At Rococo",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "C"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "reducer": "last",
+                    "refId": "C",
+                    "type": "reduce"
+                  }
+                },
+                {
+                  "refId": "D",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            500
+                          ],
+                          "type": "lt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "D"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "C",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "D",
+                    "type": "threshold"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 40,
+              "uid": "R6GKwNA4z",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "5m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "zqjpgXxnk",
+              "__panelId__": "2",
+              "summary": "Less than 500 Wococo headers have been synced to RococoBridgeHub in last 120 minutes. Relay is not running?"
+            },
+            "grafana_alert": {
+              "id": 66,
+              "orgId": 1,
+              "title": "Wococo -> RococoBridgeHub finality sync lags (00000001)",
+              "condition": "D",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "max(increase(Wococo_to_BridgeHubRococo_Sync_best_source_at_target_block_number{domain=\"parity-testnet\"}[120m]))",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "At Wococo",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "C"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "reducer": "last",
+                    "refId": "C",
+                    "type": "reduce"
+                  }
+                },
+                {
+                  "refId": "D",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            500
+                          ],
+                          "type": "lt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "D"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "C",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "D",
+                    "type": "threshold"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 38,
+              "uid": "rAM1QHAVk",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "0s",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "11",
+              "summary": "The RococoBridgeHub <> WococoBridgeHub relay (00000001) has been aborted by version guard - i.e. one of chains has been upgraded and relay wasn't redeployed"
+            },
+            "grafana_alert": {
+              "id": 67,
+              "orgId": 1,
+              "title": "Version guard has aborted RococoBridgeHub <> WococoBridgeHub relay (00000001)",
+              "condition": "B",
+              "data": [
+                {
+                  "refId": "B",
+                  "queryType": "range",
+                  "relativeTimeRange": {
+                    "from": 600,
+                    "to": 0
+                  },
+                  "datasourceUid": "P03E52D76DFE188C3",
+                  "model": {
+                    "datasource": {
+                      "type": "loki",
+                      "uid": "P03E52D76DFE188C3"
+                    },
+                    "editorMode": "code",
+                    "expr": "count_over_time({container=\"bridges-common-relay\"} |= `Aborting relay` [1m])",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "legendFormat": "Aborts per minute",
+                    "maxDataPoints": 43200,
+                    "queryType": "range",
+                    "refId": "B"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "C"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "B",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "reducer": "max",
+                    "refId": "C",
+                    "type": "reduce"
+                  }
+                },
+                {
+                  "refId": "D",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            0
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "D"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "C",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "D",
+                    "type": "threshold"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 37,
+              "uid": "TwWPeN04z",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "12",
+              "summary": "Best Rococo header at BridgeHubWococo (00000001) doesn't match the same header at Rococo"
+            },
+            "grafana_alert": {
+              "id": 69,
+              "orgId": 1,
+              "title": "Rococo headers mismatch",
+              "condition": "C",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "Rococo_to_BridgeHubWococo_Sync_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 0,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "B"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "reducer": "last",
+                    "refId": "B",
+                    "type": "reduce"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 0,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            0
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "C"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "B",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "C",
+                    "type": "threshold"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 32,
+              "uid": "08-5gv04k",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "10m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "13",
+              "summary": "Best Wococo header at BridgeHubRococo (00000001) doesn't match the same header at Wococo"
+            },
+            "grafana_alert": {
+              "id": 70,
+              "orgId": 1,
+              "title": "Wococo headers mismatch",
+              "condition": "C",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "Wococo_to_BridgeHubRococo_Sync_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 0,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "B"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "reducer": "last",
+                    "refId": "B",
+                    "type": "reduce"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 0,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            0
+                          ],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "C"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "B",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "C",
+                    "type": "threshold"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 31,
+              "uid": "Esj2gD0Vk",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "5m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "tkgc6_bnk",
+              "__panelId__": "9",
+              "summary": "Test messages from RococoBridgeHub to WococoBridgeHub are not generated. Our cronjob has died?"
+            },
+            "grafana_alert": {
+              "id": 73,
+              "orgId": 1,
+              "title": "Test messages from RococoBridgeHub to WococoBridgeHub are not generated.",
+              "condition": "D",
+              "data": [
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 21600,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "expr": "increase(BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_lane_state_nonces{domain=\"parity-testnet\", type=~\"source_latest_generated\"}[24h])",
+                    "hide": true,
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Messages generated in last 24h",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "B"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "C"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "B",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "reducer": "max",
+                    "refId": "C",
+                    "type": "reduce"
+                  }
+                },
+                {
+                  "refId": "D",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 600,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            1
+                          ],
+                          "type": "lt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "D"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "C",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "D",
+                    "type": "threshold"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 3,
+              "uid": "ry1K5SB4k",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          },
+          {
+            "expr": "",
+            "for": "5m",
+            "labels": {
+              "matrix_room": "XyVkmRJgIkjcvIBPsP"
+            },
+            "annotations": {
+              "__dashboardUid__": "UFsgbJtVz",
+              "__panelId__": "16",
+              "summary": "RococoBridgeHub <> WococoBridgeHub relay (00000001) node is down"
+            },
+            "grafana_alert": {
+              "id": 74,
+              "orgId": 1,
+              "title": "RococoBridgeHub <> WococoBridgeHub relay (00000001) node is down",
+              "condition": "C",
+              "data": [
+                {
+                  "refId": "A",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 900,
+                    "to": 0
+                  },
+                  "datasourceUid": "PC96415006F908B67",
+                  "model": {
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "PC96415006F908B67"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "up{domain=\"parity-testnet\",container=\"bridges-common-relay\"}",
+                    "instant": false,
+                    "interval": "",
+                    "intervalMs": 30000,
+                    "legendFormat": "Is relay running",
+                    "maxDataPoints": 43200,
+                    "range": true,
+                    "refId": "A"
+                  }
+                },
+                {
+                  "refId": "B",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 0,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [],
+                          "type": "gt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "B"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "A",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "reducer": "max",
+                    "refId": "B",
+                    "type": "reduce"
+                  }
+                },
+                {
+                  "refId": "C",
+                  "queryType": "",
+                  "relativeTimeRange": {
+                    "from": 0,
+                    "to": 0
+                  },
+                  "datasourceUid": "-100",
+                  "model": {
+                    "conditions": [
+                      {
+                        "evaluator": {
+                          "params": [
+                            1
+                          ],
+                          "type": "lt"
+                        },
+                        "operator": {
+                          "type": "and"
+                        },
+                        "query": {
+                          "params": [
+                            "C"
+                          ]
+                        },
+                        "reducer": {
+                          "params": [],
+                          "type": "last"
+                        },
+                        "type": "query"
+                      }
+                    ],
+                    "datasource": {
+                      "type": "__expr__",
+                      "uid": "-100"
+                    },
+                    "expression": "B",
+                    "hide": false,
+                    "intervalMs": 1000,
+                    "maxDataPoints": 43200,
+                    "refId": "C",
+                    "type": "threshold"
+                  }
+                }
+              ],
+              "updated": "2023-03-29T05:39:46Z",
+              "intervalSeconds": 60,
+              "version": 1,
+              "uid": "9YAdEUB4z",
+              "namespace_uid": "eblDiw17z",
+              "namespace_id": 140,
+              "rule_group": "Bridges",
+              "no_data_state": "OK",
+              "exec_err_state": "OK"
+            }
+          }
+        ]
+      }
+    ]
+  }

--- a/deployments/bridges/rococo-wococo/dashboard/grafana/rococo-wococo-maintenance-dashboard.json
+++ b/deployments/bridges/rococo-wococo/dashboard/grafana/rococo-wococo-maintenance-dashboard.json
@@ -1,853 +1,1031 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
           "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 284,
-    "links": [],
-    "liveNow": false,
-    "panels": [
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
         },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 5,
-          "x": 0,
-          "y": 0
-        },
-        "id": 8,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {},
-          "textMode": "name"
-        },
-        "pluginVersion": "9.3.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "substrate_relay_build_info{domain=\"parity-testnet\"}",
-            "instant": true,
-            "legendFormat": "{{commit}}",
-            "range": false,
-            "refId": "A"
-          }
-        ],
-        "title": "Relay build commit",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 5,
-          "x": 5,
-          "y": 0
-        },
-        "id": 9,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "/^1\\.0\\.1$/",
-            "values": false
-          },
-          "text": {},
-          "textMode": "name"
-        },
-        "pluginVersion": "9.3.1",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "exemplar": false,
-            "expr": "substrate_relay_build_info{domain=\"parity-testnet\"}",
-            "instant": true,
-            "legendFormat": "{{version}}",
-            "range": false,
-            "refId": "A"
-          }
-        ],
-        "title": "Relay build version",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "loki",
-          "uid": "P03E52D76DFE188C3"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 8,
-          "x": 10,
-          "y": 0
-        },
-        "id": 11,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "loki",
-              "uid": "P03E52D76DFE188C3"
-            },
-            "editorMode": "code",
-            "expr": "count_over_time({container=\"bridges-common-relay\"} |~ `(?i)(warn|error|fail)` [1m])",
-            "legendFormat": "Errors per minute",
-            "queryType": "range",
-            "refId": "A"
-          }
-        ],
-        "title": "Relay errors/warnings per minute",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 9,
-          "x": 0,
-          "y": 5
-        },
-        "id": 12,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "Rococo_to_BridgeHubWococo_Sync_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
-            "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Rococo headers mismatch",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 9,
-          "x": 9,
-          "y": 5
-        },
-        "id": 13,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "Wococo_to_BridgeHubRococo_Sync_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
-            "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "Wococo headers mismatch",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 9,
-          "x": 0,
-          "y": 12
-        },
-        "id": 2,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
-            "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "BridgeHubRococo headers mismatch",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 9,
-          "x": 9,
-          "y": 12
-        },
-        "id": 3,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
-            "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
-            "range": true,
-            "refId": "A"
-          }
-        ],
-        "title": "BridgeHubWococo headers mismatch",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 9,
-          "x": 0,
-          "y": 19
-        },
-        "id": 5,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "at_BridgeHubRococo_relay_BridgeHubWococoMessages_balance{domain=\"parity-testnet\"}",
-            "legendFormat": "Messages Relay Balance",
-            "range": true,
-            "refId": "A"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "at_BridgeHubRococo_relay_WococoHeaders_reward_for_msgs_to_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"} + at_BridgeHubRococo_relay_BridgeHubWococoMessages_reward_for_msgs_to_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"}",
-            "hide": false,
-            "legendFormat": "Pending reward",
-            "range": true,
-            "refId": "B"
-          }
-        ],
-        "title": "Relay balances at RococoBridgeHub",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PC96415006F908B67"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 9,
-          "x": 9,
-          "y": 19
-        },
-        "id": 6,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "at_BridgeHubWococo_relay_BridgeHubRococoMessages_balance{domain=\"parity-testnet\"}",
-            "legendFormat": "Messages Relay Balance",
-            "range": true,
-            "refId": "A"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PC96415006F908B67"
-            },
-            "editorMode": "code",
-            "expr": "at_BridgeHubRococo_relay_BridgeHubWococoMessages_reward_for_msgs_from_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"} + at_BridgeHubRococo_relay_BridgeHubWococoMessages_reward_for_msgs_to_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"}",
-            "hide": false,
-            "legendFormat": "Pending reward",
-            "range": true,
-            "refId": "B"
-          }
-        ],
-        "title": "Relay balances at WococoBridgeHub",
-        "type": "timeseries"
+        "type": "dashboard"
       }
-    ],
-    "refresh": "5s",
-    "schemaVersion": 37,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": []
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 284,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "name"
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "substrate_relay_build_info{domain=\"parity-testnet\"}",
+          "instant": true,
+          "legendFormat": "{{commit}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Relay build commit",
+      "type": "stat"
     },
-    "time": {
-      "from": "now-6h",
-      "to": "now"
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 5,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^1\\.0\\.1$/",
+          "values": false
+        },
+        "text": {},
+        "textMode": "name"
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "substrate_relay_build_info{domain=\"parity-testnet\"}",
+          "instant": true,
+          "legendFormat": "{{version}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Relay build version",
+      "type": "stat"
     },
-    "timepicker": {},
-    "timezone": "",
-    "title": "BridgeHubRococo <> BridgeHubWococo maintenance (00000001)",
-    "uid": "UFsgbJtVz",
-    "version": 23,
-    "weekStart": ""
-  }
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "No"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 9,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "up{domain=\"parity-testnet\",container=\"bridges-common-relay\"}",
+          "instant": false,
+          "legendFormat": "Is relay running",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Is relay running?",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 13,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "up{domain=\"parity-testnet\",container=\"bridges-common-relay\"}",
+          "instant": false,
+          "legendFormat": "Is relay running",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Is relay running? (for alert)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P03E52D76DFE188C3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 18,
+        "x": 0,
+        "y": 5
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P03E52D76DFE188C3"
+          },
+          "editorMode": "code",
+          "expr": "count_over_time({container=\"bridges-common-relay\"} |~ `(?i)(warn|error|fail)` [1m])",
+          "legendFormat": "Errors per minute",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Relay errors/warnings per minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 14
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "Rococo_to_BridgeHubWococo_Sync_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+          "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rococo headers mismatch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 9,
+        "y": 14
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "Wococo_to_BridgeHubRococo_Sync_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+          "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Wococo headers mismatch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 21
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "BridgeHubRococo_to_BridgeHubWococo_MessageLane_00000001_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+          "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "BridgeHubRococo headers mismatch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 9,
+        "y": 21
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "BridgeHubWococo_to_BridgeHubRococo_MessageLane_00000001_is_source_and_source_at_target_using_different_forks{domain=\"parity-testnet\"}",
+          "legendFormat": "Best BridgeHubRococo header at BridgeHubWococo doesn't match the same header of BridgeHubRococo",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "BridgeHubWococo headers mismatch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 28
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "at_BridgeHubRococo_relay_BridgeHubWococoMessages_balance{domain=\"parity-testnet\"}",
+          "legendFormat": "Messages Relay Balance",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "at_BridgeHubRococo_relay_WococoHeaders_reward_for_msgs_to_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"} + at_BridgeHubRococo_relay_BridgeHubWococoMessages_reward_for_msgs_to_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"}",
+          "hide": false,
+          "legendFormat": "Pending reward",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Relay balances at RococoBridgeHub",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PC96415006F908B67"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 28
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "at_BridgeHubWococo_relay_BridgeHubRococoMessages_balance{domain=\"parity-testnet\"}",
+          "legendFormat": "Messages Relay Balance",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PC96415006F908B67"
+          },
+          "editorMode": "code",
+          "expr": "at_BridgeHubRococo_relay_BridgeHubWococoMessages_reward_for_msgs_from_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"} + at_BridgeHubRococo_relay_BridgeHubWococoMessages_reward_for_msgs_to_BridgeHubWococo_on_lane_00000001{domain=\"parity-testnet\"}",
+          "hide": false,
+          "legendFormat": "Pending reward",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Relay balances at WococoBridgeHub",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "BridgeHubRococo <> BridgeHubWococo maintenance (00000001)",
+  "uid": "UFsgbJtVz",
+  "version": 26,
+  "weekStart": ""
+}


### PR DESCRIPTION
closes #1999
implementing https://github.com/paritytech/parity-bridges-common/issues/1715#issuecomment-1458366418

I've also found that in our Grafana version alerts are not a part of dashboard json model., so I've exported Bridges alerts (for the future me: https://<grafana-server>/api/ruler/grafana/api/v1/rules/Bridges) to a separate file.