### PR TITLE
Fix test step on CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,7 +155,7 @@ test:
     # Enable this, when you see: "`cargo metadata` can not fail on project `Cargo.toml`"
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-runtime\").manifest_path"`
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"kusama-runtime\").manifest_path"`
-    - CARGO_NET_OFFLINE=true SKIP_POLKADOT_RUNTIME_WASM_BUILD=1 SKIP_KUSAMA_RUNTIME_WASM_BUILD=1 SKIP_POLKADOT_TEST_RUNTIME_WASM_BUILD=1 time cargo test --verbose --workspace --features runtime-benchmarks
+    - CARGO_NET_OFFLINE=true SKIP_WASM_BUILD=1 time cargo test --verbose --workspace --features runtime-benchmarks
 
 test-nightly:
   stage:                           test


### PR DESCRIPTION
https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/2615134

#1998 doesn't help (inside `paritytech/bridges-ci:staging`), so I'm gonna change the command to skip building  all WASM runtimes. I've checked locally with docker image and now test work.

There's this other `benchmark-test` issue (https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/2615138). According to the error message, it fails to decode WASM blob (unknown wasm opcode - 192). Have no idea - whether rust now actually emits this `i32.extend8_s` instruction and we haven't updated our compilators/interpreters refs, or it is something else. Needs investigation