### PR TITLE
Fail with InsufficientDispatchWeight if dispatch_weight doesn't cover the weight of all bundled messages

### DIFF
--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -160,6 +160,16 @@ pub mod pallet {
 		///
 		/// If successful in verification, it will write the target header to the underlying storage
 		/// pallet.
+		///
+		/// The call fails if:
+		///
+		/// - the pallet is halted;
+		///
+		/// - the pallet knows better header than the `finality_target`;
+		///
+		/// - verification is not optimized or invalid;
+		///
+		/// - header contains forced authorities set change or change with non-zero delay.
 		#[pallet::call_index(0)]
 		#[pallet::weight(<T::WeightInfo as WeightInfo>::submit_finality_proof(
 			justification.commit.precommits.len().saturated_into(),

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -294,6 +294,16 @@ pub mod pallet {
 		/// `polkadot-runtime-parachains::paras` pallet instance, deployed at the bridged chain.
 		/// The proof is supposed to be crafted at the `relay_header_hash` that must already be
 		/// imported by corresponding GRANDPA pallet at this chain.
+		///
+		/// The call fails if:
+		///
+		/// - the pallet is halted;
+		///
+		/// - the relay chain block `at_relay_block` is not imported by the associated bridge
+		///   GRANDPA pallet.
+		///
+		/// The call may succeed, but some heads may not be updated e.g. because pallet knows
+		/// better head or it isn't tracked by the pallet.
 		#[pallet::call_index(0)]
 		#[pallet::weight(WeightInfoOf::<T, I>::submit_parachain_heads_weight(
 			T::DbWeight::get(),

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -238,8 +238,6 @@ pub struct ReceivedMessages<DispatchLevelResult> {
 	pub lane: LaneId,
 	/// Result of messages which we tried to dispatch
 	pub receive_results: Vec<(MessageNonce, ReceivalResult<DispatchLevelResult>)>,
-	/// Messages which were skipped and never dispatched
-	pub skipped_for_not_enough_weight: Vec<MessageNonce>,
 }
 
 impl<DispatchLevelResult> ReceivedMessages<DispatchLevelResult> {
@@ -247,15 +245,11 @@ impl<DispatchLevelResult> ReceivedMessages<DispatchLevelResult> {
 		lane: LaneId,
 		receive_results: Vec<(MessageNonce, ReceivalResult<DispatchLevelResult>)>,
 	) -> Self {
-		ReceivedMessages { lane, receive_results, skipped_for_not_enough_weight: Vec::new() }
+		ReceivedMessages { lane, receive_results }
 	}
 
 	pub fn push(&mut self, message: MessageNonce, result: ReceivalResult<DispatchLevelResult>) {
 		self.receive_results.push((message, result));
-	}
-
-	pub fn push_skipped_for_not_enough_weight(&mut self, message: MessageNonce) {
-		self.skipped_for_not_enough_weight.push(message);
 	}
 }
 

--- a/relays/client-rialto-parachain/src/codegen_runtime.rs
+++ b/relays/client-rialto-parachain/src/codegen_runtime.rs
@@ -6043,7 +6043,6 @@ pub mod api {
 					::core::primitive::u64,
 					runtime_types::bp_messages::ReceivalResult<_0>,
 				)>,
-				pub skipped_for_not_enough_weight: ::std::vec::Vec<::core::primitive::u64>,
 			}
 			#[derive(
 				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
@@ -7508,8 +7507,9 @@ pub mod api {
 					#[doc = "`receive_messages_delivery_proof` call."]
 					InvalidUnrewardedRelayersState,
 					#[codec(index = 11)]
-					#[doc = "The message someone is trying to work with (i.e. increase fee) is already-delivered."]
-					MessageIsAlreadyDelivered,
+					#[doc = "The cumulative dispatch weight, passed by relayer is not enough to cover dispatch"]
+					#[doc = "of all bundled messages."]
+					InsufficientDispatchWeight,
 					#[codec(index = 12)]
 					#[doc = "The message someone is trying to work with (i.e. increase fee) is not yet sent."]
 					MessageIsNotYetSent,


### PR DESCRIPTION
Ignoring this error isn't actual anymore, so let's be stricter here.