### PR TITLE
Reintroduce msg dispatch status reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
 name = "bp-messages"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "bp-runtime",
  "frame-support",
  "hex",
@@ -6492,6 +6493,7 @@ dependencies = [
 name = "pallet-bridge-messages"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "bp-messages",
  "bp-runtime",
  "bp-test-utils",

--- a/bin/millau/runtime/src/xcm_config.rs
+++ b/bin/millau/runtime/src/xcm_config.rs
@@ -242,7 +242,7 @@ mod tests {
 		target_chain::{DispatchMessage, DispatchMessageData, MessageDispatch},
 		LaneId, MessageKey,
 	};
-	use bridge_runtime_common::messages_xcm_extension::XcmBlobMessageDispatchResult;
+	use bridge_runtime_common::messages_xcm_extension::XcmBlobMessageDispatchError;
 	use codec::Encode;
 	use pallet_bridge_messages::OutboundLanes;
 	use xcm_executor::XcmExecutor;
@@ -352,8 +352,8 @@ mod tests {
 		let dispatch_result =
 			FromRialtoMessageDispatch::dispatch(&AccountId::from([0u8; 32]), incoming_message);
 		assert!(matches!(
-			dispatch_result.dispatch_level_result,
-			XcmBlobMessageDispatchResult::NotDispatched(_),
+			dispatch_result.dispatch_result,
+			Err(XcmBlobMessageDispatchError::NotDispatched(_)),
 		));
 	}
 
@@ -366,8 +366,8 @@ mod tests {
 		let dispatch_result =
 			FromRialtoMessageDispatch::dispatch(&AccountId::from([0u8; 32]), incoming_message);
 		assert!(matches!(
-			dispatch_result.dispatch_level_result,
-			XcmBlobMessageDispatchResult::NotDispatched(_),
+			dispatch_result.dispatch_result,
+			Err(XcmBlobMessageDispatchError::NotDispatched(_)),
 		));
 	}
 }

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -853,7 +853,7 @@ mod tests {
 		LaneId, MessageKey,
 	};
 	use bridge_runtime_common::{
-		integrity::check_additional_signed, messages_xcm_extension::XcmBlobMessageDispatchResult,
+		integrity::check_additional_signed, messages_xcm_extension::XcmBlobMessageDispatchError,
 	};
 	use codec::Encode;
 	use pallet_bridge_messages::OutboundLanes;
@@ -928,8 +928,8 @@ mod tests {
 			let dispatch_result =
 				FromMillauMessageDispatch::dispatch(&AccountId::from([0u8; 32]), incoming_message);
 			assert!(matches!(
-				dispatch_result.dispatch_level_result,
-				XcmBlobMessageDispatchResult::NotDispatched(_),
+				dispatch_result.dispatch_result,
+				Err(XcmBlobMessageDispatchError::NotDispatched(_)),
 			));
 		});
 	}

--- a/bin/rialto/runtime/src/xcm_config.rs
+++ b/bin/rialto/runtime/src/xcm_config.rs
@@ -197,7 +197,7 @@ mod tests {
 		target_chain::{DispatchMessage, DispatchMessageData, MessageDispatch},
 		LaneId, MessageKey,
 	};
-	use bridge_runtime_common::messages_xcm_extension::XcmBlobMessageDispatchResult;
+	use bridge_runtime_common::messages_xcm_extension::XcmBlobMessageDispatchError;
 	use codec::Encode;
 	use pallet_bridge_messages::OutboundLanes;
 	use xcm_executor::XcmExecutor;
@@ -269,8 +269,8 @@ mod tests {
 		let dispatch_result =
 			FromMillauMessageDispatch::dispatch(&AccountId::from([0u8; 32]), incoming_message);
 		assert!(matches!(
-			dispatch_result.dispatch_level_result,
-			XcmBlobMessageDispatchResult::NotDispatched(_),
+			dispatch_result.dispatch_result,
+			Err(XcmBlobMessageDispatchError::NotDispatched(_)),
 		));
 	}
 }

--- a/bin/runtime-common/src/integrity.rs
+++ b/bin/runtime-common/src/integrity.rs
@@ -307,8 +307,10 @@ pub fn check_message_lane_weights<C: Chain, T: frame_system::Config>(
 		messages::target::maximal_incoming_message_dispatch_weight(C::max_extrinsic_weight()),
 	);
 
-	let max_incoming_inbound_lane_data_proof_size =
-		InboundLaneData::<()>::encoded_size_hint_u32(this_chain_max_unrewarded_relayers as _);
+	let max_incoming_inbound_lane_data_proof_size = InboundLaneData::<()>::encoded_size_hint_u32(
+		this_chain_max_unrewarded_relayers as _,
+		this_chain_max_unconfirmed_messages as _,
+	);
 	pallet_bridge_messages::ensure_able_to_receive_confirmation::<Weights<T>>(
 		C::max_extrinsic_size(),
 		C::max_extrinsic_weight(),

--- a/modules/messages/Cargo.toml
+++ b/modules/messages/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+bitvec = { version = "1", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 log = { version = "0.4.17", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -301,7 +301,7 @@ benchmarks_instance_pallet! {
 			inbound_lane_data: InboundLaneData {
 				relayers: vec![UnrewardedRelayer {
 					relayer: relayer_id.clone(),
-					messages: DeliveredMessages::new(1),
+					messages: DeliveredMessages::new(1, true),
 				}].into_iter().collect(),
 				last_confirmed_nonce: 0,
 			},
@@ -333,8 +333,8 @@ benchmarks_instance_pallet! {
 			total_messages: 2,
 			last_delivered_nonce: 2,
 		};
-		let mut delivered_messages = DeliveredMessages::new(1);
-		delivered_messages.note_dispatched_message();
+		let mut delivered_messages = DeliveredMessages::new(1, true);
+		delivered_messages.note_dispatched_message(true);
 		let proof = T::prepare_message_delivery_proof(MessageDeliveryProofParams {
 			lane: T::bench_lane_id(),
 			inbound_lane_data: InboundLaneData {
@@ -379,11 +379,11 @@ benchmarks_instance_pallet! {
 				relayers: vec![
 					UnrewardedRelayer {
 						relayer: relayer1_id.clone(),
-						messages: DeliveredMessages::new(1),
+						messages: DeliveredMessages::new(1, true),
 					},
 					UnrewardedRelayer {
 						relayer: relayer2_id.clone(),
-						messages: DeliveredMessages::new(2),
+						messages: DeliveredMessages::new(2, true),
 					},
 				].into_iter().collect(),
 				last_confirmed_nonce: 0,
@@ -451,7 +451,7 @@ fn receive_messages<T: Config<I>, I: 'static>(nonce: MessageNonce) {
 	inbound_lane_storage.set_data(InboundLaneData {
 		relayers: vec![UnrewardedRelayer {
 			relayer: T::bridged_relayer_id(),
-			messages: DeliveredMessages::new(nonce),
+			messages: DeliveredMessages::new(nonce, true),
 		}]
 		.into_iter()
 		.collect(),

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -101,6 +101,7 @@ impl<T: Config<I>, I: 'static> MaxEncodedLen for StoredInboundLaneData<T, I> {
 	fn max_encoded_len() -> usize {
 		InboundLaneData::<T::InboundRelayer>::encoded_size_hint(
 			T::MaxUnrewardedRelayerEntriesAtInboundLane::get() as usize,
+			T::MaxUnconfirmedMessagesAtInboundLane::get() as usize,
 		)
 		.unwrap_or(usize::MAX)
 	}
@@ -154,6 +155,10 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		// overlap.
 		match data.relayers.front_mut() {
 			Some(entry) if entry.messages.begin < new_confirmed_nonce => {
+				entry.messages.dispatch_results = entry
+					.messages
+					.dispatch_results
+					.split_off((new_confirmed_nonce + 1 - entry.messages.begin) as _);
 				entry.messages.begin = new_confirmed_nonce + 1;
 			},
 			_ => {},
@@ -200,7 +205,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		// now let's update inbound lane storage
 		let push_new = match data.relayers.back_mut() {
 			Some(entry) if entry.relayer == *relayer_at_bridged_chain => {
-				entry.messages.note_dispatched_message();
+				entry.messages.note_dispatched_message(dispatch_result.dispatch_result.is_ok());
 				false
 			},
 			_ => true,
@@ -208,7 +213,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		if push_new {
 			data.relayers.push_back(UnrewardedRelayer {
 				relayer: (*relayer_at_bridged_chain).clone(),
-				messages: DeliveredMessages::new(nonce),
+				messages: DeliveredMessages::new(nonce, dispatch_result.dispatch_result.is_ok()),
 			});
 		}
 		self.storage.set_data(data);

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -170,7 +170,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		relayer_at_this_chain: &AccountId,
 		nonce: MessageNonce,
 		message_data: DispatchMessageData<Dispatch::DispatchPayload>,
-	) -> ReceivalResult<Dispatch::DispatchLevelResult> {
+	) -> ReceivalResult<Dispatch::DispatchError> {
 		let mut data = self.storage.data();
 		let is_correct_message = nonce == data.last_delivered_nonce() + 1;
 		if !is_correct_message {

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -527,7 +527,7 @@ pub mod pallet {
 		MessagesReceived(
 			Vec<
 				ReceivedMessages<
-					<T::MessageDispatch as MessageDispatch<T::AccountId>>::DispatchLevelResult,
+					<T::MessageDispatch as MessageDispatch<T::AccountId>>::DispatchError,
 				>,
 			>,
 		),

--- a/modules/messages/src/mock.rs
+++ b/modules/messages/src/mock.rs
@@ -19,6 +19,7 @@
 
 use crate::Config;
 
+use bitvec::prelude::*;
 use bp_messages::{
 	calc_relayers_rewards,
 	source_chain::{DeliveryConfirmationPayments, LaneMessageVerifier, TargetHeaderChain},
@@ -462,7 +463,7 @@ pub const fn message_payload(id: u64, declared_weight: u64) -> TestPayload {
 pub const fn dispatch_result(unspent_weight: u64) -> MessageDispatchResult<TestDispatchError> {
 	MessageDispatchResult {
 		unspent_weight: Weight::from_parts(unspent_weight, 0),
-		dispatch_result: Err(()),
+		dispatch_result: Ok(()),
 	}
 }
 
@@ -472,7 +473,18 @@ pub fn unrewarded_relayer(
 	end: MessageNonce,
 	relayer: TestRelayer,
 ) -> UnrewardedRelayer<TestRelayer> {
-	UnrewardedRelayer { relayer, messages: DeliveredMessages { begin, end } }
+	UnrewardedRelayer {
+		relayer,
+		messages: DeliveredMessages {
+			begin,
+			end,
+			dispatch_results: if end >= begin {
+				bitvec![u8, Msb0; 1; (end - begin + 1) as _]
+			} else {
+				Default::default()
+			},
+		},
+	}
 }
 
 /// Return test externalities to use in tests.

--- a/modules/messages/src/mock.rs
+++ b/modules/messages/src/mock.rs
@@ -478,11 +478,7 @@ pub fn unrewarded_relayer(
 		messages: DeliveredMessages {
 			begin,
 			end,
-			dispatch_results: if end >= begin {
-				bitvec![u8, Msb0; 1; (end - begin + 1) as _]
-			} else {
-				Default::default()
-			},
+			dispatch_results: bitvec![u8, Msb0; 1; (end + 1).saturating_sub(begin) as _],
 		},
 	}
 }

--- a/modules/messages/src/mock.rs
+++ b/modules/messages/src/mock.rs
@@ -62,13 +62,13 @@ pub struct TestPayload {
 	///
 	/// Note: in correct code `dispatch_result.unspent_weight` will always be <= `declared_weight`,
 	/// but for test purposes we'll be making it larger than `declared_weight` sometimes.
-	pub dispatch_result: MessageDispatchResult<TestDispatchLevelResult>,
+	pub dispatch_result: MessageDispatchResult<TestDispatchError>,
 	/// Extra bytes that affect payload size.
 	pub extra: Vec<u8>,
 }
 pub type TestMessageFee = u64;
 pub type TestRelayer = u64;
-pub type TestDispatchLevelResult = ();
+pub type TestDispatchError = ();
 
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<TestRuntime>;
@@ -412,7 +412,7 @@ pub struct TestMessageDispatch;
 
 impl MessageDispatch<AccountId> for TestMessageDispatch {
 	type DispatchPayload = TestPayload;
-	type DispatchLevelResult = TestDispatchLevelResult;
+	type DispatchError = TestDispatchError;
 
 	fn dispatch_weight(message: &mut DispatchMessage<TestPayload>) -> Weight {
 		match message.data.payload.as_ref() {
@@ -424,7 +424,7 @@ impl MessageDispatch<AccountId> for TestMessageDispatch {
 	fn dispatch(
 		_relayer_account: &AccountId,
 		message: DispatchMessage<TestPayload>,
-	) -> MessageDispatchResult<TestDispatchLevelResult> {
+	) -> MessageDispatchResult<TestDispatchError> {
 		match message.data.payload.as_ref() {
 			Ok(payload) => payload.dispatch_result.clone(),
 			Err(_) => dispatch_result(0),
@@ -459,12 +459,10 @@ pub const fn message_payload(id: u64, declared_weight: u64) -> TestPayload {
 }
 
 /// Returns message dispatch result with given unspent weight.
-pub const fn dispatch_result(
-	unspent_weight: u64,
-) -> MessageDispatchResult<TestDispatchLevelResult> {
+pub const fn dispatch_result(unspent_weight: u64) -> MessageDispatchResult<TestDispatchError> {
 	MessageDispatchResult {
 		unspent_weight: Weight::from_parts(unspent_weight, 0),
-		dispatch_level_result: (),
+		dispatch_result: Err(()),
 	}
 }
 

--- a/modules/messages/src/outbound_lane.rs
+++ b/modules/messages/src/outbound_lane.rs
@@ -18,8 +18,10 @@
 
 use crate::Config;
 
+use bitvec::prelude::*;
 use bp_messages::{
-	DeliveredMessages, LaneId, MessageNonce, MessagePayload, OutboundLaneData, UnrewardedRelayer,
+	DeliveredMessages, DispatchResultsBitVec, LaneId, MessageNonce, MessagePayload,
+	OutboundLaneData, UnrewardedRelayer,
 };
 use frame_support::{
 	weights::{RuntimeDbWeight, Weight},
@@ -65,6 +67,9 @@ pub enum ReceivalConfirmationResult {
 	/// The unrewarded relayers vec contains non-consecutive entries. May be a result of invalid
 	/// bridged chain storage.
 	NonConsecutiveUnrewardedRelayerEntries,
+	/// The unrewarded relayers vec contains entry with mismatched number of dispatch results. May
+	/// be a result of invalid bridged chain storage.
+	InvalidNumberOfDispatchResults,
 	/// The chain has more messages that need to be confirmed than there is in the proof.
 	TryingToConfirmMoreMessagesThanExpected(MessageNonce),
 }
@@ -124,9 +129,14 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 			)
 		}
 
-		if let Err(e) = ensure_unrewarded_relayers_are_correct(latest_delivered_nonce, relayers) {
-			return e
-		}
+		let dispatch_results = match extract_dispatch_results(
+			data.latest_received_nonce,
+			latest_delivered_nonce,
+			relayers,
+		) {
+			Ok(dispatch_results) => dispatch_results,
+			Err(extract_error) => return extract_error,
+		};
 
 		let prev_latest_received_nonce = data.latest_received_nonce;
 		data.latest_received_nonce = latest_delivered_nonce;
@@ -135,6 +145,7 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 		ReceivalConfirmationResult::ConfirmedMessages(DeliveredMessages {
 			begin: prev_latest_received_nonce + 1,
 			end: latest_delivered_nonce,
+			dispatch_results,
 		})
 	}
 
@@ -169,14 +180,21 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 	}
 }
 
-/// Verifies unrewarded relayers vec.
+/// Extract new dispatch results from the unrewarded relayers vec.
 ///
 /// Returns `Err(_)` if unrewarded relayers vec contains invalid data, meaning that the bridged
 /// chain has invalid runtime storage.
-fn ensure_unrewarded_relayers_are_correct<RelayerId>(
+fn extract_dispatch_results<RelayerId>(
+	prev_latest_received_nonce: MessageNonce,
 	latest_received_nonce: MessageNonce,
 	relayers: &VecDeque<UnrewardedRelayer<RelayerId>>,
-) -> Result<(), ReceivalConfirmationResult> {
+) -> Result<DispatchResultsBitVec, ReceivalConfirmationResult> {
+	// the only caller of this functions checks that the
+	// prev_latest_received_nonce..=latest_received_nonce is valid, so we're ready to accept
+	// messages in this range => with_capacity call must succeed here or we'll be unable to receive
+	// confirmations at all
+	let mut received_dispatch_result =
+		BitVec::with_capacity((latest_received_nonce - prev_latest_received_nonce + 1) as _);
 	let mut last_entry_end: Option<MessageNonce> = None;
 	for entry in relayers {
 		// unrewarded relayer entry must have at least 1 unconfirmed message
@@ -201,9 +219,33 @@ fn ensure_unrewarded_relayers_are_correct<RelayerId>(
 			// this is detected now
 			return Err(ReceivalConfirmationResult::FailedToConfirmFutureMessages)
 		}
+		// entry must have single dispatch result for every message
+		// (guaranteed by the `InboundLane::receive_message()`)
+		if entry.messages.dispatch_results.len() as MessageNonce !=
+			entry.messages.end - entry.messages.begin + 1
+		{
+			return Err(ReceivalConfirmationResult::InvalidNumberOfDispatchResults)
+		}
+
+		// now we know that the entry is valid
+		// => let's check if it brings new confirmations
+		let new_messages_begin =
+			sp_std::cmp::max(entry.messages.begin, prev_latest_received_nonce + 1);
+		let new_messages_end = sp_std::cmp::min(entry.messages.end, latest_received_nonce);
+		let new_messages_range = new_messages_begin..=new_messages_end;
+		if new_messages_range.is_empty() {
+			continue
+		}
+
+		// now we know that entry brings new confirmations
+		// => let's extract dispatch results
+		received_dispatch_result.extend_from_bitslice(
+			&entry.messages.dispatch_results
+				[(new_messages_begin - entry.messages.begin) as usize..],
+		);
 	}
 
-	Ok(())
+	Ok(received_dispatch_result)
 }
 
 #[cfg(test)]
@@ -228,7 +270,11 @@ mod tests {
 	}
 
 	fn delivered_messages(nonces: RangeInclusive<MessageNonce>) -> DeliveredMessages {
-		DeliveredMessages { begin: *nonces.start(), end: *nonces.end() }
+		DeliveredMessages {
+			begin: *nonces.start(),
+			end: *nonces.end(),
+			dispatch_results: bitvec![u8, Msb0; 1; (nonces.end() - nonces.start() + 1) as _],
+		}
 	}
 
 	fn assert_3_messages_confirmation_fails(
@@ -358,6 +404,20 @@ mod tests {
 					.collect(),
 			),
 			ReceivalConfirmationResult::NonConsecutiveUnrewardedRelayerEntries,
+		);
+	}
+
+	#[test]
+	fn confirm_delivery_fails_if_number_of_dispatch_results_in_entry_is_invalid() {
+		let mut relayers: VecDeque<_> = unrewarded_relayers(1..=1)
+			.into_iter()
+			.chain(unrewarded_relayers(2..=2).into_iter())
+			.chain(unrewarded_relayers(3..=3).into_iter())
+			.collect();
+		relayers[0].messages.dispatch_results.clear();
+		assert_eq!(
+			assert_3_messages_confirmation_fails(3, &relayers),
+			ReceivalConfirmationResult::InvalidNumberOfDispatchResults,
 		);
 	}
 

--- a/primitives/messages/Cargo.toml
+++ b/primitives/messages/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
+bitvec = { version = "1", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
 scale-info = { version = "2.5.0", default-features = false, features = ["bit-vec", "derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
@@ -28,6 +29,7 @@ hex-literal = "0.4"
 [features]
 default = ["std"]
 std = [
+	"bitvec/std",
 	"bp-runtime/std",
 	"codec/std",
 	"frame-support/std",

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -20,6 +20,7 @@
 // RuntimeApi generated functions
 #![allow(clippy::too_many_arguments)]
 
+use bitvec::prelude::*;
 use bp_runtime::{BasicOperatingMode, OperatingMode};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::RuntimeDebug;
@@ -160,7 +161,7 @@ impl<RelayerId> InboundLaneData<RelayerId> {
 	/// size of each entry.
 	///
 	/// Returns `None` if size overflows `usize` limits.
-	pub fn encoded_size_hint(relayers_entries: usize) -> Option<usize>
+	pub fn encoded_size_hint(relayers_entries: usize, messages_count: usize) -> Option<usize>
 	where
 		RelayerId: MaxEncodedLen,
 	{
@@ -168,18 +169,23 @@ impl<RelayerId> InboundLaneData<RelayerId> {
 		let relayer_id_encoded_size = RelayerId::max_encoded_len();
 		let relayers_entry_size = relayer_id_encoded_size.checked_add(2 * message_nonce_size)?;
 		let relayers_size = relayers_entries.checked_mul(relayers_entry_size)?;
-		relayers_size.checked_add(message_nonce_size)
+		let dispatch_results_per_byte = 8;
+		let dispatch_result_size =
+			sp_std::cmp::max(relayers_entries, messages_count / dispatch_results_per_byte);
+		relayers_size
+			.checked_add(message_nonce_size)
+			.and_then(|result| result.checked_add(dispatch_result_size))
 	}
 
 	/// Returns the approximate size of the struct as u32, given a number of entries in the
 	/// `relayers` set and the size of each entry.
 	///
 	/// Returns `u32::MAX` if size overflows `u32` limits.
-	pub fn encoded_size_hint_u32(relayers_entries: usize) -> u32
+	pub fn encoded_size_hint_u32(relayers_entries: usize, messages_count: usize) -> u32
 	where
 		RelayerId: MaxEncodedLen,
 	{
-		Self::encoded_size_hint(relayers_entries)
+		Self::encoded_size_hint(relayers_entries, messages_count)
 			.and_then(|x| u32::try_from(x).ok())
 			.unwrap_or(u32::MAX)
 	}
@@ -218,6 +224,9 @@ pub struct InboundMessageDetails {
 	/// message cannot be dispatched.
 	pub dispatch_weight: Weight,
 }
+
+/// Bit vector of message dispatch results.
+pub type DispatchResultsBitVec = BitVec<u8, Msb0>;
 
 /// Unrewarded relayer entry stored in the inbound lane data.
 ///
@@ -276,13 +285,19 @@ pub struct DeliveredMessages {
 	pub begin: MessageNonce,
 	/// Nonce of the last message that has been delivered (inclusive).
 	pub end: MessageNonce,
+	/// Dispatch result (`false`/`true`), returned by the message dispatcher for every
+	/// message in the `[begin; end]` range. See `dispatch_result` field of the
+	/// `bp_runtime::messages::MessageDispatchResult` structure for more information.
+	pub dispatch_results: DispatchResultsBitVec,
 }
 
 impl DeliveredMessages {
 	/// Create new `DeliveredMessages` struct that confirms delivery of single nonce with given
 	/// dispatch result.
-	pub fn new(nonce: MessageNonce) -> Self {
-		DeliveredMessages { begin: nonce, end: nonce }
+	pub fn new(nonce: MessageNonce, dispatch_result: bool) -> Self {
+		let mut dispatch_results = BitVec::with_capacity(1);
+		dispatch_results.push(dispatch_result);
+		DeliveredMessages { begin: nonce, end: nonce, dispatch_results }
 	}
 
 	/// Return total count of delivered messages.
@@ -295,13 +310,29 @@ impl DeliveredMessages {
 	}
 
 	/// Note new dispatched message.
-	pub fn note_dispatched_message(&mut self) {
+	pub fn note_dispatched_message(&mut self, dispatch_result: bool) {
 		self.end += 1;
+		self.dispatch_results.push(dispatch_result);
 	}
 
 	/// Returns true if delivered messages contain message with given nonce.
 	pub fn contains_message(&self, nonce: MessageNonce) -> bool {
 		(self.begin..=self.end).contains(&nonce)
+	}
+
+	/// Get dispatch result flag by message nonce.
+	///
+	/// Dispatch result flag must be interpreted using the knowledge of dispatch mechanism
+	/// at the target chain. See `dispatch_result` field of the
+	/// `bp_runtime::messages::MessageDispatchResult` structure for more information.
+	///
+	/// Panics if message nonce is not in the `begin..=end` range. Typically you'll first
+	/// check if message is within the range by calling `contains_message`.
+	pub fn message_dispatch_result(&self, nonce: MessageNonce) -> bool {
+		const INVALID_NONCE: &str = "Invalid nonce used to index dispatch_results";
+
+		let index = nonce.checked_sub(self.begin).expect(INVALID_NONCE) as usize;
+		*self.dispatch_results.get(index).expect(INVALID_NONCE)
 	}
 }
 
@@ -414,10 +445,10 @@ mod tests {
 		assert_eq!(
 			total_unrewarded_messages(
 				&vec![
-					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(0) },
+					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(0, true) },
 					UnrewardedRelayer {
 						relayer: 2,
-						messages: DeliveredMessages::new(MessageNonce::MAX)
+						messages: DeliveredMessages::new(MessageNonce::MAX, true)
 					},
 				]
 				.into_iter()
@@ -438,12 +469,21 @@ mod tests {
 			(13u8, 128u8),
 		];
 		for (relayer_entries, messages_count) in test_cases {
-			let expected_size = InboundLaneData::<u8>::encoded_size_hint(relayer_entries as _);
+			let expected_size =
+				InboundLaneData::<u8>::encoded_size_hint(relayer_entries as _, messages_count as _);
 			let actual_size = InboundLaneData {
 				relayers: (1u8..=relayer_entries)
-					.map(|i| UnrewardedRelayer {
-						relayer: i,
-						messages: DeliveredMessages::new(i as _),
+					.map(|i| {
+						let mut entry = UnrewardedRelayer {
+							relayer: i,
+							messages: DeliveredMessages::new(i as _, true),
+						};
+						entry.messages.dispatch_results = bitvec![
+							u8, Msb0;
+							1;
+							(messages_count / relayer_entries) as _
+						];
+						entry
 					})
 					.collect(),
 				last_confirmed_nonce: messages_count as _,
@@ -459,13 +499,16 @@ mod tests {
 	}
 
 	#[test]
-	fn contains_result_works() {
-		let delivered_messages = DeliveredMessages { begin: 100, end: 150 };
+	fn message_dispatch_result_works() {
+		let delivered_messages =
+			DeliveredMessages { begin: 100, end: 150, dispatch_results: bitvec![u8, Msb0; 1; 151] };
 
 		assert!(!delivered_messages.contains_message(99));
 		assert!(delivered_messages.contains_message(100));
 		assert!(delivered_messages.contains_message(150));
 		assert!(!delivered_messages.contains_message(151));
+
+		assert!(delivered_messages.message_dispatch_result(125));
 	}
 
 	#[test]

--- a/primitives/messages/src/target_chain.rs
+++ b/primitives/messages/src/target_chain.rs
@@ -90,7 +90,7 @@ pub trait MessageDispatch<AccountId> {
 	type DispatchPayload: Decode;
 
 	/// Fine-grained result of single message dispatch (for better diagnostic purposes)
-	type DispatchLevelResult: Clone + sp_std::fmt::Debug + Eq;
+	type DispatchError: Clone + sp_std::fmt::Debug + Eq;
 
 	/// Estimate dispatch weight.
 	///
@@ -109,7 +109,7 @@ pub trait MessageDispatch<AccountId> {
 	fn dispatch(
 		relayer_account: &AccountId,
 		message: DispatchMessage<Self::DispatchPayload>,
-	) -> MessageDispatchResult<Self::DispatchLevelResult>;
+	) -> MessageDispatchResult<Self::DispatchError>;
 }
 
 /// Manages payments that are happening at the target chain during message delivery transaction.
@@ -190,7 +190,7 @@ impl<MessagesProof, DispatchPayload: Decode, AccountId> MessageDispatch<AccountI
 	for ForbidInboundMessages<MessagesProof, DispatchPayload>
 {
 	type DispatchPayload = DispatchPayload;
-	type DispatchLevelResult = ();
+	type DispatchError = ();
 
 	fn dispatch_weight(_message: &mut DispatchMessage<Self::DispatchPayload>) -> Weight {
 		Weight::MAX
@@ -199,7 +199,7 @@ impl<MessagesProof, DispatchPayload: Decode, AccountId> MessageDispatch<AccountI
 	fn dispatch(
 		_: &AccountId,
 		_: DispatchMessage<Self::DispatchPayload>,
-	) -> MessageDispatchResult<Self::DispatchLevelResult> {
-		MessageDispatchResult { unspent_weight: Weight::zero(), dispatch_level_result: () }
+	) -> MessageDispatchResult<Self::DispatchError> {
+		MessageDispatchResult { unspent_weight: Weight::zero(), dispatch_result: Err(()) }
 	}
 }

--- a/primitives/runtime/src/messages.rs
+++ b/primitives/runtime/src/messages.rs
@@ -22,7 +22,7 @@ use scale_info::TypeInfo;
 
 /// Message dispatch result.
 #[derive(Encode, Decode, RuntimeDebug, Clone, PartialEq, Eq, TypeInfo)]
-pub struct MessageDispatchResult<DispatchLevelResult> {
+pub struct MessageDispatchResult<DispatchError> {
 	/// Unspent dispatch weight. This weight that will be deducted from total delivery transaction
 	/// weight, thus reducing the transaction cost. This shall not be zero in (at least) two cases:
 	///
@@ -31,5 +31,5 @@ pub struct MessageDispatchResult<DispatchLevelResult> {
 	/// 2) if message has not been dispatched at all.
 	pub unspent_weight: Weight,
 	/// Fine-grained result of single message dispatch (for better diagnostic purposes)
-	pub dispatch_level_result: DispatchLevelResult,
+	pub dispatch_result: Result<(), DispatchError>,
 }


### PR DESCRIPTION
Fixes #2022

Mainly reverting #1660 

Later we will also need to link this status to the original XCM message received by the source bridge hub and send some response based on it. But I'm not sure how for the moment. Will do it in a separate issue.