### PR TITLE
submit lane unblock transactions from relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5553,6 +5553,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bp-messages",
+ "env_logger",
  "finality-relay",
  "futures",
  "hex",

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -55,7 +55,7 @@ pub trait Chain: ChainBase + Clone {
 	/// Block type.
 	type SignedBlock: Member + Serialize + DeserializeOwned + BlockWithJustification<Self::Header>;
 	/// The aggregated `Call` type.
-	type Call: Clone + Codec + Debug + Send;
+	type Call: Clone + Codec + Debug + Send + Sync;
 }
 
 /// Substrate-based relay chain that supports parachains.

--- a/relays/lib-substrate-relay/src/lib.rs
+++ b/relays/lib-substrate-relay/src/lib.rs
@@ -91,7 +91,7 @@ impl<AccountId> TaggedAccount<AccountId> {
 }
 
 /// Batch call builder.
-pub trait BatchCallBuilder<Call>: Clone + Send {
+pub trait BatchCallBuilder<Call>: Clone + Send + Sync {
 	/// Create batch call from given calls vector.
 	fn build_batch_call(&self, _calls: Vec<Call>) -> Call;
 }

--- a/relays/messages/Cargo.toml
+++ b/relays/messages/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 async-std = { version = "1.6.5", features = ["attributes"] }
 async-trait = "0.1"
+env_logger = "0.10"
 futures = "0.3.28"
 hex = "0.4"
 log = "0.4.17"

--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -111,7 +111,7 @@ pub struct NoncesSubmitArtifacts<T> {
 
 /// Batch transaction that already submit some headers and needs to be extended with
 /// messages/delivery proof before sending.
-pub trait BatchTransaction<HeaderId>: Debug + Send {
+pub trait BatchTransaction<HeaderId>: Debug + Send + Sync {
 	/// Header that was required in the original call and which is bundled within this
 	/// batch transaction.
 	fn required_header_id(&self) -> HeaderId;
@@ -1204,7 +1204,6 @@ pub(crate) mod tests {
 
 	#[test]
 	fn message_lane_loop_works_with_batch_transactions() {
-		let _ = env_logger::try_init();
 		let (exit_sender, exit_receiver) = unbounded();
 		let original_data = Arc::new(Mutex::new(TestClientData {
 			source_state: ClientState {

--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -111,7 +111,7 @@ pub struct NoncesSubmitArtifacts<T> {
 
 /// Batch transaction that already submit some headers and needs to be extended with
 /// messages/delivery proof before sending.
-pub trait BatchTransaction<HeaderId>: Debug + Send {
+pub trait BatchTransaction<HeaderId>: Debug + Send + Sync {
 	/// Header that was required in the original call and which is bundled within this
 	/// batch transaction.
 	fn required_header_id(&self) -> HeaderId;

--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -111,7 +111,7 @@ pub struct NoncesSubmitArtifacts<T> {
 
 /// Batch transaction that already submit some headers and needs to be extended with
 /// messages/delivery proof before sending.
-pub trait BatchTransaction<HeaderId>: Debug + Send + Sync {
+pub trait BatchTransaction<HeaderId>: Debug + Send {
 	/// Header that was required in the original call and which is bundled within this
 	/// batch transaction.
 	fn required_header_id(&self) -> HeaderId;

--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -632,7 +632,8 @@ pub(crate) mod tests {
 			self.target_state.best_finalized_self = self.target_state.best_self;
 			self.target_latest_received_nonce = *proof.0.end();
 			if let Some(maybe_batch_tx) = maybe_batch_tx {
-				self.target_state.best_finalized_peer_at_best_self = Some(maybe_batch_tx.required_header_id());
+				self.target_state.best_finalized_peer_at_best_self =
+					Some(maybe_batch_tx.required_header_id());
 			}
 			if let Some(target_latest_confirmed_received_nonce) = proof.1 {
 				self.target_latest_confirmed_received_nonce =
@@ -650,7 +651,8 @@ pub(crate) mod tests {
 				HeaderId(self.source_state.best_self.0 + 1, self.source_state.best_self.1 + 1);
 			self.source_state.best_finalized_self = self.source_state.best_self;
 			if let Some(maybe_batch_tx) = maybe_batch_tx {
-				self.source_state.best_finalized_peer_at_best_self = Some(maybe_batch_tx.required_header_id());
+				self.source_state.best_finalized_peer_at_best_self =
+					Some(maybe_batch_tx.required_header_id());
 			}
 			self.submitted_messages_receiving_proofs.push(proof);
 			self.source_latest_confirmed_received_nonce = proof;

--- a/relays/messages/src/message_lane_loop.rs
+++ b/relays/messages/src/message_lane_loop.rs
@@ -622,11 +622,18 @@ pub(crate) mod tests {
 	}
 
 	impl TestClientData {
-		fn receive_messages(&mut self, proof: TestMessagesProof) {
+		fn receive_messages(
+			&mut self,
+			maybe_batch_tx: Option<TestMessagesBatchTransaction>,
+			proof: TestMessagesProof,
+		) {
 			self.target_state.best_self =
 				HeaderId(self.target_state.best_self.0 + 1, self.target_state.best_self.1 + 1);
 			self.target_state.best_finalized_self = self.target_state.best_self;
 			self.target_latest_received_nonce = *proof.0.end();
+			if let Some(maybe_batch_tx) = maybe_batch_tx {
+				self.target_state.best_finalized_peer_at_best_self = Some(maybe_batch_tx.required_header_id());
+			}
 			if let Some(target_latest_confirmed_received_nonce) = proof.1 {
 				self.target_latest_confirmed_received_nonce =
 					target_latest_confirmed_received_nonce;
@@ -634,10 +641,17 @@ pub(crate) mod tests {
 			self.submitted_messages_proofs.push(proof);
 		}
 
-		fn receive_messages_delivery_proof(&mut self, proof: TestMessagesReceivingProof) {
+		fn receive_messages_delivery_proof(
+			&mut self,
+			maybe_batch_tx: Option<TestConfirmationBatchTransaction>,
+			proof: TestMessagesReceivingProof,
+		) {
 			self.source_state.best_self =
 				HeaderId(self.source_state.best_self.0 + 1, self.source_state.best_self.1 + 1);
 			self.source_state.best_finalized_self = self.source_state.best_self;
+			if let Some(maybe_batch_tx) = maybe_batch_tx {
+				self.source_state.best_finalized_peer_at_best_self = Some(maybe_batch_tx.required_header_id());
+			}
 			self.submitted_messages_receiving_proofs.push(proof);
 			self.source_latest_confirmed_received_nonce = proof;
 		}
@@ -760,13 +774,13 @@ pub(crate) mod tests {
 
 		async fn submit_messages_receiving_proof(
 			&self,
-			_maybe_batch_tx: Option<Self::BatchTransaction>,
+			maybe_batch_tx: Option<Self::BatchTransaction>,
 			_generated_at_block: TargetHeaderIdOf<TestMessageLane>,
 			proof: TestMessagesReceivingProof,
 		) -> Result<Self::TransactionTracker, TestError> {
 			let mut data = self.data.lock();
 			(self.tick)(&mut data);
-			data.receive_messages_delivery_proof(proof);
+			data.receive_messages_delivery_proof(maybe_batch_tx, proof);
 			(self.post_tick)(&mut data);
 			Ok(TestTransactionTracker(data.source_tracked_transaction_status))
 		}
@@ -885,7 +899,7 @@ pub(crate) mod tests {
 
 		async fn submit_messages_proof(
 			&self,
-			_maybe_batch_tx: Option<Self::BatchTransaction>,
+			maybe_batch_tx: Option<Self::BatchTransaction>,
 			_generated_at_header: SourceHeaderIdOf<TestMessageLane>,
 			nonces: RangeInclusive<MessageNonce>,
 			proof: TestMessagesProof,
@@ -895,7 +909,7 @@ pub(crate) mod tests {
 			if data.is_target_fails {
 				return Err(TestError)
 			}
-			data.receive_messages(proof);
+			data.receive_messages(maybe_batch_tx, proof);
 			(self.post_tick)(&mut data);
 			Ok(NoncesSubmitArtifacts {
 				nonces,
@@ -1190,6 +1204,7 @@ pub(crate) mod tests {
 
 	#[test]
 	fn message_lane_loop_works_with_batch_transactions() {
+		let _ = env_logger::try_init();
 		let (exit_sender, exit_receiver) = unbounded();
 		let original_data = Arc::new(Mutex::new(TestClientData {
 			source_state: ClientState {

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -424,6 +424,7 @@ where
 		};
 
 		// check if we need unblocking transaction and we may submit it
+		#[allow(clippy::reversed_empty_ranges)]
 		let selected_nonces = match selected_nonces {
 			Some(selected_nonces) => selected_nonces,
 			None if unrewarded_limit_reached && outbound_state_proof_required => 1..=0,
@@ -1221,6 +1222,7 @@ mod tests {
 	}
 
 	#[async_std::test]
+	#[allow(clippy::reversed_empty_ranges)]
 	async fn delivery_race_is_able_to_unblock_lane() {
 		// step 1: messages 20..=23 are delivered from source to target at target block 2
 		fn at_target_block_2_deliver_messages(

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -303,11 +303,7 @@ impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 		let best_finalized_source_header_id_at_best_target =
 			race_state.best_finalized_source_header_id_at_best_target()?;
 		let latest_confirmed_nonce_at_source = self
-			.latest_confirmed_nonces_at_source
-			.iter()
-			.take_while(|(id, _)| id.0 <= best_finalized_source_header_id_at_best_target.0)
-			.last()
-			.map(|(_, nonce)| *nonce)
+			.latest_confirmed_nonce_at_source(&best_finalized_source_header_id_at_best_target)
 			.unwrap_or(best_target_nonce);
 		let target_nonces = self.target_nonces.as_ref()?;
 
@@ -438,6 +434,16 @@ impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 			selected_nonces,
 			MessageProofParameters { outbound_state_proof_required, dispatch_weight },
 		))
+	}
+
+	/// Returns lastest confirmed message at source chain, given source block.
+	fn latest_confirmed_nonce_at_source(&self, at: &SourceHeaderIdOf<P>) -> Option<MessageNonce> {
+		self
+			.latest_confirmed_nonces_at_source
+			.iter()
+			.take_while(|(id, _)| id.0 <= at.0)
+			.last()
+			.map(|(_, nonce)| *nonce)
 	}
 
 	/// Returns total weight of all undelivered messages.

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -463,7 +463,7 @@ impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 			None => return self.strategy.required_source_header_at_target(
 				&best_finalized_source_header_id_at_best_target,
 				race_state,
-			).map(RaceAction::RelayHeader),
+			).await.map(RaceAction::RelayHeader),
 		};
 
 		let dispatch_weight = self.dispatch_weight_for_range(&selected_nonces);
@@ -514,7 +514,7 @@ where
 		self.strategy.is_empty()
 	}
 
-	fn required_source_header_at_target<RS: RaceState<SourceHeaderIdOf<P>, TargetHeaderIdOf<P>>>(
+	async fn required_source_header_at_target<RS: RaceState<SourceHeaderIdOf<P>, TargetHeaderIdOf<P>>>(
 		&self,
 		current_best: &SourceHeaderIdOf<P>,
 		race_state: RS,
@@ -526,7 +526,7 @@ where
 
 		let has_nonces_to_deliver = !self.strategy.is_empty();
 		let header_required_for_messages_delivery =
-			self.strategy.required_source_header_at_target(current_best, race_state);
+			self.strategy.required_source_header_at_target(current_best, race_state).await;
 		let header_required_for_reward_confirmations_delivery = self
 			.latest_confirmed_nonces_at_source
 			.back()
@@ -1053,7 +1053,7 @@ mod tests {
 		);
 		// nothing needs to be delivered now and we don't need any new headers
 		assert_eq!(strategy.select_nonces_to_deliver(state.clone()).await, None);
-		assert_eq!(strategy.required_source_header_at_target(&header_id(1), state.clone()), None);
+		assert_eq!(strategy.required_source_header_at_target(&header_id(1), state.clone()).await, None);
 
 		// now let's generate two more nonces [24; 25] at the soruce;
 		strategy.source_nonces_updated(header_id(2), source_nonces(24..=25, 19, 0));
@@ -1061,7 +1061,7 @@ mod tests {
 		// - so now we'll need to relay source block#2 to be able to accept messages [24; 25].
 		assert_eq!(strategy.select_nonces_to_deliver(state.clone()).await, None);
 		assert_eq!(
-			strategy.required_source_header_at_target(&header_id(1), state.clone()),
+			strategy.required_source_header_at_target(&header_id(1), state.clone()).await,
 			Some(header_id(2))
 		);
 
@@ -1074,7 +1074,7 @@ mod tests {
 		// and ask strategy again => still nothing to deliver, because parallel confirmations
 		// race need to be pushed further
 		assert_eq!(strategy.select_nonces_to_deliver(state.clone()).await, None);
-		assert_eq!(strategy.required_source_header_at_target(&header_id(2), state.clone()), None);
+		assert_eq!(strategy.required_source_header_at_target(&header_id(2), state.clone()).await, None);
 
 		// let's confirm messages [20; 23]
 		strategy.source_nonces_updated(header_id(2), source_nonces(24..=25, 23, 0));
@@ -1085,7 +1085,7 @@ mod tests {
 			strategy.select_nonces_to_deliver(state.clone()).await,
 			Some(((24..=25), proof_parameters(true, 2))),
 		);
-		assert_eq!(strategy.required_source_header_at_target(&header_id(2), state), None);
+		assert_eq!(strategy.required_source_header_at_target(&header_id(2), state).await, None);
 	}
 
 	#[async_std::test]
@@ -1114,9 +1114,9 @@ mod tests {
 		);
 	}
 
-	#[test]
+	#[async_std::test]
 	#[allow(clippy::reversed_empty_ranges)]
-	fn no_source_headers_required_at_target_if_lanes_are_empty() {
+	async fn no_source_headers_required_at_target_if_lanes_are_empty() {
 		let (state, _) = prepare_strategy();
 		let mut strategy = TestStrategy {
 			max_unrewarded_relayer_entries_at_target: 4,
@@ -1146,7 +1146,7 @@ mod tests {
 			strategy.latest_confirmed_nonces_at_source,
 			VecDeque::from([(source_header_id, 0)])
 		);
-		assert_eq!(strategy.required_source_header_at_target(&source_header_id, state), None);
+		assert_eq!(strategy.required_source_header_at_target(&source_header_id, state).await, None);
 	}
 
 	#[async_std::test]
@@ -1307,7 +1307,7 @@ mod tests {
 			max_unconfirmed_nonces_at_target - 1,
 		);
 		at_source_block_2_deliver_confirmations(&mut strategy, &mut state);
-		assert_eq!(strategy.required_source_header_at_target(&header_id(2), state.clone()), None);
+		assert_eq!(strategy.required_source_header_at_target(&header_id(2), state.clone()).await, None);
 		assert_eq!(at_target_block_3_select_nonces_to_deliver(&strategy, state).await, None);
 
 		// when lane is blocked by no-relayer-slots in unrewarded relayers vector
@@ -1320,7 +1320,7 @@ mod tests {
 		);
 		at_source_block_2_deliver_confirmations(&mut strategy, &mut state);
 		assert_eq!(
-			strategy.required_source_header_at_target(&header_id(2), state.clone()),
+			strategy.required_source_header_at_target(&header_id(2), state.clone()).await,
 			Some(header_id(2))
 		);
 		assert_eq!(
@@ -1338,7 +1338,7 @@ mod tests {
 		);
 		at_source_block_2_deliver_confirmations(&mut strategy, &mut state);
 		assert_eq!(
-			strategy.required_source_header_at_target(&header_id(2), state.clone()),
+			strategy.required_source_header_at_target(&header_id(2), state.clone()).await,
 			Some(header_id(2))
 		);
 		assert_eq!(
@@ -1357,7 +1357,7 @@ mod tests {
 		);
 		at_source_block_2_deliver_confirmations(&mut strategy, &mut state);
 		assert_eq!(
-			strategy.required_source_header_at_target(&header_id(2), state.clone()),
+			strategy.required_source_header_at_target(&header_id(2), state.clone()).await,
 			Some(header_id(2))
 		);
 		assert_eq!(

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -290,6 +290,24 @@ impl<P: MessageLane, SC, TC> std::fmt::Debug for MessageDeliveryStrategy<P, SC, 
 	}
 }
 
+/// Delivery race action.
+enum RaceAction<SourceHeaderId> {
+	/// Relay given source header to target.
+	RelayHeader(SourceHeaderId),
+	/// Relay given messages to target.
+	RelayMessages(RangeInclusive<MessageNonce>, MessageProofParameters),
+}
+
+impl<SourceHeaderId> RaceAction<SourceHeaderId> {
+	/// Convert self into messages relay request.
+	fn into_relay_messages(self) -> Option<(RangeInclusive<MessageNonce>, MessageProofParameters)> {
+		match self {
+			Self::RelayMessages(messages, proof_parameters) => Some((messages, proof_parameters)),
+			_ => None,
+		}
+	}
+}
+
 impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 	P: MessageLane,
 	SC: MessageLaneSourceClient<P>,
@@ -298,7 +316,7 @@ impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 	async fn select_race_action<RS: RaceState<SourceHeaderIdOf<P>, TargetHeaderIdOf<P>>>(
 		&self,
 		race_state: RS,
-	) -> Option<(RangeInclusive<MessageNonce>, MessageProofParameters)> {
+	) -> Option<RaceAction<SourceHeaderIdOf<P>>> {
 		let best_target_nonce = self.strategy.best_at_target()?;
 		let best_finalized_source_header_id_at_best_target =
 			race_state.best_finalized_source_header_id_at_best_target()?;
@@ -364,7 +382,23 @@ impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 			let enough_rewards_being_proved = number_of_rewards_being_proved >=
 				target_nonces.nonces_data.unrewarded_relayers.messages_in_oldest_entry;
 			if !enough_rewards_being_proved {
-				return None
+				// we can't submit delivery transaction right now, but maybe we can ask for more
+				// source headers at target node, thus increasing the `latest_confirmed_nonce_at_source`
+				// and opening way to delivery transaction?
+				let future_best_finalized_source_header_id_at_best_target = race_state
+					.best_finalized_source_header_id_at_source()?;
+				let future_latest_confirmed_nonce_at_source = self
+					.latest_confirmed_nonce_at_source(&future_best_finalized_source_header_id_at_best_target)
+					.unwrap_or(best_target_nonce);
+				let future_number_of_rewards_being_proved =
+					future_latest_confirmed_nonce_at_source.saturating_sub(latest_confirmed_nonce_at_target);
+				let future_enough_rewards_being_proved = future_number_of_rewards_being_proved >=
+					target_nonces.nonces_data.unrewarded_relayers.messages_in_oldest_entry;
+				if future_enough_rewards_being_proved {
+					return Some(RaceAction::RelayHeader(future_best_finalized_source_header_id_at_best_target));
+				} else {
+					return None;
+				}
 			}
 		}
 
@@ -397,7 +431,7 @@ impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 		let lane_target_client = self.lane_target_client.clone();
 
 		// select nonces from nonces, available for delivery
-		let selected_nonces = match self.strategy.available_source_queue_indices(race_state) {
+		let selected_nonces = match self.strategy.available_source_queue_indices(race_state.clone()) {
 			Some(available_source_queue_indices) => {
 				let source_queue = self.strategy.source_queue();
 				let reference = RelayMessagesBatchReference {
@@ -426,11 +460,14 @@ impl<P: MessageLane, SC, TC> MessageDeliveryStrategy<P, SC, TC> where
 		let selected_nonces = match selected_nonces {
 			Some(selected_nonces) => selected_nonces,
 			None if unrewarded_limit_reached && outbound_state_proof_required => 1..=0,
-			_ => return None,
+			None => return self.strategy.required_source_header_at_target(
+				&best_finalized_source_header_id_at_best_target,
+				race_state,
+			).map(RaceAction::RelayHeader),
 		};
 
 		let dispatch_weight = self.dispatch_weight_for_range(&selected_nonces);
-		Some((
+		Some(RaceAction::RelayMessages(
 			selected_nonces,
 			MessageProofParameters { outbound_state_proof_required, dispatch_weight },
 		))
@@ -591,7 +628,9 @@ where
 		&self,
 		race_state: RS,
 	) -> Option<(RangeInclusive<MessageNonce>, Self::ProofParameters)> {
-		self.select_race_action(race_state).await
+		self.select_race_action(race_state)
+			.await
+			.and_then(RaceAction::into_relay_messages)
 	}
 }
 

--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -177,7 +177,6 @@ pub trait RaceStrategy<SourceHeaderId, TargetHeaderId, Proof>: Debug {
 	/// Return id of source header that is required to be on target to continue synchronization.
 	async fn required_source_header_at_target<RS: RaceState<SourceHeaderId, TargetHeaderId>>(
 		&self,
-		current_best: &SourceHeaderId,
 		race_state: RS,
 	) -> Option<SourceHeaderId>;
 	/// Return the best nonce at source node.
@@ -430,12 +429,9 @@ pub async fn run<P: MessageRace, SC: SourceClient<P>, TC: TargetClient<P>>(
 				).fail_if_connection_error(FailedClient::Source)?;
 
 				// ask for more headers if we have nonces to deliver and required headers are missing
-				source_required_header = match race_state.best_finalized_source_header_id_at_best_target {
-					Some(ref best) => strategy
-						.required_source_header_at_target(best, race_state.clone())
-						.await,
-					None => None,
-				}
+				source_required_header = strategy
+					.required_source_header_at_target(race_state.clone())
+					.await;
 			},
 			nonces = target_best_nonces => {
 				target_best_nonces_required = false;

--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -41,14 +41,14 @@ use std::{
 /// One of races within lane.
 pub trait MessageRace {
 	/// Header id of the race source.
-	type SourceHeaderId: Debug + Clone + PartialEq + Send + Sync;
+	type SourceHeaderId: Debug + Clone + PartialEq + Send;
 	/// Header id of the race source.
-	type TargetHeaderId: Debug + Clone + PartialEq + Send + Sync;
+	type TargetHeaderId: Debug + Clone + PartialEq + Send;
 
 	/// Message nonce used in the race.
 	type MessageNonce: Debug + Clone;
 	/// Proof that is generated and delivered in this race.
-	type Proof: Debug + Clone + Send + Sync;
+	type Proof: Debug + Clone + Send;
 
 	/// Name of the race source.
 	fn source_name() -> String;
@@ -217,7 +217,7 @@ pub trait RaceStrategy<SourceHeaderId, TargetHeaderId, Proof>: Debug {
 }
 
 /// State of the race.
-pub trait RaceState<SourceHeaderId, TargetHeaderId>: Clone + Send + Sync {
+pub trait RaceState<SourceHeaderId, TargetHeaderId>: Send {
 	/// Best finalized source header id at the source client.
 	fn best_finalized_source_header_id_at_source(&self) -> Option<SourceHeaderId>;
 	/// Best finalized source header id at the best block on the target
@@ -280,10 +280,10 @@ impl<SourceHeaderId, TargetHeaderId, Proof, BatchTx> Default
 impl<SourceHeaderId, TargetHeaderId, Proof, BatchTx> RaceState<SourceHeaderId, TargetHeaderId>
 	for RaceStateImpl<SourceHeaderId, TargetHeaderId, Proof, BatchTx>
 where
-	SourceHeaderId: Clone + Send + Sync,
-	TargetHeaderId: Clone + Send + Sync,
-	Proof: Clone + Send + Sync,
-	BatchTx: Clone + Send + Sync,
+	SourceHeaderId: Clone + Send,
+	TargetHeaderId: Clone + Send,
+	Proof: Clone + Send,
+	BatchTx: Clone + Send,
 {
 	fn best_finalized_source_header_id_at_source(&self) -> Option<SourceHeaderId> {
 		self.best_finalized_source_header_id_at_source.clone()

--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -221,7 +221,7 @@ pub trait RaceState<SourceHeaderId, TargetHeaderId>: Clone + Send + Sync {
 	/// Set best finalized source header id at the best block on the target
 	/// client (at the `best_finalized_source_header_id_at_best_target`).
 	fn set_best_finalized_source_header_id_at_best_target(&mut self, id: SourceHeaderId);
-	
+
 	/// Best finalized source header id at the source client.
 	fn best_finalized_source_header_id_at_source(&self) -> Option<SourceHeaderId>;
 	/// Best finalized source header id at the best block on the target

--- a/relays/messages/src/message_race_loop.rs
+++ b/relays/messages/src/message_race_loop.rs
@@ -41,14 +41,14 @@ use std::{
 /// One of races within lane.
 pub trait MessageRace {
 	/// Header id of the race source.
-	type SourceHeaderId: Debug + Clone + PartialEq + Send;
+	type SourceHeaderId: Debug + Clone + PartialEq + Send + Sync;
 	/// Header id of the race source.
-	type TargetHeaderId: Debug + Clone + PartialEq + Send;
+	type TargetHeaderId: Debug + Clone + PartialEq + Send + Sync;
 
 	/// Message nonce used in the race.
 	type MessageNonce: Debug + Clone;
 	/// Proof that is generated and delivered in this race.
-	type Proof: Debug + Clone + Send;
+	type Proof: Debug + Clone + Send + Sync;
 
 	/// Name of the race source.
 	fn source_name() -> String;
@@ -218,7 +218,7 @@ pub trait RaceStrategy<SourceHeaderId, TargetHeaderId, Proof>: Debug {
 }
 
 /// State of the race.
-pub trait RaceState<SourceHeaderId, TargetHeaderId>: Send {
+pub trait RaceState<SourceHeaderId, TargetHeaderId>: Clone + Send + Sync {
 	/// Best finalized source header id at the source client.
 	fn best_finalized_source_header_id_at_source(&self) -> Option<SourceHeaderId>;
 	/// Best finalized source header id at the best block on the target
@@ -281,10 +281,10 @@ impl<SourceHeaderId, TargetHeaderId, Proof, BatchTx> Default
 impl<SourceHeaderId, TargetHeaderId, Proof, BatchTx> RaceState<SourceHeaderId, TargetHeaderId>
 	for RaceStateImpl<SourceHeaderId, TargetHeaderId, Proof, BatchTx>
 where
-	SourceHeaderId: Clone + Send,
-	TargetHeaderId: Clone + Send,
-	Proof: Clone + Send,
-	BatchTx: Clone + Send,
+	SourceHeaderId: Clone + Send + Sync,
+	TargetHeaderId: Clone + Send + Sync,
+	Proof: Clone + Send + Sync,
+	BatchTx: Clone + Send + Sync,
 {
 	fn best_finalized_source_header_id_at_source(&self) -> Option<SourceHeaderId> {
 		self.best_finalized_source_header_id_at_source.clone()

--- a/relays/messages/src/message_race_strategy.rs
+++ b/relays/messages/src/message_race_strategy.rs
@@ -205,7 +205,7 @@ impl<
 		self.source_queue.is_empty()
 	}
 
-	fn required_source_header_at_target<
+	async fn required_source_header_at_target<
 		RS: RaceState<
 			HeaderId<SourceHeaderHash, SourceHeaderNumber>,
 			HeaderId<TargetHeaderHash, TargetHeaderNumber>,

--- a/relays/messages/src/message_race_strategy.rs
+++ b/relays/messages/src/message_race_strategy.rs
@@ -212,9 +212,9 @@ impl<
 		>,
 	>(
 		&self,
-		current_best: &HeaderId<SourceHeaderHash, SourceHeaderNumber>,
-		_race_state: RS,
+		race_state: RS,
 	) -> Option<HeaderId<SourceHeaderHash, SourceHeaderNumber>> {
+		let current_best = race_state.best_finalized_source_header_id_at_best_target()?;
 		self.source_queue
 			.back()
 			.and_then(|(h, _)| if h.0 > current_best.0 { Some(h.clone()) } else { None })


### PR DESCRIPTION
closes #2026 

I've started working on that, but imo right now the #2020 is more important - it is about runtime && this PR is about relayer and edge cases. What's left in this PR:
- [x] we need to require source headers at target when they're required to unblock the lane (see failed test for details).