### PR TITLE
Fix CI build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -238,7 +238,7 @@ build:
     # Enable this, when you see: "`cargo metadata` can not fail on project `Cargo.toml`"
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"polkadot-runtime\").manifest_path"`
     #- time cargo fetch --manifest-path=`cargo metadata --format-version=1 | jq --compact-output --raw-output  ".packages[] | select(.name == \"kusama-runtime\").manifest_path"`
-    - CARGO_NET_OFFLINE=true SKIP_WASM_BUILD=1 time cargo build --release --verbose --workspace
+    - CARGO_NET_OFFLINE=true time cargo build --release --verbose --workspace
   after_script:
     # Prepare artifacts
     - mkdir -p ./artifacts


### PR DESCRIPTION
I'm getting the following error when trying to start the test deployments:

```
Thread 'main' panicked at 'WASM binary was not build, please build it!', bin/rialto-parachain/node/src/chain_spec.rs:183
```

I think we shouldn't use `SKIP_WASM_BUILD=1`