### PR TITLE
Bump `subxt` and `subxt-codegen` to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11616,14 +11616,56 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d823d4be477fc33321f93d08fb6c2698273d044f01362dc27573a750deb7c233"
+checksum = "c7e5527e4b3bf079d4c0b2f253418598c380722ba37ef20fac9088081407f2b6"
 dependencies = [
  "parity-scale-codec",
+ "primitive-types",
  "scale-bits",
+ "scale-decode-derive",
  "scale-info",
  "thiserror",
+]
+
+[[package]]
+name = "scale-decode-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38741b2f78e4391b94eac6b102af0f6ea2b0f7fe65adb55d7f4004f507854db"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "scale-encode"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15546e5efbb45f0fc2291f7e202dee8623274c5d8bbfdf9c6886cc8b44a7ced3"
+dependencies = [
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-bits",
+ "scale-encode-derive",
+ "scale-info",
+ "thiserror",
+]
+
+[[package]]
+name = "scale-encode-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd983cf0a9effd76138554ead18a6de542d1af175ac12fd5e91836c5c0268082"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2 1.0.56",
+ "quote 1.0.26",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -11654,15 +11696,16 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a5e7810815bd295da73e4216d1dfbced3c7c7c7054d70fa5f6e4c58123fff4"
+checksum = "11f549769261561e6764218f847e500588f9a79a289de49ce92f9e26642a3574"
 dependencies = [
  "either",
  "frame-metadata",
  "parity-scale-codec",
  "scale-bits",
  "scale-decode",
+ "scale-encode",
  "scale-info",
  "serde",
  "thiserror",
@@ -12433,16 +12476,16 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing"
-version = "6.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc2d1947252b7a4e403b0a260f596920443742791765ec111daa2bbf98eff25"
+checksum = "27449abdfbe41b473e625bce8113745e81d65777dd1d5a8462cf24137930dad8"
 dependencies = [
- "blake2",
+ "blake2b_simd",
  "byteorder",
  "digest 0.10.6",
  "sha2 0.10.6",
  "sha3",
- "sp-std 6.0.0",
+ "sp-std 7.0.0",
  "twox-hash",
 ]
 
@@ -12742,9 +12785,9 @@ source = "git+https://github.com/paritytech/substrate?branch=master#a6cb6d0fb79c
 
 [[package]]
 name = "sp-std"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0ee286f98455272f64ac5bb1384ff21ac029fbb669afbaf48477faff12760e"
+checksum = "1de8eef39962b5b97478719c493bed2926cf70cb621005bbf68ebe58252ff986"
 
 [[package]]
 name = "sp-storage"
@@ -13314,13 +13357,14 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54639dba6a113584083968b6a8f457dedae612abe1bd214762101ca29f12e332"
+checksum = "53b9c4ddefcb2d87eb18a6336f65635c29208f766d0deefaa2a1a19f7426a993"
 dependencies = [
  "base58",
  "blake2",
  "derivative",
+ "either",
  "frame-metadata",
  "futures",
  "getrandom 0.2.8",
@@ -13331,11 +13375,12 @@ dependencies = [
  "primitive-types",
  "scale-bits",
  "scale-decode",
+ "scale-encode",
  "scale-info",
  "scale-value",
  "serde",
  "serde_json",
- "sp-core-hashing 6.0.0",
+ "sp-core-hashing 8.0.0",
  "subxt-macro",
  "subxt-metadata",
  "thiserror",
@@ -13344,9 +13389,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e86cb719003f1cedf2710a6e55ca4c37aba4c989bbd3b81dd1c52af9e4827e"
+checksum = "e924f41069e9273236398ff89662d6d336468a5d94faac812129d44547db0e7f"
 dependencies = [
  "darling",
  "frame-metadata",
@@ -13354,20 +13399,20 @@ dependencies = [
  "hex",
  "jsonrpsee 0.16.2",
  "parity-scale-codec",
- "proc-macro-error",
  "proc-macro2 1.0.56",
  "quote 1.0.26",
  "scale-info",
  "subxt-metadata",
  "syn 1.0.109",
+ "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "subxt-macro"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c08de402a78c4c06c3ee3702c80e519efdcb65911348e018b6998d04404916"
+checksum = "ced0b043a069ee039f8700d3dfda01be156e4229c82277c305bc8e79a7dd855d"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -13377,14 +13422,14 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593ab5f53435e6352675af4f9851342607f37785d84c7a3fb3139550d3c35f0"
+checksum = "18be3b8f4308fe7369ee1df66ae59c2eca79de20eab57b0f41c75736e843300f"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
  "scale-info",
- "sp-core-hashing 6.0.0",
+ "sp-core-hashing 8.0.0",
 ]
 
 [[package]]
@@ -15473,9 +15518,9 @@ dependencies = [
 
 [[package]]
 name = "yap"
-version = "0.7.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc77f52dc9e9b10d55d3f4462c3b7fc393c4f17975d641542833ab2d3bc26ef"
+checksum = "e2a7eb6d82a11e4d0b8e6bda8347169aff4ccd8235d039bba7c47482d977dcf7"
 
 [[package]]
 name = "yasna"

--- a/relays/client-rialto-parachain/Cargo.toml
+++ b/relays/client-rialto-parachain/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5" }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
-subxt = { version = "0.27.1", default-features = false, features = [] }
+subxt = { version = "0.28.0", default-features = false, features = [] }
 
 # Bridge dependencies
 

--- a/relays/client-rialto-parachain/src/codegen_runtime.rs
+++ b/relays/client-rialto-parachain/src/codegen_runtime.rs
@@ -22,5956 +22,24 @@
 #[allow(clippy::all)]
 pub mod api {
 	use super::api as root_mod;
-	pub static PALLETS: [&str; 16usize] = [
-		"System",
-		"Timestamp",
-		"Sudo",
-		"TransactionPayment",
-		"ParachainSystem",
-		"ParachainInfo",
-		"Balances",
-		"Aura",
-		"AuraExt",
-		"XcmpQueue",
-		"PolkadotXcm",
-		"CumulusXcm",
-		"DmpQueue",
-		"BridgeRelayers",
-		"BridgeMillauGrandpa",
-		"BridgeMillauMessages",
-	];
-	#[derive(
-		:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-	)]
-	pub enum Event {
-		#[codec(index = 0)]
-		System(system::Event),
-		#[codec(index = 2)]
-		Sudo(sudo::Event),
-		#[codec(index = 3)]
-		TransactionPayment(transaction_payment::Event),
-		#[codec(index = 20)]
-		ParachainSystem(parachain_system::Event),
-		#[codec(index = 30)]
-		Balances(balances::Event),
-		#[codec(index = 50)]
-		XcmpQueue(xcmp_queue::Event),
-		#[codec(index = 51)]
-		PolkadotXcm(polkadot_xcm::Event),
-		#[codec(index = 52)]
-		CumulusXcm(cumulus_xcm::Event),
-		#[codec(index = 53)]
-		DmpQueue(dmp_queue::Event),
-		#[codec(index = 54)]
-		BridgeRelayers(bridge_relayers::Event),
-		#[codec(index = 55)]
-		BridgeMillauGrandpa(bridge_millau_grandpa::Event),
-		#[codec(index = 56)]
-		BridgeMillauMessages(bridge_millau_messages::Event),
-	}
-	pub mod system {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct Remark {
-				pub remark: ::std::vec::Vec<::core::primitive::u8>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			pub struct SetHeapPages {
-				pub pages: ::core::primitive::u64,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetCode {
-				pub code: ::std::vec::Vec<::core::primitive::u8>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetCodeWithoutChecks {
-				pub code: ::std::vec::Vec<::core::primitive::u8>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetStorage {
-				pub items: ::std::vec::Vec<(
-					::std::vec::Vec<::core::primitive::u8>,
-					::std::vec::Vec<::core::primitive::u8>,
-				)>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct KillStorage {
-				pub keys: ::std::vec::Vec<::std::vec::Vec<::core::primitive::u8>>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct KillPrefix {
-				pub prefix: ::std::vec::Vec<::core::primitive::u8>,
-				pub subkeys: ::core::primitive::u32,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct RemarkWithEvent {
-				pub remark: ::std::vec::Vec<::core::primitive::u8>,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Make some on-chain remark."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- `O(1)`"]
-				pub fn remark(
-					&self,
-					remark: ::std::vec::Vec<::core::primitive::u8>,
-				) -> ::subxt::tx::StaticTxPayload<Remark> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"remark",
-						Remark { remark },
-						[
-							101u8, 80u8, 195u8, 226u8, 224u8, 247u8, 60u8, 128u8, 3u8, 101u8, 51u8,
-							147u8, 96u8, 126u8, 76u8, 230u8, 194u8, 227u8, 191u8, 73u8, 160u8,
-							146u8, 87u8, 147u8, 243u8, 28u8, 228u8, 116u8, 224u8, 181u8, 129u8,
-							160u8,
-						],
-					)
-				}
-				#[doc = "Set the number of pages in the WebAssembly environment's heap."]
-				pub fn set_heap_pages(
-					&self,
-					pages: ::core::primitive::u64,
-				) -> ::subxt::tx::StaticTxPayload<SetHeapPages> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"set_heap_pages",
-						SetHeapPages { pages },
-						[
-							43u8, 103u8, 128u8, 49u8, 156u8, 136u8, 11u8, 204u8, 80u8, 6u8, 244u8,
-							86u8, 171u8, 44u8, 140u8, 225u8, 142u8, 198u8, 43u8, 87u8, 26u8, 45u8,
-							125u8, 222u8, 165u8, 254u8, 172u8, 158u8, 39u8, 178u8, 86u8, 87u8,
-						],
-					)
-				}
-				#[doc = "Set the new runtime code."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- `O(C + S)` where `C` length of `code` and `S` complexity of `can_set_code`"]
-				pub fn set_code(
-					&self,
-					code: ::std::vec::Vec<::core::primitive::u8>,
-				) -> ::subxt::tx::StaticTxPayload<SetCode> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"set_code",
-						SetCode { code },
-						[
-							27u8, 104u8, 244u8, 205u8, 188u8, 254u8, 121u8, 13u8, 106u8, 120u8,
-							244u8, 108u8, 97u8, 84u8, 100u8, 68u8, 26u8, 69u8, 93u8, 128u8, 107u8,
-							4u8, 3u8, 142u8, 13u8, 134u8, 196u8, 62u8, 113u8, 181u8, 14u8, 40u8,
-						],
-					)
-				}
-				#[doc = "Set the new runtime code without doing any checks of the given `code`."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- `O(C)` where `C` length of `code`"]
-				pub fn set_code_without_checks(
-					&self,
-					code: ::std::vec::Vec<::core::primitive::u8>,
-				) -> ::subxt::tx::StaticTxPayload<SetCodeWithoutChecks> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"set_code_without_checks",
-						SetCodeWithoutChecks { code },
-						[
-							102u8, 160u8, 125u8, 235u8, 30u8, 23u8, 45u8, 239u8, 112u8, 148u8,
-							159u8, 158u8, 42u8, 93u8, 206u8, 94u8, 80u8, 250u8, 66u8, 195u8, 60u8,
-							40u8, 142u8, 169u8, 183u8, 80u8, 80u8, 96u8, 3u8, 231u8, 99u8, 216u8,
-						],
-					)
-				}
-				#[doc = "Set some items of storage."]
-				pub fn set_storage(
-					&self,
-					items: ::std::vec::Vec<(
-						::std::vec::Vec<::core::primitive::u8>,
-						::std::vec::Vec<::core::primitive::u8>,
-					)>,
-				) -> ::subxt::tx::StaticTxPayload<SetStorage> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"set_storage",
-						SetStorage { items },
-						[
-							74u8, 43u8, 106u8, 255u8, 50u8, 151u8, 192u8, 155u8, 14u8, 90u8, 19u8,
-							45u8, 165u8, 16u8, 235u8, 242u8, 21u8, 131u8, 33u8, 172u8, 119u8, 78u8,
-							140u8, 10u8, 107u8, 202u8, 122u8, 235u8, 181u8, 191u8, 22u8, 116u8,
-						],
-					)
-				}
-				#[doc = "Kill some items from storage."]
-				pub fn kill_storage(
-					&self,
-					keys: ::std::vec::Vec<::std::vec::Vec<::core::primitive::u8>>,
-				) -> ::subxt::tx::StaticTxPayload<KillStorage> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"kill_storage",
-						KillStorage { keys },
-						[
-							174u8, 174u8, 13u8, 174u8, 75u8, 138u8, 128u8, 235u8, 222u8, 216u8,
-							85u8, 18u8, 198u8, 1u8, 138u8, 70u8, 19u8, 108u8, 209u8, 41u8, 228u8,
-							67u8, 130u8, 230u8, 160u8, 207u8, 11u8, 180u8, 139u8, 242u8, 41u8,
-							15u8,
-						],
-					)
-				}
-				#[doc = "Kill all storage items with a key that starts with the given prefix."]
-				#[doc = ""]
-				#[doc = "**NOTE:** We rely on the Root origin to provide us the number of subkeys under"]
-				#[doc = "the prefix we are removing to accurately calculate the weight of this function."]
-				pub fn kill_prefix(
-					&self,
-					prefix: ::std::vec::Vec<::core::primitive::u8>,
-					subkeys: ::core::primitive::u32,
-				) -> ::subxt::tx::StaticTxPayload<KillPrefix> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"kill_prefix",
-						KillPrefix { prefix, subkeys },
-						[
-							203u8, 116u8, 217u8, 42u8, 154u8, 215u8, 77u8, 217u8, 13u8, 22u8,
-							193u8, 2u8, 128u8, 115u8, 179u8, 115u8, 187u8, 218u8, 129u8, 34u8,
-							80u8, 4u8, 173u8, 120u8, 92u8, 35u8, 237u8, 112u8, 201u8, 207u8, 200u8,
-							48u8,
-						],
-					)
-				}
-				#[doc = "Make some on-chain remark and emit event."]
-				pub fn remark_with_event(
-					&self,
-					remark: ::std::vec::Vec<::core::primitive::u8>,
-				) -> ::subxt::tx::StaticTxPayload<RemarkWithEvent> {
-					::subxt::tx::StaticTxPayload::new(
-						"System",
-						"remark_with_event",
-						RemarkWithEvent { remark },
-						[
-							123u8, 225u8, 180u8, 179u8, 144u8, 74u8, 27u8, 85u8, 101u8, 75u8,
-							134u8, 44u8, 181u8, 25u8, 183u8, 158u8, 14u8, 213u8, 56u8, 225u8,
-							136u8, 88u8, 26u8, 114u8, 178u8, 43u8, 176u8, 43u8, 240u8, 84u8, 116u8,
-							46u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "Event for the System pallet."]
-		pub type Event = runtime_types::frame_system::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An extrinsic completed successfully."]
-			pub struct ExtrinsicSuccess {
-				pub dispatch_info: runtime_types::frame_support::dispatch::DispatchInfo,
-			}
-			impl ::subxt::events::StaticEvent for ExtrinsicSuccess {
-				const PALLET: &'static str = "System";
-				const EVENT: &'static str = "ExtrinsicSuccess";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An extrinsic failed."]
-			pub struct ExtrinsicFailed {
-				pub dispatch_error: runtime_types::sp_runtime::DispatchError,
-				pub dispatch_info: runtime_types::frame_support::dispatch::DispatchInfo,
-			}
-			impl ::subxt::events::StaticEvent for ExtrinsicFailed {
-				const PALLET: &'static str = "System";
-				const EVENT: &'static str = "ExtrinsicFailed";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "`:code` was updated."]
-			pub struct CodeUpdated;
-			impl ::subxt::events::StaticEvent for CodeUpdated {
-				const PALLET: &'static str = "System";
-				const EVENT: &'static str = "CodeUpdated";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A new account was created."]
-			pub struct NewAccount {
-				pub account: ::sp_core::crypto::AccountId32,
-			}
-			impl ::subxt::events::StaticEvent for NewAccount {
-				const PALLET: &'static str = "System";
-				const EVENT: &'static str = "NewAccount";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An account was reaped."]
-			pub struct KilledAccount {
-				pub account: ::sp_core::crypto::AccountId32,
-			}
-			impl ::subxt::events::StaticEvent for KilledAccount {
-				const PALLET: &'static str = "System";
-				const EVENT: &'static str = "KilledAccount";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "On on-chain remark happened."]
-			pub struct Remarked {
-				pub sender: ::sp_core::crypto::AccountId32,
-				pub hash: ::subxt::utils::H256,
-			}
-			impl ::subxt::events::StaticEvent for Remarked {
-				const PALLET: &'static str = "System";
-				const EVENT: &'static str = "Remarked";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " The full account information for a particular account ID."]
-				pub fn account(
-					&self,
-					_0: impl ::std::borrow::Borrow<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::frame_system::AccountInfo<
-							::core::primitive::u32,
-							runtime_types::pallet_balances::types::AccountData<
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"Account",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							248u8, 178u8, 160u8, 222u8, 45u8, 231u8, 115u8, 164u8, 98u8, 184u8,
-							174u8, 206u8, 149u8, 190u8, 175u8, 34u8, 202u8, 230u8, 69u8, 218u8,
-							83u8, 43u8, 170u8, 41u8, 106u8, 77u8, 233u8, 97u8, 114u8, 14u8, 155u8,
-							131u8,
-						],
-					)
-				}
-				#[doc = " The full account information for a particular account ID."]
-				pub fn account_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::frame_system::AccountInfo<
-							::core::primitive::u32,
-							runtime_types::pallet_balances::types::AccountData<
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"Account",
-						Vec::new(),
-						[
-							248u8, 178u8, 160u8, 222u8, 45u8, 231u8, 115u8, 164u8, 98u8, 184u8,
-							174u8, 206u8, 149u8, 190u8, 175u8, 34u8, 202u8, 230u8, 69u8, 218u8,
-							83u8, 43u8, 170u8, 41u8, 106u8, 77u8, 233u8, 97u8, 114u8, 14u8, 155u8,
-							131u8,
-						],
-					)
-				}
-				#[doc = " Total extrinsics count for the current block."]
-				pub fn extrinsic_count(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"ExtrinsicCount",
-						vec![],
-						[
-							223u8, 60u8, 201u8, 120u8, 36u8, 44u8, 180u8, 210u8, 242u8, 53u8,
-							222u8, 154u8, 123u8, 176u8, 249u8, 8u8, 225u8, 28u8, 232u8, 4u8, 136u8,
-							41u8, 151u8, 82u8, 189u8, 149u8, 49u8, 166u8, 139u8, 9u8, 163u8, 231u8,
-						],
-					)
-				}
-				#[doc = " The current weight for the block."]
-				pub fn block_weight(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::frame_support::dispatch::PerDispatchClass<
-							::sp_weights::Weight,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"BlockWeight",
-						vec![],
-						[
-							120u8, 67u8, 71u8, 163u8, 36u8, 202u8, 52u8, 106u8, 143u8, 155u8,
-							144u8, 87u8, 142u8, 241u8, 232u8, 183u8, 56u8, 235u8, 27u8, 237u8,
-							20u8, 202u8, 33u8, 85u8, 189u8, 0u8, 28u8, 52u8, 198u8, 40u8, 219u8,
-							54u8,
-						],
-					)
-				}
-				#[doc = " Total length (in bytes) for all extrinsics put together, for the current block."]
-				pub fn all_extrinsics_len(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"AllExtrinsicsLen",
-						vec![],
-						[
-							202u8, 145u8, 209u8, 225u8, 40u8, 220u8, 174u8, 74u8, 93u8, 164u8,
-							254u8, 248u8, 254u8, 192u8, 32u8, 117u8, 96u8, 149u8, 53u8, 145u8,
-							219u8, 64u8, 234u8, 18u8, 217u8, 200u8, 203u8, 141u8, 145u8, 28u8,
-							134u8, 60u8,
-						],
-					)
-				}
-				#[doc = " Map of block numbers to block hashes."]
-				pub fn block_hash(
-					&self,
-					_0: impl ::std::borrow::Borrow<::core::primitive::u32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::subxt::utils::H256>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"BlockHash",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Twox64Concat,
-						)],
-						[
-							50u8, 112u8, 176u8, 239u8, 175u8, 18u8, 205u8, 20u8, 241u8, 195u8,
-							21u8, 228u8, 186u8, 57u8, 200u8, 25u8, 38u8, 44u8, 106u8, 20u8, 168u8,
-							80u8, 76u8, 235u8, 12u8, 51u8, 137u8, 149u8, 200u8, 4u8, 220u8, 237u8,
-						],
-					)
-				}
-				#[doc = " Map of block numbers to block hashes."]
-				pub fn block_hash_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::subxt::utils::H256>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"BlockHash",
-						Vec::new(),
-						[
-							50u8, 112u8, 176u8, 239u8, 175u8, 18u8, 205u8, 20u8, 241u8, 195u8,
-							21u8, 228u8, 186u8, 57u8, 200u8, 25u8, 38u8, 44u8, 106u8, 20u8, 168u8,
-							80u8, 76u8, 235u8, 12u8, 51u8, 137u8, 149u8, 200u8, 4u8, 220u8, 237u8,
-						],
-					)
-				}
-				#[doc = " Extrinsics data for the current block (maps an extrinsic's index to its data)."]
-				pub fn extrinsic_data(
-					&self,
-					_0: impl ::std::borrow::Borrow<::core::primitive::u32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"ExtrinsicData",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Twox64Concat,
-						)],
-						[
-							210u8, 224u8, 211u8, 186u8, 118u8, 210u8, 185u8, 194u8, 238u8, 211u8,
-							254u8, 73u8, 67u8, 184u8, 31u8, 229u8, 168u8, 125u8, 98u8, 23u8, 241u8,
-							59u8, 49u8, 86u8, 126u8, 9u8, 114u8, 163u8, 160u8, 62u8, 50u8, 67u8,
-						],
-					)
-				}
-				#[doc = " Extrinsics data for the current block (maps an extrinsic's index to its data)."]
-				pub fn extrinsic_data_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"ExtrinsicData",
-						Vec::new(),
-						[
-							210u8, 224u8, 211u8, 186u8, 118u8, 210u8, 185u8, 194u8, 238u8, 211u8,
-							254u8, 73u8, 67u8, 184u8, 31u8, 229u8, 168u8, 125u8, 98u8, 23u8, 241u8,
-							59u8, 49u8, 86u8, 126u8, 9u8, 114u8, 163u8, 160u8, 62u8, 50u8, 67u8,
-						],
-					)
-				}
-				#[doc = " The current block number being processed. Set by `execute_block`."]
-				pub fn number(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"Number",
-						vec![],
-						[
-							228u8, 96u8, 102u8, 190u8, 252u8, 130u8, 239u8, 172u8, 126u8, 235u8,
-							246u8, 139u8, 208u8, 15u8, 88u8, 245u8, 141u8, 232u8, 43u8, 204u8,
-							36u8, 87u8, 211u8, 141u8, 187u8, 68u8, 236u8, 70u8, 193u8, 235u8,
-							164u8, 191u8,
-						],
-					)
-				}
-				#[doc = " Hash of the previous block."]
-				pub fn parent_hash(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::subxt::utils::H256>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"ParentHash",
-						vec![],
-						[
-							232u8, 206u8, 177u8, 119u8, 38u8, 57u8, 233u8, 50u8, 225u8, 49u8,
-							169u8, 176u8, 210u8, 51u8, 231u8, 176u8, 234u8, 186u8, 188u8, 112u8,
-							15u8, 152u8, 195u8, 232u8, 201u8, 97u8, 208u8, 249u8, 9u8, 163u8, 69u8,
-							36u8,
-						],
-					)
-				}
-				#[doc = " Digest of the current block, also part of the block header."]
-				pub fn digest(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::sp_runtime::generic::Digest>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"Digest",
-						vec![],
-						[
-							83u8, 141u8, 200u8, 132u8, 182u8, 55u8, 197u8, 122u8, 13u8, 159u8,
-							31u8, 42u8, 60u8, 191u8, 89u8, 221u8, 242u8, 47u8, 199u8, 213u8, 48u8,
-							216u8, 131u8, 168u8, 245u8, 82u8, 56u8, 190u8, 62u8, 69u8, 96u8, 37u8,
-						],
-					)
-				}
-				#[doc = " Events deposited for the current block."]
-				#[doc = ""]
-				#[doc = " NOTE: The item is unbound and should therefore never be read on chain."]
-				#[doc = " It could otherwise inflate the PoV size of a block."]
-				#[doc = ""]
-				#[doc = " Events have a large in-memory size. Box the events to not go out-of-memory"]
-				#[doc = " just in case someone still reads them from within the runtime."]
-				pub fn events(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<
-							runtime_types::frame_system::EventRecord<
-								runtime_types::rialto_parachain_runtime::RuntimeEvent,
-								::subxt::utils::H256,
-							>,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"Events",
-						vec![],
-						[
-							76u8, 19u8, 44u8, 121u8, 59u8, 168u8, 101u8, 101u8, 248u8, 3u8, 172u8,
-							27u8, 249u8, 200u8, 147u8, 17u8, 4u8, 102u8, 186u8, 6u8, 152u8, 62u8,
-							76u8, 195u8, 45u8, 188u8, 191u8, 30u8, 134u8, 78u8, 199u8, 93u8,
-						],
-					)
-				}
-				#[doc = " The number of events in the `Events<T>` list."]
-				pub fn event_count(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"EventCount",
-						vec![],
-						[
-							236u8, 93u8, 90u8, 177u8, 250u8, 211u8, 138u8, 187u8, 26u8, 208u8,
-							203u8, 113u8, 221u8, 233u8, 227u8, 9u8, 249u8, 25u8, 202u8, 185u8,
-							161u8, 144u8, 167u8, 104u8, 127u8, 187u8, 38u8, 18u8, 52u8, 61u8, 66u8,
-							112u8,
-						],
-					)
-				}
-				#[doc = " Mapping between a topic (represented by T::Hash) and a vector of indexes"]
-				#[doc = " of events in the `<Events<T>>` list."]
-				#[doc = ""]
-				#[doc = " All topic vectors have deterministic storage locations depending on the topic. This"]
-				#[doc = " allows light-clients to leverage the changes trie storage tracking mechanism and"]
-				#[doc = " in case of changes fetch the list of events of interest."]
-				#[doc = ""]
-				#[doc = " The value has the type `(T::BlockNumber, EventIndex)` because if we used only just"]
-				#[doc = " the `EventIndex` then in case if the topic has the same contents on the next block"]
-				#[doc = " no notification will be triggered thus the event might be lost."]
-				pub fn event_topics(
-					&self,
-					_0: impl ::std::borrow::Borrow<::subxt::utils::H256>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<(::core::primitive::u32, ::core::primitive::u32)>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"EventTopics",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							205u8, 90u8, 142u8, 190u8, 176u8, 37u8, 94u8, 82u8, 98u8, 1u8, 129u8,
-							63u8, 246u8, 101u8, 130u8, 58u8, 216u8, 16u8, 139u8, 196u8, 154u8,
-							111u8, 110u8, 178u8, 24u8, 44u8, 183u8, 176u8, 232u8, 82u8, 223u8,
-							38u8,
-						],
-					)
-				}
-				#[doc = " Mapping between a topic (represented by T::Hash) and a vector of indexes"]
-				#[doc = " of events in the `<Events<T>>` list."]
-				#[doc = ""]
-				#[doc = " All topic vectors have deterministic storage locations depending on the topic. This"]
-				#[doc = " allows light-clients to leverage the changes trie storage tracking mechanism and"]
-				#[doc = " in case of changes fetch the list of events of interest."]
-				#[doc = ""]
-				#[doc = " The value has the type `(T::BlockNumber, EventIndex)` because if we used only just"]
-				#[doc = " the `EventIndex` then in case if the topic has the same contents on the next block"]
-				#[doc = " no notification will be triggered thus the event might be lost."]
-				pub fn event_topics_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<(::core::primitive::u32, ::core::primitive::u32)>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"EventTopics",
-						Vec::new(),
-						[
-							205u8, 90u8, 142u8, 190u8, 176u8, 37u8, 94u8, 82u8, 98u8, 1u8, 129u8,
-							63u8, 246u8, 101u8, 130u8, 58u8, 216u8, 16u8, 139u8, 196u8, 154u8,
-							111u8, 110u8, 178u8, 24u8, 44u8, 183u8, 176u8, 232u8, 82u8, 223u8,
-							38u8,
-						],
-					)
-				}
-				#[doc = " Stores the `spec_version` and `spec_name` of when the last runtime upgrade happened."]
-				pub fn last_runtime_upgrade(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::frame_system::LastRuntimeUpgradeInfo,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"LastRuntimeUpgrade",
-						vec![],
-						[
-							52u8, 37u8, 117u8, 111u8, 57u8, 130u8, 196u8, 14u8, 99u8, 77u8, 91u8,
-							126u8, 178u8, 249u8, 78u8, 34u8, 9u8, 194u8, 92u8, 105u8, 113u8, 81u8,
-							185u8, 127u8, 245u8, 184u8, 60u8, 29u8, 234u8, 182u8, 96u8, 196u8,
-						],
-					)
-				}
-				#[doc = " True if we have upgraded so that `type RefCount` is `u32`. False (default) if not."]
-				pub fn upgraded_to_u32_ref_count(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::bool>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"UpgradedToU32RefCount",
-						vec![],
-						[
-							171u8, 88u8, 244u8, 92u8, 122u8, 67u8, 27u8, 18u8, 59u8, 175u8, 175u8,
-							178u8, 20u8, 150u8, 213u8, 59u8, 222u8, 141u8, 32u8, 107u8, 3u8, 114u8,
-							83u8, 250u8, 180u8, 233u8, 152u8, 54u8, 187u8, 99u8, 131u8, 204u8,
-						],
-					)
-				}
-				#[doc = " True if we have upgraded so that AccountInfo contains three types of `RefCount`. False"]
-				#[doc = " (default) if not."]
-				pub fn upgraded_to_triple_ref_count(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::bool>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"UpgradedToTripleRefCount",
-						vec![],
-						[
-							90u8, 33u8, 56u8, 86u8, 90u8, 101u8, 89u8, 133u8, 203u8, 56u8, 201u8,
-							210u8, 244u8, 232u8, 150u8, 18u8, 51u8, 105u8, 14u8, 230u8, 103u8,
-							155u8, 246u8, 99u8, 53u8, 207u8, 225u8, 128u8, 186u8, 76u8, 40u8,
-							185u8,
-						],
-					)
-				}
-				#[doc = " The execution phase of the block."]
-				pub fn execution_phase(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<runtime_types::frame_system::Phase>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"System",
-						"ExecutionPhase",
-						vec![],
-						[
-							230u8, 183u8, 221u8, 135u8, 226u8, 223u8, 55u8, 104u8, 138u8, 224u8,
-							103u8, 156u8, 222u8, 99u8, 203u8, 199u8, 164u8, 168u8, 193u8, 133u8,
-							201u8, 155u8, 63u8, 95u8, 17u8, 206u8, 165u8, 123u8, 161u8, 33u8,
-							172u8, 93u8,
-						],
-					)
-				}
-			}
-		}
-		pub mod constants {
-			use super::runtime_types;
-			pub struct ConstantsApi;
-			impl ConstantsApi {
-				#[doc = " Block & extrinsics weights: base values and limits."]
-				pub fn block_weights(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::frame_system::limits::BlockWeights,
-					>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"System",
-						"BlockWeights",
-						[
-							118u8, 253u8, 239u8, 217u8, 145u8, 115u8, 85u8, 86u8, 172u8, 248u8,
-							139u8, 32u8, 158u8, 126u8, 172u8, 188u8, 197u8, 105u8, 145u8, 235u8,
-							171u8, 50u8, 31u8, 225u8, 167u8, 187u8, 241u8, 87u8, 6u8, 17u8, 234u8,
-							185u8,
-						],
-					)
-				}
-				#[doc = " The maximum length of a block (in bytes)."]
-				pub fn block_length(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::frame_system::limits::BlockLength,
-					>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"System",
-						"BlockLength",
-						[
-							116u8, 184u8, 225u8, 228u8, 207u8, 203u8, 4u8, 220u8, 234u8, 198u8,
-							150u8, 108u8, 205u8, 87u8, 194u8, 131u8, 229u8, 51u8, 140u8, 4u8, 47u8,
-							12u8, 200u8, 144u8, 153u8, 62u8, 51u8, 39u8, 138u8, 205u8, 203u8,
-							236u8,
-						],
-					)
-				}
-				#[doc = " Maximum number of block number to block hash mappings to keep (oldest pruned first)."]
-				pub fn block_hash_count(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"System",
-						"BlockHashCount",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-				#[doc = " The weight of runtime database operations the runtime can invoke."]
-				pub fn db_weight(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<runtime_types::sp_weights::RuntimeDbWeight>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"System",
-						"DbWeight",
-						[
-							124u8, 162u8, 190u8, 149u8, 49u8, 177u8, 162u8, 231u8, 62u8, 167u8,
-							199u8, 181u8, 43u8, 232u8, 185u8, 116u8, 195u8, 51u8, 233u8, 223u8,
-							20u8, 129u8, 246u8, 13u8, 65u8, 180u8, 64u8, 9u8, 157u8, 59u8, 245u8,
-							118u8,
-						],
-					)
-				}
-				#[doc = " Get the chain's current version."]
-				pub fn version(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<runtime_types::sp_version::RuntimeVersion>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"System",
-						"Version",
-						[
-							93u8, 98u8, 57u8, 243u8, 229u8, 8u8, 234u8, 231u8, 72u8, 230u8, 139u8,
-							47u8, 63u8, 181u8, 17u8, 2u8, 220u8, 231u8, 104u8, 237u8, 185u8, 143u8,
-							165u8, 253u8, 188u8, 76u8, 147u8, 12u8, 170u8, 26u8, 74u8, 200u8,
-						],
-					)
-				}
-				#[doc = " The designated SS58 prefix of this chain."]
-				#[doc = ""]
-				#[doc = " This replaces the \"ss58Format\" property declared in the chain spec. Reason is"]
-				#[doc = " that the runtime should know about the prefix in order to make use of it as"]
-				#[doc = " an identifier of the chain."]
-				pub fn ss58_prefix(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u16>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"System",
-						"SS58Prefix",
-						[
-							116u8, 33u8, 2u8, 170u8, 181u8, 147u8, 171u8, 169u8, 167u8, 227u8,
-							41u8, 144u8, 11u8, 236u8, 82u8, 100u8, 74u8, 60u8, 184u8, 72u8, 169u8,
-							90u8, 208u8, 135u8, 15u8, 117u8, 10u8, 123u8, 128u8, 193u8, 29u8, 70u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod timestamp {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct Set {
-				#[codec(compact)]
-				pub now: ::core::primitive::u64,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Set the current time."]
-				#[doc = ""]
-				#[doc = "This call should be invoked exactly once per block. It will panic at the finalization"]
-				#[doc = "phase, if this call hasn't been invoked by that time."]
-				#[doc = ""]
-				#[doc = "The timestamp should be greater than the previous one by the amount specified by"]
-				#[doc = "`MinimumPeriod`."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call must be `Inherent`."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- `O(1)` (Note that implementations of `OnTimestampSet` must also be `O(1)`)"]
-				#[doc = "- 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in"]
-				#[doc = "  `on_finalize`)"]
-				#[doc = "- 1 event handler `on_timestamp_set`. Must be `O(1)`."]
-				pub fn set(
-					&self,
-					now: ::core::primitive::u64,
-				) -> ::subxt::tx::StaticTxPayload<Set> {
-					::subxt::tx::StaticTxPayload::new(
-						"Timestamp",
-						"set",
-						Set { now },
-						[
-							6u8, 97u8, 172u8, 236u8, 118u8, 238u8, 228u8, 114u8, 15u8, 115u8,
-							102u8, 85u8, 66u8, 151u8, 16u8, 33u8, 187u8, 17u8, 166u8, 88u8, 127u8,
-							214u8, 182u8, 51u8, 168u8, 88u8, 43u8, 101u8, 185u8, 8u8, 1u8, 28u8,
-						],
-					)
-				}
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " Current time for the current block."]
-				pub fn now(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u64>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Timestamp",
-						"Now",
-						vec![],
-						[
-							148u8, 53u8, 50u8, 54u8, 13u8, 161u8, 57u8, 150u8, 16u8, 83u8, 144u8,
-							221u8, 59u8, 75u8, 158u8, 130u8, 39u8, 123u8, 106u8, 134u8, 202u8,
-							185u8, 83u8, 85u8, 60u8, 41u8, 120u8, 96u8, 210u8, 34u8, 2u8, 250u8,
-						],
-					)
-				}
-				#[doc = " Did the timestamp get updated in this block?"]
-				pub fn did_update(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::bool>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Timestamp",
-						"DidUpdate",
-						vec![],
-						[
-							70u8, 13u8, 92u8, 186u8, 80u8, 151u8, 167u8, 90u8, 158u8, 232u8, 175u8,
-							13u8, 103u8, 135u8, 2u8, 78u8, 16u8, 6u8, 39u8, 158u8, 167u8, 85u8,
-							27u8, 47u8, 122u8, 73u8, 127u8, 26u8, 35u8, 168u8, 72u8, 204u8,
-						],
-					)
-				}
-			}
-		}
-		pub mod constants {
-			use super::runtime_types;
-			pub struct ConstantsApi;
-			impl ConstantsApi {
-				#[doc = " The minimum period between blocks. Beware that this is different to the *expected*"]
-				#[doc = " period that the block production apparatus provides. Your chosen consensus system will"]
-				#[doc = " generally work with this to determine a sensible block time. e.g. For Aura, it will be"]
-				#[doc = " double this period on default settings."]
-				pub fn minimum_period(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u64>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"Timestamp",
-						"MinimumPeriod",
-						[
-							128u8, 214u8, 205u8, 242u8, 181u8, 142u8, 124u8, 231u8, 190u8, 146u8,
-							59u8, 226u8, 157u8, 101u8, 103u8, 117u8, 249u8, 65u8, 18u8, 191u8,
-							103u8, 119u8, 53u8, 85u8, 81u8, 96u8, 220u8, 42u8, 184u8, 239u8, 42u8,
-							246u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod sudo {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct Sudo {
-				pub call: ::std::boxed::Box<runtime_types::rialto_parachain_runtime::RuntimeCall>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SudoUncheckedWeight {
-				pub call: ::std::boxed::Box<runtime_types::rialto_parachain_runtime::RuntimeCall>,
-				pub weight: ::sp_weights::Weight,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetKey {
-				pub new: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SudoAs {
-				pub who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				pub call: ::std::boxed::Box<runtime_types::rialto_parachain_runtime::RuntimeCall>,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Authenticates the sudo key and dispatches a function call with `Root` origin."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call must be _Signed_."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- O(1)."]
-				pub fn sudo(
-					&self,
-					call: runtime_types::rialto_parachain_runtime::RuntimeCall,
-				) -> ::subxt::tx::StaticTxPayload<Sudo> {
-					::subxt::tx::StaticTxPayload::new(
-						"Sudo",
-						"sudo",
-						Sudo { call: ::std::boxed::Box::new(call) },
-						[
-							19u8, 178u8, 172u8, 30u8, 28u8, 209u8, 160u8, 61u8, 76u8, 239u8, 71u8,
-							124u8, 21u8, 34u8, 233u8, 176u8, 100u8, 90u8, 198u8, 118u8, 117u8, 2u8,
-							147u8, 7u8, 109u8, 1u8, 32u8, 35u8, 99u8, 0u8, 107u8, 145u8,
-						],
-					)
-				}
-				#[doc = "Authenticates the sudo key and dispatches a function call with `Root` origin."]
-				#[doc = "This function does not check the weight of the call, and instead allows the"]
-				#[doc = "Sudo user to specify the weight of the call."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call must be _Signed_."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- O(1)."]
-				pub fn sudo_unchecked_weight(
-					&self,
-					call: runtime_types::rialto_parachain_runtime::RuntimeCall,
-					weight: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<SudoUncheckedWeight> {
-					::subxt::tx::StaticTxPayload::new(
-						"Sudo",
-						"sudo_unchecked_weight",
-						SudoUncheckedWeight { call: ::std::boxed::Box::new(call), weight },
-						[
-							145u8, 160u8, 12u8, 105u8, 228u8, 240u8, 115u8, 105u8, 220u8, 99u8,
-							215u8, 228u8, 115u8, 71u8, 109u8, 28u8, 149u8, 247u8, 159u8, 216u8,
-							76u8, 71u8, 68u8, 87u8, 254u8, 146u8, 185u8, 174u8, 251u8, 209u8, 72u8,
-							122u8,
-						],
-					)
-				}
-				#[doc = "Authenticates the current sudo key and sets the given AccountId (`new`) as the new sudo"]
-				#[doc = "key."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call must be _Signed_."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- O(1)."]
-				pub fn set_key(
-					&self,
-					new: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				) -> ::subxt::tx::StaticTxPayload<SetKey> {
-					::subxt::tx::StaticTxPayload::new(
-						"Sudo",
-						"set_key",
-						SetKey { new },
-						[
-							23u8, 224u8, 218u8, 169u8, 8u8, 28u8, 111u8, 199u8, 26u8, 88u8, 225u8,
-							105u8, 17u8, 19u8, 87u8, 156u8, 97u8, 67u8, 89u8, 173u8, 70u8, 0u8,
-							5u8, 246u8, 198u8, 135u8, 182u8, 180u8, 44u8, 9u8, 212u8, 95u8,
-						],
-					)
-				}
-				#[doc = "Authenticates the sudo key and dispatches a function call with `Signed` origin from"]
-				#[doc = "a given account."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call must be _Signed_."]
-				#[doc = ""]
-				#[doc = "## Complexity"]
-				#[doc = "- O(1)."]
-				pub fn sudo_as(
-					&self,
-					who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					call: runtime_types::rialto_parachain_runtime::RuntimeCall,
-				) -> ::subxt::tx::StaticTxPayload<SudoAs> {
-					::subxt::tx::StaticTxPayload::new(
-						"Sudo",
-						"sudo_as",
-						SudoAs { who, call: ::std::boxed::Box::new(call) },
-						[
-							229u8, 45u8, 129u8, 96u8, 54u8, 29u8, 159u8, 77u8, 210u8, 144u8, 29u8,
-							97u8, 127u8, 133u8, 122u8, 110u8, 152u8, 194u8, 211u8, 246u8, 97u8,
-							197u8, 187u8, 203u8, 46u8, 12u8, 104u8, 125u8, 15u8, 226u8, 28u8,
-							183u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::pallet_sudo::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A sudo just took place. \\[result\\]"]
-			pub struct Sudid {
-				pub sudo_result:
-					::core::result::Result<(), runtime_types::sp_runtime::DispatchError>,
-			}
-			impl ::subxt::events::StaticEvent for Sudid {
-				const PALLET: &'static str = "Sudo";
-				const EVENT: &'static str = "Sudid";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "The \\[sudoer\\] just switched identity; the old key is supplied if one existed."]
-			pub struct KeyChanged {
-				pub old_sudoer: ::core::option::Option<::sp_core::crypto::AccountId32>,
-			}
-			impl ::subxt::events::StaticEvent for KeyChanged {
-				const PALLET: &'static str = "Sudo";
-				const EVENT: &'static str = "KeyChanged";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A sudo just took place. \\[result\\]"]
-			pub struct SudoAsDone {
-				pub sudo_result:
-					::core::result::Result<(), runtime_types::sp_runtime::DispatchError>,
-			}
-			impl ::subxt::events::StaticEvent for SudoAsDone {
-				const PALLET: &'static str = "Sudo";
-				const EVENT: &'static str = "SudoAsDone";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " The `AccountId` of the sudo key."]
-				pub fn key(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::sp_core::crypto::AccountId32>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Sudo",
-						"Key",
-						vec![],
-						[
-							244u8, 73u8, 188u8, 136u8, 218u8, 163u8, 68u8, 179u8, 122u8, 173u8,
-							34u8, 108u8, 137u8, 28u8, 182u8, 16u8, 196u8, 92u8, 138u8, 34u8, 102u8,
-							80u8, 199u8, 88u8, 107u8, 207u8, 36u8, 22u8, 168u8, 167u8, 20u8, 142u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod transaction_payment {
-		use super::{root_mod, runtime_types};
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::pallet_transaction_payment::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,"]
-			#[doc = "has been paid by `who`."]
-			pub struct TransactionFeePaid {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub actual_fee: ::core::primitive::u128,
-				pub tip: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for TransactionFeePaid {
-				const PALLET: &'static str = "TransactionPayment";
-				const EVENT: &'static str = "TransactionFeePaid";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				pub fn next_fee_multiplier(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::sp_arithmetic::fixed_point::FixedU128,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"TransactionPayment",
-						"NextFeeMultiplier",
-						vec![],
-						[
-							210u8, 0u8, 206u8, 165u8, 183u8, 10u8, 206u8, 52u8, 14u8, 90u8, 218u8,
-							197u8, 189u8, 125u8, 113u8, 216u8, 52u8, 161u8, 45u8, 24u8, 245u8,
-							237u8, 121u8, 41u8, 106u8, 29u8, 45u8, 129u8, 250u8, 203u8, 206u8,
-							180u8,
-						],
-					)
-				}
-				pub fn storage_version(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::pallet_transaction_payment::Releases,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"TransactionPayment",
-						"StorageVersion",
-						vec![],
-						[
-							219u8, 243u8, 82u8, 176u8, 65u8, 5u8, 132u8, 114u8, 8u8, 82u8, 176u8,
-							200u8, 97u8, 150u8, 177u8, 164u8, 166u8, 11u8, 34u8, 12u8, 12u8, 198u8,
-							58u8, 191u8, 186u8, 221u8, 221u8, 119u8, 181u8, 253u8, 154u8, 228u8,
-						],
-					)
-				}
-			}
-		}
-		pub mod constants {
-			use super::runtime_types;
-			pub struct ConstantsApi;
-			impl ConstantsApi {
-				#[doc = " A fee mulitplier for `Operational` extrinsics to compute \"virtual tip\" to boost their"]
-				#[doc = " `priority`"]
-				#[doc = ""]
-				#[doc = " This value is multipled by the `final_fee` to obtain a \"virtual tip\" that is later"]
-				#[doc = " added to a tip component in regular `priority` calculations."]
-				#[doc = " It means that a `Normal` transaction can front-run a similarly-sized `Operational`"]
-				#[doc = " extrinsic (with no tip), by including a tip value greater than the virtual tip."]
-				#[doc = ""]
-				#[doc = " ```rust,ignore"]
-				#[doc = " // For `Normal`"]
-				#[doc = " let priority = priority_calc(tip);"]
-				#[doc = ""]
-				#[doc = " // For `Operational`"]
-				#[doc = " let virtual_tip = (inclusion_fee + tip) * OperationalFeeMultiplier;"]
-				#[doc = " let priority = priority_calc(tip + virtual_tip);"]
-				#[doc = " ```"]
-				#[doc = ""]
-				#[doc = " Note that since we use `final_fee` the multiplier applies also to the regular `tip`"]
-				#[doc = " sent with the transaction. So, not only does the transaction get a priority bump based"]
-				#[doc = " on the `inclusion_fee`, but we also amplify the impact of tips applied to `Operational`"]
-				#[doc = " transactions."]
-				pub fn operational_fee_multiplier(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u8>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"TransactionPayment",
-						"OperationalFeeMultiplier",
-						[
-							141u8, 130u8, 11u8, 35u8, 226u8, 114u8, 92u8, 179u8, 168u8, 110u8,
-							28u8, 91u8, 221u8, 64u8, 4u8, 148u8, 201u8, 193u8, 185u8, 66u8, 226u8,
-							114u8, 97u8, 79u8, 62u8, 212u8, 202u8, 114u8, 237u8, 228u8, 183u8,
-							165u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod parachain_system {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetValidationData {
-				pub data:
-					runtime_types::cumulus_primitives_parachain_inherent::ParachainInherentData,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SudoSendUpwardMessage {
-				pub message: ::std::vec::Vec<::core::primitive::u8>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct AuthorizeUpgrade {
-				pub code_hash: ::subxt::utils::H256,
-				pub check_version: ::core::primitive::bool,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct EnactAuthorizedUpgrade {
-				pub code: ::std::vec::Vec<::core::primitive::u8>,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Set the current validation data."]
-				#[doc = ""]
-				#[doc = "This should be invoked exactly once per block. It will panic at the finalization"]
-				#[doc = "phase if the call was not invoked."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call must be `Inherent`"]
-				#[doc = ""]
-				#[doc = "As a side effect, this function upgrades the current validation function"]
-				#[doc = "if the appropriate time has come."]
-				pub fn set_validation_data(
-					&self,
-					data : runtime_types :: cumulus_primitives_parachain_inherent :: ParachainInherentData,
-				) -> ::subxt::tx::StaticTxPayload<SetValidationData> {
-					::subxt::tx::StaticTxPayload::new(
-						"ParachainSystem",
-						"set_validation_data",
-						SetValidationData { data },
-						[
-							200u8, 80u8, 163u8, 177u8, 184u8, 117u8, 61u8, 203u8, 244u8, 214u8,
-							106u8, 151u8, 128u8, 131u8, 254u8, 120u8, 254u8, 76u8, 104u8, 39u8,
-							215u8, 227u8, 233u8, 254u8, 26u8, 62u8, 17u8, 42u8, 19u8, 127u8, 108u8,
-							242u8,
-						],
-					)
-				}
-				pub fn sudo_send_upward_message(
-					&self,
-					message: ::std::vec::Vec<::core::primitive::u8>,
-				) -> ::subxt::tx::StaticTxPayload<SudoSendUpwardMessage> {
-					::subxt::tx::StaticTxPayload::new(
-						"ParachainSystem",
-						"sudo_send_upward_message",
-						SudoSendUpwardMessage { message },
-						[
-							127u8, 79u8, 45u8, 183u8, 190u8, 205u8, 184u8, 169u8, 255u8, 191u8,
-							86u8, 154u8, 134u8, 25u8, 249u8, 63u8, 47u8, 194u8, 108u8, 62u8, 60u8,
-							170u8, 81u8, 240u8, 113u8, 48u8, 181u8, 171u8, 95u8, 63u8, 26u8, 222u8,
-						],
-					)
-				}
-				#[doc = "Authorize an upgrade to a given `code_hash` for the runtime. The runtime can be supplied"]
-				#[doc = "later."]
-				#[doc = ""]
-				#[doc = "The `check_version` parameter sets a boolean flag for whether or not the runtime's spec"]
-				#[doc = "version and name should be verified on upgrade. Since the authorization only has a hash,"]
-				#[doc = "it cannot actually perform the verification."]
-				#[doc = ""]
-				#[doc = "This call requires Root origin."]
-				pub fn authorize_upgrade(
-					&self,
-					code_hash: ::subxt::utils::H256,
-					check_version: ::core::primitive::bool,
-				) -> ::subxt::tx::StaticTxPayload<AuthorizeUpgrade> {
-					::subxt::tx::StaticTxPayload::new(
-						"ParachainSystem",
-						"authorize_upgrade",
-						AuthorizeUpgrade { code_hash, check_version },
-						[
-							208u8, 115u8, 62u8, 35u8, 70u8, 223u8, 65u8, 57u8, 216u8, 44u8, 169u8,
-							249u8, 90u8, 112u8, 17u8, 208u8, 30u8, 131u8, 102u8, 131u8, 240u8,
-							217u8, 230u8, 214u8, 145u8, 198u8, 55u8, 13u8, 217u8, 51u8, 178u8,
-							141u8,
-						],
-					)
-				}
-				#[doc = "Provide the preimage (runtime binary) `code` for an upgrade that has been authorized."]
-				#[doc = ""]
-				#[doc = "If the authorization required a version check, this call will ensure the spec name"]
-				#[doc = "remains unchanged and that the spec version has increased."]
-				#[doc = ""]
-				#[doc = "Note that this function will not apply the new `code`, but only attempt to schedule the"]
-				#[doc = "upgrade with the Relay Chain."]
-				#[doc = ""]
-				#[doc = "All origins are allowed."]
-				pub fn enact_authorized_upgrade(
-					&self,
-					code: ::std::vec::Vec<::core::primitive::u8>,
-				) -> ::subxt::tx::StaticTxPayload<EnactAuthorizedUpgrade> {
-					::subxt::tx::StaticTxPayload::new(
-						"ParachainSystem",
-						"enact_authorized_upgrade",
-						EnactAuthorizedUpgrade { code },
-						[
-							43u8, 157u8, 1u8, 230u8, 134u8, 72u8, 230u8, 35u8, 159u8, 13u8, 201u8,
-							134u8, 184u8, 94u8, 167u8, 13u8, 108u8, 157u8, 145u8, 166u8, 119u8,
-							37u8, 51u8, 121u8, 252u8, 255u8, 48u8, 251u8, 126u8, 152u8, 247u8, 5u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::cumulus_pallet_parachain_system::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "The validation function has been scheduled to apply."]
-			pub struct ValidationFunctionStored;
-			impl ::subxt::events::StaticEvent for ValidationFunctionStored {
-				const PALLET: &'static str = "ParachainSystem";
-				const EVENT: &'static str = "ValidationFunctionStored";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			#[doc = "The validation function was applied as of the contained relay chain block number."]
-			pub struct ValidationFunctionApplied {
-				pub relay_chain_block_num: ::core::primitive::u32,
-			}
-			impl ::subxt::events::StaticEvent for ValidationFunctionApplied {
-				const PALLET: &'static str = "ParachainSystem";
-				const EVENT: &'static str = "ValidationFunctionApplied";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "The relay-chain aborted the upgrade process."]
-			pub struct ValidationFunctionDiscarded;
-			impl ::subxt::events::StaticEvent for ValidationFunctionDiscarded {
-				const PALLET: &'static str = "ParachainSystem";
-				const EVENT: &'static str = "ValidationFunctionDiscarded";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An upgrade has been authorized."]
-			pub struct UpgradeAuthorized {
-				pub code_hash: ::subxt::utils::H256,
-			}
-			impl ::subxt::events::StaticEvent for UpgradeAuthorized {
-				const PALLET: &'static str = "ParachainSystem";
-				const EVENT: &'static str = "UpgradeAuthorized";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			#[doc = "Some downward messages have been received and will be processed."]
-			pub struct DownwardMessagesReceived {
-				pub count: ::core::primitive::u32,
-			}
-			impl ::subxt::events::StaticEvent for DownwardMessagesReceived {
-				const PALLET: &'static str = "ParachainSystem";
-				const EVENT: &'static str = "DownwardMessagesReceived";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward messages were processed using the given weight."]
-			pub struct DownwardMessagesProcessed {
-				pub weight_used: ::sp_weights::Weight,
-				pub dmq_head: ::subxt::utils::H256,
-			}
-			impl ::subxt::events::StaticEvent for DownwardMessagesProcessed {
-				const PALLET: &'static str = "ParachainSystem";
-				const EVENT: &'static str = "DownwardMessagesProcessed";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An upward message was sent to the relay chain."]
-			pub struct UpwardMessageSent {
-				pub message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
-			}
-			impl ::subxt::events::StaticEvent for UpwardMessageSent {
-				const PALLET: &'static str = "ParachainSystem";
-				const EVENT: &'static str = "UpwardMessageSent";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " In case of a scheduled upgrade, this storage field contains the validation code to be applied."]
-				#[doc = ""]
-				#[doc = " As soon as the relay chain gives us the go-ahead signal, we will overwrite the [`:code`][well_known_keys::CODE]"]
-				#[doc = " which will result the next block process with the new validation code. This concludes the upgrade process."]
-				#[doc = ""]
-				#[doc = " [well_known_keys::CODE]: sp_core::storage::well_known_keys::CODE"]
-				pub fn pending_validation_code(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"PendingValidationCode",
-						vec![],
-						[
-							162u8, 35u8, 108u8, 76u8, 160u8, 93u8, 215u8, 84u8, 20u8, 249u8, 57u8,
-							187u8, 88u8, 161u8, 15u8, 131u8, 213u8, 89u8, 140u8, 20u8, 227u8,
-							204u8, 79u8, 176u8, 114u8, 119u8, 8u8, 7u8, 64u8, 15u8, 90u8, 92u8,
-						],
-					)
-				}
-				#[doc = " Validation code that is set by the parachain and is to be communicated to collator and"]
-				#[doc = " consequently the relay-chain."]
-				#[doc = ""]
-				#[doc = " This will be cleared in `on_initialize` of each new block if no other pallet already set"]
-				#[doc = " the value."]
-				pub fn new_validation_code(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"NewValidationCode",
-						vec![],
-						[
-							224u8, 174u8, 53u8, 106u8, 240u8, 49u8, 48u8, 79u8, 219u8, 74u8, 142u8,
-							166u8, 92u8, 204u8, 244u8, 200u8, 43u8, 169u8, 177u8, 207u8, 190u8,
-							106u8, 180u8, 65u8, 245u8, 131u8, 134u8, 4u8, 53u8, 45u8, 76u8, 3u8,
-						],
-					)
-				}
-				#[doc = " The [`PersistedValidationData`] set for this block."]
-				#[doc = " This value is expected to be set only once per block and it's never stored"]
-				#[doc = " in the trie."]
-				pub fn validation_data(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::polkadot_primitives::v4::PersistedValidationData<
-							::subxt::utils::H256,
-							::core::primitive::u32,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"ValidationData",
-						vec![],
-						[
-							112u8, 58u8, 240u8, 81u8, 219u8, 110u8, 244u8, 186u8, 251u8, 90u8,
-							195u8, 217u8, 229u8, 102u8, 233u8, 24u8, 109u8, 96u8, 219u8, 72u8,
-							139u8, 93u8, 58u8, 140u8, 40u8, 110u8, 167u8, 98u8, 199u8, 12u8, 138u8,
-							131u8,
-						],
-					)
-				}
-				#[doc = " Were the validation data set to notify the relay chain?"]
-				pub fn did_set_validation_code(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::bool>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"DidSetValidationCode",
-						vec![],
-						[
-							89u8, 83u8, 74u8, 174u8, 234u8, 188u8, 149u8, 78u8, 140u8, 17u8, 92u8,
-							165u8, 243u8, 87u8, 59u8, 97u8, 135u8, 81u8, 192u8, 86u8, 193u8, 187u8,
-							113u8, 22u8, 108u8, 83u8, 242u8, 208u8, 174u8, 40u8, 49u8, 245u8,
-						],
-					)
-				}
-				#[doc = " The relay chain block number associated with the last parachain block."]
-				pub fn last_relay_chain_block_number(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"LastRelayChainBlockNumber",
-						vec![],
-						[
-							68u8, 121u8, 6u8, 159u8, 181u8, 94u8, 151u8, 215u8, 225u8, 244u8, 4u8,
-							158u8, 216u8, 85u8, 55u8, 228u8, 197u8, 35u8, 200u8, 33u8, 29u8, 182u8,
-							17u8, 83u8, 59u8, 63u8, 25u8, 180u8, 132u8, 23u8, 97u8, 252u8,
-						],
-					)
-				}
-				#[doc = " An option which indicates if the relay-chain restricts signalling a validation code upgrade."]
-				#[doc = " In other words, if this is `Some` and [`NewValidationCode`] is `Some` then the produced"]
-				#[doc = " candidate will be invalid."]
-				#[doc = ""]
-				#[doc = " This storage item is a mirror of the corresponding value for the current parachain from the"]
-				#[doc = " relay-chain. This value is ephemeral which means it doesn't hit the storage. This value is"]
-				#[doc = " set after the inherent."]
-				pub fn upgrade_restriction_signal(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::core::option::Option<
-							runtime_types::polkadot_primitives::v4::UpgradeRestriction,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"UpgradeRestrictionSignal",
-						vec![],
-						[
-							61u8, 3u8, 26u8, 6u8, 88u8, 114u8, 109u8, 63u8, 7u8, 115u8, 245u8,
-							198u8, 73u8, 234u8, 28u8, 228u8, 126u8, 27u8, 151u8, 18u8, 133u8, 54u8,
-							144u8, 149u8, 246u8, 43u8, 83u8, 47u8, 77u8, 238u8, 10u8, 196u8,
-						],
-					)
-				}
-				#[doc = " The state proof for the last relay parent block."]
-				#[doc = ""]
-				#[doc = " This field is meant to be updated each block with the validation data inherent. Therefore,"]
-				#[doc = " before processing of the inherent, e.g. in `on_initialize` this data may be stale."]
-				#[doc = ""]
-				#[doc = " This data is also absent from the genesis."]
-				pub fn relay_state_proof(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::sp_trie::storage_proof::StorageProof,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"RelayStateProof",
-						vec![],
-						[
-							35u8, 124u8, 167u8, 221u8, 162u8, 145u8, 158u8, 186u8, 57u8, 154u8,
-							225u8, 6u8, 176u8, 13u8, 178u8, 195u8, 209u8, 122u8, 221u8, 26u8,
-							155u8, 126u8, 153u8, 246u8, 101u8, 221u8, 61u8, 145u8, 211u8, 236u8,
-							48u8, 130u8,
-						],
-					)
-				}
-				#[doc = " The snapshot of some state related to messaging relevant to the current parachain as per"]
-				#[doc = " the relay parent."]
-				#[doc = ""]
-				#[doc = " This field is meant to be updated each block with the validation data inherent. Therefore,"]
-				#[doc = " before processing of the inherent, e.g. in `on_initialize` this data may be stale."]
-				#[doc = ""]
-				#[doc = " This data is also absent from the genesis."]				pub fn relevant_messaging_state (& self ,) -> :: subxt :: storage :: address :: StaticStorageAddress :: < :: subxt :: metadata :: DecodeStaticType < runtime_types :: cumulus_pallet_parachain_system :: relay_state_snapshot :: MessagingStateSnapshot > , :: subxt :: storage :: address :: Yes , () , () >{
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"RelevantMessagingState",
-						vec![],
-						[
-							68u8, 241u8, 114u8, 83u8, 200u8, 99u8, 8u8, 244u8, 110u8, 134u8, 106u8,
-							153u8, 17u8, 90u8, 184u8, 157u8, 100u8, 140u8, 157u8, 83u8, 25u8,
-							166u8, 173u8, 31u8, 221u8, 24u8, 236u8, 85u8, 176u8, 223u8, 237u8,
-							65u8,
-						],
-					)
-				}
-				#[doc = " The parachain host configuration that was obtained from the relay parent."]
-				#[doc = ""]
-				#[doc = " This field is meant to be updated each block with the validation data inherent. Therefore,"]
-				#[doc = " before processing of the inherent, e.g. in `on_initialize` this data may be stale."]
-				#[doc = ""]
-				#[doc = " This data is also absent from the genesis."]
-				pub fn host_configuration(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::polkadot_primitives::v4::AbridgedHostConfiguration,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"HostConfiguration",
-						vec![],
-						[
-							104u8, 200u8, 30u8, 202u8, 119u8, 204u8, 233u8, 20u8, 67u8, 199u8,
-							47u8, 166u8, 254u8, 152u8, 10u8, 187u8, 240u8, 255u8, 148u8, 201u8,
-							134u8, 41u8, 130u8, 201u8, 112u8, 65u8, 68u8, 103u8, 56u8, 123u8,
-							178u8, 113u8,
-						],
-					)
-				}
-				#[doc = " The last downward message queue chain head we have observed."]
-				#[doc = ""]
-				#[doc = " This value is loaded before and saved after processing inbound downward messages carried"]
-				#[doc = " by the system inherent."]
-				pub fn last_dmq_mqc_head(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::cumulus_primitives_parachain_inherent::MessageQueueChain,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"LastDmqMqcHead",
-						vec![],
-						[
-							176u8, 255u8, 246u8, 125u8, 36u8, 120u8, 24u8, 44u8, 26u8, 64u8, 236u8,
-							210u8, 189u8, 237u8, 50u8, 78u8, 45u8, 139u8, 58u8, 141u8, 112u8,
-							253u8, 178u8, 198u8, 87u8, 71u8, 77u8, 248u8, 21u8, 145u8, 187u8, 52u8,
-						],
-					)
-				}
-				#[doc = " The message queue chain heads we have observed per each channel incoming channel."]
-				#[doc = ""]
-				#[doc = " This value is loaded before and saved after processing inbound downward messages carried"]
-				#[doc = " by the system inherent."]
-				pub fn last_hrmp_mqc_heads(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::subxt::utils::KeyedVec<
-							runtime_types::polkadot_parachain::primitives::Id,
-							runtime_types::cumulus_primitives_parachain_inherent::MessageQueueChain,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"LastHrmpMqcHeads",
-						vec![],
-						[
-							55u8, 179u8, 35u8, 16u8, 173u8, 0u8, 122u8, 179u8, 236u8, 98u8, 9u8,
-							112u8, 11u8, 219u8, 241u8, 89u8, 131u8, 198u8, 64u8, 139u8, 103u8,
-							158u8, 77u8, 107u8, 83u8, 236u8, 255u8, 208u8, 47u8, 61u8, 219u8,
-							240u8,
-						],
-					)
-				}
-				#[doc = " Number of downward messages processed in a block."]
-				#[doc = ""]
-				#[doc = " This will be cleared in `on_initialize` of each new block."]
-				pub fn processed_downward_messages(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"ProcessedDownwardMessages",
-						vec![],
-						[
-							48u8, 177u8, 84u8, 228u8, 101u8, 235u8, 181u8, 27u8, 66u8, 55u8, 50u8,
-							146u8, 245u8, 223u8, 77u8, 132u8, 178u8, 80u8, 74u8, 90u8, 166u8, 81u8,
-							109u8, 25u8, 91u8, 69u8, 5u8, 69u8, 123u8, 197u8, 160u8, 146u8,
-						],
-					)
-				}
-				#[doc = " HRMP watermark that was set in a block."]
-				#[doc = ""]
-				#[doc = " This will be cleared in `on_initialize` of each new block."]
-				pub fn hrmp_watermark(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"HrmpWatermark",
-						vec![],
-						[
-							189u8, 59u8, 183u8, 195u8, 69u8, 185u8, 241u8, 226u8, 62u8, 204u8,
-							230u8, 77u8, 102u8, 75u8, 86u8, 157u8, 249u8, 140u8, 219u8, 72u8, 94u8,
-							64u8, 176u8, 72u8, 34u8, 205u8, 114u8, 103u8, 231u8, 233u8, 206u8,
-							111u8,
-						],
-					)
-				}
-				#[doc = " HRMP messages that were sent in a block."]
-				#[doc = ""]
-				#[doc = " This will be cleared in `on_initialize` of each new block."]
-				pub fn hrmp_outbound_messages(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<
-							runtime_types::polkadot_core_primitives::OutboundHrmpMessage<
-								runtime_types::polkadot_parachain::primitives::Id,
-							>,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"HrmpOutboundMessages",
-						vec![],
-						[
-							74u8, 86u8, 173u8, 248u8, 90u8, 230u8, 71u8, 225u8, 127u8, 164u8,
-							221u8, 62u8, 146u8, 13u8, 73u8, 9u8, 98u8, 168u8, 6u8, 14u8, 97u8,
-							166u8, 45u8, 70u8, 62u8, 210u8, 9u8, 32u8, 83u8, 18u8, 4u8, 201u8,
-						],
-					)
-				}
-				#[doc = " Upward messages that were sent in a block."]
-				#[doc = ""]
-				#[doc = " This will be cleared in `on_initialize` of each new block."]
-				pub fn upward_messages(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<::std::vec::Vec<::core::primitive::u8>>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"UpwardMessages",
-						vec![],
-						[
-							129u8, 208u8, 187u8, 36u8, 48u8, 108u8, 135u8, 56u8, 204u8, 60u8,
-							100u8, 158u8, 113u8, 238u8, 46u8, 92u8, 228u8, 41u8, 178u8, 177u8,
-							208u8, 195u8, 148u8, 149u8, 127u8, 21u8, 93u8, 92u8, 29u8, 115u8, 10u8,
-							248u8,
-						],
-					)
-				}
-				#[doc = " Upward messages that are still pending and not yet send to the relay chain."]
-				pub fn pending_upward_messages(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<::std::vec::Vec<::core::primitive::u8>>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"PendingUpwardMessages",
-						vec![],
-						[
-							223u8, 46u8, 224u8, 227u8, 222u8, 119u8, 225u8, 244u8, 59u8, 87u8,
-							127u8, 19u8, 217u8, 237u8, 103u8, 61u8, 6u8, 210u8, 107u8, 201u8,
-							117u8, 25u8, 85u8, 248u8, 36u8, 231u8, 28u8, 202u8, 41u8, 140u8, 208u8,
-							254u8,
-						],
-					)
-				}
-				#[doc = " The number of HRMP messages we observed in `on_initialize` and thus used that number for"]
-				#[doc = " announcing the weight of `on_initialize` and `on_finalize`."]
-				pub fn announced_hrmp_messages_per_candidate(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"AnnouncedHrmpMessagesPerCandidate",
-						vec![],
-						[
-							132u8, 61u8, 162u8, 129u8, 251u8, 243u8, 20u8, 144u8, 162u8, 73u8,
-							237u8, 51u8, 248u8, 41u8, 127u8, 171u8, 180u8, 79u8, 137u8, 23u8, 66u8,
-							134u8, 106u8, 222u8, 182u8, 154u8, 0u8, 145u8, 184u8, 156u8, 36u8,
-							97u8,
-						],
-					)
-				}
-				#[doc = " The weight we reserve at the beginning of the block for processing XCMP messages. This"]
-				#[doc = " overrides the amount set in the Config trait."]
-				pub fn reserved_xcmp_weight_override(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::sp_weights::Weight>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"ReservedXcmpWeightOverride",
-						vec![],
-						[
-							180u8, 90u8, 34u8, 178u8, 1u8, 242u8, 211u8, 97u8, 100u8, 34u8, 39u8,
-							42u8, 142u8, 249u8, 236u8, 194u8, 244u8, 164u8, 96u8, 54u8, 98u8, 46u8,
-							92u8, 196u8, 185u8, 51u8, 231u8, 234u8, 249u8, 143u8, 244u8, 64u8,
-						],
-					)
-				}
-				#[doc = " The weight we reserve at the beginning of the block for processing DMP messages. This"]
-				#[doc = " overrides the amount set in the Config trait."]
-				pub fn reserved_dmp_weight_override(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::sp_weights::Weight>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"ReservedDmpWeightOverride",
-						vec![],
-						[
-							90u8, 122u8, 168u8, 240u8, 95u8, 195u8, 160u8, 109u8, 175u8, 170u8,
-							227u8, 44u8, 139u8, 176u8, 32u8, 161u8, 57u8, 233u8, 56u8, 55u8, 123u8,
-							168u8, 174u8, 96u8, 159u8, 62u8, 186u8, 186u8, 17u8, 70u8, 57u8, 246u8,
-						],
-					)
-				}
-				#[doc = " The next authorized upgrade, if there is one."]
-				pub fn authorized_upgrade(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::cumulus_pallet_parachain_system::CodeUpgradeAuthorization,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"AuthorizedUpgrade",
-						vec![],
-						[
-							12u8, 212u8, 71u8, 191u8, 89u8, 101u8, 195u8, 3u8, 23u8, 180u8, 233u8,
-							52u8, 53u8, 133u8, 207u8, 94u8, 58u8, 43u8, 221u8, 236u8, 161u8, 41u8,
-							30u8, 194u8, 125u8, 2u8, 118u8, 152u8, 197u8, 49u8, 34u8, 33u8,
-						],
-					)
-				}
-				#[doc = " A custom head data that should be returned as result of `validate_block`."]
-				#[doc = ""]
-				#[doc = " See [`Pallet::set_custom_validation_head_data`] for more information."]
-				pub fn custom_validation_head_data(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainSystem",
-						"CustomValidationHeadData",
-						vec![],
-						[
-							189u8, 150u8, 234u8, 128u8, 111u8, 27u8, 173u8, 92u8, 109u8, 4u8, 98u8,
-							103u8, 158u8, 19u8, 16u8, 5u8, 107u8, 135u8, 126u8, 170u8, 62u8, 64u8,
-							149u8, 80u8, 33u8, 17u8, 83u8, 22u8, 176u8, 118u8, 26u8, 223u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod parachain_info {
-		use super::{root_mod, runtime_types};
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				pub fn parachain_id(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::polkadot_parachain::primitives::Id,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"ParachainInfo",
-						"ParachainId",
-						vec![],
-						[
-							151u8, 191u8, 241u8, 118u8, 192u8, 47u8, 166u8, 151u8, 217u8, 240u8,
-							165u8, 232u8, 51u8, 113u8, 243u8, 1u8, 89u8, 240u8, 11u8, 1u8, 77u8,
-							104u8, 12u8, 56u8, 17u8, 135u8, 214u8, 19u8, 114u8, 135u8, 66u8, 76u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod balances {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct TransferAllowDeath {
-				pub dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				#[codec(compact)]
-				pub value: ::core::primitive::u128,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetBalanceDeprecated {
-				pub who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				#[codec(compact)]
-				pub new_free: ::core::primitive::u128,
-				#[codec(compact)]
-				pub old_reserved: ::core::primitive::u128,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ForceTransfer {
-				pub source: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				pub dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				#[codec(compact)]
-				pub value: ::core::primitive::u128,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct TransferKeepAlive {
-				pub dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				#[codec(compact)]
-				pub value: ::core::primitive::u128,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct TransferAll {
-				pub dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				pub keep_alive: ::core::primitive::bool,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ForceUnreserve {
-				pub who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				pub amount: ::core::primitive::u128,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct UpgradeAccounts {
-				pub who: ::std::vec::Vec<::sp_core::crypto::AccountId32>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct Transfer {
-				pub dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				#[codec(compact)]
-				pub value: ::core::primitive::u128,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ForceSetBalance {
-				pub who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-				#[codec(compact)]
-				pub new_free: ::core::primitive::u128,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Transfer some liquid free balance to another account."]
-				#[doc = ""]
-				#[doc = "`transfer_allow_death` will set the `FreeBalance` of the sender and receiver."]
-				#[doc = "If the sender's account is below the existential deposit as a result"]
-				#[doc = "of the transfer, the account will be reaped."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call must be `Signed` by the transactor."]
-				pub fn transfer_allow_death(
-					&self,
-					dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					value: ::core::primitive::u128,
-				) -> ::subxt::tx::StaticTxPayload<TransferAllowDeath> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"transfer_allow_death",
-						TransferAllowDeath { dest, value },
-						[
-							234u8, 130u8, 149u8, 36u8, 235u8, 112u8, 159u8, 189u8, 104u8, 148u8,
-							108u8, 230u8, 25u8, 198u8, 71u8, 158u8, 112u8, 3u8, 162u8, 25u8, 145u8,
-							252u8, 44u8, 63u8, 47u8, 34u8, 47u8, 158u8, 61u8, 14u8, 120u8, 255u8,
-						],
-					)
-				}
-				#[doc = "Set the regular balance of a given account; it also takes a reserved balance but this"]
-				#[doc = "must be the same as the account's current reserved balance."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call is `root`."]
-				#[doc = ""]
-				#[doc = "WARNING: This call is DEPRECATED! Use `force_set_balance` instead."]
-				pub fn set_balance_deprecated(
-					&self,
-					who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					new_free: ::core::primitive::u128,
-					old_reserved: ::core::primitive::u128,
-				) -> ::subxt::tx::StaticTxPayload<SetBalanceDeprecated> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"set_balance_deprecated",
-						SetBalanceDeprecated { who, new_free, old_reserved },
-						[
-							240u8, 107u8, 184u8, 206u8, 78u8, 106u8, 115u8, 152u8, 130u8, 56u8,
-							156u8, 176u8, 105u8, 27u8, 176u8, 187u8, 49u8, 171u8, 229u8, 79u8,
-							254u8, 248u8, 8u8, 162u8, 134u8, 12u8, 89u8, 100u8, 137u8, 102u8,
-							132u8, 158u8,
-						],
-					)
-				}
-				#[doc = "Exactly as `transfer_allow_death`, except the origin must be root and the source account"]
-				#[doc = "may be specified."]
-				pub fn force_transfer(
-					&self,
-					source: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					value: ::core::primitive::u128,
-				) -> ::subxt::tx::StaticTxPayload<ForceTransfer> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"force_transfer",
-						ForceTransfer { source, dest, value },
-						[
-							79u8, 174u8, 212u8, 108u8, 184u8, 33u8, 170u8, 29u8, 232u8, 254u8,
-							195u8, 218u8, 221u8, 134u8, 57u8, 99u8, 6u8, 70u8, 181u8, 227u8, 56u8,
-							239u8, 243u8, 158u8, 157u8, 245u8, 36u8, 162u8, 11u8, 237u8, 147u8,
-							15u8,
-						],
-					)
-				}
-				#[doc = "Same as the [`transfer_allow_death`] call, but with a check that the transfer will not"]
-				#[doc = "kill the origin account."]
-				#[doc = ""]
-				#[doc = "99% of the time you want [`transfer_allow_death`] instead."]
-				#[doc = ""]
-				#[doc = "[`transfer_allow_death`]: struct.Pallet.html#method.transfer"]
-				pub fn transfer_keep_alive(
-					&self,
-					dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					value: ::core::primitive::u128,
-				) -> ::subxt::tx::StaticTxPayload<TransferKeepAlive> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"transfer_keep_alive",
-						TransferKeepAlive { dest, value },
-						[
-							112u8, 179u8, 75u8, 168u8, 193u8, 221u8, 9u8, 82u8, 190u8, 113u8,
-							253u8, 13u8, 130u8, 134u8, 170u8, 216u8, 136u8, 111u8, 242u8, 220u8,
-							202u8, 112u8, 47u8, 79u8, 73u8, 244u8, 226u8, 59u8, 240u8, 188u8,
-							210u8, 208u8,
-						],
-					)
-				}
-				#[doc = "Transfer the entire transferable balance from the caller account."]
-				#[doc = ""]
-				#[doc = "NOTE: This function only attempts to transfer _transferable_ balances. This means that"]
-				#[doc = "any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be"]
-				#[doc = "transferred by this function. To ensure that this function results in a killed account,"]
-				#[doc = "you might need to prepare the account by removing any reference counters, storage"]
-				#[doc = "deposits, etc..."]
-				#[doc = ""]
-				#[doc = "The dispatch origin of this call must be Signed."]
-				#[doc = ""]
-				#[doc = "- `dest`: The recipient of the transfer."]
-				#[doc = "- `keep_alive`: A boolean to determine if the `transfer_all` operation should send all"]
-				#[doc = "  of the funds the account has, causing the sender account to be killed (false), or"]
-				#[doc = "  transfer everything except at least the existential deposit, which will guarantee to"]
-				#[doc = "  keep the sender account alive (true)."]
-				pub fn transfer_all(
-					&self,
-					dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					keep_alive: ::core::primitive::bool,
-				) -> ::subxt::tx::StaticTxPayload<TransferAll> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"transfer_all",
-						TransferAll { dest, keep_alive },
-						[
-							46u8, 129u8, 29u8, 177u8, 221u8, 107u8, 245u8, 69u8, 238u8, 126u8,
-							145u8, 26u8, 219u8, 208u8, 14u8, 80u8, 149u8, 1u8, 214u8, 63u8, 67u8,
-							201u8, 144u8, 45u8, 129u8, 145u8, 174u8, 71u8, 238u8, 113u8, 208u8,
-							34u8,
-						],
-					)
-				}
-				#[doc = "Unreserve some balance from a user by force."]
-				#[doc = ""]
-				#[doc = "Can only be called by ROOT."]
-				pub fn force_unreserve(
-					&self,
-					who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					amount: ::core::primitive::u128,
-				) -> ::subxt::tx::StaticTxPayload<ForceUnreserve> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"force_unreserve",
-						ForceUnreserve { who, amount },
-						[
-							160u8, 146u8, 137u8, 76u8, 157u8, 187u8, 66u8, 148u8, 207u8, 76u8,
-							32u8, 254u8, 82u8, 215u8, 35u8, 161u8, 213u8, 52u8, 32u8, 98u8, 102u8,
-							106u8, 234u8, 123u8, 6u8, 175u8, 184u8, 188u8, 174u8, 106u8, 176u8,
-							78u8,
-						],
-					)
-				}
-				#[doc = "Upgrade a specified account."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be `Signed`."]
-				#[doc = "- `who`: The account to be upgraded."]
-				#[doc = ""]
-				#[doc = "This will waive the transaction fee if at least all but 10% of the accounts needed to"]
-				#[doc = "be upgraded. (We let some not have to be upgraded just in order to allow for the"]
-				#[doc = "possibililty of churn)."]
-				pub fn upgrade_accounts(
-					&self,
-					who: ::std::vec::Vec<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::tx::StaticTxPayload<UpgradeAccounts> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"upgrade_accounts",
-						UpgradeAccounts { who },
-						[
-							164u8, 61u8, 119u8, 24u8, 165u8, 46u8, 197u8, 59u8, 39u8, 198u8, 228u8,
-							96u8, 228u8, 45u8, 85u8, 51u8, 37u8, 5u8, 75u8, 40u8, 241u8, 163u8,
-							86u8, 228u8, 151u8, 217u8, 47u8, 105u8, 203u8, 103u8, 207u8, 4u8,
-						],
-					)
-				}
-				#[doc = "Alias for `transfer_allow_death`, provided only for name-wise compatibility."]
-				#[doc = ""]
-				#[doc = "WARNING: DEPRECATED! Will be released in approximately 3 months."]
-				pub fn transfer(
-					&self,
-					dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					value: ::core::primitive::u128,
-				) -> ::subxt::tx::StaticTxPayload<Transfer> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"transfer",
-						Transfer { dest, value },
-						[
-							111u8, 222u8, 32u8, 56u8, 171u8, 77u8, 252u8, 29u8, 194u8, 155u8,
-							200u8, 192u8, 198u8, 81u8, 23u8, 115u8, 236u8, 91u8, 218u8, 114u8,
-							107u8, 141u8, 138u8, 100u8, 237u8, 21u8, 58u8, 172u8, 3u8, 20u8, 216u8,
-							38u8,
-						],
-					)
-				}
-				#[doc = "Set the regular balance of a given account."]
-				#[doc = ""]
-				#[doc = "The dispatch origin for this call is `root`."]
-				pub fn force_set_balance(
-					&self,
-					who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
-					new_free: ::core::primitive::u128,
-				) -> ::subxt::tx::StaticTxPayload<ForceSetBalance> {
-					::subxt::tx::StaticTxPayload::new(
-						"Balances",
-						"force_set_balance",
-						ForceSetBalance { who, new_free },
-						[
-							237u8, 4u8, 41u8, 58u8, 62u8, 179u8, 160u8, 4u8, 50u8, 71u8, 178u8,
-							36u8, 130u8, 130u8, 92u8, 229u8, 16u8, 245u8, 169u8, 109u8, 165u8,
-							72u8, 94u8, 70u8, 196u8, 136u8, 37u8, 94u8, 140u8, 215u8, 125u8, 125u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::pallet_balances::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An account was created with some free balance."]
-			pub struct Endowed {
-				pub account: ::sp_core::crypto::AccountId32,
-				pub free_balance: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Endowed {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Endowed";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An account was removed whose balance was non-zero but below ExistentialDeposit,"]
-			#[doc = "resulting in an outright loss."]
-			pub struct DustLost {
-				pub account: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for DustLost {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "DustLost";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Transfer succeeded."]
-			pub struct Transfer {
-				pub from: ::sp_core::crypto::AccountId32,
-				pub to: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Transfer {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Transfer";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A balance was set by root."]
-			pub struct BalanceSet {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub free: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for BalanceSet {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "BalanceSet";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some balance was reserved (moved from free to reserved)."]
-			pub struct Reserved {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Reserved {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Reserved";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some balance was unreserved (moved from reserved to free)."]
-			pub struct Unreserved {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Unreserved {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Unreserved";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some balance was moved from the reserve of the first account to the second account."]
-			#[doc = "Final argument indicates the destination balance type."]
-			pub struct ReserveRepatriated {
-				pub from: ::sp_core::crypto::AccountId32,
-				pub to: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-				pub destination_status:
-					runtime_types::frame_support::traits::tokens::misc::BalanceStatus,
-			}
-			impl ::subxt::events::StaticEvent for ReserveRepatriated {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "ReserveRepatriated";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some amount was deposited (e.g. for transaction fees)."]
-			pub struct Deposit {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Deposit {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Deposit";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some amount was withdrawn from the account (e.g. for transaction fees)."]
-			pub struct Withdraw {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Withdraw {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Withdraw";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some amount was removed from the account (e.g. for misbehavior)."]
-			pub struct Slashed {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Slashed {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Slashed";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some amount was minted into an account."]
-			pub struct Minted {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Minted {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Minted";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some amount was burned from an account."]
-			pub struct Burned {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Burned {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Burned";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some amount was suspended from an account (it can be restored later)."]
-			pub struct Suspended {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Suspended {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Suspended";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some amount was restored into an account."]
-			pub struct Restored {
-				pub who: ::sp_core::crypto::AccountId32,
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Restored {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Restored";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An account was upgraded."]
-			pub struct Upgraded {
-				pub who: ::sp_core::crypto::AccountId32,
-			}
-			impl ::subxt::events::StaticEvent for Upgraded {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Upgraded";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			#[doc = "Total issuance was increased by `amount`, creating a credit to be balanced."]
-			pub struct Issued {
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Issued {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Issued";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			#[doc = "Total issuance was decreased by `amount`, creating a debt to be balanced."]
-			pub struct Rescinded {
-				pub amount: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for Rescinded {
-				const PALLET: &'static str = "Balances";
-				const EVENT: &'static str = "Rescinded";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " The total units issued in the system."]
-				pub fn total_issuance(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u128>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"TotalIssuance",
-						vec![],
-						[
-							1u8, 206u8, 252u8, 237u8, 6u8, 30u8, 20u8, 232u8, 164u8, 115u8, 51u8,
-							156u8, 156u8, 206u8, 241u8, 187u8, 44u8, 84u8, 25u8, 164u8, 235u8,
-							20u8, 86u8, 242u8, 124u8, 23u8, 28u8, 140u8, 26u8, 73u8, 231u8, 51u8,
-						],
-					)
-				}
-				#[doc = " The total units of outstanding deactivated balance in the system."]
-				pub fn inactive_issuance(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u128>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"InactiveIssuance",
-						vec![],
-						[
-							74u8, 203u8, 111u8, 142u8, 225u8, 104u8, 173u8, 51u8, 226u8, 12u8,
-							85u8, 135u8, 41u8, 206u8, 177u8, 238u8, 94u8, 246u8, 184u8, 250u8,
-							140u8, 213u8, 91u8, 118u8, 163u8, 111u8, 211u8, 46u8, 204u8, 160u8,
-							154u8, 21u8,
-						],
-					)
-				}
-				#[doc = " The Balances pallet example of storing the balance of an account."]
-				#[doc = ""]
-				#[doc = " # Example"]
-				#[doc = ""]
-				#[doc = " ```nocompile"]
-				#[doc = "  impl pallet_balances::Config for Runtime {"]
-				#[doc = "    type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>"]
-				#[doc = "  }"]
-				#[doc = " ```"]
-				#[doc = ""]
-				#[doc = " You can also store the balance of an account in the `System` pallet."]
-				#[doc = ""]
-				#[doc = " # Example"]
-				#[doc = ""]
-				#[doc = " ```nocompile"]
-				#[doc = "  impl pallet_balances::Config for Runtime {"]
-				#[doc = "   type AccountStore = System"]
-				#[doc = "  }"]
-				#[doc = " ```"]
-				#[doc = ""]
-				#[doc = " But this comes with tradeoffs, storing account balances in the system pallet stores"]
-				#[doc = " `frame_system` data alongside the account data contrary to storing account balances in the"]
-				#[doc = " `Balances` pallet, which uses a `StorageMap` to store balances data only."]
-				#[doc = " NOTE: This is only used in the case that this pallet is used to store balances."]
-				pub fn account(
-					&self,
-					_0: impl ::std::borrow::Borrow<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::pallet_balances::types::AccountData<::core::primitive::u128>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Account",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							109u8, 250u8, 18u8, 96u8, 139u8, 232u8, 4u8, 139u8, 133u8, 239u8, 30u8,
-							237u8, 73u8, 209u8, 143u8, 160u8, 94u8, 248u8, 124u8, 43u8, 224u8,
-							165u8, 11u8, 6u8, 176u8, 144u8, 189u8, 161u8, 174u8, 210u8, 56u8,
-							225u8,
-						],
-					)
-				}
-				#[doc = " The Balances pallet example of storing the balance of an account."]
-				#[doc = ""]
-				#[doc = " # Example"]
-				#[doc = ""]
-				#[doc = " ```nocompile"]
-				#[doc = "  impl pallet_balances::Config for Runtime {"]
-				#[doc = "    type AccountStore = StorageMapShim<Self::Account<Runtime>, frame_system::Provider<Runtime>, AccountId, Self::AccountData<Balance>>"]
-				#[doc = "  }"]
-				#[doc = " ```"]
-				#[doc = ""]
-				#[doc = " You can also store the balance of an account in the `System` pallet."]
-				#[doc = ""]
-				#[doc = " # Example"]
-				#[doc = ""]
-				#[doc = " ```nocompile"]
-				#[doc = "  impl pallet_balances::Config for Runtime {"]
-				#[doc = "   type AccountStore = System"]
-				#[doc = "  }"]
-				#[doc = " ```"]
-				#[doc = ""]
-				#[doc = " But this comes with tradeoffs, storing account balances in the system pallet stores"]
-				#[doc = " `frame_system` data alongside the account data contrary to storing account balances in the"]
-				#[doc = " `Balances` pallet, which uses a `StorageMap` to store balances data only."]
-				#[doc = " NOTE: This is only used in the case that this pallet is used to store balances."]
-				pub fn account_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::pallet_balances::types::AccountData<::core::primitive::u128>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Account",
-						Vec::new(),
-						[
-							109u8, 250u8, 18u8, 96u8, 139u8, 232u8, 4u8, 139u8, 133u8, 239u8, 30u8,
-							237u8, 73u8, 209u8, 143u8, 160u8, 94u8, 248u8, 124u8, 43u8, 224u8,
-							165u8, 11u8, 6u8, 176u8, 144u8, 189u8, 161u8, 174u8, 210u8, 56u8,
-							225u8,
-						],
-					)
-				}
-				#[doc = " Any liquidity locks on some account balances."]
-				#[doc = " NOTE: Should only be accessed when setting, changing and freeing a lock."]
-				pub fn locks(
-					&self,
-					_0: impl ::std::borrow::Borrow<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::weak_bounded_vec::WeakBoundedVec<
-							runtime_types::pallet_balances::types::BalanceLock<
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Locks",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							216u8, 253u8, 87u8, 73u8, 24u8, 218u8, 35u8, 0u8, 244u8, 134u8, 195u8,
-							58u8, 255u8, 64u8, 153u8, 212u8, 210u8, 232u8, 4u8, 122u8, 90u8, 212u8,
-							136u8, 14u8, 127u8, 232u8, 8u8, 192u8, 40u8, 233u8, 18u8, 250u8,
-						],
-					)
-				}
-				#[doc = " Any liquidity locks on some account balances."]
-				#[doc = " NOTE: Should only be accessed when setting, changing and freeing a lock."]
-				pub fn locks_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::weak_bounded_vec::WeakBoundedVec<
-							runtime_types::pallet_balances::types::BalanceLock<
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Locks",
-						Vec::new(),
-						[
-							216u8, 253u8, 87u8, 73u8, 24u8, 218u8, 35u8, 0u8, 244u8, 134u8, 195u8,
-							58u8, 255u8, 64u8, 153u8, 212u8, 210u8, 232u8, 4u8, 122u8, 90u8, 212u8,
-							136u8, 14u8, 127u8, 232u8, 8u8, 192u8, 40u8, 233u8, 18u8, 250u8,
-						],
-					)
-				}
-				#[doc = " Named reserves on some account balances."]
-				pub fn reserves(
-					&self,
-					_0: impl ::std::borrow::Borrow<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							runtime_types::pallet_balances::types::ReserveData<
-								[::core::primitive::u8; 8usize],
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Reserves",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							17u8, 32u8, 191u8, 46u8, 76u8, 220u8, 101u8, 100u8, 42u8, 250u8, 128u8,
-							167u8, 117u8, 44u8, 85u8, 96u8, 105u8, 216u8, 16u8, 147u8, 74u8, 55u8,
-							183u8, 94u8, 160u8, 177u8, 26u8, 187u8, 71u8, 197u8, 187u8, 163u8,
-						],
-					)
-				}
-				#[doc = " Named reserves on some account balances."]
-				pub fn reserves_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							runtime_types::pallet_balances::types::ReserveData<
-								[::core::primitive::u8; 8usize],
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Reserves",
-						Vec::new(),
-						[
-							17u8, 32u8, 191u8, 46u8, 76u8, 220u8, 101u8, 100u8, 42u8, 250u8, 128u8,
-							167u8, 117u8, 44u8, 85u8, 96u8, 105u8, 216u8, 16u8, 147u8, 74u8, 55u8,
-							183u8, 94u8, 160u8, 177u8, 26u8, 187u8, 71u8, 197u8, 187u8, 163u8,
-						],
-					)
-				}
-				#[doc = " Holds on account balances."]
-				pub fn holds(
-					&self,
-					_0: impl ::std::borrow::Borrow<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							runtime_types::pallet_balances::types::IdAmount<
-								(),
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Holds",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							247u8, 81u8, 4u8, 220u8, 77u8, 205u8, 28u8, 131u8, 215u8, 74u8, 197u8,
-							137u8, 113u8, 214u8, 249u8, 91u8, 81u8, 216u8, 8u8, 5u8, 233u8, 39u8,
-							104u8, 250u8, 3u8, 228u8, 148u8, 78u8, 4u8, 34u8, 45u8, 143u8,
-						],
-					)
-				}
-				#[doc = " Holds on account balances."]
-				pub fn holds_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							runtime_types::pallet_balances::types::IdAmount<
-								(),
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Holds",
-						Vec::new(),
-						[
-							247u8, 81u8, 4u8, 220u8, 77u8, 205u8, 28u8, 131u8, 215u8, 74u8, 197u8,
-							137u8, 113u8, 214u8, 249u8, 91u8, 81u8, 216u8, 8u8, 5u8, 233u8, 39u8,
-							104u8, 250u8, 3u8, 228u8, 148u8, 78u8, 4u8, 34u8, 45u8, 143u8,
-						],
-					)
-				}
-				#[doc = " Freeze locks on account balances."]
-				pub fn freezes(
-					&self,
-					_0: impl ::std::borrow::Borrow<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							runtime_types::pallet_balances::types::IdAmount<
-								(),
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Freezes",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							211u8, 24u8, 237u8, 217u8, 47u8, 230u8, 147u8, 39u8, 112u8, 209u8,
-							193u8, 47u8, 242u8, 13u8, 241u8, 0u8, 100u8, 45u8, 116u8, 130u8, 246u8,
-							196u8, 50u8, 134u8, 135u8, 112u8, 206u8, 1u8, 12u8, 53u8, 106u8, 131u8,
-						],
-					)
-				}
-				#[doc = " Freeze locks on account balances."]
-				pub fn freezes_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							runtime_types::pallet_balances::types::IdAmount<
-								(),
-								::core::primitive::u128,
-							>,
-						>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"Balances",
-						"Freezes",
-						Vec::new(),
-						[
-							211u8, 24u8, 237u8, 217u8, 47u8, 230u8, 147u8, 39u8, 112u8, 209u8,
-							193u8, 47u8, 242u8, 13u8, 241u8, 0u8, 100u8, 45u8, 116u8, 130u8, 246u8,
-							196u8, 50u8, 134u8, 135u8, 112u8, 206u8, 1u8, 12u8, 53u8, 106u8, 131u8,
-						],
-					)
-				}
-			}
-		}
-		pub mod constants {
-			use super::runtime_types;
-			pub struct ConstantsApi;
-			impl ConstantsApi {
-				#[doc = " The minimum amount required to keep an account open."]
-				pub fn existential_deposit(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u128>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"Balances",
-						"ExistentialDeposit",
-						[
-							84u8, 157u8, 140u8, 4u8, 93u8, 57u8, 29u8, 133u8, 105u8, 200u8, 214u8,
-							27u8, 144u8, 208u8, 218u8, 160u8, 130u8, 109u8, 101u8, 54u8, 210u8,
-							136u8, 71u8, 63u8, 49u8, 237u8, 234u8, 15u8, 178u8, 98u8, 148u8, 156u8,
-						],
-					)
-				}
-				#[doc = " The maximum number of locks that should exist on an account."]
-				#[doc = " Not strictly enforced, but used for weight estimation."]
-				pub fn max_locks(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"Balances",
-						"MaxLocks",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-				#[doc = " The maximum number of named reserves that can exist on an account."]
-				pub fn max_reserves(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"Balances",
-						"MaxReserves",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-				#[doc = " The maximum number of holds that can exist on an account at any time."]
-				pub fn max_holds(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"Balances",
-						"MaxHolds",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-				#[doc = " The maximum number of individual freeze locks that can exist on an account at any time."]
-				pub fn max_freezes(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"Balances",
-						"MaxFreezes",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod aura {
-		use super::{root_mod, runtime_types};
-	}
-	pub mod aura_ext {
-		use super::{root_mod, runtime_types};
-	}
-	pub mod xcmp_queue {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ServiceOverweight {
-				pub index: ::core::primitive::u64,
-				pub weight_limit: ::sp_weights::Weight,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SuspendXcmExecution;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ResumeXcmExecution;
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			pub struct UpdateSuspendThreshold {
-				pub new: ::core::primitive::u32,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			pub struct UpdateDropThreshold {
-				pub new: ::core::primitive::u32,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			pub struct UpdateResumeThreshold {
-				pub new: ::core::primitive::u32,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct UpdateThresholdWeight {
-				pub new: ::sp_weights::Weight,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct UpdateWeightRestrictDecay {
-				pub new: ::sp_weights::Weight,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct UpdateXcmpMaxIndividualWeight {
-				pub new: ::sp_weights::Weight,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Services a single overweight XCM."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `ExecuteOverweightOrigin`."]
-				#[doc = "- `index`: The index of the overweight XCM to service"]
-				#[doc = "- `weight_limit`: The amount of weight that XCM execution may take."]
-				#[doc = ""]
-				#[doc = "Errors:"]
-				#[doc = "- `BadOverweightIndex`: XCM under `index` is not found in the `Overweight` storage map."]
-				#[doc = "- `BadXcm`: XCM under `index` cannot be properly decoded into a valid XCM format."]
-				#[doc = "- `WeightOverLimit`: XCM execution may use greater `weight_limit`."]
-				#[doc = ""]
-				#[doc = "Events:"]
-				#[doc = "- `OverweightServiced`: On success."]
-				pub fn service_overweight(
-					&self,
-					index: ::core::primitive::u64,
-					weight_limit: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<ServiceOverweight> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"service_overweight",
-						ServiceOverweight { index, weight_limit },
-						[
-							121u8, 236u8, 235u8, 23u8, 210u8, 238u8, 238u8, 122u8, 15u8, 86u8,
-							34u8, 119u8, 105u8, 100u8, 214u8, 236u8, 117u8, 39u8, 254u8, 235u8,
-							189u8, 15u8, 72u8, 74u8, 225u8, 134u8, 148u8, 126u8, 31u8, 203u8,
-							144u8, 106u8,
-						],
-					)
-				}
-				#[doc = "Suspends all XCM executions for the XCMP queue, regardless of the sender's origin."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `ControllerOrigin`."]
-				pub fn suspend_xcm_execution(
-					&self,
-				) -> ::subxt::tx::StaticTxPayload<SuspendXcmExecution> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"suspend_xcm_execution",
-						SuspendXcmExecution {},
-						[
-							139u8, 76u8, 166u8, 86u8, 106u8, 144u8, 16u8, 47u8, 105u8, 185u8, 7u8,
-							7u8, 63u8, 14u8, 250u8, 236u8, 99u8, 121u8, 101u8, 143u8, 28u8, 175u8,
-							108u8, 197u8, 226u8, 43u8, 103u8, 92u8, 186u8, 12u8, 51u8, 153u8,
-						],
-					)
-				}
-				#[doc = "Resumes all XCM executions for the XCMP queue."]
-				#[doc = ""]
-				#[doc = "Note that this function doesn't change the status of the in/out bound channels."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `ControllerOrigin`."]
-				pub fn resume_xcm_execution(
-					&self,
-				) -> ::subxt::tx::StaticTxPayload<ResumeXcmExecution> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"resume_xcm_execution",
-						ResumeXcmExecution {},
-						[
-							67u8, 111u8, 47u8, 237u8, 79u8, 42u8, 90u8, 56u8, 245u8, 2u8, 20u8,
-							23u8, 33u8, 121u8, 135u8, 50u8, 204u8, 147u8, 195u8, 80u8, 177u8,
-							202u8, 8u8, 160u8, 164u8, 138u8, 64u8, 252u8, 178u8, 63u8, 102u8,
-							245u8,
-						],
-					)
-				}
-				#[doc = "Overwrites the number of pages of messages which must be in the queue for the other side to be told to"]
-				#[doc = "suspend their sending."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `Root`."]
-				#[doc = "- `new`: Desired value for `QueueConfigData.suspend_value`"]
-				pub fn update_suspend_threshold(
-					&self,
-					new: ::core::primitive::u32,
-				) -> ::subxt::tx::StaticTxPayload<UpdateSuspendThreshold> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"update_suspend_threshold",
-						UpdateSuspendThreshold { new },
-						[
-							155u8, 120u8, 9u8, 228u8, 110u8, 62u8, 233u8, 36u8, 57u8, 85u8, 19u8,
-							67u8, 246u8, 88u8, 81u8, 116u8, 243u8, 236u8, 174u8, 130u8, 8u8, 246u8,
-							254u8, 97u8, 155u8, 207u8, 123u8, 60u8, 164u8, 14u8, 196u8, 97u8,
-						],
-					)
-				}
-				#[doc = "Overwrites the number of pages of messages which must be in the queue after which we drop any further"]
-				#[doc = "messages from the channel."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `Root`."]
-				#[doc = "- `new`: Desired value for `QueueConfigData.drop_threshold`"]
-				pub fn update_drop_threshold(
-					&self,
-					new: ::core::primitive::u32,
-				) -> ::subxt::tx::StaticTxPayload<UpdateDropThreshold> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"update_drop_threshold",
-						UpdateDropThreshold { new },
-						[
-							146u8, 177u8, 164u8, 96u8, 247u8, 182u8, 229u8, 175u8, 194u8, 101u8,
-							186u8, 168u8, 94u8, 114u8, 172u8, 119u8, 35u8, 222u8, 175u8, 21u8,
-							67u8, 61u8, 216u8, 144u8, 194u8, 10u8, 181u8, 62u8, 166u8, 198u8,
-							138u8, 243u8,
-						],
-					)
-				}
-				#[doc = "Overwrites the number of pages of messages which the queue must be reduced to before it signals that"]
-				#[doc = "message sending may recommence after it has been suspended."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `Root`."]
-				#[doc = "- `new`: Desired value for `QueueConfigData.resume_threshold`"]
-				pub fn update_resume_threshold(
-					&self,
-					new: ::core::primitive::u32,
-				) -> ::subxt::tx::StaticTxPayload<UpdateResumeThreshold> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"update_resume_threshold",
-						UpdateResumeThreshold { new },
-						[
-							231u8, 128u8, 80u8, 179u8, 61u8, 50u8, 103u8, 209u8, 103u8, 55u8,
-							101u8, 113u8, 150u8, 10u8, 202u8, 7u8, 0u8, 77u8, 58u8, 4u8, 227u8,
-							17u8, 225u8, 112u8, 121u8, 203u8, 184u8, 113u8, 231u8, 156u8, 174u8,
-							154u8,
-						],
-					)
-				}
-				#[doc = "Overwrites the amount of remaining weight under which we stop processing messages."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `Root`."]
-				#[doc = "- `new`: Desired value for `QueueConfigData.threshold_weight`"]
-				pub fn update_threshold_weight(
-					&self,
-					new: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<UpdateThresholdWeight> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"update_threshold_weight",
-						UpdateThresholdWeight { new },
-						[
-							14u8, 144u8, 112u8, 207u8, 195u8, 208u8, 184u8, 164u8, 94u8, 41u8, 8u8,
-							58u8, 180u8, 80u8, 239u8, 39u8, 210u8, 159u8, 114u8, 169u8, 152u8,
-							176u8, 26u8, 161u8, 32u8, 43u8, 250u8, 156u8, 56u8, 21u8, 43u8, 159u8,
-						],
-					)
-				}
-				#[doc = "Overwrites the speed to which the available weight approaches the maximum weight."]
-				#[doc = "A lower number results in a faster progression. A value of 1 makes the entire weight available initially."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `Root`."]
-				#[doc = "- `new`: Desired value for `QueueConfigData.weight_restrict_decay`."]
-				pub fn update_weight_restrict_decay(
-					&self,
-					new: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<UpdateWeightRestrictDecay> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"update_weight_restrict_decay",
-						UpdateWeightRestrictDecay { new },
-						[
-							42u8, 53u8, 83u8, 191u8, 51u8, 227u8, 210u8, 193u8, 142u8, 218u8,
-							244u8, 177u8, 19u8, 87u8, 148u8, 177u8, 231u8, 197u8, 196u8, 255u8,
-							41u8, 130u8, 245u8, 139u8, 107u8, 212u8, 90u8, 161u8, 82u8, 248u8,
-							160u8, 223u8,
-						],
-					)
-				}
-				#[doc = "Overwrite the maximum amount of weight any individual message may consume."]
-				#[doc = "Messages above this weight go into the overweight queue and may only be serviced explicitly."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must pass `Root`."]
-				#[doc = "- `new`: Desired value for `QueueConfigData.xcmp_max_individual_weight`."]
-				pub fn update_xcmp_max_individual_weight(
-					&self,
-					new: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<UpdateXcmpMaxIndividualWeight> {
-					::subxt::tx::StaticTxPayload::new(
-						"XcmpQueue",
-						"update_xcmp_max_individual_weight",
-						UpdateXcmpMaxIndividualWeight { new },
-						[
-							148u8, 185u8, 89u8, 36u8, 152u8, 220u8, 248u8, 233u8, 236u8, 82u8,
-							170u8, 111u8, 225u8, 142u8, 25u8, 211u8, 72u8, 248u8, 250u8, 14u8,
-							45u8, 72u8, 78u8, 95u8, 92u8, 196u8, 245u8, 104u8, 112u8, 128u8, 27u8,
-							109u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::cumulus_pallet_xcmp_queue::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some XCM was executed ok."]
-			pub struct Success {
-				pub message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
-				pub weight: ::sp_weights::Weight,
-			}
-			impl ::subxt::events::StaticEvent for Success {
-				const PALLET: &'static str = "XcmpQueue";
-				const EVENT: &'static str = "Success";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some XCM failed."]
-			pub struct Fail {
-				pub message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
-				pub error: runtime_types::xcm::v3::traits::Error,
-				pub weight: ::sp_weights::Weight,
-			}
-			impl ::subxt::events::StaticEvent for Fail {
-				const PALLET: &'static str = "XcmpQueue";
-				const EVENT: &'static str = "Fail";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Bad XCM version used."]
-			pub struct BadVersion {
-				pub message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
-			}
-			impl ::subxt::events::StaticEvent for BadVersion {
-				const PALLET: &'static str = "XcmpQueue";
-				const EVENT: &'static str = "BadVersion";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Bad XCM format used."]
-			pub struct BadFormat {
-				pub message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
-			}
-			impl ::subxt::events::StaticEvent for BadFormat {
-				const PALLET: &'static str = "XcmpQueue";
-				const EVENT: &'static str = "BadFormat";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An HRMP message was sent to a sibling parachain."]
-			pub struct XcmpMessageSent {
-				pub message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
-			}
-			impl ::subxt::events::StaticEvent for XcmpMessageSent {
-				const PALLET: &'static str = "XcmpQueue";
-				const EVENT: &'static str = "XcmpMessageSent";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An XCM exceeded the individual message weight budget."]
-			pub struct OverweightEnqueued {
-				pub sender: runtime_types::polkadot_parachain::primitives::Id,
-				pub sent_at: ::core::primitive::u32,
-				pub index: ::core::primitive::u64,
-				pub required: ::sp_weights::Weight,
-			}
-			impl ::subxt::events::StaticEvent for OverweightEnqueued {
-				const PALLET: &'static str = "XcmpQueue";
-				const EVENT: &'static str = "OverweightEnqueued";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An XCM from the overweight queue was executed with the given actual weight used."]
-			pub struct OverweightServiced {
-				pub index: ::core::primitive::u64,
-				pub used: ::sp_weights::Weight,
-			}
-			impl ::subxt::events::StaticEvent for OverweightServiced {
-				const PALLET: &'static str = "XcmpQueue";
-				const EVENT: &'static str = "OverweightServiced";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " Status of the inbound XCMP channels."]
-				pub fn inbound_xcmp_status(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<
-							runtime_types::cumulus_pallet_xcmp_queue::InboundChannelDetails,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"InboundXcmpStatus",
-						vec![],
-						[
-							183u8, 198u8, 237u8, 153u8, 132u8, 201u8, 87u8, 182u8, 121u8, 164u8,
-							129u8, 241u8, 58u8, 192u8, 115u8, 152u8, 7u8, 33u8, 95u8, 51u8, 2u8,
-							176u8, 144u8, 12u8, 125u8, 83u8, 92u8, 198u8, 211u8, 101u8, 28u8, 50u8,
-						],
-					)
-				}
-				#[doc = " Inbound aggregate XCMP messages. It can only be one per ParaId/block."]
-				pub fn inbound_xcmp_messages(
-					&self,
-					_0: impl ::std::borrow::Borrow<runtime_types::polkadot_parachain::primitives::Id>,
-					_1: impl ::std::borrow::Borrow<::core::primitive::u32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"InboundXcmpMessages",
-						vec![
-							::subxt::storage::address::StorageMapKey::new(
-								_0.borrow(),
-								::subxt::storage::address::StorageHasher::Blake2_128Concat,
-							),
-							::subxt::storage::address::StorageMapKey::new(
-								_1.borrow(),
-								::subxt::storage::address::StorageHasher::Twox64Concat,
-							),
-						],
-						[
-							157u8, 232u8, 222u8, 97u8, 218u8, 96u8, 96u8, 90u8, 216u8, 205u8, 39u8,
-							130u8, 109u8, 152u8, 127u8, 57u8, 54u8, 63u8, 104u8, 135u8, 33u8,
-							175u8, 197u8, 166u8, 238u8, 22u8, 137u8, 162u8, 226u8, 199u8, 87u8,
-							25u8,
-						],
-					)
-				}
-				#[doc = " Inbound aggregate XCMP messages. It can only be one per ParaId/block."]
-				pub fn inbound_xcmp_messages_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"InboundXcmpMessages",
-						Vec::new(),
-						[
-							157u8, 232u8, 222u8, 97u8, 218u8, 96u8, 96u8, 90u8, 216u8, 205u8, 39u8,
-							130u8, 109u8, 152u8, 127u8, 57u8, 54u8, 63u8, 104u8, 135u8, 33u8,
-							175u8, 197u8, 166u8, 238u8, 22u8, 137u8, 162u8, 226u8, 199u8, 87u8,
-							25u8,
-						],
-					)
-				}
-				#[doc = " The non-empty XCMP channels in order of becoming non-empty, and the index of the first"]
-				#[doc = " and last outbound message. If the two indices are equal, then it indicates an empty"]
-				#[doc = " queue and there must be a non-`Ok` `OutboundStatus`. We assume queues grow no greater"]
-				#[doc = " than 65535 items. Queue indices for normal messages begin at one; zero is reserved in"]
-				#[doc = " case of the need to send a high-priority signal message this block."]
-				#[doc = " The bool is true if there is a signal message waiting to be sent."]
-				pub fn outbound_xcmp_status(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<
-							runtime_types::cumulus_pallet_xcmp_queue::OutboundChannelDetails,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"OutboundXcmpStatus",
-						vec![],
-						[
-							238u8, 120u8, 185u8, 141u8, 82u8, 159u8, 41u8, 68u8, 204u8, 15u8, 46u8,
-							152u8, 144u8, 74u8, 250u8, 83u8, 71u8, 105u8, 54u8, 53u8, 226u8, 87u8,
-							14u8, 202u8, 58u8, 160u8, 54u8, 162u8, 239u8, 248u8, 227u8, 116u8,
-						],
-					)
-				}
-				#[doc = " The messages outbound in a given XCMP channel."]
-				pub fn outbound_xcmp_messages(
-					&self,
-					_0: impl ::std::borrow::Borrow<runtime_types::polkadot_parachain::primitives::Id>,
-					_1: impl ::std::borrow::Borrow<::core::primitive::u16>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"OutboundXcmpMessages",
-						vec![
-							::subxt::storage::address::StorageMapKey::new(
-								_0.borrow(),
-								::subxt::storage::address::StorageHasher::Blake2_128Concat,
-							),
-							::subxt::storage::address::StorageMapKey::new(
-								_1.borrow(),
-								::subxt::storage::address::StorageHasher::Twox64Concat,
-							),
-						],
-						[
-							50u8, 182u8, 237u8, 191u8, 106u8, 67u8, 54u8, 1u8, 17u8, 107u8, 70u8,
-							90u8, 202u8, 8u8, 63u8, 184u8, 171u8, 111u8, 192u8, 196u8, 7u8, 31u8,
-							186u8, 68u8, 31u8, 63u8, 71u8, 61u8, 83u8, 223u8, 79u8, 200u8,
-						],
-					)
-				}
-				#[doc = " The messages outbound in a given XCMP channel."]
-				pub fn outbound_xcmp_messages_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"OutboundXcmpMessages",
-						Vec::new(),
-						[
-							50u8, 182u8, 237u8, 191u8, 106u8, 67u8, 54u8, 1u8, 17u8, 107u8, 70u8,
-							90u8, 202u8, 8u8, 63u8, 184u8, 171u8, 111u8, 192u8, 196u8, 7u8, 31u8,
-							186u8, 68u8, 31u8, 63u8, 71u8, 61u8, 83u8, 223u8, 79u8, 200u8,
-						],
-					)
-				}
-				#[doc = " Any signal messages waiting to be sent."]
-				pub fn signal_messages(
-					&self,
-					_0: impl ::std::borrow::Borrow<runtime_types::polkadot_parachain::primitives::Id>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"SignalMessages",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							156u8, 242u8, 186u8, 89u8, 177u8, 195u8, 90u8, 121u8, 94u8, 106u8,
-							222u8, 78u8, 19u8, 162u8, 179u8, 96u8, 38u8, 113u8, 209u8, 148u8, 29u8,
-							110u8, 106u8, 167u8, 162u8, 96u8, 221u8, 20u8, 33u8, 179u8, 168u8,
-							142u8,
-						],
-					)
-				}
-				#[doc = " Any signal messages waiting to be sent."]
-				pub fn signal_messages_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::std::vec::Vec<::core::primitive::u8>>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"SignalMessages",
-						Vec::new(),
-						[
-							156u8, 242u8, 186u8, 89u8, 177u8, 195u8, 90u8, 121u8, 94u8, 106u8,
-							222u8, 78u8, 19u8, 162u8, 179u8, 96u8, 38u8, 113u8, 209u8, 148u8, 29u8,
-							110u8, 106u8, 167u8, 162u8, 96u8, 221u8, 20u8, 33u8, 179u8, 168u8,
-							142u8,
-						],
-					)
-				}
-				#[doc = " The configuration which controls the dynamics of the outbound queue."]
-				pub fn queue_config(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::cumulus_pallet_xcmp_queue::QueueConfigData,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"QueueConfig",
-						vec![],
-						[
-							154u8, 172u8, 227u8, 208u8, 130u8, 93u8, 173u8, 129u8, 33u8, 75u8,
-							180u8, 100u8, 35u8, 154u8, 40u8, 188u8, 86u8, 53u8, 74u8, 118u8, 131u8,
-							159u8, 240u8, 159u8, 185u8, 45u8, 165u8, 6u8, 90u8, 125u8, 77u8, 253u8,
-						],
-					)
-				}
-				#[doc = " The messages that exceeded max individual message weight budget."]
-				#[doc = ""]
-				#[doc = " These message stay in this storage map until they are manually dispatched via"]
-				#[doc = " `service_overweight`."]
-				pub fn overweight(
-					&self,
-					_0: impl ::std::borrow::Borrow<::core::primitive::u64>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<(
-						runtime_types::polkadot_parachain::primitives::Id,
-						::core::primitive::u32,
-						::std::vec::Vec<::core::primitive::u8>,
-					)>,
-					::subxt::storage::address::Yes,
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"Overweight",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Twox64Concat,
-						)],
-						[
-							222u8, 249u8, 232u8, 110u8, 117u8, 229u8, 165u8, 164u8, 219u8, 219u8,
-							149u8, 204u8, 25u8, 78u8, 204u8, 116u8, 111u8, 114u8, 120u8, 222u8,
-							56u8, 77u8, 122u8, 147u8, 108u8, 15u8, 94u8, 161u8, 212u8, 50u8, 7u8,
-							7u8,
-						],
-					)
-				}
-				#[doc = " The messages that exceeded max individual message weight budget."]
-				#[doc = ""]
-				#[doc = " These message stay in this storage map until they are manually dispatched via"]
-				#[doc = " `service_overweight`."]
-				pub fn overweight_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<(
-						runtime_types::polkadot_parachain::primitives::Id,
-						::core::primitive::u32,
-						::std::vec::Vec<::core::primitive::u8>,
-					)>,
-					(),
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"Overweight",
-						Vec::new(),
-						[
-							222u8, 249u8, 232u8, 110u8, 117u8, 229u8, 165u8, 164u8, 219u8, 219u8,
-							149u8, 204u8, 25u8, 78u8, 204u8, 116u8, 111u8, 114u8, 120u8, 222u8,
-							56u8, 77u8, 122u8, 147u8, 108u8, 15u8, 94u8, 161u8, 212u8, 50u8, 7u8,
-							7u8,
-						],
-					)
-				}
-				#[doc = "Counter for the related counted storage map"]
-				pub fn counter_for_overweight(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"CounterForOverweight",
-						vec![],
-						[
-							148u8, 226u8, 248u8, 107u8, 165u8, 97u8, 218u8, 160u8, 127u8, 48u8,
-							185u8, 251u8, 35u8, 137u8, 119u8, 251u8, 151u8, 167u8, 189u8, 66u8,
-							80u8, 74u8, 134u8, 129u8, 222u8, 180u8, 51u8, 182u8, 50u8, 110u8, 10u8,
-							43u8,
-						],
-					)
-				}
-				#[doc = " The number of overweight messages ever recorded in `Overweight`. Also doubles as the next"]
-				#[doc = " available free overweight index."]
-				pub fn overweight_count(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u64>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"OverweightCount",
-						vec![],
-						[
-							102u8, 180u8, 196u8, 148u8, 115u8, 62u8, 46u8, 238u8, 97u8, 116u8,
-							117u8, 42u8, 14u8, 5u8, 72u8, 237u8, 230u8, 46u8, 150u8, 126u8, 89u8,
-							64u8, 233u8, 166u8, 180u8, 137u8, 52u8, 233u8, 252u8, 255u8, 36u8,
-							20u8,
-						],
-					)
-				}
-				#[doc = " Whether or not the XCMP queue is suspended from executing incoming XCMs or not."]
-				pub fn queue_suspended(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::bool>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"XcmpQueue",
-						"QueueSuspended",
-						vec![],
-						[
-							23u8, 37u8, 48u8, 112u8, 222u8, 17u8, 252u8, 65u8, 160u8, 217u8, 218u8,
-							30u8, 2u8, 1u8, 204u8, 0u8, 251u8, 17u8, 138u8, 197u8, 164u8, 50u8,
-							122u8, 0u8, 31u8, 238u8, 147u8, 213u8, 30u8, 132u8, 184u8, 215u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod polkadot_xcm {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct Send {
-				pub dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub message: ::std::boxed::Box<runtime_types::xcm::VersionedXcm>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct TeleportAssets {
-				pub dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub assets: ::std::boxed::Box<runtime_types::xcm::VersionedMultiAssets>,
-				pub fee_asset_item: ::core::primitive::u32,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ReserveTransferAssets {
-				pub dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub assets: ::std::boxed::Box<runtime_types::xcm::VersionedMultiAssets>,
-				pub fee_asset_item: ::core::primitive::u32,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct Execute {
-				pub message: ::std::boxed::Box<runtime_types::xcm::VersionedXcm>,
-				pub max_weight: ::sp_weights::Weight,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ForceXcmVersion {
-				pub location:
-					::std::boxed::Box<runtime_types::xcm::v3::multilocation::MultiLocation>,
-				pub xcm_version: ::core::primitive::u32,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ForceDefaultXcmVersion {
-				pub maybe_xcm_version: ::core::option::Option<::core::primitive::u32>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ForceSubscribeVersionNotify {
-				pub location: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ForceUnsubscribeVersionNotify {
-				pub location: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct LimitedReserveTransferAssets {
-				pub dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub assets: ::std::boxed::Box<runtime_types::xcm::VersionedMultiAssets>,
-				pub fee_asset_item: ::core::primitive::u32,
-				pub weight_limit: runtime_types::xcm::v3::WeightLimit,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct LimitedTeleportAssets {
-				pub dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
-				pub assets: ::std::boxed::Box<runtime_types::xcm::VersionedMultiAssets>,
-				pub fee_asset_item: ::core::primitive::u32,
-				pub weight_limit: runtime_types::xcm::v3::WeightLimit,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				pub fn send(
-					&self,
-					dest: runtime_types::xcm::VersionedMultiLocation,
-					message: runtime_types::xcm::VersionedXcm,
-				) -> ::subxt::tx::StaticTxPayload<Send> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"send",
-						Send {
-							dest: ::std::boxed::Box::new(dest),
-							message: ::std::boxed::Box::new(message),
-						},
-						[
-							246u8, 35u8, 227u8, 112u8, 223u8, 7u8, 44u8, 186u8, 60u8, 225u8, 153u8,
-							249u8, 104u8, 51u8, 123u8, 227u8, 143u8, 65u8, 232u8, 209u8, 178u8,
-							104u8, 70u8, 56u8, 230u8, 14u8, 75u8, 83u8, 250u8, 160u8, 9u8, 39u8,
-						],
-					)
-				}
-				#[doc = "Teleport some assets from the local chain to some destination chain."]
-				#[doc = ""]
-				#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-				#[doc = "index `fee_asset_item`. The weight limit for fees is not provided and thus is unlimited,"]
-				#[doc = "with all fees taken as needed from the asset."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-				#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-				#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-				#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-				#[doc = "  an `AccountId32` value."]
-				#[doc = "- `assets`: The assets to be withdrawn. The first item should be the currency used to to pay the fee on the"]
-				#[doc = "  `dest` side. May not be empty."]
-				#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-				#[doc = "  fees."]
-				pub fn teleport_assets(
-					&self,
-					dest: runtime_types::xcm::VersionedMultiLocation,
-					beneficiary: runtime_types::xcm::VersionedMultiLocation,
-					assets: runtime_types::xcm::VersionedMultiAssets,
-					fee_asset_item: ::core::primitive::u32,
-				) -> ::subxt::tx::StaticTxPayload<TeleportAssets> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"teleport_assets",
-						TeleportAssets {
-							dest: ::std::boxed::Box::new(dest),
-							beneficiary: ::std::boxed::Box::new(beneficiary),
-							assets: ::std::boxed::Box::new(assets),
-							fee_asset_item,
-						},
-						[
-							187u8, 42u8, 2u8, 96u8, 105u8, 125u8, 74u8, 53u8, 2u8, 21u8, 31u8,
-							160u8, 201u8, 197u8, 157u8, 190u8, 40u8, 145u8, 5u8, 99u8, 194u8, 41u8,
-							114u8, 60u8, 165u8, 186u8, 15u8, 226u8, 85u8, 113u8, 159u8, 136u8,
-						],
-					)
-				}
-				#[doc = "Transfer some assets from the local chain to the sovereign account of a destination"]
-				#[doc = "chain and forward a notification XCM."]
-				#[doc = ""]
-				#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-				#[doc = "index `fee_asset_item`. The weight limit for fees is not provided and thus is unlimited,"]
-				#[doc = "with all fees taken as needed from the asset."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-				#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-				#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-				#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-				#[doc = "  an `AccountId32` value."]
-				#[doc = "- `assets`: The assets to be withdrawn. This should include the assets used to pay the fee on the"]
-				#[doc = "  `dest` side."]
-				#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-				#[doc = "  fees."]
-				pub fn reserve_transfer_assets(
-					&self,
-					dest: runtime_types::xcm::VersionedMultiLocation,
-					beneficiary: runtime_types::xcm::VersionedMultiLocation,
-					assets: runtime_types::xcm::VersionedMultiAssets,
-					fee_asset_item: ::core::primitive::u32,
-				) -> ::subxt::tx::StaticTxPayload<ReserveTransferAssets> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"reserve_transfer_assets",
-						ReserveTransferAssets {
-							dest: ::std::boxed::Box::new(dest),
-							beneficiary: ::std::boxed::Box::new(beneficiary),
-							assets: ::std::boxed::Box::new(assets),
-							fee_asset_item,
-						},
-						[
-							249u8, 177u8, 76u8, 204u8, 186u8, 165u8, 16u8, 186u8, 129u8, 239u8,
-							65u8, 252u8, 9u8, 132u8, 32u8, 164u8, 117u8, 177u8, 40u8, 21u8, 196u8,
-							246u8, 147u8, 2u8, 95u8, 110u8, 68u8, 162u8, 148u8, 9u8, 59u8, 170u8,
-						],
-					)
-				}
-				#[doc = "Execute an XCM message from a local, signed, origin."]
-				#[doc = ""]
-				#[doc = "An event is deposited indicating whether `msg` could be executed completely or only"]
-				#[doc = "partially."]
-				#[doc = ""]
-				#[doc = "No more than `max_weight` will be used in its attempted execution. If this is less than the"]
-				#[doc = "maximum amount of weight that the message could take to be executed, then no execution"]
-				#[doc = "attempt will be made."]
-				#[doc = ""]
-				#[doc = "NOTE: A successful return to this does *not* imply that the `msg` was executed successfully"]
-				#[doc = "to completion; only that *some* of it was executed."]
-				pub fn execute(
-					&self,
-					message: runtime_types::xcm::VersionedXcm,
-					max_weight: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<Execute> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"execute",
-						Execute { message: ::std::boxed::Box::new(message), max_weight },
-						[
-							102u8, 41u8, 146u8, 29u8, 241u8, 205u8, 95u8, 153u8, 228u8, 141u8,
-							11u8, 228u8, 13u8, 44u8, 75u8, 204u8, 174u8, 35u8, 155u8, 104u8, 204u8,
-							82u8, 239u8, 98u8, 249u8, 187u8, 193u8, 1u8, 122u8, 88u8, 162u8, 200u8,
-						],
-					)
-				}
-				#[doc = "Extoll that a particular destination can be communicated with through a particular"]
-				#[doc = "version of XCM."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be Root."]
-				#[doc = "- `location`: The destination that is being described."]
-				#[doc = "- `xcm_version`: The latest version of XCM that `location` supports."]
-				pub fn force_xcm_version(
-					&self,
-					location: runtime_types::xcm::v3::multilocation::MultiLocation,
-					xcm_version: ::core::primitive::u32,
-				) -> ::subxt::tx::StaticTxPayload<ForceXcmVersion> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"force_xcm_version",
-						ForceXcmVersion { location: ::std::boxed::Box::new(location), xcm_version },
-						[
-							68u8, 48u8, 95u8, 61u8, 152u8, 95u8, 213u8, 126u8, 209u8, 176u8, 230u8,
-							160u8, 164u8, 42u8, 128u8, 62u8, 175u8, 3u8, 161u8, 170u8, 20u8, 31u8,
-							216u8, 122u8, 31u8, 77u8, 64u8, 182u8, 121u8, 41u8, 23u8, 80u8,
-						],
-					)
-				}
-				#[doc = "Set a safe XCM version (the version that XCM should be encoded with if the most recent"]
-				#[doc = "version a destination can accept is unknown)."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be Root."]
-				#[doc = "- `maybe_xcm_version`: The default XCM encoding version, or `None` to disable."]
-				pub fn force_default_xcm_version(
-					&self,
-					maybe_xcm_version: ::core::option::Option<::core::primitive::u32>,
-				) -> ::subxt::tx::StaticTxPayload<ForceDefaultXcmVersion> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"force_default_xcm_version",
-						ForceDefaultXcmVersion { maybe_xcm_version },
-						[
-							38u8, 36u8, 59u8, 231u8, 18u8, 79u8, 76u8, 9u8, 200u8, 125u8, 214u8,
-							166u8, 37u8, 99u8, 111u8, 161u8, 135u8, 2u8, 133u8, 157u8, 165u8, 18u8,
-							152u8, 81u8, 209u8, 255u8, 137u8, 237u8, 28u8, 126u8, 224u8, 141u8,
-						],
-					)
-				}
-				#[doc = "Ask a location to notify us regarding their XCM version and any changes to it."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be Root."]
-				#[doc = "- `location`: The location to which we should subscribe for XCM version notifications."]
-				pub fn force_subscribe_version_notify(
-					&self,
-					location: runtime_types::xcm::VersionedMultiLocation,
-				) -> ::subxt::tx::StaticTxPayload<ForceSubscribeVersionNotify> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"force_subscribe_version_notify",
-						ForceSubscribeVersionNotify { location: ::std::boxed::Box::new(location) },
-						[
-							236u8, 37u8, 153u8, 26u8, 174u8, 187u8, 154u8, 38u8, 179u8, 223u8,
-							130u8, 32u8, 128u8, 30u8, 148u8, 229u8, 7u8, 185u8, 174u8, 9u8, 96u8,
-							215u8, 189u8, 178u8, 148u8, 141u8, 249u8, 118u8, 7u8, 238u8, 1u8, 49u8,
-						],
-					)
-				}
-				#[doc = "Require that a particular destination should no longer notify us regarding any XCM"]
-				#[doc = "version changes."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be Root."]
-				#[doc = "- `location`: The location to which we are currently subscribed for XCM version"]
-				#[doc = "  notifications which we no longer desire."]
-				pub fn force_unsubscribe_version_notify(
-					&self,
-					location: runtime_types::xcm::VersionedMultiLocation,
-				) -> ::subxt::tx::StaticTxPayload<ForceUnsubscribeVersionNotify> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"force_unsubscribe_version_notify",
-						ForceUnsubscribeVersionNotify {
-							location: ::std::boxed::Box::new(location),
-						},
-						[
-							154u8, 169u8, 145u8, 211u8, 185u8, 71u8, 9u8, 63u8, 3u8, 158u8, 187u8,
-							173u8, 115u8, 166u8, 100u8, 66u8, 12u8, 40u8, 198u8, 40u8, 213u8,
-							104u8, 95u8, 183u8, 215u8, 53u8, 94u8, 158u8, 106u8, 56u8, 149u8, 52u8,
-						],
-					)
-				}
-				#[doc = "Transfer some assets from the local chain to the sovereign account of a destination"]
-				#[doc = "chain and forward a notification XCM."]
-				#[doc = ""]
-				#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-				#[doc = "index `fee_asset_item`, up to enough to pay for `weight_limit` of weight. If more weight"]
-				#[doc = "is needed than `weight_limit`, then the operation will fail and the assets send may be"]
-				#[doc = "at risk."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-				#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-				#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-				#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-				#[doc = "  an `AccountId32` value."]
-				#[doc = "- `assets`: The assets to be withdrawn. This should include the assets used to pay the fee on the"]
-				#[doc = "  `dest` side."]
-				#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-				#[doc = "  fees."]
-				#[doc = "- `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase."]
-				pub fn limited_reserve_transfer_assets(
-					&self,
-					dest: runtime_types::xcm::VersionedMultiLocation,
-					beneficiary: runtime_types::xcm::VersionedMultiLocation,
-					assets: runtime_types::xcm::VersionedMultiAssets,
-					fee_asset_item: ::core::primitive::u32,
-					weight_limit: runtime_types::xcm::v3::WeightLimit,
-				) -> ::subxt::tx::StaticTxPayload<LimitedReserveTransferAssets> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"limited_reserve_transfer_assets",
-						LimitedReserveTransferAssets {
-							dest: ::std::boxed::Box::new(dest),
-							beneficiary: ::std::boxed::Box::new(beneficiary),
-							assets: ::std::boxed::Box::new(assets),
-							fee_asset_item,
-							weight_limit,
-						},
-						[
-							131u8, 191u8, 89u8, 27u8, 236u8, 142u8, 130u8, 129u8, 245u8, 95u8,
-							159u8, 96u8, 252u8, 80u8, 28u8, 40u8, 128u8, 55u8, 41u8, 123u8, 22u8,
-							18u8, 0u8, 236u8, 77u8, 68u8, 135u8, 181u8, 40u8, 47u8, 92u8, 240u8,
-						],
-					)
-				}
-				#[doc = "Teleport some assets from the local chain to some destination chain."]
-				#[doc = ""]
-				#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-				#[doc = "index `fee_asset_item`, up to enough to pay for `weight_limit` of weight. If more weight"]
-				#[doc = "is needed than `weight_limit`, then the operation will fail and the assets send may be"]
-				#[doc = "at risk."]
-				#[doc = ""]
-				#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-				#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-				#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-				#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-				#[doc = "  an `AccountId32` value."]
-				#[doc = "- `assets`: The assets to be withdrawn. The first item should be the currency used to to pay the fee on the"]
-				#[doc = "  `dest` side. May not be empty."]
-				#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-				#[doc = "  fees."]
-				#[doc = "- `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase."]
-				pub fn limited_teleport_assets(
-					&self,
-					dest: runtime_types::xcm::VersionedMultiLocation,
-					beneficiary: runtime_types::xcm::VersionedMultiLocation,
-					assets: runtime_types::xcm::VersionedMultiAssets,
-					fee_asset_item: ::core::primitive::u32,
-					weight_limit: runtime_types::xcm::v3::WeightLimit,
-				) -> ::subxt::tx::StaticTxPayload<LimitedTeleportAssets> {
-					::subxt::tx::StaticTxPayload::new(
-						"PolkadotXcm",
-						"limited_teleport_assets",
-						LimitedTeleportAssets {
-							dest: ::std::boxed::Box::new(dest),
-							beneficiary: ::std::boxed::Box::new(beneficiary),
-							assets: ::std::boxed::Box::new(assets),
-							fee_asset_item,
-							weight_limit,
-						},
-						[
-							234u8, 19u8, 104u8, 174u8, 98u8, 159u8, 205u8, 110u8, 240u8, 78u8,
-							186u8, 138u8, 236u8, 116u8, 104u8, 215u8, 57u8, 178u8, 166u8, 208u8,
-							197u8, 113u8, 101u8, 56u8, 23u8, 56u8, 84u8, 14u8, 173u8, 70u8, 211u8,
-							201u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::pallet_xcm::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Execution of an XCM message was attempted."]
-			#[doc = ""]
-			#[doc = "\\[ outcome \\]"]
-			pub struct Attempted(pub runtime_types::xcm::v3::traits::Outcome);
-			impl ::subxt::events::StaticEvent for Attempted {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "Attempted";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A XCM message was sent."]
-			#[doc = ""]
-			#[doc = "\\[ origin, destination, message \\]"]
-			pub struct Sent(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::v3::Xcm,
-			);
-			impl ::subxt::events::StaticEvent for Sent {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "Sent";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Query response received which does not match a registered query. This may be because a"]
-			#[doc = "matching query was never registered, it may be because it is a duplicate response, or"]
-			#[doc = "because the query timed out."]
-			#[doc = ""]
-			#[doc = "\\[ origin location, id \\]"]
-			pub struct UnexpectedResponse(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u64,
-			);
-			impl ::subxt::events::StaticEvent for UnexpectedResponse {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "UnexpectedResponse";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Query response has been received and is ready for taking with `take_response`. There is"]
-			#[doc = "no registered notification call."]
-			#[doc = ""]
-			#[doc = "\\[ id, response \\]"]
-			pub struct ResponseReady(
-				pub ::core::primitive::u64,
-				pub runtime_types::xcm::v3::Response,
-			);
-			impl ::subxt::events::StaticEvent for ResponseReady {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "ResponseReady";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Query response has been received and query is removed. The registered notification has"]
-			#[doc = "been dispatched and executed successfully."]
-			#[doc = ""]
-			#[doc = "\\[ id, pallet index, call index \\]"]
-			pub struct Notified(
-				pub ::core::primitive::u64,
-				pub ::core::primitive::u8,
-				pub ::core::primitive::u8,
-			);
-			impl ::subxt::events::StaticEvent for Notified {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "Notified";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Query response has been received and query is removed. The registered notification could"]
-			#[doc = "not be dispatched because the dispatch weight is greater than the maximum weight"]
-			#[doc = "originally budgeted by this runtime for the query result."]
-			#[doc = ""]
-			#[doc = "\\[ id, pallet index, call index, actual weight, max budgeted weight \\]"]
-			pub struct NotifyOverweight(
-				pub ::core::primitive::u64,
-				pub ::core::primitive::u8,
-				pub ::core::primitive::u8,
-				pub ::sp_weights::Weight,
-				pub ::sp_weights::Weight,
-			);
-			impl ::subxt::events::StaticEvent for NotifyOverweight {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "NotifyOverweight";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Query response has been received and query is removed. There was a general error with"]
-			#[doc = "dispatching the notification call."]
-			#[doc = ""]
-			#[doc = "\\[ id, pallet index, call index \\]"]
-			pub struct NotifyDispatchError(
-				pub ::core::primitive::u64,
-				pub ::core::primitive::u8,
-				pub ::core::primitive::u8,
-			);
-			impl ::subxt::events::StaticEvent for NotifyDispatchError {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "NotifyDispatchError";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Query response has been received and query is removed. The dispatch was unable to be"]
-			#[doc = "decoded into a `Call`; this might be due to dispatch function having a signature which"]
-			#[doc = "is not `(origin, QueryId, Response)`."]
-			#[doc = ""]
-			#[doc = "\\[ id, pallet index, call index \\]"]
-			pub struct NotifyDecodeFailed(
-				pub ::core::primitive::u64,
-				pub ::core::primitive::u8,
-				pub ::core::primitive::u8,
-			);
-			impl ::subxt::events::StaticEvent for NotifyDecodeFailed {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "NotifyDecodeFailed";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Expected query response has been received but the origin location of the response does"]
-			#[doc = "not match that expected. The query remains registered for a later, valid, response to"]
-			#[doc = "be received and acted upon."]
-			#[doc = ""]
-			#[doc = "\\[ origin location, id, expected location \\]"]
-			pub struct InvalidResponder(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u64,
-				pub ::core::option::Option<runtime_types::xcm::v3::multilocation::MultiLocation>,
-			);
-			impl ::subxt::events::StaticEvent for InvalidResponder {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "InvalidResponder";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Expected query response has been received but the expected origin location placed in"]
-			#[doc = "storage by this runtime previously cannot be decoded. The query remains registered."]
-			#[doc = ""]
-			#[doc = "This is unexpected (since a location placed in storage in a previously executing"]
-			#[doc = "runtime should be readable prior to query timeout) and dangerous since the possibly"]
-			#[doc = "valid response will be dropped. Manual governance intervention is probably going to be"]
-			#[doc = "needed."]
-			#[doc = ""]
-			#[doc = "\\[ origin location, id \\]"]
-			pub struct InvalidResponderVersion(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u64,
-			);
-			impl ::subxt::events::StaticEvent for InvalidResponderVersion {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "InvalidResponderVersion";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: CompactAs,
-				:: subxt :: ext :: codec :: Decode,
-				:: subxt :: ext :: codec :: Encode,
-				Clone,
-				Debug,
-			)]
-			#[doc = "Received query response has been read and removed."]
-			#[doc = ""]
-			#[doc = "\\[ id \\]"]
-			pub struct ResponseTaken(pub ::core::primitive::u64);
-			impl ::subxt::events::StaticEvent for ResponseTaken {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "ResponseTaken";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some assets have been placed in an asset trap."]
-			#[doc = ""]
-			#[doc = "\\[ hash, origin, assets \\]"]
-			pub struct AssetsTrapped(
-				pub ::subxt::utils::H256,
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::VersionedMultiAssets,
-			);
-			impl ::subxt::events::StaticEvent for AssetsTrapped {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "AssetsTrapped";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "An XCM version change notification message has been attempted to be sent."]
-			#[doc = ""]
-			#[doc = "The cost of sending it (borne by the chain) is included."]
-			#[doc = ""]
-			#[doc = "\\[ destination, result, cost \\]"]
-			pub struct VersionChangeNotified(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u32,
-				pub runtime_types::xcm::v3::multiasset::MultiAssets,
-			);
-			impl ::subxt::events::StaticEvent for VersionChangeNotified {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "VersionChangeNotified";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "The supported version of a location has been changed. This might be through an"]
-			#[doc = "automatic notification or a manual intervention."]
-			#[doc = ""]
-			#[doc = "\\[ location, XCM version \\]"]
-			pub struct SupportedVersionChanged(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u32,
-			);
-			impl ::subxt::events::StaticEvent for SupportedVersionChanged {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "SupportedVersionChanged";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A given location which had a version change subscription was dropped owing to an error"]
-			#[doc = "sending the notification to it."]
-			#[doc = ""]
-			#[doc = "\\[ location, query ID, error \\]"]
-			pub struct NotifyTargetSendFail(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u64,
-				pub runtime_types::xcm::v3::traits::Error,
-			);
-			impl ::subxt::events::StaticEvent for NotifyTargetSendFail {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "NotifyTargetSendFail";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A given location which had a version change subscription was dropped owing to an error"]
-			#[doc = "migrating the location to our new XCM format."]
-			#[doc = ""]
-			#[doc = "\\[ location, query ID \\]"]
-			pub struct NotifyTargetMigrationFail(
-				pub runtime_types::xcm::VersionedMultiLocation,
-				pub ::core::primitive::u64,
-			);
-			impl ::subxt::events::StaticEvent for NotifyTargetMigrationFail {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "NotifyTargetMigrationFail";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Expected query response has been received but the expected querier location placed in"]
-			#[doc = "storage by this runtime previously cannot be decoded. The query remains registered."]
-			#[doc = ""]
-			#[doc = "This is unexpected (since a location placed in storage in a previously executing"]
-			#[doc = "runtime should be readable prior to query timeout) and dangerous since the possibly"]
-			#[doc = "valid response will be dropped. Manual governance intervention is probably going to be"]
-			#[doc = "needed."]
-			#[doc = ""]
-			#[doc = "\\[ origin location, id \\]"]
-			pub struct InvalidQuerierVersion(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u64,
-			);
-			impl ::subxt::events::StaticEvent for InvalidQuerierVersion {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "InvalidQuerierVersion";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Expected query response has been received but the querier location of the response does"]
-			#[doc = "not match the expected. The query remains registered for a later, valid, response to"]
-			#[doc = "be received and acted upon."]
-			#[doc = ""]
-			#[doc = "\\[ origin location, id, expected querier, maybe actual querier \\]"]
-			pub struct InvalidQuerier(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::primitive::u64,
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub ::core::option::Option<runtime_types::xcm::v3::multilocation::MultiLocation>,
-			);
-			impl ::subxt::events::StaticEvent for InvalidQuerier {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "InvalidQuerier";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "A remote has requested XCM version change notification from us and we have honored it."]
-			#[doc = "A version information message is sent to them and its cost is included."]
-			#[doc = ""]
-			#[doc = "\\[ destination location, cost \\]"]
-			pub struct VersionNotifyStarted(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::v3::multiasset::MultiAssets,
-			);
-			impl ::subxt::events::StaticEvent for VersionNotifyStarted {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "VersionNotifyStarted";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "We have requested that a remote chain sends us XCM version change notifications."]
-			#[doc = ""]
-			#[doc = "\\[ destination location, cost \\]"]
-			pub struct VersionNotifyRequested(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::v3::multiasset::MultiAssets,
-			);
-			impl ::subxt::events::StaticEvent for VersionNotifyRequested {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "VersionNotifyRequested";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "We have requested that a remote chain stops sending us XCM version change notifications."]
-			#[doc = ""]
-			#[doc = "\\[ destination location, cost \\]"]
-			pub struct VersionNotifyUnrequested(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::v3::multiasset::MultiAssets,
-			);
-			impl ::subxt::events::StaticEvent for VersionNotifyUnrequested {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "VersionNotifyUnrequested";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Fees were paid from a location for an operation (often for using `SendXcm`)."]
-			#[doc = ""]
-			#[doc = "\\[ paying location, fees \\]"]
-			pub struct FeesPaid(
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::v3::multiasset::MultiAssets,
-			);
-			impl ::subxt::events::StaticEvent for FeesPaid {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "FeesPaid";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Some assets have been claimed from an asset trap"]
-			#[doc = ""]
-			#[doc = "\\[ hash, origin, assets \\]"]
-			pub struct AssetsClaimed(
-				pub ::subxt::utils::H256,
-				pub runtime_types::xcm::v3::multilocation::MultiLocation,
-				pub runtime_types::xcm::VersionedMultiAssets,
-			);
-			impl ::subxt::events::StaticEvent for AssetsClaimed {
-				const PALLET: &'static str = "PolkadotXcm";
-				const EVENT: &'static str = "AssetsClaimed";
-			}
-		}
-	}
-	pub mod cumulus_xcm {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			pub struct TransactionApi;
-			impl TransactionApi {}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::cumulus_pallet_xcm::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message is invalid XCM."]
-			#[doc = "\\[ id \\]"]
-			pub struct InvalidFormat(pub [::core::primitive::u8; 32usize]);
-			impl ::subxt::events::StaticEvent for InvalidFormat {
-				const PALLET: &'static str = "CumulusXcm";
-				const EVENT: &'static str = "InvalidFormat";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message is unsupported version of XCM."]
-			#[doc = "\\[ id \\]"]
-			pub struct UnsupportedVersion(pub [::core::primitive::u8; 32usize]);
-			impl ::subxt::events::StaticEvent for UnsupportedVersion {
-				const PALLET: &'static str = "CumulusXcm";
-				const EVENT: &'static str = "UnsupportedVersion";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message executed with the given outcome."]
-			#[doc = "\\[ id, outcome \\]"]
-			pub struct ExecutedDownward(
-				pub [::core::primitive::u8; 32usize],
-				pub runtime_types::xcm::v3::traits::Outcome,
-			);
-			impl ::subxt::events::StaticEvent for ExecutedDownward {
-				const PALLET: &'static str = "CumulusXcm";
-				const EVENT: &'static str = "ExecutedDownward";
-			}
-		}
-	}
-	pub mod dmp_queue {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ServiceOverweight {
-				pub index: ::core::primitive::u64,
-				pub weight_limit: ::sp_weights::Weight,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Service a single overweight message."]
-				pub fn service_overweight(
-					&self,
-					index: ::core::primitive::u64,
-					weight_limit: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<ServiceOverweight> {
-					::subxt::tx::StaticTxPayload::new(
-						"DmpQueue",
-						"service_overweight",
-						ServiceOverweight { index, weight_limit },
-						[
-							121u8, 236u8, 235u8, 23u8, 210u8, 238u8, 238u8, 122u8, 15u8, 86u8,
-							34u8, 119u8, 105u8, 100u8, 214u8, 236u8, 117u8, 39u8, 254u8, 235u8,
-							189u8, 15u8, 72u8, 74u8, 225u8, 134u8, 148u8, 126u8, 31u8, 203u8,
-							144u8, 106u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::cumulus_pallet_dmp_queue::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message is invalid XCM."]
-			pub struct InvalidFormat {
-				pub message_id: [::core::primitive::u8; 32usize],
-			}
-			impl ::subxt::events::StaticEvent for InvalidFormat {
-				const PALLET: &'static str = "DmpQueue";
-				const EVENT: &'static str = "InvalidFormat";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message is unsupported version of XCM."]
-			pub struct UnsupportedVersion {
-				pub message_id: [::core::primitive::u8; 32usize],
-			}
-			impl ::subxt::events::StaticEvent for UnsupportedVersion {
-				const PALLET: &'static str = "DmpQueue";
-				const EVENT: &'static str = "UnsupportedVersion";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message executed with the given outcome."]
-			pub struct ExecutedDownward {
-				pub message_id: [::core::primitive::u8; 32usize],
-				pub outcome: runtime_types::xcm::v3::traits::Outcome,
-			}
-			impl ::subxt::events::StaticEvent for ExecutedDownward {
-				const PALLET: &'static str = "DmpQueue";
-				const EVENT: &'static str = "ExecutedDownward";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "The weight limit for handling downward messages was reached."]
-			pub struct WeightExhausted {
-				pub message_id: [::core::primitive::u8; 32usize],
-				pub remaining_weight: ::sp_weights::Weight,
-				pub required_weight: ::sp_weights::Weight,
-			}
-			impl ::subxt::events::StaticEvent for WeightExhausted {
-				const PALLET: &'static str = "DmpQueue";
-				const EVENT: &'static str = "WeightExhausted";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message is overweight and was placed in the overweight queue."]
-			pub struct OverweightEnqueued {
-				pub message_id: [::core::primitive::u8; 32usize],
-				pub overweight_index: ::core::primitive::u64,
-				pub required_weight: ::sp_weights::Weight,
-			}
-			impl ::subxt::events::StaticEvent for OverweightEnqueued {
-				const PALLET: &'static str = "DmpQueue";
-				const EVENT: &'static str = "OverweightEnqueued";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Downward message from the overweight queue was executed."]
-			pub struct OverweightServiced {
-				pub overweight_index: ::core::primitive::u64,
-				pub weight_used: ::sp_weights::Weight,
-			}
-			impl ::subxt::events::StaticEvent for OverweightServiced {
-				const PALLET: &'static str = "DmpQueue";
-				const EVENT: &'static str = "OverweightServiced";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "The maximum number of downward messages was."]
-			pub struct MaxMessagesExhausted {
-				pub message_id: [::core::primitive::u8; 32usize],
-			}
-			impl ::subxt::events::StaticEvent for MaxMessagesExhausted {
-				const PALLET: &'static str = "DmpQueue";
-				const EVENT: &'static str = "MaxMessagesExhausted";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " The configuration."]
-				pub fn configuration(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::cumulus_pallet_dmp_queue::ConfigData,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"DmpQueue",
-						"Configuration",
-						vec![],
-						[
-							133u8, 113u8, 115u8, 164u8, 128u8, 145u8, 234u8, 106u8, 150u8, 54u8,
-							247u8, 135u8, 181u8, 197u8, 178u8, 30u8, 204u8, 46u8, 6u8, 137u8, 82u8,
-							1u8, 75u8, 171u8, 7u8, 157u8, 3u8, 19u8, 92u8, 10u8, 234u8, 66u8,
-						],
-					)
-				}
-				#[doc = " The page index."]
-				pub fn page_index(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::cumulus_pallet_dmp_queue::PageIndexData,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"DmpQueue",
-						"PageIndex",
-						vec![],
-						[
-							94u8, 132u8, 34u8, 67u8, 10u8, 22u8, 235u8, 96u8, 168u8, 26u8, 57u8,
-							200u8, 130u8, 218u8, 37u8, 71u8, 28u8, 119u8, 78u8, 107u8, 209u8,
-							120u8, 190u8, 2u8, 101u8, 215u8, 122u8, 187u8, 94u8, 38u8, 255u8,
-							234u8,
-						],
-					)
-				}
-				#[doc = " The queue pages."]
-				pub fn pages(
-					&self,
-					_0: impl ::std::borrow::Borrow<::core::primitive::u32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<(
-							::core::primitive::u32,
-							::std::vec::Vec<::core::primitive::u8>,
-						)>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"DmpQueue",
-						"Pages",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							228u8, 86u8, 33u8, 107u8, 248u8, 4u8, 223u8, 175u8, 222u8, 25u8, 204u8,
-							42u8, 235u8, 21u8, 215u8, 91u8, 167u8, 14u8, 133u8, 151u8, 190u8, 57u8,
-							138u8, 208u8, 79u8, 244u8, 132u8, 14u8, 48u8, 247u8, 171u8, 108u8,
-						],
-					)
-				}
-				#[doc = " The queue pages."]
-				pub fn pages_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						::std::vec::Vec<(
-							::core::primitive::u32,
-							::std::vec::Vec<::core::primitive::u8>,
-						)>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"DmpQueue",
-						"Pages",
-						Vec::new(),
-						[
-							228u8, 86u8, 33u8, 107u8, 248u8, 4u8, 223u8, 175u8, 222u8, 25u8, 204u8,
-							42u8, 235u8, 21u8, 215u8, 91u8, 167u8, 14u8, 133u8, 151u8, 190u8, 57u8,
-							138u8, 208u8, 79u8, 244u8, 132u8, 14u8, 48u8, 247u8, 171u8, 108u8,
-						],
-					)
-				}
-				#[doc = " The overweight messages."]
-				pub fn overweight(
-					&self,
-					_0: impl ::std::borrow::Borrow<::core::primitive::u64>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<(
-						::core::primitive::u32,
-						::std::vec::Vec<::core::primitive::u8>,
-					)>,
-					::subxt::storage::address::Yes,
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"DmpQueue",
-						"Overweight",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							222u8, 85u8, 143u8, 49u8, 42u8, 248u8, 138u8, 163u8, 46u8, 199u8,
-							188u8, 61u8, 137u8, 135u8, 127u8, 146u8, 210u8, 254u8, 121u8, 42u8,
-							112u8, 114u8, 22u8, 228u8, 207u8, 207u8, 245u8, 175u8, 152u8, 140u8,
-							225u8, 237u8,
-						],
-					)
-				}
-				#[doc = " The overweight messages."]
-				pub fn overweight_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<(
-						::core::primitive::u32,
-						::std::vec::Vec<::core::primitive::u8>,
-					)>,
-					(),
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"DmpQueue",
-						"Overweight",
-						Vec::new(),
-						[
-							222u8, 85u8, 143u8, 49u8, 42u8, 248u8, 138u8, 163u8, 46u8, 199u8,
-							188u8, 61u8, 137u8, 135u8, 127u8, 146u8, 210u8, 254u8, 121u8, 42u8,
-							112u8, 114u8, 22u8, 228u8, 207u8, 207u8, 245u8, 175u8, 152u8, 140u8,
-							225u8, 237u8,
-						],
-					)
-				}
-				#[doc = "Counter for the related counted storage map"]
-				pub fn counter_for_overweight(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"DmpQueue",
-						"CounterForOverweight",
-						vec![],
-						[
-							148u8, 226u8, 248u8, 107u8, 165u8, 97u8, 218u8, 160u8, 127u8, 48u8,
-							185u8, 251u8, 35u8, 137u8, 119u8, 251u8, 151u8, 167u8, 189u8, 66u8,
-							80u8, 74u8, 134u8, 129u8, 222u8, 180u8, 51u8, 182u8, 50u8, 110u8, 10u8,
-							43u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod bridge_relayers {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ClaimRewards {
-				pub rewards_account_params: runtime_types::bp_relayers::RewardsAccountParams,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Claim accumulated rewards."]
-				pub fn claim_rewards(
-					&self,
-					rewards_account_params: runtime_types::bp_relayers::RewardsAccountParams,
-				) -> ::subxt::tx::StaticTxPayload<ClaimRewards> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeRelayers",
-						"claim_rewards",
-						ClaimRewards { rewards_account_params },
-						[
-							141u8, 52u8, 193u8, 42u8, 145u8, 26u8, 147u8, 35u8, 227u8, 221u8,
-							221u8, 188u8, 104u8, 186u8, 123u8, 46u8, 190u8, 236u8, 120u8, 19u8,
-							230u8, 219u8, 238u8, 227u8, 75u8, 35u8, 36u8, 177u8, 227u8, 130u8,
-							103u8, 128u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::pallet_bridge_relayers::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Reward has been paid to the relayer."]
-			pub struct RewardPaid {
-				pub relayer: ::sp_core::crypto::AccountId32,
-				pub rewards_account_params: runtime_types::bp_relayers::RewardsAccountParams,
-				pub reward: ::core::primitive::u128,
-			}
-			impl ::subxt::events::StaticEvent for RewardPaid {
-				const PALLET: &'static str = "BridgeRelayers";
-				const EVENT: &'static str = "RewardPaid";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " Map of the relayer => accumulated reward."]
-				pub fn relayer_rewards(
-					&self,
-					_0: impl ::std::borrow::Borrow<::sp_core::crypto::AccountId32>,
-					_1: impl ::std::borrow::Borrow<runtime_types::bp_relayers::RewardsAccountParams>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u128>,
-					::subxt::storage::address::Yes,
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeRelayers",
-						"RelayerRewards",
-						vec![
-							::subxt::storage::address::StorageMapKey::new(
-								_0.borrow(),
-								::subxt::storage::address::StorageHasher::Blake2_128Concat,
-							),
-							::subxt::storage::address::StorageMapKey::new(
-								_1.borrow(),
-								::subxt::storage::address::StorageHasher::Identity,
-							),
-						],
-						[
-							116u8, 81u8, 48u8, 55u8, 199u8, 26u8, 100u8, 7u8, 177u8, 230u8, 132u8,
-							248u8, 221u8, 90u8, 33u8, 155u8, 198u8, 216u8, 43u8, 149u8, 92u8,
-							100u8, 199u8, 183u8, 150u8, 214u8, 199u8, 222u8, 224u8, 228u8, 238u8,
-							108u8,
-						],
-					)
-				}
-				#[doc = " Map of the relayer => accumulated reward."]
-				pub fn relayer_rewards_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u128>,
-					(),
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeRelayers",
-						"RelayerRewards",
-						Vec::new(),
-						[
-							116u8, 81u8, 48u8, 55u8, 199u8, 26u8, 100u8, 7u8, 177u8, 230u8, 132u8,
-							248u8, 221u8, 90u8, 33u8, 155u8, 198u8, 216u8, 43u8, 149u8, 92u8,
-							100u8, 199u8, 183u8, 150u8, 214u8, 199u8, 222u8, 224u8, 228u8, 238u8,
-							108u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod bridge_millau_grandpa {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SubmitFinalityProof {
-				pub finality_target: ::std::boxed::Box<
-					::sp_runtime::generic::Header<
-						::core::primitive::u64,
-						::bp_millau::BlakeTwoAndKeccak256,
-					>,
-				>,
-				pub justification: ::bp_header_chain::justification::GrandpaJustification<
-					::sp_runtime::generic::Header<
-						::core::primitive::u64,
-						::bp_millau::BlakeTwoAndKeccak256,
-					>,
-				>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct Initialize {
-				pub init_data: ::bp_header_chain::InitializationData<
-					::sp_runtime::generic::Header<
-						::core::primitive::u64,
-						::bp_millau::BlakeTwoAndKeccak256,
-					>,
-				>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetOwner {
-				pub new_owner: ::core::option::Option<::sp_core::crypto::AccountId32>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetOperatingMode {
-				pub operating_mode: runtime_types::bp_runtime::BasicOperatingMode,
-			}
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Verify a target header is finalized according to the given finality proof."]
-				#[doc = ""]
-				#[doc = "It will use the underlying storage pallet to fetch information about the current"]
-				#[doc = "authorities and best finalized header in order to verify that the header is finalized."]
-				#[doc = ""]
-				#[doc = "If successful in verification, it will write the target header to the underlying storage"]
-				#[doc = "pallet."]
-				pub fn submit_finality_proof(
-					&self,
-					finality_target: ::sp_runtime::generic::Header<
-						::core::primitive::u64,
-						::bp_millau::BlakeTwoAndKeccak256,
-					>,
-					justification: ::bp_header_chain::justification::GrandpaJustification<
-						::sp_runtime::generic::Header<
-							::core::primitive::u64,
-							::bp_millau::BlakeTwoAndKeccak256,
-						>,
-					>,
-				) -> ::subxt::tx::StaticTxPayload<SubmitFinalityProof> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauGrandpa",
-						"submit_finality_proof",
-						SubmitFinalityProof {
-							finality_target: ::std::boxed::Box::new(finality_target),
-							justification,
-						},
-						[
-							3u8, 161u8, 243u8, 208u8, 245u8, 135u8, 86u8, 233u8, 103u8, 140u8,
-							81u8, 3u8, 119u8, 185u8, 68u8, 167u8, 208u8, 155u8, 169u8, 201u8,
-							209u8, 248u8, 162u8, 45u8, 155u8, 225u8, 173u8, 62u8, 156u8, 171u8,
-							19u8, 190u8,
-						],
-					)
-				}
-				#[doc = "Bootstrap the bridge pallet with an initial header and authority set from which to sync."]
-				#[doc = ""]
-				#[doc = "The initial configuration provided does not need to be the genesis header of the bridged"]
-				#[doc = "chain, it can be any arbitrary header. You can also provide the next scheduled set"]
-				#[doc = "change if it is already know."]
-				#[doc = ""]
-				#[doc = "This function is only allowed to be called from a trusted origin and writes to storage"]
-				#[doc = "with practically no checks in terms of the validity of the data. It is important that"]
-				#[doc = "you ensure that valid data is being passed in."]
-				pub fn initialize(
-					&self,
-					init_data: ::bp_header_chain::InitializationData<
-						::sp_runtime::generic::Header<
-							::core::primitive::u64,
-							::bp_millau::BlakeTwoAndKeccak256,
-						>,
-					>,
-				) -> ::subxt::tx::StaticTxPayload<Initialize> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauGrandpa",
-						"initialize",
-						Initialize { init_data },
-						[
-							244u8, 188u8, 202u8, 145u8, 218u8, 91u8, 74u8, 80u8, 41u8, 185u8,
-							239u8, 178u8, 231u8, 128u8, 198u8, 90u8, 135u8, 219u8, 200u8, 23u8,
-							194u8, 47u8, 61u8, 222u8, 194u8, 84u8, 142u8, 37u8, 64u8, 37u8, 69u8,
-							198u8,
-						],
-					)
-				}
-				#[doc = "Change `PalletOwner`."]
-				#[doc = ""]
-				#[doc = "May only be called either by root, or by `PalletOwner`."]
-				pub fn set_owner(
-					&self,
-					new_owner: ::core::option::Option<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::tx::StaticTxPayload<SetOwner> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauGrandpa",
-						"set_owner",
-						SetOwner { new_owner },
-						[
-							100u8, 221u8, 84u8, 142u8, 158u8, 5u8, 47u8, 212u8, 9u8, 35u8, 82u8,
-							135u8, 108u8, 238u8, 231u8, 197u8, 77u8, 219u8, 176u8, 222u8, 88u8,
-							167u8, 152u8, 34u8, 177u8, 244u8, 160u8, 195u8, 211u8, 3u8, 66u8,
-							253u8,
-						],
-					)
-				}
-				#[doc = "Halt or resume all pallet operations."]
-				#[doc = ""]
-				#[doc = "May only be called either by root, or by `PalletOwner`."]
-				pub fn set_operating_mode(
-					&self,
-					operating_mode: runtime_types::bp_runtime::BasicOperatingMode,
-				) -> ::subxt::tx::StaticTxPayload<SetOperatingMode> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauGrandpa",
-						"set_operating_mode",
-						SetOperatingMode { operating_mode },
-						[
-							128u8, 25u8, 81u8, 145u8, 111u8, 185u8, 226u8, 152u8, 18u8, 51u8, 89u8,
-							236u8, 200u8, 157u8, 157u8, 186u8, 207u8, 208u8, 152u8, 168u8, 12u8,
-							39u8, 249u8, 48u8, 195u8, 160u8, 54u8, 73u8, 30u8, 230u8, 25u8, 46u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::pallet_bridge_grandpa::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Best finalized chain header has been updated to the header with given number and hash."]
-			pub struct UpdatedBestFinalizedHeader {
-				pub number: ::core::primitive::u64,
-				pub hash: ::bp_millau::MillauHash,
-			}
-			impl ::subxt::events::StaticEvent for UpdatedBestFinalizedHeader {
-				const PALLET: &'static str = "BridgeMillauGrandpa";
-				const EVENT: &'static str = "UpdatedBestFinalizedHeader";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " The current number of requests which have written to storage."]
-				#[doc = ""]
-				#[doc = " If the `RequestCount` hits `MaxRequests`, no more calls will be allowed to the pallet until"]
-				#[doc = " the request capacity is increased."]
-				#[doc = ""]
-				#[doc = " The `RequestCount` is decreased by one at the beginning of every block. This is to ensure"]
-				#[doc = " that the pallet can always make progress."]
-				pub fn request_count(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"RequestCount",
-						vec![],
-						[
-							100u8, 156u8, 98u8, 176u8, 229u8, 85u8, 81u8, 159u8, 120u8, 156u8,
-							33u8, 179u8, 224u8, 237u8, 52u8, 198u8, 81u8, 81u8, 10u8, 180u8, 53u8,
-							141u8, 96u8, 4u8, 39u8, 217u8, 58u8, 9u8, 57u8, 79u8, 47u8, 201u8,
-						],
-					)
-				}
-				#[doc = " Hash of the header used to bootstrap the pallet."]
-				pub fn initial_hash(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::bp_millau::MillauHash>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"InitialHash",
-						vec![],
-						[
-							167u8, 131u8, 64u8, 215u8, 102u8, 70u8, 21u8, 34u8, 254u8, 233u8, 2u8,
-							49u8, 253u8, 67u8, 235u8, 10u8, 21u8, 223u8, 220u8, 198u8, 180u8,
-							137u8, 88u8, 251u8, 230u8, 108u8, 9u8, 104u8, 101u8, 105u8, 38u8,
-							138u8,
-						],
-					)
-				}
-				#[doc = " Hash of the best finalized header."]
-				pub fn best_finalized(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_runtime::HeaderId<
-							::bp_millau::MillauHash,
-							::core::primitive::u64,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"BestFinalized",
-						vec![],
-						[
-							61u8, 173u8, 97u8, 223u8, 180u8, 235u8, 85u8, 126u8, 217u8, 228u8,
-							87u8, 174u8, 116u8, 156u8, 162u8, 252u8, 100u8, 200u8, 138u8, 14u8,
-							102u8, 177u8, 66u8, 164u8, 216u8, 114u8, 18u8, 223u8, 94u8, 78u8,
-							107u8, 58u8,
-						],
-					)
-				}
-				#[doc = " A ring buffer of imported hashes. Ordered by the insertion time."]
-				pub fn imported_hashes(
-					&self,
-					_0: impl ::std::borrow::Borrow<::core::primitive::u32>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::bp_millau::MillauHash>,
-					::subxt::storage::address::Yes,
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"ImportedHashes",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Identity,
-						)],
-						[
-							249u8, 185u8, 202u8, 36u8, 40u8, 197u8, 111u8, 168u8, 136u8, 138u8,
-							84u8, 135u8, 69u8, 34u8, 181u8, 46u8, 158u8, 16u8, 150u8, 190u8, 81u8,
-							53u8, 239u8, 199u8, 83u8, 93u8, 197u8, 205u8, 129u8, 173u8, 141u8,
-							43u8,
-						],
-					)
-				}
-				#[doc = " A ring buffer of imported hashes. Ordered by the insertion time."]
-				pub fn imported_hashes_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::bp_millau::MillauHash>,
-					(),
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"ImportedHashes",
-						Vec::new(),
-						[
-							249u8, 185u8, 202u8, 36u8, 40u8, 197u8, 111u8, 168u8, 136u8, 138u8,
-							84u8, 135u8, 69u8, 34u8, 181u8, 46u8, 158u8, 16u8, 150u8, 190u8, 81u8,
-							53u8, 239u8, 199u8, 83u8, 93u8, 197u8, 205u8, 129u8, 173u8, 141u8,
-							43u8,
-						],
-					)
-				}
-				#[doc = " Current ring buffer position."]
-				pub fn imported_hashes_pointer(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"ImportedHashesPointer",
-						vec![],
-						[
-							159u8, 83u8, 35u8, 45u8, 27u8, 249u8, 155u8, 131u8, 181u8, 196u8,
-							224u8, 26u8, 92u8, 132u8, 127u8, 237u8, 13u8, 142u8, 196u8, 147u8,
-							221u8, 216u8, 11u8, 78u8, 190u8, 241u8, 201u8, 96u8, 74u8, 185u8,
-							208u8, 42u8,
-						],
-					)
-				}
-				#[doc = " Relevant fields of imported headers."]
-				pub fn imported_headers(
-					&self,
-					_0: impl ::std::borrow::Borrow<::bp_millau::MillauHash>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_header_chain::StoredHeaderData<
-							::core::primitive::u64,
-							::bp_millau::MillauHash,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"ImportedHeaders",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Identity,
-						)],
-						[
-							109u8, 41u8, 102u8, 223u8, 133u8, 169u8, 46u8, 221u8, 235u8, 67u8,
-							28u8, 192u8, 2u8, 242u8, 215u8, 166u8, 227u8, 182u8, 136u8, 217u8,
-							61u8, 10u8, 246u8, 70u8, 17u8, 246u8, 223u8, 113u8, 9u8, 136u8, 181u8,
-							242u8,
-						],
-					)
-				}
-				#[doc = " Relevant fields of imported headers."]
-				pub fn imported_headers_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_header_chain::StoredHeaderData<
-							::core::primitive::u64,
-							::bp_millau::MillauHash,
-						>,
-					>,
-					(),
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"ImportedHeaders",
-						Vec::new(),
-						[
-							109u8, 41u8, 102u8, 223u8, 133u8, 169u8, 46u8, 221u8, 235u8, 67u8,
-							28u8, 192u8, 2u8, 242u8, 215u8, 166u8, 227u8, 182u8, 136u8, 217u8,
-							61u8, 10u8, 246u8, 70u8, 17u8, 246u8, 223u8, 113u8, 9u8, 136u8, 181u8,
-							242u8,
-						],
-					)
-				}
-				#[doc = " The current GRANDPA Authority set."]
-				pub fn current_authority_set(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::pallet_bridge_grandpa::storage_types::StoredAuthoritySet,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"CurrentAuthoritySet",
-						vec![],
-						[
-							249u8, 40u8, 229u8, 120u8, 141u8, 219u8, 206u8, 5u8, 54u8, 121u8,
-							207u8, 77u8, 8u8, 80u8, 105u8, 107u8, 151u8, 111u8, 82u8, 119u8, 8u8,
-							31u8, 104u8, 82u8, 92u8, 156u8, 37u8, 160u8, 235u8, 64u8, 62u8, 94u8,
-						],
-					)
-				}
-				#[doc = " Optional pallet owner."]
-				#[doc = ""]
-				#[doc = " Pallet owner has a right to halt all pallet operations and then resume it. If it is"]
-				#[doc = " `None`, then there are no direct ways to halt/resume pallet operations, but other"]
-				#[doc = " runtime methods may still be used to do that (i.e. democracy::referendum to update halt"]
-				#[doc = " flag directly or call the `halt_operations`)."]
-				pub fn pallet_owner(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::sp_core::crypto::AccountId32>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"PalletOwner",
-						vec![],
-						[
-							89u8, 42u8, 74u8, 119u8, 21u8, 164u8, 30u8, 115u8, 207u8, 126u8, 98u8,
-							16u8, 162u8, 214u8, 67u8, 172u8, 178u8, 223u8, 139u8, 121u8, 174u8,
-							89u8, 215u8, 75u8, 200u8, 161u8, 61u8, 195u8, 65u8, 222u8, 246u8,
-							233u8,
-						],
-					)
-				}
-				#[doc = " The current operating mode of the pallet."]
-				#[doc = ""]
-				#[doc = " Depending on the mode either all, or no transactions will be allowed."]
-				pub fn pallet_operating_mode(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_runtime::BasicOperatingMode,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauGrandpa",
-						"PalletOperatingMode",
-						vec![],
-						[
-							218u8, 66u8, 212u8, 71u8, 38u8, 152u8, 55u8, 129u8, 125u8, 231u8, 91u8,
-							216u8, 157u8, 141u8, 173u8, 146u8, 30u8, 40u8, 132u8, 107u8, 97u8,
-							39u8, 36u8, 81u8, 231u8, 222u8, 113u8, 136u8, 233u8, 212u8, 225u8,
-							75u8,
-						],
-					)
-				}
-			}
-		}
-		pub mod constants {
-			use super::runtime_types;
-			pub struct ConstantsApi;
-			impl ConstantsApi {
-				#[doc = " The upper bound on the number of requests allowed by the pallet."]
-				#[doc = ""]
-				#[doc = " A request refers to an action which writes a header to storage."]
-				#[doc = ""]
-				#[doc = " Once this bound is reached the pallet will not allow any dispatchables to be called"]
-				#[doc = " until the request count has decreased."]
-				pub fn max_requests(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"BridgeMillauGrandpa",
-						"MaxRequests",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-				#[doc = " Maximal number of finalized headers to keep in the storage."]
-				#[doc = ""]
-				#[doc = " The setting is there to prevent growing the on-chain state indefinitely. Note"]
-				#[doc = " the setting does not relate to block numbers - we will simply keep as much items"]
-				#[doc = " in the storage, so it doesn't guarantee any fixed timeframe for finality headers."]
-				#[doc = ""]
-				#[doc = " Incautious change of this constant may lead to orphan entries in the runtime storage."]
-				pub fn headers_to_keep(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"BridgeMillauGrandpa",
-						"HeadersToKeep",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-			}
-		}
-	}
-	pub mod bridge_millau_messages {
-		use super::{root_mod, runtime_types};
-		#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
-		pub mod calls {
-			use super::{root_mod, runtime_types};
-			type DispatchError = runtime_types::sp_runtime::DispatchError;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetOwner {
-				pub new_owner: ::core::option::Option<::sp_core::crypto::AccountId32>,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct SetOperatingMode {
-				pub operating_mode: runtime_types::bp_messages::MessagesOperatingMode,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ReceiveMessagesProof {
-				pub relayer_id_at_bridged_chain: ::sp_core::crypto::AccountId32,
-				pub proof: ::bridge_runtime_common::messages::target::FromBridgedChainMessagesProof<
-					::bp_millau::MillauHash,
-				>,
-				pub messages_count: ::core::primitive::u32,
-				pub dispatch_weight: ::sp_weights::Weight,
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			pub struct ReceiveMessagesDeliveryProof { pub proof : :: bridge_runtime_common :: messages :: source :: FromBridgedChainMessagesDeliveryProof < :: bp_millau :: MillauHash > , pub relayers_state : :: bp_messages :: UnrewardedRelayersState , }
-			pub struct TransactionApi;
-			impl TransactionApi {
-				#[doc = "Change `PalletOwner`."]
-				#[doc = ""]
-				#[doc = "May only be called either by root, or by `PalletOwner`."]
-				pub fn set_owner(
-					&self,
-					new_owner: ::core::option::Option<::sp_core::crypto::AccountId32>,
-				) -> ::subxt::tx::StaticTxPayload<SetOwner> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauMessages",
-						"set_owner",
-						SetOwner { new_owner },
-						[
-							100u8, 221u8, 84u8, 142u8, 158u8, 5u8, 47u8, 212u8, 9u8, 35u8, 82u8,
-							135u8, 108u8, 238u8, 231u8, 197u8, 77u8, 219u8, 176u8, 222u8, 88u8,
-							167u8, 152u8, 34u8, 177u8, 244u8, 160u8, 195u8, 211u8, 3u8, 66u8,
-							253u8,
-						],
-					)
-				}
-				#[doc = "Halt or resume all/some pallet operations."]
-				#[doc = ""]
-				#[doc = "May only be called either by root, or by `PalletOwner`."]
-				pub fn set_operating_mode(
-					&self,
-					operating_mode: runtime_types::bp_messages::MessagesOperatingMode,
-				) -> ::subxt::tx::StaticTxPayload<SetOperatingMode> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauMessages",
-						"set_operating_mode",
-						SetOperatingMode { operating_mode },
-						[
-							236u8, 230u8, 127u8, 17u8, 145u8, 186u8, 102u8, 200u8, 227u8, 208u8,
-							230u8, 121u8, 102u8, 199u8, 123u8, 118u8, 199u8, 160u8, 131u8, 116u8,
-							102u8, 167u8, 119u8, 144u8, 70u8, 114u8, 0u8, 223u8, 54u8, 197u8, 39u8,
-							58u8,
-						],
-					)
-				}
-				#[doc = "Receive messages proof from bridged chain."]
-				#[doc = ""]
-				#[doc = "The weight of the call assumes that the transaction always brings outbound lane"]
-				#[doc = "state update. Because of that, the submitter (relayer) has no benefit of not including"]
-				#[doc = "this data in the transaction, so reward confirmations lags should be minimal."]
-				pub fn receive_messages_proof(
-					&self,
-					relayer_id_at_bridged_chain: ::sp_core::crypto::AccountId32,
-					proof: ::bridge_runtime_common::messages::target::FromBridgedChainMessagesProof<
-						::bp_millau::MillauHash,
-					>,
-					messages_count: ::core::primitive::u32,
-					dispatch_weight: ::sp_weights::Weight,
-				) -> ::subxt::tx::StaticTxPayload<ReceiveMessagesProof> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauMessages",
-						"receive_messages_proof",
-						ReceiveMessagesProof {
-							relayer_id_at_bridged_chain,
-							proof,
-							messages_count,
-							dispatch_weight,
-						},
-						[
-							14u8, 23u8, 191u8, 242u8, 252u8, 163u8, 87u8, 149u8, 211u8, 25u8,
-							112u8, 192u8, 206u8, 49u8, 135u8, 124u8, 79u8, 92u8, 204u8, 39u8, 80u8,
-							139u8, 155u8, 124u8, 134u8, 1u8, 66u8, 68u8, 213u8, 85u8, 42u8, 250u8,
-						],
-					)
-				}
-				#[doc = "Receive messages delivery proof from bridged chain."]
-				pub fn receive_messages_delivery_proof(
-					&self,
-					proof : :: bridge_runtime_common :: messages :: source :: FromBridgedChainMessagesDeliveryProof < :: bp_millau :: MillauHash >,
-					relayers_state: ::bp_messages::UnrewardedRelayersState,
-				) -> ::subxt::tx::StaticTxPayload<ReceiveMessagesDeliveryProof> {
-					::subxt::tx::StaticTxPayload::new(
-						"BridgeMillauMessages",
-						"receive_messages_delivery_proof",
-						ReceiveMessagesDeliveryProof { proof, relayers_state },
-						[
-							216u8, 113u8, 64u8, 20u8, 16u8, 64u8, 144u8, 143u8, 105u8, 30u8, 192u8,
-							89u8, 74u8, 34u8, 56u8, 151u8, 20u8, 234u8, 14u8, 211u8, 64u8, 103u8,
-							218u8, 164u8, 69u8, 107u8, 6u8, 119u8, 13u8, 90u8, 150u8, 24u8,
-						],
-					)
-				}
-			}
-		}
-		#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
-		pub type Event = runtime_types::pallet_bridge_messages::pallet::Event;
-		pub mod events {
-			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Message has been accepted and is waiting to be delivered."]
-			pub struct MessageAccepted {
-				pub lane_id: runtime_types::bp_messages::LaneId,
-				pub nonce: ::core::primitive::u64,
-			}
-			impl ::subxt::events::StaticEvent for MessageAccepted {
-				const PALLET: &'static str = "BridgeMillauMessages";
-				const EVENT: &'static str = "MessageAccepted";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Messages have been received from the bridged chain."]
-			pub struct MessagesReceived (pub :: std :: vec :: Vec < runtime_types :: bp_messages :: ReceivedMessages < runtime_types :: bridge_runtime_common :: messages_xcm_extension :: XcmBlobMessageDispatchResult > > ,) ;
-			impl ::subxt::events::StaticEvent for MessagesReceived {
-				const PALLET: &'static str = "BridgeMillauMessages";
-				const EVENT: &'static str = "MessagesReceived";
-			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
-			#[doc = "Messages in the inclusive range have been delivered to the bridged chain."]
-			pub struct MessagesDelivered {
-				pub lane_id: runtime_types::bp_messages::LaneId,
-				pub messages: runtime_types::bp_messages::DeliveredMessages,
-			}
-			impl ::subxt::events::StaticEvent for MessagesDelivered {
-				const PALLET: &'static str = "BridgeMillauMessages";
-				const EVENT: &'static str = "MessagesDelivered";
-			}
-		}
-		pub mod storage {
-			use super::runtime_types;
-			pub struct StorageApi;
-			impl StorageApi {
-				#[doc = " Optional pallet owner."]
-				#[doc = ""]
-				#[doc = " Pallet owner has a right to halt all pallet operations and then resume it. If it is"]
-				#[doc = " `None`, then there are no direct ways to halt/resume pallet operations, but other"]
-				#[doc = " runtime methods may still be used to do that (i.e. democracy::referendum to update halt"]
-				#[doc = " flag directly or call the `halt_operations`)."]
-				pub fn pallet_owner(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<::sp_core::crypto::AccountId32>,
-					::subxt::storage::address::Yes,
-					(),
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"PalletOwner",
-						vec![],
-						[
-							89u8, 42u8, 74u8, 119u8, 21u8, 164u8, 30u8, 115u8, 207u8, 126u8, 98u8,
-							16u8, 162u8, 214u8, 67u8, 172u8, 178u8, 223u8, 139u8, 121u8, 174u8,
-							89u8, 215u8, 75u8, 200u8, 161u8, 61u8, 195u8, 65u8, 222u8, 246u8,
-							233u8,
-						],
-					)
-				}
-				#[doc = " The current operating mode of the pallet."]
-				#[doc = ""]
-				#[doc = " Depending on the mode either all, some, or no transactions will be allowed."]
-				pub fn pallet_operating_mode(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_messages::MessagesOperatingMode,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					(),
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"PalletOperatingMode",
-						vec![],
-						[
-							215u8, 195u8, 85u8, 231u8, 158u8, 22u8, 160u8, 132u8, 69u8, 206u8,
-							238u8, 14u8, 56u8, 100u8, 134u8, 41u8, 58u8, 120u8, 225u8, 164u8,
-							173u8, 87u8, 22u8, 123u8, 102u8, 167u8, 68u8, 70u8, 184u8, 131u8,
-							232u8, 65u8,
-						],
-					)
-				}
-				#[doc = " Map of lane id => inbound lane data."]
-				pub fn inbound_lanes(
-					&self,
-					_0: impl ::std::borrow::Borrow<runtime_types::bp_messages::LaneId>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_messages::InboundLaneData<::sp_core::crypto::AccountId32>,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"InboundLanes",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							38u8, 58u8, 110u8, 130u8, 112u8, 76u8, 231u8, 76u8, 56u8, 241u8, 183u8,
-							153u8, 112u8, 41u8, 248u8, 208u8, 217u8, 57u8, 102u8, 30u8, 107u8,
-							98u8, 59u8, 78u8, 56u8, 119u8, 186u8, 183u8, 213u8, 72u8, 199u8, 90u8,
-						],
-					)
-				}
-				#[doc = " Map of lane id => inbound lane data."]
-				pub fn inbound_lanes_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_messages::InboundLaneData<::sp_core::crypto::AccountId32>,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"InboundLanes",
-						Vec::new(),
-						[
-							38u8, 58u8, 110u8, 130u8, 112u8, 76u8, 231u8, 76u8, 56u8, 241u8, 183u8,
-							153u8, 112u8, 41u8, 248u8, 208u8, 217u8, 57u8, 102u8, 30u8, 107u8,
-							98u8, 59u8, 78u8, 56u8, 119u8, 186u8, 183u8, 213u8, 72u8, 199u8, 90u8,
-						],
-					)
-				}
-				#[doc = " Map of lane id => outbound lane data."]
-				pub fn outbound_lanes(
-					&self,
-					_0: impl ::std::borrow::Borrow<runtime_types::bp_messages::LaneId>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_messages::OutboundLaneData,
-					>,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"OutboundLanes",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							67u8, 155u8, 173u8, 244u8, 80u8, 38u8, 26u8, 71u8, 51u8, 150u8, 86u8,
-							146u8, 132u8, 122u8, 70u8, 122u8, 172u8, 246u8, 106u8, 232u8, 149u8,
-							227u8, 240u8, 146u8, 51u8, 184u8, 30u8, 182u8, 200u8, 43u8, 190u8,
-							38u8,
-						],
-					)
-				}
-				#[doc = " Map of lane id => outbound lane data."]
-				pub fn outbound_lanes_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bp_messages::OutboundLaneData,
-					>,
-					(),
-					::subxt::storage::address::Yes,
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"OutboundLanes",
-						Vec::new(),
-						[
-							67u8, 155u8, 173u8, 244u8, 80u8, 38u8, 26u8, 71u8, 51u8, 150u8, 86u8,
-							146u8, 132u8, 122u8, 70u8, 122u8, 172u8, 246u8, 106u8, 232u8, 149u8,
-							227u8, 240u8, 146u8, 51u8, 184u8, 30u8, 182u8, 200u8, 43u8, 190u8,
-							38u8,
-						],
-					)
-				}
-				#[doc = " All queued outbound messages."]
-				pub fn outbound_messages(
-					&self,
-					_0: impl ::std::borrow::Borrow<runtime_types::bp_messages::MessageKey>,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							::core::primitive::u8,
-						>,
-					>,
-					::subxt::storage::address::Yes,
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"OutboundMessages",
-						vec![::subxt::storage::address::StorageMapKey::new(
-							_0.borrow(),
-							::subxt::storage::address::StorageHasher::Blake2_128Concat,
-						)],
-						[
-							44u8, 35u8, 2u8, 25u8, 91u8, 101u8, 152u8, 23u8, 48u8, 250u8, 178u8,
-							15u8, 194u8, 118u8, 146u8, 1u8, 112u8, 83u8, 243u8, 166u8, 124u8,
-							153u8, 48u8, 193u8, 43u8, 31u8, 33u8, 72u8, 228u8, 113u8, 86u8, 217u8,
-						],
-					)
-				}
-				#[doc = " All queued outbound messages."]
-				pub fn outbound_messages_root(
-					&self,
-				) -> ::subxt::storage::address::StaticStorageAddress<
-					::subxt::metadata::DecodeStaticType<
-						runtime_types::bounded_collections::bounded_vec::BoundedVec<
-							::core::primitive::u8,
-						>,
-					>,
-					(),
-					(),
-					::subxt::storage::address::Yes,
-				> {
-					::subxt::storage::address::StaticStorageAddress::new(
-						"BridgeMillauMessages",
-						"OutboundMessages",
-						Vec::new(),
-						[
-							44u8, 35u8, 2u8, 25u8, 91u8, 101u8, 152u8, 23u8, 48u8, 250u8, 178u8,
-							15u8, 194u8, 118u8, 146u8, 1u8, 112u8, 83u8, 243u8, 166u8, 124u8,
-							153u8, 48u8, 193u8, 43u8, 31u8, 33u8, 72u8, 228u8, 113u8, 86u8, 217u8,
-						],
-					)
-				}
-			}
-		}
-		pub mod constants {
-			use super::runtime_types;
-			pub struct ConstantsApi;
-			impl ConstantsApi {
-				#[doc = " Gets the chain id value from the instance."]
-				pub fn bridged_chain_id(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<[::core::primitive::u8; 4usize]>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"BridgeMillauMessages",
-						"BridgedChainId",
-						[
-							101u8, 157u8, 37u8, 163u8, 190u8, 134u8, 129u8, 212u8, 240u8, 135u8,
-							174u8, 76u8, 220u8, 179u8, 252u8, 69u8, 65u8, 253u8, 69u8, 214u8, 61u8,
-							249u8, 4u8, 38u8, 181u8, 237u8, 25u8, 131u8, 242u8, 20u8, 17u8, 152u8,
-						],
-					)
-				}
-				#[doc = " Maximal encoded size of the outbound payload."]
-				pub fn maximal_outbound_payload_size(
-					&self,
-				) -> ::subxt::constants::StaticConstantAddress<
-					::subxt::metadata::DecodeStaticType<::core::primitive::u32>,
-				> {
-					::subxt::constants::StaticConstantAddress::new(
-						"BridgeMillauMessages",
-						"MaximalOutboundPayloadSize",
-						[
-							98u8, 252u8, 116u8, 72u8, 26u8, 180u8, 225u8, 83u8, 200u8, 157u8,
-							125u8, 151u8, 53u8, 76u8, 168u8, 26u8, 10u8, 9u8, 98u8, 68u8, 9u8,
-							178u8, 197u8, 113u8, 31u8, 79u8, 200u8, 90u8, 203u8, 100u8, 41u8,
-							145u8,
-						],
-					)
-				}
-			}
-		}
-	}
 	pub mod runtime_types {
 		use super::runtime_types;
 		pub mod bounded_collections {
 			use super::runtime_types;
 			pub mod bounded_vec {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct BoundedVec<_0>(pub ::std::vec::Vec<_0>);
 			}
 			pub mod weak_bounded_vec {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct WeakBoundedVec<_0>(pub ::std::vec::Vec<_0>);
 			}
 		}
 		pub mod bp_header_chain {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct StoredHeaderData<_0, _1> {
 				pub number: _0,
 				pub state_root: _1,
@@ -5979,51 +47,37 @@ pub mod api {
 		}
 		pub mod bp_messages {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct DeliveredMessages {
 				pub begin: ::core::primitive::u64,
 				pub end: ::core::primitive::u64,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct InboundLaneData<_0> {
 				pub relayers: ::std::vec::Vec<runtime_types::bp_messages::UnrewardedRelayer<_0>>,
 				pub last_confirmed_nonce: ::core::primitive::u64,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct LaneId(pub [::core::primitive::u8; 4usize]);
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct MessageKey {
 				pub lane_id: runtime_types::bp_messages::LaneId,
 				pub nonce: ::core::primitive::u64,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum MessagesOperatingMode {
 				#[codec(index = 0)]
 				Basic(runtime_types::bp_runtime::BasicOperatingMode),
 				#[codec(index = 1)]
 				RejectingOutboundMessages,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct OutboundLaneData {
 				pub oldest_unpruned_nonce: ::core::primitive::u64,
 				pub latest_received_nonce: ::core::primitive::u64,
 				pub latest_generated_nonce: ::core::primitive::u64,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum ReceivalResult<_0> {
 				#[codec(index = 0)]
 				Dispatched(runtime_types::bp_runtime::messages::MessageDispatchResult<_0>),
@@ -6034,9 +88,7 @@ pub mod api {
 				#[codec(index = 3)]
 				TooManyUnconfirmedMessages,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct ReceivedMessages<_0> {
 				pub lane: runtime_types::bp_messages::LaneId,
 				pub receive_results: ::std::vec::Vec<(
@@ -6044,9 +96,7 @@ pub mod api {
 					runtime_types::bp_messages::ReceivalResult<_0>,
 				)>,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct UnrewardedRelayer<_0> {
 				pub relayer: _0,
 				pub messages: runtime_types::bp_messages::DeliveredMessages,
@@ -6054,18 +104,14 @@ pub mod api {
 		}
 		pub mod bp_relayers {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum RewardsAccountOwner {
 				#[codec(index = 0)]
 				ThisChain,
 				#[codec(index = 1)]
 				BridgedChain,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct RewardsAccountParams {
 				pub lane_id: runtime_types::bp_messages::LaneId,
 				pub bridged_chain_id: [::core::primitive::u8; 4usize],
@@ -6076,33 +122,22 @@ pub mod api {
 			use super::runtime_types;
 			pub mod messages {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct MessageDispatchResult<_0> {
 					pub unspent_weight: ::sp_weights::Weight,
 					pub dispatch_level_result: _0,
 				}
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum BasicOperatingMode {
 				#[codec(index = 0)]
 				Normal,
 				#[codec(index = 1)]
 				Halted,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct HeaderId<_0, _1>(pub _1, pub _0);
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum OwnedBridgeModuleError {
 				#[codec(index = 0)]
 				Halted,
@@ -6112,12 +147,7 @@ pub mod api {
 			use super::runtime_types;
 			pub mod messages_xcm_extension {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum XcmBlobMessageDispatchResult {
 					#[codec(index = 0)]
 					InvalidPayload,
@@ -6132,90 +162,58 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Service a single overweight message."]
 					service_overweight {
 						index: ::core::primitive::u64,
 						weight_limit: ::sp_weights::Weight,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "The message index given is unknown."]
 					Unknown,
 					#[codec(index = 1)]
-					#[doc = "The amount of weight given is possibly not enough for executing the message."]
 					OverLimit,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "Downward message is invalid XCM."]
 					InvalidFormat { message_id: [::core::primitive::u8; 32usize] },
 					#[codec(index = 1)]
-					#[doc = "Downward message is unsupported version of XCM."]
 					UnsupportedVersion { message_id: [::core::primitive::u8; 32usize] },
 					#[codec(index = 2)]
-					#[doc = "Downward message executed with the given outcome."]
 					ExecutedDownward {
 						message_id: [::core::primitive::u8; 32usize],
 						outcome: runtime_types::xcm::v3::traits::Outcome,
 					},
 					#[codec(index = 3)]
-					#[doc = "The weight limit for handling downward messages was reached."]
 					WeightExhausted {
 						message_id: [::core::primitive::u8; 32usize],
 						remaining_weight: ::sp_weights::Weight,
 						required_weight: ::sp_weights::Weight,
 					},
 					#[codec(index = 4)]
-					#[doc = "Downward message is overweight and was placed in the overweight queue."]
 					OverweightEnqueued {
 						message_id: [::core::primitive::u8; 32usize],
 						overweight_index: ::core::primitive::u64,
 						required_weight: ::sp_weights::Weight,
 					},
 					#[codec(index = 5)]
-					#[doc = "Downward message from the overweight queue was executed."]
 					OverweightServiced {
 						overweight_index: ::core::primitive::u64,
 						weight_used: ::sp_weights::Weight,
 					},
 					#[codec(index = 6)]
-					#[doc = "The maximum number of downward messages was."]
 					MaxMessagesExhausted { message_id: [::core::primitive::u8; 32usize] },
 				}
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct ConfigData {
 				pub max_individual: ::sp_weights::Weight,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct PageIndexData {
 				pub begin_used: ::core::primitive::u32,
 				pub end_used: ::core::primitive::u32,
@@ -6226,80 +224,46 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
-					# [codec (index = 0)] # [doc = "Set the current validation data."] # [doc = ""] # [doc = "This should be invoked exactly once per block. It will panic at the finalization"] # [doc = "phase if the call was not invoked."] # [doc = ""] # [doc = "The dispatch origin for this call must be `Inherent`"] # [doc = ""] # [doc = "As a side effect, this function upgrades the current validation function"] # [doc = "if the appropriate time has come."] set_validation_data { data : runtime_types :: cumulus_primitives_parachain_inherent :: ParachainInherentData , } , # [codec (index = 1)] sudo_send_upward_message { message : :: std :: vec :: Vec < :: core :: primitive :: u8 > , } , # [codec (index = 2)] # [doc = "Authorize an upgrade to a given `code_hash` for the runtime. The runtime can be supplied"] # [doc = "later."] # [doc = ""] # [doc = "The `check_version` parameter sets a boolean flag for whether or not the runtime's spec"] # [doc = "version and name should be verified on upgrade. Since the authorization only has a hash,"] # [doc = "it cannot actually perform the verification."] # [doc = ""] # [doc = "This call requires Root origin."] authorize_upgrade { code_hash : :: subxt :: utils :: H256 , check_version : :: core :: primitive :: bool , } , # [codec (index = 3)] # [doc = "Provide the preimage (runtime binary) `code` for an upgrade that has been authorized."] # [doc = ""] # [doc = "If the authorization required a version check, this call will ensure the spec name"] # [doc = "remains unchanged and that the spec version has increased."] # [doc = ""] # [doc = "Note that this function will not apply the new `code`, but only attempt to schedule the"] # [doc = "upgrade with the Relay Chain."] # [doc = ""] # [doc = "All origins are allowed."] enact_authorized_upgrade { code : :: std :: vec :: Vec < :: core :: primitive :: u8 > , } , }
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+					# [codec (index = 0)] set_validation_data { data : runtime_types :: cumulus_primitives_parachain_inherent :: ParachainInherentData , } , # [codec (index = 1)] sudo_send_upward_message { message : :: std :: vec :: Vec < :: core :: primitive :: u8 > , } , # [codec (index = 2)] authorize_upgrade { code_hash : :: subxt :: utils :: H256 , check_version : :: core :: primitive :: bool , } , # [codec (index = 3)] enact_authorized_upgrade { code : :: std :: vec :: Vec < :: core :: primitive :: u8 > , } , }
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "Attempt to upgrade validation function while existing upgrade pending."]
 					OverlappingUpgrades,
 					#[codec(index = 1)]
-					#[doc = "Polkadot currently prohibits this parachain from upgrading its validation function."]
 					ProhibitedByPolkadot,
 					#[codec(index = 2)]
-					#[doc = "The supplied validation function has compiled into a blob larger than Polkadot is"]
-					#[doc = "willing to run."]
 					TooBig,
 					#[codec(index = 3)]
-					#[doc = "The inherent which supplies the validation data did not run this block."]
 					ValidationDataNotAvailable,
 					#[codec(index = 4)]
-					#[doc = "The inherent which supplies the host configuration did not run this block."]
 					HostConfigurationNotAvailable,
 					#[codec(index = 5)]
-					#[doc = "No validation function upgrade is currently scheduled."]
 					NotScheduled,
 					#[codec(index = 6)]
-					#[doc = "No code upgrade has been authorized."]
 					NothingAuthorized,
 					#[codec(index = 7)]
-					#[doc = "The given code upgrade has not been authorized."]
 					Unauthorized,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "The validation function has been scheduled to apply."]
 					ValidationFunctionStored,
 					#[codec(index = 1)]
-					#[doc = "The validation function was applied as of the contained relay chain block number."]
 					ValidationFunctionApplied { relay_chain_block_num: ::core::primitive::u32 },
 					#[codec(index = 2)]
-					#[doc = "The relay-chain aborted the upgrade process."]
 					ValidationFunctionDiscarded,
 					#[codec(index = 3)]
-					#[doc = "An upgrade has been authorized."]
 					UpgradeAuthorized { code_hash: ::subxt::utils::H256 },
 					#[codec(index = 4)]
-					#[doc = "Some downward messages have been received and will be processed."]
 					DownwardMessagesReceived { count: ::core::primitive::u32 },
 					#[codec(index = 5)]
-					#[doc = "Downward messages were processed using the given weight."]
 					DownwardMessagesProcessed {
 						weight_used: ::sp_weights::Weight,
 						dmq_head: ::subxt::utils::H256,
 					},
 					#[codec(index = 6)]
-					#[doc = "An upward message was sent to the relay chain."]
 					UpwardMessageSent {
 						message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
 					},
@@ -6307,12 +271,7 @@ pub mod api {
 			}
 			pub mod relay_state_snapshot {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct MessagingStateSnapshot {
 					pub dmq_mqc_head: ::subxt::utils::H256,
 					pub relay_dispatch_queue_size: (::core::primitive::u32, ::core::primitive::u32),
@@ -6326,9 +285,7 @@ pub mod api {
 					)>,
 				}
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct CodeUpgradeAuthorization {
 				pub code_hash: ::subxt::utils::H256,
 				pub check_version: ::core::primitive::bool,
@@ -6338,41 +295,17 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "Downward message is invalid XCM."]
-					#[doc = "\\[ id \\]"]
 					InvalidFormat([::core::primitive::u8; 32usize]),
 					#[codec(index = 1)]
-					#[doc = "Downward message is unsupported version of XCM."]
-					#[doc = "\\[ id \\]"]
 					UnsupportedVersion([::core::primitive::u8; 32usize]),
 					#[codec(index = 2)]
-					#[doc = "Downward message executed with the given outcome."]
-					#[doc = "\\[ id, outcome \\]"]
 					ExecutedDownward(
 						[::core::primitive::u8; 32usize],
 						runtime_types::xcm::v3::traits::Outcome,
@@ -6384,148 +317,69 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Services a single overweight XCM."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `ExecuteOverweightOrigin`."]
-					#[doc = "- `index`: The index of the overweight XCM to service"]
-					#[doc = "- `weight_limit`: The amount of weight that XCM execution may take."]
-					#[doc = ""]
-					#[doc = "Errors:"]
-					#[doc = "- `BadOverweightIndex`: XCM under `index` is not found in the `Overweight` storage map."]
-					#[doc = "- `BadXcm`: XCM under `index` cannot be properly decoded into a valid XCM format."]
-					#[doc = "- `WeightOverLimit`: XCM execution may use greater `weight_limit`."]
-					#[doc = ""]
-					#[doc = "Events:"]
-					#[doc = "- `OverweightServiced`: On success."]
 					service_overweight {
 						index: ::core::primitive::u64,
 						weight_limit: ::sp_weights::Weight,
 					},
 					#[codec(index = 1)]
-					#[doc = "Suspends all XCM executions for the XCMP queue, regardless of the sender's origin."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `ControllerOrigin`."]
 					suspend_xcm_execution,
 					#[codec(index = 2)]
-					#[doc = "Resumes all XCM executions for the XCMP queue."]
-					#[doc = ""]
-					#[doc = "Note that this function doesn't change the status of the in/out bound channels."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `ControllerOrigin`."]
 					resume_xcm_execution,
 					#[codec(index = 3)]
-					#[doc = "Overwrites the number of pages of messages which must be in the queue for the other side to be told to"]
-					#[doc = "suspend their sending."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `Root`."]
-					#[doc = "- `new`: Desired value for `QueueConfigData.suspend_value`"]
 					update_suspend_threshold { new: ::core::primitive::u32 },
 					#[codec(index = 4)]
-					#[doc = "Overwrites the number of pages of messages which must be in the queue after which we drop any further"]
-					#[doc = "messages from the channel."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `Root`."]
-					#[doc = "- `new`: Desired value for `QueueConfigData.drop_threshold`"]
 					update_drop_threshold { new: ::core::primitive::u32 },
 					#[codec(index = 5)]
-					#[doc = "Overwrites the number of pages of messages which the queue must be reduced to before it signals that"]
-					#[doc = "message sending may recommence after it has been suspended."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `Root`."]
-					#[doc = "- `new`: Desired value for `QueueConfigData.resume_threshold`"]
 					update_resume_threshold { new: ::core::primitive::u32 },
 					#[codec(index = 6)]
-					#[doc = "Overwrites the amount of remaining weight under which we stop processing messages."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `Root`."]
-					#[doc = "- `new`: Desired value for `QueueConfigData.threshold_weight`"]
 					update_threshold_weight { new: ::sp_weights::Weight },
 					#[codec(index = 7)]
-					#[doc = "Overwrites the speed to which the available weight approaches the maximum weight."]
-					#[doc = "A lower number results in a faster progression. A value of 1 makes the entire weight available initially."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `Root`."]
-					#[doc = "- `new`: Desired value for `QueueConfigData.weight_restrict_decay`."]
 					update_weight_restrict_decay { new: ::sp_weights::Weight },
 					#[codec(index = 8)]
-					#[doc = "Overwrite the maximum amount of weight any individual message may consume."]
-					#[doc = "Messages above this weight go into the overweight queue and may only be serviced explicitly."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must pass `Root`."]
-					#[doc = "- `new`: Desired value for `QueueConfigData.xcmp_max_individual_weight`."]
 					update_xcmp_max_individual_weight { new: ::sp_weights::Weight },
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "Failed to send XCM message."]
 					FailedToSend,
 					#[codec(index = 1)]
-					#[doc = "Bad XCM origin."]
 					BadXcmOrigin,
 					#[codec(index = 2)]
-					#[doc = "Bad XCM data."]
 					BadXcm,
 					#[codec(index = 3)]
-					#[doc = "Bad overweight index."]
 					BadOverweightIndex,
 					#[codec(index = 4)]
-					#[doc = "Provided weight is possibly not enough to execute the message."]
 					WeightOverLimit,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "Some XCM was executed ok."]
 					Success {
 						message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
 						weight: ::sp_weights::Weight,
 					},
 					#[codec(index = 1)]
-					#[doc = "Some XCM failed."]
 					Fail {
 						message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
 						error: runtime_types::xcm::v3::traits::Error,
 						weight: ::sp_weights::Weight,
 					},
 					#[codec(index = 2)]
-					#[doc = "Bad XCM version used."]
 					BadVersion {
 						message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
 					},
 					#[codec(index = 3)]
-					#[doc = "Bad XCM format used."]
 					BadFormat {
 						message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
 					},
 					#[codec(index = 4)]
-					#[doc = "An HRMP message was sent to a sibling parachain."]
 					XcmpMessageSent {
 						message_hash: ::core::option::Option<[::core::primitive::u8; 32usize]>,
 					},
 					#[codec(index = 5)]
-					#[doc = "An XCM exceeded the individual message weight budget."]
 					OverweightEnqueued {
 						sender: runtime_types::polkadot_parachain::primitives::Id,
 						sent_at: ::core::primitive::u32,
@@ -6533,13 +387,10 @@ pub mod api {
 						required: ::sp_weights::Weight,
 					},
 					#[codec(index = 6)]
-					#[doc = "An XCM from the overweight queue was executed with the given actual weight used."]
 					OverweightServiced { index: ::core::primitive::u64, used: ::sp_weights::Weight },
 				}
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct InboundChannelDetails {
 				pub sender: runtime_types::polkadot_parachain::primitives::Id,
 				pub state: runtime_types::cumulus_pallet_xcmp_queue::InboundState,
@@ -6548,18 +399,14 @@ pub mod api {
 					runtime_types::polkadot_parachain::primitives::XcmpMessageFormat,
 				)>,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum InboundState {
 				#[codec(index = 0)]
 				Ok,
 				#[codec(index = 1)]
 				Suspended,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct OutboundChannelDetails {
 				pub recipient: runtime_types::polkadot_parachain::primitives::Id,
 				pub state: runtime_types::cumulus_pallet_xcmp_queue::OutboundState,
@@ -6567,18 +414,14 @@ pub mod api {
 				pub first_index: ::core::primitive::u16,
 				pub last_index: ::core::primitive::u16,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum OutboundState {
 				#[codec(index = 0)]
 				Ok,
 				#[codec(index = 1)]
 				Suspended,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct QueueConfigData {
 				pub suspend_threshold: ::core::primitive::u32,
 				pub drop_threshold: ::core::primitive::u32,
@@ -6590,13 +433,9 @@ pub mod api {
 		}
 		pub mod cumulus_primitives_parachain_inherent {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct MessageQueueChain(pub ::subxt::utils::H256);
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct ParachainInherentData {
 				pub validation_data:
 					runtime_types::polkadot_primitives::v4::PersistedValidationData<
@@ -6621,9 +460,7 @@ pub mod api {
 		}
 		pub mod finality_grandpa {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct Commit<_0, _1, _2, _3> {
 				pub target_hash: _0,
 				pub target_number: _1,
@@ -6631,16 +468,12 @@ pub mod api {
 					runtime_types::finality_grandpa::SignedPrecommit<_0, _1, _2, _3>,
 				>,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct Precommit<_0, _1> {
 				pub target_hash: _0,
 				pub target_number: _1,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct SignedPrecommit<_0, _1, _2, _3> {
 				pub precommit: runtime_types::finality_grandpa::Precommit<_0, _1>,
 				pub signature: _2,
@@ -6651,12 +484,7 @@ pub mod api {
 			use super::runtime_types;
 			pub mod dispatch {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum DispatchClass {
 					#[codec(index = 0)]
 					Normal,
@@ -6665,35 +493,20 @@ pub mod api {
 					#[codec(index = 2)]
 					Mandatory,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct DispatchInfo {
 					pub weight: ::sp_weights::Weight,
 					pub class: runtime_types::frame_support::dispatch::DispatchClass,
 					pub pays_fee: runtime_types::frame_support::dispatch::Pays,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Pays {
 					#[codec(index = 0)]
 					Yes,
 					#[codec(index = 1)]
 					No,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct PerDispatchClass<_0> {
 					pub normal: _0,
 					pub operational: _0,
@@ -6706,12 +519,7 @@ pub mod api {
 					use super::runtime_types;
 					pub mod misc {
 						use super::runtime_types;
-						#[derive(
-							:: subxt :: ext :: codec :: Decode,
-							:: subxt :: ext :: codec :: Encode,
-							Clone,
-							Debug,
-						)]
+						#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 						pub enum BalanceStatus {
 							#[codec(index = 0)]
 							Free,
@@ -6728,94 +536,49 @@ pub mod api {
 				use super::runtime_types;
 				pub mod check_genesis {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct CheckGenesis;
 				}
 				pub mod check_mortality {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct CheckMortality(pub ::sp_runtime::generic::Era);
 				}
 				pub mod check_non_zero_sender {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct CheckNonZeroSender;
 				}
 				pub mod check_nonce {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct CheckNonce(#[codec(compact)] pub ::core::primitive::u32);
 				}
 				pub mod check_spec_version {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct CheckSpecVersion;
 				}
 				pub mod check_tx_version {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct CheckTxVersion;
 				}
 				pub mod check_weight {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct CheckWeight;
 				}
 			}
 			pub mod limits {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct BlockLength {
 					pub max: runtime_types::frame_support::dispatch::PerDispatchClass<
 						::core::primitive::u32,
 					>,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct BlockWeights {
 					pub base_block: ::sp_weights::Weight,
 					pub max_block: ::sp_weights::Weight,
@@ -6823,12 +586,7 @@ pub mod api {
 						runtime_types::frame_system::limits::WeightsPerClass,
 					>,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct WeightsPerClass {
 					pub base_extrinsic: ::sp_weights::Weight,
 					pub max_extrinsic: ::core::option::Option<::sp_weights::Weight>,
@@ -6838,37 +596,17 @@ pub mod api {
 			}
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Make some on-chain remark."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- `O(1)`"]
 					remark { remark: ::std::vec::Vec<::core::primitive::u8> },
 					#[codec(index = 1)]
-					#[doc = "Set the number of pages in the WebAssembly environment's heap."]
 					set_heap_pages { pages: ::core::primitive::u64 },
 					#[codec(index = 2)]
-					#[doc = "Set the new runtime code."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- `O(C + S)` where `C` length of `code` and `S` complexity of `can_set_code`"]
 					set_code { code: ::std::vec::Vec<::core::primitive::u8> },
 					#[codec(index = 3)]
-					#[doc = "Set the new runtime code without doing any checks of the given `code`."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- `O(C)` where `C` length of `code`"]
 					set_code_without_checks { code: ::std::vec::Vec<::core::primitive::u8> },
 					#[codec(index = 4)]
-					#[doc = "Set some items of storage."]
 					set_storage {
 						items: ::std::vec::Vec<(
 							::std::vec::Vec<::core::primitive::u8>,
@@ -6876,88 +614,52 @@ pub mod api {
 						)>,
 					},
 					#[codec(index = 5)]
-					#[doc = "Kill some items from storage."]
 					kill_storage { keys: ::std::vec::Vec<::std::vec::Vec<::core::primitive::u8>> },
 					#[codec(index = 6)]
-					#[doc = "Kill all storage items with a key that starts with the given prefix."]
-					#[doc = ""]
-					#[doc = "**NOTE:** We rely on the Root origin to provide us the number of subkeys under"]
-					#[doc = "the prefix we are removing to accurately calculate the weight of this function."]
 					kill_prefix {
 						prefix: ::std::vec::Vec<::core::primitive::u8>,
 						subkeys: ::core::primitive::u32,
 					},
 					#[codec(index = 7)]
-					#[doc = "Make some on-chain remark and emit event."]
 					remark_with_event { remark: ::std::vec::Vec<::core::primitive::u8> },
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Error for the System pallet"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "The name of specification does not match between the current runtime"]
-					#[doc = "and the new runtime."]
 					InvalidSpecName,
 					#[codec(index = 1)]
-					#[doc = "The specification version is not allowed to decrease between the current runtime"]
-					#[doc = "and the new runtime."]
 					SpecVersionNeedsToIncrease,
 					#[codec(index = 2)]
-					#[doc = "Failed to extract the runtime version from the new runtime."]
-					#[doc = ""]
-					#[doc = "Either calling `Core_version` or decoding `RuntimeVersion` failed."]
 					FailedToExtractRuntimeVersion,
 					#[codec(index = 3)]
-					#[doc = "Suicide called when the account has non-default composite data."]
 					NonDefaultComposite,
 					#[codec(index = 4)]
-					#[doc = "There is a non-zero reference count preventing the account from being purged."]
 					NonZeroRefCount,
 					#[codec(index = 5)]
-					#[doc = "The origin filter prevent the call to be dispatched."]
 					CallFiltered,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Event for the System pallet."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "An extrinsic completed successfully."]
 					ExtrinsicSuccess {
 						dispatch_info: runtime_types::frame_support::dispatch::DispatchInfo,
 					},
 					#[codec(index = 1)]
-					#[doc = "An extrinsic failed."]
 					ExtrinsicFailed {
 						dispatch_error: runtime_types::sp_runtime::DispatchError,
 						dispatch_info: runtime_types::frame_support::dispatch::DispatchInfo,
 					},
 					#[codec(index = 2)]
-					#[doc = "`:code` was updated."]
 					CodeUpdated,
 					#[codec(index = 3)]
-					#[doc = "A new account was created."]
 					NewAccount { account: ::sp_core::crypto::AccountId32 },
 					#[codec(index = 4)]
-					#[doc = "An account was reaped."]
 					KilledAccount { account: ::sp_core::crypto::AccountId32 },
 					#[codec(index = 5)]
-					#[doc = "On on-chain remark happened."]
 					Remarked { sender: ::sp_core::crypto::AccountId32, hash: ::subxt::utils::H256 },
 				}
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct AccountInfo<_0, _1> {
 				pub nonce: _0,
 				pub consumers: _0,
@@ -6965,25 +667,19 @@ pub mod api {
 				pub sufficients: _0,
 				pub data: _1,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct EventRecord<_0, _1> {
 				pub phase: runtime_types::frame_system::Phase,
 				pub event: _0,
 				pub topics: ::std::vec::Vec<_1>,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct LastRuntimeUpgradeInfo {
 				#[codec(compact)]
 				pub spec_version: ::core::primitive::u32,
 				pub spec_name: ::std::string::String,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum Phase {
 				#[codec(index = 0)]
 				ApplyExtrinsic(::core::primitive::u32),
@@ -6997,34 +693,15 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Transfer some liquid free balance to another account."]
-					#[doc = ""]
-					#[doc = "`transfer_allow_death` will set the `FreeBalance` of the sender and receiver."]
-					#[doc = "If the sender's account is below the existential deposit as a result"]
-					#[doc = "of the transfer, the account will be reaped."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call must be `Signed` by the transactor."]
 					transfer_allow_death {
 						dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						#[codec(compact)]
 						value: ::core::primitive::u128,
 					},
 					#[codec(index = 1)]
-					#[doc = "Set the regular balance of a given account; it also takes a reserved balance but this"]
-					#[doc = "must be the same as the account's current reserved balance."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call is `root`."]
-					#[doc = ""]
-					#[doc = "WARNING: This call is DEPRECATED! Use `force_set_balance` instead."]
 					set_balance_deprecated {
 						who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						#[codec(compact)]
@@ -7033,8 +710,6 @@ pub mod api {
 						old_reserved: ::core::primitive::u128,
 					},
 					#[codec(index = 2)]
-					#[doc = "Exactly as `transfer_allow_death`, except the origin must be root and the source account"]
-					#[doc = "may be specified."]
 					force_transfer {
 						source: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
@@ -7042,162 +717,93 @@ pub mod api {
 						value: ::core::primitive::u128,
 					},
 					#[codec(index = 3)]
-					#[doc = "Same as the [`transfer_allow_death`] call, but with a check that the transfer will not"]
-					#[doc = "kill the origin account."]
-					#[doc = ""]
-					#[doc = "99% of the time you want [`transfer_allow_death`] instead."]
-					#[doc = ""]
-					#[doc = "[`transfer_allow_death`]: struct.Pallet.html#method.transfer"]
 					transfer_keep_alive {
 						dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						#[codec(compact)]
 						value: ::core::primitive::u128,
 					},
 					#[codec(index = 4)]
-					#[doc = "Transfer the entire transferable balance from the caller account."]
-					#[doc = ""]
-					#[doc = "NOTE: This function only attempts to transfer _transferable_ balances. This means that"]
-					#[doc = "any locked, reserved, or existential deposits (when `keep_alive` is `true`), will not be"]
-					#[doc = "transferred by this function. To ensure that this function results in a killed account,"]
-					#[doc = "you might need to prepare the account by removing any reference counters, storage"]
-					#[doc = "deposits, etc..."]
-					#[doc = ""]
-					#[doc = "The dispatch origin of this call must be Signed."]
-					#[doc = ""]
-					#[doc = "- `dest`: The recipient of the transfer."]
-					#[doc = "- `keep_alive`: A boolean to determine if the `transfer_all` operation should send all"]
-					#[doc = "  of the funds the account has, causing the sender account to be killed (false), or"]
-					#[doc = "  transfer everything except at least the existential deposit, which will guarantee to"]
-					#[doc = "  keep the sender account alive (true)."]
 					transfer_all {
 						dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						keep_alive: ::core::primitive::bool,
 					},
 					#[codec(index = 5)]
-					#[doc = "Unreserve some balance from a user by force."]
-					#[doc = ""]
-					#[doc = "Can only be called by ROOT."]
 					force_unreserve {
 						who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 6)]
-					#[doc = "Upgrade a specified account."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be `Signed`."]
-					#[doc = "- `who`: The account to be upgraded."]
-					#[doc = ""]
-					#[doc = "This will waive the transaction fee if at least all but 10% of the accounts needed to"]
-					#[doc = "be upgraded. (We let some not have to be upgraded just in order to allow for the"]
-					#[doc = "possibililty of churn)."]
 					upgrade_accounts { who: ::std::vec::Vec<::sp_core::crypto::AccountId32> },
 					#[codec(index = 7)]
-					#[doc = "Alias for `transfer_allow_death`, provided only for name-wise compatibility."]
-					#[doc = ""]
-					#[doc = "WARNING: DEPRECATED! Will be released in approximately 3 months."]
 					transfer {
 						dest: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						#[codec(compact)]
 						value: ::core::primitive::u128,
 					},
 					#[codec(index = 8)]
-					#[doc = "Set the regular balance of a given account."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call is `root`."]
 					force_set_balance {
 						who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						#[codec(compact)]
 						new_free: ::core::primitive::u128,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "Vesting balance too high to send value."]
 					VestingBalance,
 					#[codec(index = 1)]
-					#[doc = "Account liquidity restrictions prevent withdrawal."]
 					LiquidityRestrictions,
 					#[codec(index = 2)]
-					#[doc = "Balance too low to send value."]
 					InsufficientBalance,
 					#[codec(index = 3)]
-					#[doc = "Value too low to create account due to existential deposit."]
 					ExistentialDeposit,
 					#[codec(index = 4)]
-					#[doc = "Transfer/payment would kill account."]
 					Expendability,
 					#[codec(index = 5)]
-					#[doc = "A vesting schedule already exists for this account."]
 					ExistingVestingSchedule,
 					#[codec(index = 6)]
-					#[doc = "Beneficiary account must pre-exist."]
 					DeadAccount,
 					#[codec(index = 7)]
-					#[doc = "Number of named reserves exceed `MaxReserves`."]
 					TooManyReserves,
 					#[codec(index = 8)]
-					#[doc = "Number of holds exceed `MaxHolds`."]
 					TooManyHolds,
 					#[codec(index = 9)]
-					#[doc = "Number of freezes exceed `MaxFreezes`."]
 					TooManyFreezes,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "An account was created with some free balance."]
 					Endowed {
 						account: ::sp_core::crypto::AccountId32,
 						free_balance: ::core::primitive::u128,
 					},
 					#[codec(index = 1)]
-					#[doc = "An account was removed whose balance was non-zero but below ExistentialDeposit,"]
-					#[doc = "resulting in an outright loss."]
 					DustLost {
 						account: ::sp_core::crypto::AccountId32,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 2)]
-					#[doc = "Transfer succeeded."]
 					Transfer {
 						from: ::sp_core::crypto::AccountId32,
 						to: ::sp_core::crypto::AccountId32,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 3)]
-					#[doc = "A balance was set by root."]
 					BalanceSet {
 						who: ::sp_core::crypto::AccountId32,
 						free: ::core::primitive::u128,
 					},
 					#[codec(index = 4)]
-					#[doc = "Some balance was reserved (moved from free to reserved)."]
 					Reserved {
 						who: ::sp_core::crypto::AccountId32,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 5)]
-					#[doc = "Some balance was unreserved (moved from reserved to free)."]
 					Unreserved {
 						who: ::sp_core::crypto::AccountId32,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 6)]
-					#[doc = "Some balance was moved from the reserve of the first account to the second account."]
-					#[doc = "Final argument indicates the destination balance type."]
 					ReserveRepatriated {
 						from: ::sp_core::crypto::AccountId32,
 						to: ::sp_core::crypto::AccountId32,
@@ -7206,95 +812,72 @@ pub mod api {
 							runtime_types::frame_support::traits::tokens::misc::BalanceStatus,
 					},
 					#[codec(index = 7)]
-					#[doc = "Some amount was deposited (e.g. for transaction fees)."]
 					Deposit { who: ::sp_core::crypto::AccountId32, amount: ::core::primitive::u128 },
 					#[codec(index = 8)]
-					#[doc = "Some amount was withdrawn from the account (e.g. for transaction fees)."]
 					Withdraw {
 						who: ::sp_core::crypto::AccountId32,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 9)]
-					#[doc = "Some amount was removed from the account (e.g. for misbehavior)."]
 					Slashed { who: ::sp_core::crypto::AccountId32, amount: ::core::primitive::u128 },
 					#[codec(index = 10)]
-					#[doc = "Some amount was minted into an account."]
 					Minted { who: ::sp_core::crypto::AccountId32, amount: ::core::primitive::u128 },
 					#[codec(index = 11)]
-					#[doc = "Some amount was burned from an account."]
 					Burned { who: ::sp_core::crypto::AccountId32, amount: ::core::primitive::u128 },
 					#[codec(index = 12)]
-					#[doc = "Some amount was suspended from an account (it can be restored later)."]
 					Suspended {
 						who: ::sp_core::crypto::AccountId32,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 13)]
-					#[doc = "Some amount was restored into an account."]
 					Restored {
 						who: ::sp_core::crypto::AccountId32,
 						amount: ::core::primitive::u128,
 					},
 					#[codec(index = 14)]
-					#[doc = "An account was upgraded."]
 					Upgraded { who: ::sp_core::crypto::AccountId32 },
 					#[codec(index = 15)]
-					#[doc = "Total issuance was increased by `amount`, creating a credit to be balanced."]
 					Issued { amount: ::core::primitive::u128 },
 					#[codec(index = 16)]
-					#[doc = "Total issuance was decreased by `amount`, creating a debt to be balanced."]
 					Rescinded { amount: ::core::primitive::u128 },
+					#[codec(index = 17)]
+					Locked { who: ::sp_core::crypto::AccountId32, amount: ::core::primitive::u128 },
+					#[codec(index = 18)]
+					Unlocked {
+						who: ::sp_core::crypto::AccountId32,
+						amount: ::core::primitive::u128,
+					},
 				}
 			}
 			pub mod types {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct AccountData<_0> {
 					pub free: _0,
 					pub reserved: _0,
 					pub frozen: _0,
 					pub flags: runtime_types::pallet_balances::types::ExtraFlags,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct BalanceLock<_0> {
 					pub id: [::core::primitive::u8; 8usize],
 					pub amount: _0,
 					pub reasons: runtime_types::pallet_balances::types::Reasons,
 				}
 				#[derive(
+					:: codec :: Decode,
+					:: codec :: Encode,
 					:: subxt :: ext :: codec :: CompactAs,
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
 					Clone,
 					Debug,
 				)]
 				pub struct ExtraFlags(pub ::core::primitive::u128);
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct IdAmount<_0, _1> {
 					pub id: _0,
 					pub amount: _1,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Reasons {
 					#[codec(index = 0)]
 					Fee,
@@ -7303,12 +886,7 @@ pub mod api {
 					#[codec(index = 2)]
 					All,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct ReserveData<_0, _1> {
 					pub id: _0,
 					pub amount: _1,
@@ -7319,22 +897,9 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Verify a target header is finalized according to the given finality proof."]
-					#[doc = ""]
-					#[doc = "It will use the underlying storage pallet to fetch information about the current"]
-					#[doc = "authorities and best finalized header in order to verify that the header is finalized."]
-					#[doc = ""]
-					#[doc = "If successful in verification, it will write the target header to the underlying storage"]
-					#[doc = "pallet."]
 					submit_finality_proof {
 						finality_target: ::std::boxed::Box<
 							::sp_runtime::generic::Header<
@@ -7350,15 +915,6 @@ pub mod api {
 						>,
 					},
 					#[codec(index = 1)]
-					#[doc = "Bootstrap the bridge pallet with an initial header and authority set from which to sync."]
-					#[doc = ""]
-					#[doc = "The initial configuration provided does not need to be the genesis header of the bridged"]
-					#[doc = "chain, it can be any arbitrary header. You can also provide the next scheduled set"]
-					#[doc = "change if it is already know."]
-					#[doc = ""]
-					#[doc = "This function is only allowed to be called from a trusted origin and writes to storage"]
-					#[doc = "with practically no checks in terms of the validity of the data. It is important that"]
-					#[doc = "you ensure that valid data is being passed in."]
 					initialize {
 						init_data: ::bp_header_chain::InitializationData<
 							::sp_runtime::generic::Header<
@@ -7368,66 +924,34 @@ pub mod api {
 						>,
 					},
 					#[codec(index = 2)]
-					#[doc = "Change `PalletOwner`."]
-					#[doc = ""]
-					#[doc = "May only be called either by root, or by `PalletOwner`."]
 					set_owner { new_owner: ::core::option::Option<::sp_core::crypto::AccountId32> },
 					#[codec(index = 3)]
-					#[doc = "Halt or resume all pallet operations."]
-					#[doc = ""]
-					#[doc = "May only be called either by root, or by `PalletOwner`."]
 					set_operating_mode {
 						operating_mode: runtime_types::bp_runtime::BasicOperatingMode,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "The given justification is invalid for the given header."]
 					InvalidJustification,
 					#[codec(index = 1)]
-					#[doc = "The authority set from the underlying header chain is invalid."]
 					InvalidAuthoritySet,
 					#[codec(index = 2)]
-					#[doc = "There are too many requests for the current window to handle."]
-					TooManyRequests,
-					#[codec(index = 3)]
-					#[doc = "The header being imported is older than the best finalized header known to the pallet."]
 					OldHeader,
-					#[codec(index = 4)]
-					#[doc = "The scheduled authority set change found in the header is unsupported by the pallet."]
-					#[doc = ""]
-					#[doc = "This is the case for non-standard (e.g forced) authority set changes."]
+					#[codec(index = 3)]
 					UnsupportedScheduledChange,
-					#[codec(index = 5)]
-					#[doc = "The pallet is not yet initialized."]
+					#[codec(index = 4)]
 					NotInitialized,
-					#[codec(index = 6)]
-					#[doc = "The pallet has already been initialized."]
+					#[codec(index = 5)]
 					AlreadyInitialized,
-					#[codec(index = 7)]
-					#[doc = "Too many authorities in the set."]
+					#[codec(index = 6)]
 					TooManyAuthoritiesInSet,
-					#[codec(index = 8)]
-					#[doc = "Error generated by the `OwnedBridgeModule` trait."]
+					#[codec(index = 7)]
 					BridgeModule(runtime_types::bp_runtime::OwnedBridgeModuleError),
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "Best finalized chain header has been updated to the header with given number and hash."]
 					UpdatedBestFinalizedHeader {
 						number: ::core::primitive::u64,
 						hash: ::bp_millau::MillauHash,
@@ -7436,12 +960,7 @@ pub mod api {
 			}
 			pub mod storage_types {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct StoredAuthoritySet {
 					pub authorities: runtime_types::bounded_collections::bounded_vec::BoundedVec<(
 						runtime_types::sp_consensus_grandpa::app::Public,
@@ -7455,126 +974,68 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
-					# [codec (index = 0)] # [doc = "Change `PalletOwner`."] # [doc = ""] # [doc = "May only be called either by root, or by `PalletOwner`."] set_owner { new_owner : :: core :: option :: Option < :: sp_core :: crypto :: AccountId32 > , } , # [codec (index = 1)] # [doc = "Halt or resume all/some pallet operations."] # [doc = ""] # [doc = "May only be called either by root, or by `PalletOwner`."] set_operating_mode { operating_mode : runtime_types :: bp_messages :: MessagesOperatingMode , } , # [codec (index = 2)] # [doc = "Receive messages proof from bridged chain."] # [doc = ""] # [doc = "The weight of the call assumes that the transaction always brings outbound lane"] # [doc = "state update. Because of that, the submitter (relayer) has no benefit of not including"] # [doc = "this data in the transaction, so reward confirmations lags should be minimal."] receive_messages_proof { relayer_id_at_bridged_chain : :: sp_core :: crypto :: AccountId32 , proof : :: bridge_runtime_common :: messages :: target :: FromBridgedChainMessagesProof < :: bp_millau :: MillauHash > , messages_count : :: core :: primitive :: u32 , dispatch_weight : :: sp_weights :: Weight , } , # [codec (index = 3)] # [doc = "Receive messages delivery proof from bridged chain."] receive_messages_delivery_proof { proof : :: bridge_runtime_common :: messages :: source :: FromBridgedChainMessagesDeliveryProof < :: bp_millau :: MillauHash > , relayers_state : :: bp_messages :: UnrewardedRelayersState , } , }
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+					# [codec (index = 0)] set_owner { new_owner : :: core :: option :: Option < :: sp_core :: crypto :: AccountId32 > , } , # [codec (index = 1)] set_operating_mode { operating_mode : runtime_types :: bp_messages :: MessagesOperatingMode , } , # [codec (index = 2)] receive_messages_proof { relayer_id_at_bridged_chain : :: sp_core :: crypto :: AccountId32 , proof : :: bridge_runtime_common :: messages :: target :: FromBridgedChainMessagesProof < :: bp_millau :: MillauHash > , messages_count : :: core :: primitive :: u32 , dispatch_weight : :: sp_weights :: Weight , } , # [codec (index = 3)] receive_messages_delivery_proof { proof : :: bridge_runtime_common :: messages :: source :: FromBridgedChainMessagesDeliveryProof < :: bp_millau :: MillauHash > , relayers_state : :: bp_messages :: UnrewardedRelayersState , } , }
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "Pallet is not in Normal operating mode."]
 					NotOperatingNormally,
 					#[codec(index = 1)]
-					#[doc = "The outbound lane is inactive."]
 					InactiveOutboundLane,
 					#[codec(index = 2)]
-					#[doc = "The message is too large to be sent over the bridge."]
 					MessageIsTooLarge,
 					#[codec(index = 3)]
-					#[doc = "Message has been treated as invalid by chain verifier."]
 					MessageRejectedByChainVerifier,
 					#[codec(index = 4)]
-					#[doc = "Message has been treated as invalid by lane verifier."]
 					MessageRejectedByLaneVerifier,
 					#[codec(index = 5)]
-					#[doc = "Submitter has failed to pay fee for delivering and dispatching messages."]
 					FailedToWithdrawMessageFee,
 					#[codec(index = 6)]
-					#[doc = "The transaction brings too many messages."]
 					TooManyMessagesInTheProof,
 					#[codec(index = 7)]
-					#[doc = "Invalid messages has been submitted."]
 					InvalidMessagesProof,
 					#[codec(index = 8)]
-					#[doc = "Invalid messages delivery proof has been submitted."]
 					InvalidMessagesDeliveryProof,
 					#[codec(index = 9)]
-					#[doc = "The bridged chain has invalid `UnrewardedRelayers` in its storage (fatal for the lane)."]
 					InvalidUnrewardedRelayers,
 					#[codec(index = 10)]
-					#[doc = "The relayer has declared invalid unrewarded relayers state in the"]
-					#[doc = "`receive_messages_delivery_proof` call."]
 					InvalidUnrewardedRelayersState,
 					#[codec(index = 11)]
-					#[doc = "The cumulative dispatch weight, passed by relayer is not enough to cover dispatch"]
-					#[doc = "of all bundled messages."]
 					InsufficientDispatchWeight,
 					#[codec(index = 12)]
-					#[doc = "The message someone is trying to work with (i.e. increase fee) is not yet sent."]
 					MessageIsNotYetSent,
 					#[codec(index = 13)]
-					#[doc = "The number of actually confirmed messages is going to be larger than the number of"]
-					#[doc = "messages in the proof. This may mean that this or bridged chain storage is corrupted."]
 					TryingToConfirmMoreMessagesThanExpected,
 					#[codec(index = 14)]
-					#[doc = "Error generated by the `OwnedBridgeModule` trait."]
 					BridgeModule(runtime_types::bp_runtime::OwnedBridgeModuleError),
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
-					# [codec (index = 0)] # [doc = "Message has been accepted and is waiting to be delivered."] MessageAccepted { lane_id : runtime_types :: bp_messages :: LaneId , nonce : :: core :: primitive :: u64 , } , # [codec (index = 1)] # [doc = "Messages have been received from the bridged chain."] MessagesReceived (:: std :: vec :: Vec < runtime_types :: bp_messages :: ReceivedMessages < runtime_types :: bridge_runtime_common :: messages_xcm_extension :: XcmBlobMessageDispatchResult > > ,) , # [codec (index = 2)] # [doc = "Messages in the inclusive range have been delivered to the bridged chain."] MessagesDelivered { lane_id : runtime_types :: bp_messages :: LaneId , messages : runtime_types :: bp_messages :: DeliveredMessages , } , }
+					# [codec (index = 0)] MessageAccepted { lane_id : runtime_types :: bp_messages :: LaneId , nonce : :: core :: primitive :: u64 , } , # [codec (index = 1)] MessagesReceived (:: std :: vec :: Vec < runtime_types :: bp_messages :: ReceivedMessages < runtime_types :: bridge_runtime_common :: messages_xcm_extension :: XcmBlobMessageDispatchResult > > ,) , # [codec (index = 2)] MessagesDelivered { lane_id : runtime_types :: bp_messages :: LaneId , messages : runtime_types :: bp_messages :: DeliveredMessages , } , }
 			}
 		}
 		pub mod pallet_bridge_relayers {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Claim accumulated rewards."]
 					claim_rewards {
 						rewards_account_params: runtime_types::bp_relayers::RewardsAccountParams,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "No reward can be claimed by given relayer."]
 					NoRewardForRelayer,
 					#[codec(index = 1)]
-					#[doc = "Reward payment procedure has failed."]
 					FailedToPayReward,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "Reward has been paid to the relayer."]
 					RewardPaid {
 						relayer: ::sp_core::crypto::AccountId32,
 						rewards_account_params: runtime_types::bp_relayers::RewardsAccountParams,
@@ -7587,97 +1048,47 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Authenticates the sudo key and dispatches a function call with `Root` origin."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call must be _Signed_."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- O(1)."]
 					sudo {
 						call:
 							::std::boxed::Box<runtime_types::rialto_parachain_runtime::RuntimeCall>,
 					},
 					#[codec(index = 1)]
-					#[doc = "Authenticates the sudo key and dispatches a function call with `Root` origin."]
-					#[doc = "This function does not check the weight of the call, and instead allows the"]
-					#[doc = "Sudo user to specify the weight of the call."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call must be _Signed_."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- O(1)."]
 					sudo_unchecked_weight {
 						call:
 							::std::boxed::Box<runtime_types::rialto_parachain_runtime::RuntimeCall>,
 						weight: ::sp_weights::Weight,
 					},
 					#[codec(index = 2)]
-					#[doc = "Authenticates the current sudo key and sets the given AccountId (`new`) as the new sudo"]
-					#[doc = "key."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call must be _Signed_."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- O(1)."]
 					set_key {
 						new: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 					},
 					#[codec(index = 3)]
-					#[doc = "Authenticates the sudo key and dispatches a function call with `Signed` origin from"]
-					#[doc = "a given account."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call must be _Signed_."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- O(1)."]
 					sudo_as {
 						who: ::subxt::utils::MultiAddress<::sp_core::crypto::AccountId32, ()>,
 						call:
 							::std::boxed::Box<runtime_types::rialto_parachain_runtime::RuntimeCall>,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Error for the Sudo pallet"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "Sender must be the Sudo account"]
 					RequireSudo,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "A sudo just took place. \\[result\\]"]
 					Sudid {
 						sudo_result:
 							::core::result::Result<(), runtime_types::sp_runtime::DispatchError>,
 					},
 					#[codec(index = 1)]
-					#[doc = "The \\[sudoer\\] just switched identity; the old key is supplied if one existed."]
 					KeyChanged {
 						old_sudoer: ::core::option::Option<::sp_core::crypto::AccountId32>,
 					},
 					#[codec(index = 2)]
-					#[doc = "A sudo just took place. \\[result\\]"]
 					SudoAsDone {
 						sudo_result:
 							::core::result::Result<(), runtime_types::sp_runtime::DispatchError>,
@@ -7689,30 +1100,9 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
-					#[doc = "Set the current time."]
-					#[doc = ""]
-					#[doc = "This call should be invoked exactly once per block. It will panic at the finalization"]
-					#[doc = "phase, if this call hasn't been invoked by that time."]
-					#[doc = ""]
-					#[doc = "The timestamp should be greater than the previous one by the amount specified by"]
-					#[doc = "`MinimumPeriod`."]
-					#[doc = ""]
-					#[doc = "The dispatch origin for this call must be `Inherent`."]
-					#[doc = ""]
-					#[doc = "## Complexity"]
-					#[doc = "- `O(1)` (Note that implementations of `OnTimestampSet` must also be `O(1)`)"]
-					#[doc = "- 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in"]
-					#[doc = "  `on_finalize`)"]
-					#[doc = "- 1 event handler `on_timestamp_set`. Must be `O(1)`."]
 					set {
 						#[codec(compact)]
 						now: ::core::primitive::u64,
@@ -7724,17 +1114,9 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "A transaction fee `actual_fee`, of which `tip` was added to the minimum inclusion fee,"]
-					#[doc = "has been paid by `who`."]
 					TransactionFeePaid {
 						who: ::sp_core::crypto::AccountId32,
 						actual_fee: ::core::primitive::u128,
@@ -7742,13 +1124,9 @@ pub mod api {
 					},
 				}
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct ChargeTransactionPayment(#[codec(compact)] pub ::core::primitive::u128);
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum Releases {
 				#[codec(index = 0)]
 				V1Ancient,
@@ -7760,13 +1138,7 @@ pub mod api {
 			use super::runtime_types;
 			pub mod pallet {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "Contains one variant per dispatchable that can be called by an extrinsic."]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Call {
 					#[codec(index = 0)]
 					send {
@@ -7774,21 +1146,6 @@ pub mod api {
 						message: ::std::boxed::Box<runtime_types::xcm::VersionedXcm>,
 					},
 					#[codec(index = 1)]
-					#[doc = "Teleport some assets from the local chain to some destination chain."]
-					#[doc = ""]
-					#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-					#[doc = "index `fee_asset_item`. The weight limit for fees is not provided and thus is unlimited,"]
-					#[doc = "with all fees taken as needed from the asset."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-					#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-					#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-					#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-					#[doc = "  an `AccountId32` value."]
-					#[doc = "- `assets`: The assets to be withdrawn. The first item should be the currency used to to pay the fee on the"]
-					#[doc = "  `dest` side. May not be empty."]
-					#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-					#[doc = "  fees."]
 					teleport_assets {
 						dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
 						beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
@@ -7796,22 +1153,6 @@ pub mod api {
 						fee_asset_item: ::core::primitive::u32,
 					},
 					#[codec(index = 2)]
-					#[doc = "Transfer some assets from the local chain to the sovereign account of a destination"]
-					#[doc = "chain and forward a notification XCM."]
-					#[doc = ""]
-					#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-					#[doc = "index `fee_asset_item`. The weight limit for fees is not provided and thus is unlimited,"]
-					#[doc = "with all fees taken as needed from the asset."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-					#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-					#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-					#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-					#[doc = "  an `AccountId32` value."]
-					#[doc = "- `assets`: The assets to be withdrawn. This should include the assets used to pay the fee on the"]
-					#[doc = "  `dest` side."]
-					#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-					#[doc = "  fees."]
 					reserve_transfer_assets {
 						dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
 						beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
@@ -7819,79 +1160,29 @@ pub mod api {
 						fee_asset_item: ::core::primitive::u32,
 					},
 					#[codec(index = 3)]
-					#[doc = "Execute an XCM message from a local, signed, origin."]
-					#[doc = ""]
-					#[doc = "An event is deposited indicating whether `msg` could be executed completely or only"]
-					#[doc = "partially."]
-					#[doc = ""]
-					#[doc = "No more than `max_weight` will be used in its attempted execution. If this is less than the"]
-					#[doc = "maximum amount of weight that the message could take to be executed, then no execution"]
-					#[doc = "attempt will be made."]
-					#[doc = ""]
-					#[doc = "NOTE: A successful return to this does *not* imply that the `msg` was executed successfully"]
-					#[doc = "to completion; only that *some* of it was executed."]
 					execute {
 						message: ::std::boxed::Box<runtime_types::xcm::VersionedXcm>,
 						max_weight: ::sp_weights::Weight,
 					},
 					#[codec(index = 4)]
-					#[doc = "Extoll that a particular destination can be communicated with through a particular"]
-					#[doc = "version of XCM."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be Root."]
-					#[doc = "- `location`: The destination that is being described."]
-					#[doc = "- `xcm_version`: The latest version of XCM that `location` supports."]
 					force_xcm_version {
 						location:
 							::std::boxed::Box<runtime_types::xcm::v3::multilocation::MultiLocation>,
 						xcm_version: ::core::primitive::u32,
 					},
 					#[codec(index = 5)]
-					#[doc = "Set a safe XCM version (the version that XCM should be encoded with if the most recent"]
-					#[doc = "version a destination can accept is unknown)."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be Root."]
-					#[doc = "- `maybe_xcm_version`: The default XCM encoding version, or `None` to disable."]
 					force_default_xcm_version {
 						maybe_xcm_version: ::core::option::Option<::core::primitive::u32>,
 					},
 					#[codec(index = 6)]
-					#[doc = "Ask a location to notify us regarding their XCM version and any changes to it."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be Root."]
-					#[doc = "- `location`: The location to which we should subscribe for XCM version notifications."]
 					force_subscribe_version_notify {
 						location: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
 					},
 					#[codec(index = 7)]
-					#[doc = "Require that a particular destination should no longer notify us regarding any XCM"]
-					#[doc = "version changes."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be Root."]
-					#[doc = "- `location`: The location to which we are currently subscribed for XCM version"]
-					#[doc = "  notifications which we no longer desire."]
 					force_unsubscribe_version_notify {
 						location: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
 					},
 					#[codec(index = 8)]
-					#[doc = "Transfer some assets from the local chain to the sovereign account of a destination"]
-					#[doc = "chain and forward a notification XCM."]
-					#[doc = ""]
-					#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-					#[doc = "index `fee_asset_item`, up to enough to pay for `weight_limit` of weight. If more weight"]
-					#[doc = "is needed than `weight_limit`, then the operation will fail and the assets send may be"]
-					#[doc = "at risk."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-					#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-					#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-					#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-					#[doc = "  an `AccountId32` value."]
-					#[doc = "- `assets`: The assets to be withdrawn. This should include the assets used to pay the fee on the"]
-					#[doc = "  `dest` side."]
-					#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-					#[doc = "  fees."]
-					#[doc = "- `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase."]
 					limited_reserve_transfer_assets {
 						dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
 						beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
@@ -7900,23 +1191,6 @@ pub mod api {
 						weight_limit: runtime_types::xcm::v3::WeightLimit,
 					},
 					#[codec(index = 9)]
-					#[doc = "Teleport some assets from the local chain to some destination chain."]
-					#[doc = ""]
-					#[doc = "Fee payment on the destination side is made from the asset in the `assets` vector of"]
-					#[doc = "index `fee_asset_item`, up to enough to pay for `weight_limit` of weight. If more weight"]
-					#[doc = "is needed than `weight_limit`, then the operation will fail and the assets send may be"]
-					#[doc = "at risk."]
-					#[doc = ""]
-					#[doc = "- `origin`: Must be capable of withdrawing the `assets` and executing XCM."]
-					#[doc = "- `dest`: Destination context for the assets. Will typically be `X2(Parent, Parachain(..))` to send"]
-					#[doc = "  from parachain to parachain, or `X1(Parachain(..))` to send from relay to parachain."]
-					#[doc = "- `beneficiary`: A beneficiary location for the assets in the context of `dest`. Will generally be"]
-					#[doc = "  an `AccountId32` value."]
-					#[doc = "- `assets`: The assets to be withdrawn. The first item should be the currency used to to pay the fee on the"]
-					#[doc = "  `dest` side. May not be empty."]
-					#[doc = "- `fee_asset_item`: The index into `assets` of the item which should be used to pay"]
-					#[doc = "  fees."]
-					#[doc = "- `weight_limit`: The remote-side weight limit, if any, for the XCM fee purchase."]
 					limited_teleport_assets {
 						dest: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
 						beneficiary: ::std::boxed::Box<runtime_types::xcm::VersionedMultiLocation>,
@@ -7925,128 +1199,69 @@ pub mod api {
 						weight_limit: runtime_types::xcm::v3::WeightLimit,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tCustom [dispatch errors](https://docs.substrate.io/main-docs/build/events-errors/)\n\t\t\tof this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Error {
 					#[codec(index = 0)]
-					#[doc = "The desired destination was unreachable, generally because there is a no way of routing"]
-					#[doc = "to it."]
 					Unreachable,
 					#[codec(index = 1)]
-					#[doc = "There was some other issue (i.e. not to do with routing) in sending the message. Perhaps"]
-					#[doc = "a lack of space for buffering the message."]
 					SendFailure,
 					#[codec(index = 2)]
-					#[doc = "The message execution fails the filter."]
 					Filtered,
 					#[codec(index = 3)]
-					#[doc = "The message's weight could not be determined."]
 					UnweighableMessage,
 					#[codec(index = 4)]
-					#[doc = "The destination `MultiLocation` provided cannot be inverted."]
 					DestinationNotInvertible,
 					#[codec(index = 5)]
-					#[doc = "The assets to be sent are empty."]
 					Empty,
 					#[codec(index = 6)]
-					#[doc = "Could not re-anchor the assets to declare the fees for the destination chain."]
 					CannotReanchor,
 					#[codec(index = 7)]
-					#[doc = "Too many assets have been attempted for transfer."]
 					TooManyAssets,
 					#[codec(index = 8)]
-					#[doc = "Origin is invalid for sending."]
 					InvalidOrigin,
 					#[codec(index = 9)]
-					#[doc = "The version of the `Versioned` value used is not able to be interpreted."]
 					BadVersion,
 					#[codec(index = 10)]
-					#[doc = "The given location could not be used (e.g. because it cannot be expressed in the"]
-					#[doc = "desired version of XCM)."]
 					BadLocation,
 					#[codec(index = 11)]
-					#[doc = "The referenced subscription could not be found."]
 					NoSubscription,
 					#[codec(index = 12)]
-					#[doc = "The location is invalid since it already has a subscription from us."]
 					AlreadySubscribed,
 					#[codec(index = 13)]
-					#[doc = "Invalid asset for the operation."]
 					InvalidAsset,
 					#[codec(index = 14)]
-					#[doc = "The owner does not own (all) of the asset that they wish to do the operation on."]
 					LowBalance,
 					#[codec(index = 15)]
-					#[doc = "The asset owner has too many locks on the asset."]
 					TooManyLocks,
 					#[codec(index = 16)]
-					#[doc = "The given account is not an identifiable sovereign account for any location."]
 					AccountNotSovereign,
 					#[codec(index = 17)]
-					#[doc = "The operation required fees to be paid which the initiator could not meet."]
 					FeesNotMet,
 					#[codec(index = 18)]
-					#[doc = "A remote lock with the corresponding data could not be found."]
 					LockNotFound,
 					#[codec(index = 19)]
-					#[doc = "The unlock operation cannot succeed because there are still users of the lock."]
 					InUse,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
-				#[doc = "\n\t\t\tThe [event](https://docs.substrate.io/main-docs/build/events-errors/) emitted\n\t\t\tby this pallet.\n\t\t\t"]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Event {
 					#[codec(index = 0)]
-					#[doc = "Execution of an XCM message was attempted."]
-					#[doc = ""]
-					#[doc = "\\[ outcome \\]"]
 					Attempted(runtime_types::xcm::v3::traits::Outcome),
 					#[codec(index = 1)]
-					#[doc = "A XCM message was sent."]
-					#[doc = ""]
-					#[doc = "\\[ origin, destination, message \\]"]
 					Sent(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						runtime_types::xcm::v3::Xcm,
 					),
 					#[codec(index = 2)]
-					#[doc = "Query response received which does not match a registered query. This may be because a"]
-					#[doc = "matching query was never registered, it may be because it is a duplicate response, or"]
-					#[doc = "because the query timed out."]
-					#[doc = ""]
-					#[doc = "\\[ origin location, id \\]"]
 					UnexpectedResponse(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u64,
 					),
 					#[codec(index = 3)]
-					#[doc = "Query response has been received and is ready for taking with `take_response`. There is"]
-					#[doc = "no registered notification call."]
-					#[doc = ""]
-					#[doc = "\\[ id, response \\]"]
 					ResponseReady(::core::primitive::u64, runtime_types::xcm::v3::Response),
 					#[codec(index = 4)]
-					#[doc = "Query response has been received and query is removed. The registered notification has"]
-					#[doc = "been dispatched and executed successfully."]
-					#[doc = ""]
-					#[doc = "\\[ id, pallet index, call index \\]"]
 					Notified(::core::primitive::u64, ::core::primitive::u8, ::core::primitive::u8),
 					#[codec(index = 5)]
-					#[doc = "Query response has been received and query is removed. The registered notification could"]
-					#[doc = "not be dispatched because the dispatch weight is greater than the maximum weight"]
-					#[doc = "originally budgeted by this runtime for the query result."]
-					#[doc = ""]
-					#[doc = "\\[ id, pallet index, call index, actual weight, max budgeted weight \\]"]
 					NotifyOverweight(
 						::core::primitive::u64,
 						::core::primitive::u8,
@@ -8055,32 +1270,18 @@ pub mod api {
 						::sp_weights::Weight,
 					),
 					#[codec(index = 6)]
-					#[doc = "Query response has been received and query is removed. There was a general error with"]
-					#[doc = "dispatching the notification call."]
-					#[doc = ""]
-					#[doc = "\\[ id, pallet index, call index \\]"]
 					NotifyDispatchError(
 						::core::primitive::u64,
 						::core::primitive::u8,
 						::core::primitive::u8,
 					),
 					#[codec(index = 7)]
-					#[doc = "Query response has been received and query is removed. The dispatch was unable to be"]
-					#[doc = "decoded into a `Call`; this might be due to dispatch function having a signature which"]
-					#[doc = "is not `(origin, QueryId, Response)`."]
-					#[doc = ""]
-					#[doc = "\\[ id, pallet index, call index \\]"]
 					NotifyDecodeFailed(
 						::core::primitive::u64,
 						::core::primitive::u8,
 						::core::primitive::u8,
 					),
 					#[codec(index = 8)]
-					#[doc = "Expected query response has been received but the origin location of the response does"]
-					#[doc = "not match that expected. The query remains registered for a later, valid, response to"]
-					#[doc = "be received and acted upon."]
-					#[doc = ""]
-					#[doc = "\\[ origin location, id, expected location \\]"]
 					InvalidResponder(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u64,
@@ -8089,92 +1290,46 @@ pub mod api {
 						>,
 					),
 					#[codec(index = 9)]
-					#[doc = "Expected query response has been received but the expected origin location placed in"]
-					#[doc = "storage by this runtime previously cannot be decoded. The query remains registered."]
-					#[doc = ""]
-					#[doc = "This is unexpected (since a location placed in storage in a previously executing"]
-					#[doc = "runtime should be readable prior to query timeout) and dangerous since the possibly"]
-					#[doc = "valid response will be dropped. Manual governance intervention is probably going to be"]
-					#[doc = "needed."]
-					#[doc = ""]
-					#[doc = "\\[ origin location, id \\]"]
 					InvalidResponderVersion(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u64,
 					),
 					#[codec(index = 10)]
-					#[doc = "Received query response has been read and removed."]
-					#[doc = ""]
-					#[doc = "\\[ id \\]"]
 					ResponseTaken(::core::primitive::u64),
 					#[codec(index = 11)]
-					#[doc = "Some assets have been placed in an asset trap."]
-					#[doc = ""]
-					#[doc = "\\[ hash, origin, assets \\]"]
 					AssetsTrapped(
 						::subxt::utils::H256,
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						runtime_types::xcm::VersionedMultiAssets,
 					),
 					#[codec(index = 12)]
-					#[doc = "An XCM version change notification message has been attempted to be sent."]
-					#[doc = ""]
-					#[doc = "The cost of sending it (borne by the chain) is included."]
-					#[doc = ""]
-					#[doc = "\\[ destination, result, cost \\]"]
 					VersionChangeNotified(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u32,
 						runtime_types::xcm::v3::multiasset::MultiAssets,
 					),
 					#[codec(index = 13)]
-					#[doc = "The supported version of a location has been changed. This might be through an"]
-					#[doc = "automatic notification or a manual intervention."]
-					#[doc = ""]
-					#[doc = "\\[ location, XCM version \\]"]
 					SupportedVersionChanged(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u32,
 					),
 					#[codec(index = 14)]
-					#[doc = "A given location which had a version change subscription was dropped owing to an error"]
-					#[doc = "sending the notification to it."]
-					#[doc = ""]
-					#[doc = "\\[ location, query ID, error \\]"]
 					NotifyTargetSendFail(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u64,
 						runtime_types::xcm::v3::traits::Error,
 					),
 					#[codec(index = 15)]
-					#[doc = "A given location which had a version change subscription was dropped owing to an error"]
-					#[doc = "migrating the location to our new XCM format."]
-					#[doc = ""]
-					#[doc = "\\[ location, query ID \\]"]
 					NotifyTargetMigrationFail(
 						runtime_types::xcm::VersionedMultiLocation,
 						::core::primitive::u64,
 					),
 					#[codec(index = 16)]
-					#[doc = "Expected query response has been received but the expected querier location placed in"]
-					#[doc = "storage by this runtime previously cannot be decoded. The query remains registered."]
-					#[doc = ""]
-					#[doc = "This is unexpected (since a location placed in storage in a previously executing"]
-					#[doc = "runtime should be readable prior to query timeout) and dangerous since the possibly"]
-					#[doc = "valid response will be dropped. Manual governance intervention is probably going to be"]
-					#[doc = "needed."]
-					#[doc = ""]
-					#[doc = "\\[ origin location, id \\]"]
 					InvalidQuerierVersion(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u64,
 					),
 					#[codec(index = 17)]
-					#[doc = "Expected query response has been received but the querier location of the response does"]
-					#[doc = "not match the expected. The query remains registered for a later, valid, response to"]
-					#[doc = "be received and acted upon."]
-					#[doc = ""]
-					#[doc = "\\[ origin location, id, expected querier, maybe actual querier \\]"]
 					InvalidQuerier(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						::core::primitive::u64,
@@ -8184,42 +1339,26 @@ pub mod api {
 						>,
 					),
 					#[codec(index = 18)]
-					#[doc = "A remote has requested XCM version change notification from us and we have honored it."]
-					#[doc = "A version information message is sent to them and its cost is included."]
-					#[doc = ""]
-					#[doc = "\\[ destination location, cost \\]"]
 					VersionNotifyStarted(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						runtime_types::xcm::v3::multiasset::MultiAssets,
 					),
 					#[codec(index = 19)]
-					#[doc = "We have requested that a remote chain sends us XCM version change notifications."]
-					#[doc = ""]
-					#[doc = "\\[ destination location, cost \\]"]
 					VersionNotifyRequested(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						runtime_types::xcm::v3::multiasset::MultiAssets,
 					),
 					#[codec(index = 20)]
-					#[doc = "We have requested that a remote chain stops sending us XCM version change notifications."]
-					#[doc = ""]
-					#[doc = "\\[ destination location, cost \\]"]
 					VersionNotifyUnrequested(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						runtime_types::xcm::v3::multiasset::MultiAssets,
 					),
 					#[codec(index = 21)]
-					#[doc = "Fees were paid from a location for an operation (often for using `SendXcm`)."]
-					#[doc = ""]
-					#[doc = "\\[ paying location, fees \\]"]
 					FeesPaid(
 						runtime_types::xcm::v3::multilocation::MultiLocation,
 						runtime_types::xcm::v3::multiasset::MultiAssets,
 					),
 					#[codec(index = 22)]
-					#[doc = "Some assets have been claimed from an asset trap"]
-					#[doc = ""]
-					#[doc = "\\[ hash, origin, assets \\]"]
 					AssetsClaimed(
 						::subxt::utils::H256,
 						runtime_types::xcm::v3::multilocation::MultiLocation,
@@ -8230,23 +1369,17 @@ pub mod api {
 		}
 		pub mod polkadot_core_primitives {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct InboundDownwardMessage<_0> {
 				pub sent_at: _0,
 				pub msg: ::std::vec::Vec<::core::primitive::u8>,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct InboundHrmpMessage<_0> {
 				pub sent_at: _0,
 				pub data: ::std::vec::Vec<::core::primitive::u8>,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct OutboundHrmpMessage<_0> {
 				pub recipient: _0,
 				pub data: ::std::vec::Vec<::core::primitive::u8>,
@@ -8256,27 +1389,17 @@ pub mod api {
 			use super::runtime_types;
 			pub mod primitives {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct HeadData(pub ::std::vec::Vec<::core::primitive::u8>);
 				#[derive(
+					:: codec :: Decode,
+					:: codec :: Encode,
 					:: subxt :: ext :: codec :: CompactAs,
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
 					Clone,
 					Debug,
 				)]
 				pub struct Id(pub ::core::primitive::u32);
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum XcmpMessageFormat {
 					#[codec(index = 0)]
 					ConcatenatedVersionedXcm,
@@ -8291,12 +1414,7 @@ pub mod api {
 			use super::runtime_types;
 			pub mod v4 {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct AbridgedHostConfiguration {
 					pub max_code_size: ::core::primitive::u32,
 					pub max_head_data_size: ::core::primitive::u32,
@@ -8308,12 +1426,7 @@ pub mod api {
 					pub validation_upgrade_cooldown: ::core::primitive::u32,
 					pub validation_upgrade_delay: ::core::primitive::u32,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct AbridgedHrmpChannel {
 					pub max_capacity: ::core::primitive::u32,
 					pub max_total_size: ::core::primitive::u32,
@@ -8322,24 +1435,14 @@ pub mod api {
 					pub total_size: ::core::primitive::u32,
 					pub mqc_head: ::core::option::Option<::subxt::utils::H256>,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct PersistedValidationData<_0, _1> {
 					pub parent_head: runtime_types::polkadot_parachain::primitives::HeadData,
 					pub relay_parent_number: _1,
 					pub relay_parent_storage_root: _0,
 					pub max_pov_size: _1,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum UpgradeRestriction {
 					#[codec(index = 0)]
 					Present,
@@ -8348,21 +1451,13 @@ pub mod api {
 		}
 		pub mod rialto_parachain_runtime {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct BridgeRejectObsoleteHeadersAndMessages;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct DummyBridgeRefundMillauMessages;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct Runtime;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum RuntimeCall {
 				#[codec(index = 0)]
 				System(runtime_types::frame_system::pallet::Call),
@@ -8389,9 +1484,7 @@ pub mod api {
 				#[codec(index = 56)]
 				BridgeMillauMessages(runtime_types::pallet_bridge_messages::pallet::Call),
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum RuntimeEvent {
 				#[codec(index = 0)]
 				System(runtime_types::frame_system::pallet::Event),
@@ -8424,17 +1517,15 @@ pub mod api {
 			pub mod fixed_point {
 				use super::runtime_types;
 				#[derive(
+					:: codec :: Decode,
+					:: codec :: Encode,
 					:: subxt :: ext :: codec :: CompactAs,
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
 					Clone,
 					Debug,
 				)]
 				pub struct FixedU128(pub ::core::primitive::u128);
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum ArithmeticError {
 				#[codec(index = 0)]
 				Underflow,
@@ -8448,19 +1539,9 @@ pub mod api {
 			use super::runtime_types;
 			pub mod app {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Public(pub runtime_types::sp_core::ed25519::Public);
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Signature(pub runtime_types::sp_core::ed25519::Signature);
 			}
 		}
@@ -8468,39 +1549,19 @@ pub mod api {
 			use super::runtime_types;
 			pub mod ecdsa {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Signature(pub [::core::primitive::u8; 65usize]);
 			}
 			pub mod ed25519 {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Public(pub [::core::primitive::u8; 32usize]);
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Signature(pub [::core::primitive::u8; 64usize]);
 			}
 			pub mod sr25519 {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Signature(pub [::core::primitive::u8; 64usize]);
 			}
 		}
@@ -8510,12 +1571,7 @@ pub mod api {
 				use super::runtime_types;
 				pub mod digest {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum DigestItem {
 						#[codec(index = 6)]
 						PreRuntime(
@@ -8540,21 +1596,14 @@ pub mod api {
 				}
 				pub mod unchecked_extrinsic {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct UncheckedExtrinsic<_0, _1, _2, _3>(
 						pub ::std::vec::Vec<::core::primitive::u8>,
 						#[codec(skip)] pub ::core::marker::PhantomData<(_1, _0, _2, _3)>,
 					);
 				}
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum DispatchError {
 				#[codec(index = 0)]
 				Other,
@@ -8583,16 +1632,12 @@ pub mod api {
 				#[codec(index = 12)]
 				Unavailable,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct ModuleError {
 				pub index: ::core::primitive::u8,
 				pub error: [::core::primitive::u8; 4usize],
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum MultiSignature {
 				#[codec(index = 0)]
 				Ed25519(runtime_types::sp_core::ed25519::Signature),
@@ -8601,9 +1646,7 @@ pub mod api {
 				#[codec(index = 2)]
 				Ecdsa(runtime_types::sp_core::ecdsa::Signature),
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum TokenError {
 				#[codec(index = 0)]
 				FundsUnavailable,
@@ -8624,9 +1667,7 @@ pub mod api {
 				#[codec(index = 8)]
 				NotExpendable,
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum TransactionalError {
 				#[codec(index = 0)]
 				LimitReached,
@@ -8638,12 +1679,7 @@ pub mod api {
 			use super::runtime_types;
 			pub mod storage_proof {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct StorageProof {
 					pub trie_nodes: ::std::vec::Vec<::std::vec::Vec<::core::primitive::u8>>,
 				}
@@ -8651,9 +1687,7 @@ pub mod api {
 		}
 		pub mod sp_version {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct RuntimeVersion {
 				pub spec_name: ::std::string::String,
 				pub impl_name: ::std::string::String,
@@ -8668,9 +1702,7 @@ pub mod api {
 		}
 		pub mod sp_weights {
 			use super::runtime_types;
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub struct RuntimeDbWeight {
 				pub read: ::core::primitive::u64,
 				pub write: ::core::primitive::u64,
@@ -8680,12 +1712,7 @@ pub mod api {
 			use super::runtime_types;
 			pub mod double_encoded {
 				use super::runtime_types;
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct DoubleEncoded {
 					pub encoded: ::std::vec::Vec<::core::primitive::u8>,
 				}
@@ -8694,12 +1721,7 @@ pub mod api {
 				use super::runtime_types;
 				pub mod junction {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Junction {
 						#[codec(index = 0)]
 						Parachain(#[codec(compact)] ::core::primitive::u32),
@@ -8740,24 +1762,14 @@ pub mod api {
 				}
 				pub mod multiasset {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum AssetId {
 						#[codec(index = 0)]
 						Concrete(runtime_types::xcm::v2::multilocation::MultiLocation),
 						#[codec(index = 1)]
 						Abstract(::std::vec::Vec<::core::primitive::u8>),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum AssetInstance {
 						#[codec(index = 0)]
 						Undefined,
@@ -8774,67 +1786,37 @@ pub mod api {
 						#[codec(index = 6)]
 						Blob(::std::vec::Vec<::core::primitive::u8>),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Fungibility {
 						#[codec(index = 0)]
 						Fungible(#[codec(compact)] ::core::primitive::u128),
 						#[codec(index = 1)]
 						NonFungible(runtime_types::xcm::v2::multiasset::AssetInstance),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct MultiAsset {
 						pub id: runtime_types::xcm::v2::multiasset::AssetId,
 						pub fun: runtime_types::xcm::v2::multiasset::Fungibility,
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum MultiAssetFilter {
 						#[codec(index = 0)]
 						Definite(runtime_types::xcm::v2::multiasset::MultiAssets),
 						#[codec(index = 1)]
 						Wild(runtime_types::xcm::v2::multiasset::WildMultiAsset),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct MultiAssets(
 						pub ::std::vec::Vec<runtime_types::xcm::v2::multiasset::MultiAsset>,
 					);
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum WildFungibility {
 						#[codec(index = 0)]
 						Fungible,
 						#[codec(index = 1)]
 						NonFungible,
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum WildMultiAsset {
 						#[codec(index = 0)]
 						All,
@@ -8847,12 +1829,7 @@ pub mod api {
 				}
 				pub mod multilocation {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Junctions {
 						#[codec(index = 0)]
 						Here,
@@ -8915,12 +1892,7 @@ pub mod api {
 							runtime_types::xcm::v2::junction::Junction,
 						),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct MultiLocation {
 						pub parents: ::core::primitive::u8,
 						pub interior: runtime_types::xcm::v2::multilocation::Junctions,
@@ -8928,12 +1900,7 @@ pub mod api {
 				}
 				pub mod traits {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Error {
 						#[codec(index = 0)]
 						Overflow,
@@ -8989,12 +1956,7 @@ pub mod api {
 						WeightNotComputable,
 					}
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum BodyId {
 					#[codec(index = 0)]
 					Unit,
@@ -9021,12 +1983,7 @@ pub mod api {
 					#[codec(index = 9)]
 					Treasury,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum BodyPart {
 					#[codec(index = 0)]
 					Voice,
@@ -9057,12 +2014,7 @@ pub mod api {
 						denom: ::core::primitive::u32,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Instruction {
 					#[codec(index = 0)]
 					WithdrawAsset(runtime_types::xcm::v2::multiasset::MultiAssets),
@@ -9202,12 +2154,7 @@ pub mod api {
 					#[codec(index = 27)]
 					UnsubscribeVersion,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum NetworkId {
 					#[codec(index = 0)]
 					Any,
@@ -9222,12 +2169,7 @@ pub mod api {
 					#[codec(index = 3)]
 					Kusama,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum OriginKind {
 					#[codec(index = 0)]
 					Native,
@@ -9238,12 +2180,7 @@ pub mod api {
 					#[codec(index = 3)]
 					Xcm,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Response {
 					#[codec(index = 0)]
 					Null,
@@ -9259,36 +2196,21 @@ pub mod api {
 					#[codec(index = 3)]
 					Version(::core::primitive::u32),
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum WeightLimit {
 					#[codec(index = 0)]
 					Unlimited,
 					#[codec(index = 1)]
 					Limited(#[codec(compact)] ::core::primitive::u64),
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Xcm(pub ::std::vec::Vec<runtime_types::xcm::v2::Instruction>);
 			}
 			pub mod v3 {
 				use super::runtime_types;
 				pub mod junction {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum BodyId {
 						#[codec(index = 0)]
 						Unit,
@@ -9311,12 +2233,7 @@ pub mod api {
 						#[codec(index = 9)]
 						Treasury,
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum BodyPart {
 						#[codec(index = 0)]
 						Voice,
@@ -9347,12 +2264,7 @@ pub mod api {
 							denom: ::core::primitive::u32,
 						},
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Junction {
 						#[codec(index = 0)]
 						Parachain(#[codec(compact)] ::core::primitive::u32),
@@ -9394,12 +2306,7 @@ pub mod api {
 						#[codec(index = 9)]
 						GlobalConsensus(runtime_types::xcm::v3::junction::NetworkId),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum NetworkId {
 						#[codec(index = 0)]
 						ByGenesis([::core::primitive::u8; 32usize]),
@@ -9431,12 +2338,7 @@ pub mod api {
 				}
 				pub mod junctions {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Junctions {
 						#[codec(index = 0)]
 						Here,
@@ -9502,24 +2404,14 @@ pub mod api {
 				}
 				pub mod multiasset {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum AssetId {
 						#[codec(index = 0)]
 						Concrete(runtime_types::xcm::v3::multilocation::MultiLocation),
 						#[codec(index = 1)]
 						Abstract([::core::primitive::u8; 32usize]),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum AssetInstance {
 						#[codec(index = 0)]
 						Undefined,
@@ -9534,67 +2426,37 @@ pub mod api {
 						#[codec(index = 5)]
 						Array32([::core::primitive::u8; 32usize]),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Fungibility {
 						#[codec(index = 0)]
 						Fungible(#[codec(compact)] ::core::primitive::u128),
 						#[codec(index = 1)]
 						NonFungible(runtime_types::xcm::v3::multiasset::AssetInstance),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct MultiAsset {
 						pub id: runtime_types::xcm::v3::multiasset::AssetId,
 						pub fun: runtime_types::xcm::v3::multiasset::Fungibility,
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum MultiAssetFilter {
 						#[codec(index = 0)]
 						Definite(runtime_types::xcm::v3::multiasset::MultiAssets),
 						#[codec(index = 1)]
 						Wild(runtime_types::xcm::v3::multiasset::WildMultiAsset),
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct MultiAssets(
 						pub ::std::vec::Vec<runtime_types::xcm::v3::multiasset::MultiAsset>,
 					);
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum WildFungibility {
 						#[codec(index = 0)]
 						Fungible,
 						#[codec(index = 1)]
 						NonFungible,
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum WildMultiAsset {
 						#[codec(index = 0)]
 						All,
@@ -9616,12 +2478,7 @@ pub mod api {
 				}
 				pub mod multilocation {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub struct MultiLocation {
 						pub parents: ::core::primitive::u8,
 						pub interior: runtime_types::xcm::v3::junctions::Junctions,
@@ -9629,12 +2486,7 @@ pub mod api {
 				}
 				pub mod traits {
 					use super::runtime_types;
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Error {
 						#[codec(index = 0)]
 						Overflow,
@@ -9717,12 +2569,7 @@ pub mod api {
 						#[codec(index = 39)]
 						ExceedsStackLimit,
 					}
-					#[derive(
-						:: subxt :: ext :: codec :: Decode,
-						:: subxt :: ext :: codec :: Encode,
-						Clone,
-						Debug,
-					)]
+					#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 					pub enum Outcome {
 						#[codec(index = 0)]
 						Complete(::sp_weights::Weight),
@@ -9732,12 +2579,7 @@ pub mod api {
 						Error(runtime_types::xcm::v3::traits::Error),
 					}
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Instruction {
 					#[codec(index = 0)]
 					WithdrawAsset(runtime_types::xcm::v3::multiasset::MultiAssets),
@@ -9946,12 +2788,7 @@ pub mod api {
 						>,
 					},
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum MaybeErrorCode {
 					#[codec(index = 0)]
 					Success,
@@ -9968,12 +2805,7 @@ pub mod api {
 						>,
 					),
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct PalletInfo {
 					#[codec(compact)]
 					pub index: ::core::primitive::u32,
@@ -9990,24 +2822,14 @@ pub mod api {
 					#[codec(compact)]
 					pub patch: ::core::primitive::u32,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct QueryResponseInfo {
 					pub destination: runtime_types::xcm::v3::multilocation::MultiLocation,
 					#[codec(compact)]
 					pub query_id: ::core::primitive::u64,
 					pub max_weight: ::sp_weights::Weight,
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum Response {
 					#[codec(index = 0)]
 					Null,
@@ -10031,180 +2853,37 @@ pub mod api {
 					#[codec(index = 5)]
 					DispatchResult(runtime_types::xcm::v3::MaybeErrorCode),
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub enum WeightLimit {
 					#[codec(index = 0)]
 					Unlimited,
 					#[codec(index = 1)]
 					Limited(::sp_weights::Weight),
 				}
-				#[derive(
-					:: subxt :: ext :: codec :: Decode,
-					:: subxt :: ext :: codec :: Encode,
-					Clone,
-					Debug,
-				)]
+				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 				pub struct Xcm(pub ::std::vec::Vec<runtime_types::xcm::v3::Instruction>);
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum VersionedMultiAssets {
 				#[codec(index = 1)]
 				V2(runtime_types::xcm::v2::multiasset::MultiAssets),
 				#[codec(index = 3)]
 				V3(runtime_types::xcm::v3::multiasset::MultiAssets),
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum VersionedMultiLocation {
 				#[codec(index = 1)]
 				V2(runtime_types::xcm::v2::multilocation::MultiLocation),
 				#[codec(index = 3)]
 				V3(runtime_types::xcm::v3::multilocation::MultiLocation),
 			}
-			#[derive(
-				:: subxt :: ext :: codec :: Decode, :: subxt :: ext :: codec :: Encode, Clone, Debug,
-			)]
+			#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug)]
 			pub enum VersionedXcm {
 				#[codec(index = 2)]
 				V2(runtime_types::xcm::v2::Xcm),
 				#[codec(index = 3)]
 				V3(runtime_types::xcm::v3::Xcm),
 			}
-		}
-	}
-	#[doc = r" The default error type returned when there is a runtime issue,"]
-	#[doc = r" exposed here for ease of use."]
-	pub type DispatchError = runtime_types::sp_runtime::DispatchError;
-	pub fn constants() -> ConstantsApi {
-		ConstantsApi
-	}
-	pub fn storage() -> StorageApi {
-		StorageApi
-	}
-	pub fn tx() -> TransactionApi {
-		TransactionApi
-	}
-	pub struct ConstantsApi;
-	impl ConstantsApi {
-		pub fn system(&self) -> system::constants::ConstantsApi {
-			system::constants::ConstantsApi
-		}
-		pub fn timestamp(&self) -> timestamp::constants::ConstantsApi {
-			timestamp::constants::ConstantsApi
-		}
-		pub fn transaction_payment(&self) -> transaction_payment::constants::ConstantsApi {
-			transaction_payment::constants::ConstantsApi
-		}
-		pub fn balances(&self) -> balances::constants::ConstantsApi {
-			balances::constants::ConstantsApi
-		}
-		pub fn bridge_millau_grandpa(&self) -> bridge_millau_grandpa::constants::ConstantsApi {
-			bridge_millau_grandpa::constants::ConstantsApi
-		}
-		pub fn bridge_millau_messages(&self) -> bridge_millau_messages::constants::ConstantsApi {
-			bridge_millau_messages::constants::ConstantsApi
-		}
-	}
-	pub struct StorageApi;
-	impl StorageApi {
-		pub fn system(&self) -> system::storage::StorageApi {
-			system::storage::StorageApi
-		}
-		pub fn timestamp(&self) -> timestamp::storage::StorageApi {
-			timestamp::storage::StorageApi
-		}
-		pub fn sudo(&self) -> sudo::storage::StorageApi {
-			sudo::storage::StorageApi
-		}
-		pub fn transaction_payment(&self) -> transaction_payment::storage::StorageApi {
-			transaction_payment::storage::StorageApi
-		}
-		pub fn parachain_system(&self) -> parachain_system::storage::StorageApi {
-			parachain_system::storage::StorageApi
-		}
-		pub fn parachain_info(&self) -> parachain_info::storage::StorageApi {
-			parachain_info::storage::StorageApi
-		}
-		pub fn balances(&self) -> balances::storage::StorageApi {
-			balances::storage::StorageApi
-		}
-		pub fn xcmp_queue(&self) -> xcmp_queue::storage::StorageApi {
-			xcmp_queue::storage::StorageApi
-		}
-		pub fn dmp_queue(&self) -> dmp_queue::storage::StorageApi {
-			dmp_queue::storage::StorageApi
-		}
-		pub fn bridge_relayers(&self) -> bridge_relayers::storage::StorageApi {
-			bridge_relayers::storage::StorageApi
-		}
-		pub fn bridge_millau_grandpa(&self) -> bridge_millau_grandpa::storage::StorageApi {
-			bridge_millau_grandpa::storage::StorageApi
-		}
-		pub fn bridge_millau_messages(&self) -> bridge_millau_messages::storage::StorageApi {
-			bridge_millau_messages::storage::StorageApi
-		}
-	}
-	pub struct TransactionApi;
-	impl TransactionApi {
-		pub fn system(&self) -> system::calls::TransactionApi {
-			system::calls::TransactionApi
-		}
-		pub fn timestamp(&self) -> timestamp::calls::TransactionApi {
-			timestamp::calls::TransactionApi
-		}
-		pub fn sudo(&self) -> sudo::calls::TransactionApi {
-			sudo::calls::TransactionApi
-		}
-		pub fn parachain_system(&self) -> parachain_system::calls::TransactionApi {
-			parachain_system::calls::TransactionApi
-		}
-		pub fn balances(&self) -> balances::calls::TransactionApi {
-			balances::calls::TransactionApi
-		}
-		pub fn xcmp_queue(&self) -> xcmp_queue::calls::TransactionApi {
-			xcmp_queue::calls::TransactionApi
-		}
-		pub fn polkadot_xcm(&self) -> polkadot_xcm::calls::TransactionApi {
-			polkadot_xcm::calls::TransactionApi
-		}
-		pub fn cumulus_xcm(&self) -> cumulus_xcm::calls::TransactionApi {
-			cumulus_xcm::calls::TransactionApi
-		}
-		pub fn dmp_queue(&self) -> dmp_queue::calls::TransactionApi {
-			dmp_queue::calls::TransactionApi
-		}
-		pub fn bridge_relayers(&self) -> bridge_relayers::calls::TransactionApi {
-			bridge_relayers::calls::TransactionApi
-		}
-		pub fn bridge_millau_grandpa(&self) -> bridge_millau_grandpa::calls::TransactionApi {
-			bridge_millau_grandpa::calls::TransactionApi
-		}
-		pub fn bridge_millau_messages(&self) -> bridge_millau_messages::calls::TransactionApi {
-			bridge_millau_messages::calls::TransactionApi
-		}
-	}
-	#[doc = r" check whether the Client you are using is aligned with the statically generated codegen."]
-	pub fn validate_codegen<T: ::subxt::Config, C: ::subxt::client::OfflineClientT<T>>(
-		client: &C,
-	) -> Result<(), ::subxt::error::MetadataError> {
-		let runtime_metadata_hash = client.metadata().metadata_hash(&PALLETS);
-		if runtime_metadata_hash !=
-			[
-				244u8, 26u8, 245u8, 96u8, 241u8, 56u8, 22u8, 163u8, 219u8, 209u8, 103u8, 161u8,
-				138u8, 242u8, 33u8, 114u8, 162u8, 107u8, 1u8, 216u8, 115u8, 116u8, 164u8, 126u8,
-				81u8, 51u8, 88u8, 36u8, 180u8, 113u8, 18u8, 58u8,
-			] {
-			Err(::subxt::error::MetadataError::IncompatibleMetadata)
-		} else {
-			Ok(())
 		}
 	}
 }

--- a/relays/client-rialto-parachain/src/lib.rs
+++ b/relays/client-rialto-parachain/src/lib.rs
@@ -61,8 +61,7 @@ impl Chain for RialtoParachain {
 
 impl ChainWithBalances for RialtoParachain {
 	fn account_info_storage_key(account_id: &Self::AccountId) -> StorageKey {
-		let key = codegen_runtime::api::storage().system().account(account_id);
-		StorageKey(key.to_bytes())
+		bp_polkadot_core::AccountInfoStorageMapKeyProvider::final_key(account_id)
 	}
 }
 

--- a/tools/runtime-codegen/Cargo.lock
+++ b/tools/runtime-codegen/Cargo.lock
@@ -42,7 +42,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -54,16 +54,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -84,6 +84,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "anstream"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -127,13 +176,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -156,12 +205,6 @@ dependencies = [
  "object 0.30.3",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base58"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base64"
@@ -221,6 +264,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,7 +292,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -247,7 +301,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -272,10 +326,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.12.0"
+name = "bs58"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bumpalo"
+version = "3.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "byte-slice-cast"
@@ -330,39 +390,46 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.13"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
+checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
  "clap_lex",
- "is-terminal",
  "once_cell",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.12"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -402,6 +469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpp_demangle"
@@ -428,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -545,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -598,7 +677,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -608,7 +687,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
@@ -618,7 +697,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "subtle",
 ]
 
@@ -650,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -662,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -672,24 +751,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -753,7 +832,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -883,13 +962,13 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -907,6 +986,19 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "expander"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f360349150728553f92e4c997a16af8915f418d3a0f21b440d34c5632f16ed84"
+dependencies = [
+ "blake2",
+ "fs-err",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "eyre"
@@ -969,15 +1061,21 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "15.0.0"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6bb8542ef006ef0de09a5c4420787d79823c0ed7924225822362fd2bf2ff2d"
+checksum = "878babb0b136e731cc77ec2fd883ff02745ff21e6fb662729953d44923df009c"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
  "scale-info",
  "serde",
 ]
+
+[[package]]
+name = "fs-err"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
 name = "funty"
@@ -987,9 +1085,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1002,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1012,15 +1110,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1030,32 +1128,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
@@ -1069,9 +1167,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1105,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1126,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1199,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -1218,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "hash-db"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
+checksum = "8e7d7786361d7425ae2fe4f9e407eb0efaa0840f5212d109cc018c40c35c6ab4"
 
 [[package]]
 name = "hash256-std-hasher"
@@ -1312,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.6",
+ "generic-array 0.14.7",
  "hmac 0.8.1",
 ]
 
@@ -1358,9 +1456,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1389,18 +1487,33 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
- "webpki-roots",
+ "tokio-rustls 0.23.4",
+ "webpki-roots 0.22.6",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls 0.21.0",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1473,9 +1586,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -1493,25 +1606,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
- "windows-sys 0.45.0",
+ "rustix 0.37.14",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1553,21 +1666,22 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
- "jsonrpsee-client-transport 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-core 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-http-client 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-client-transport 0.16.2",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-http-client 0.16.2",
+ "jsonrpsee-types 0.16.2",
 ]
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.2"
-source = "git+https://github.com/paritytech/jsonrpsee#7144be544f6fbbb607a5df858b736a2b917edc10"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b971ce0f6cd1521ede485afc564b95b2c8e7079b9da41d4273bd9b55140a55d"
 dependencies = [
- "jsonrpsee-client-transport 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-core 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-http-client 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-types 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
+ "jsonrpsee-client-transport 0.17.1",
+ "jsonrpsee-core 0.17.1",
+ "jsonrpsee-http-client 0.17.1",
+ "jsonrpsee-types 0.17.1",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
 ]
@@ -1580,38 +1694,39 @@ checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
 dependencies = [
  "futures-util",
  "http",
- "jsonrpsee-core 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-types 0.16.2",
  "pin-project",
  "rustls-native-certs",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.16.2"
-source = "git+https://github.com/paritytech/jsonrpsee#7144be544f6fbbb607a5df858b736a2b917edc10"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca00d975eda834826b04ad57d4e690c67439bb51b02eb0f8b7e4c30fcef8ab9"
 dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
  "http",
- "jsonrpsee-core 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
+ "jsonrpsee-core 0.17.1",
  "pin-project",
  "rustls-native-certs",
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -1628,7 +1743,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hyper",
- "jsonrpsee-types 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee-types 0.16.2",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1639,8 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.16.2"
-source = "git+https://github.com/paritytech/jsonrpsee#7144be544f6fbbb607a5df858b736a2b917edc10"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b83cca7a5a7899eed8b2935d5f755c8c4052ad66ab5b328bd34ac2b3ffd3515f"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -1649,7 +1765,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hyper",
- "jsonrpsee-types 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
+ "jsonrpsee-types 0.17.1",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1668,9 +1784,9 @@ checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls",
- "jsonrpsee-core 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpsee-types 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-rustls 0.23.2",
+ "jsonrpsee-core 0.16.2",
+ "jsonrpsee-types 0.16.2",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1681,14 +1797,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.16.2"
-source = "git+https://github.com/paritytech/jsonrpsee#7144be544f6fbbb607a5df858b736a2b917edc10"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6483fea826f62260a88a132fa750a47b40d4218d41e3391936579533c6c67509"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls",
- "jsonrpsee-core 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-types 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
+ "hyper-rustls 0.24.0",
+ "jsonrpsee-core 0.17.1",
+ "jsonrpsee-types 0.17.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -1713,8 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.16.2"
-source = "git+https://github.com/paritytech/jsonrpsee#7144be544f6fbbb607a5df858b736a2b917edc10"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd301ccc3e08718393432d1961539d78c4580dcca86014dfe6769c308b2c08b2"
 dependencies = [
  "anyhow",
  "beef",
@@ -1726,23 +1844,25 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.16.2"
-source = "git+https://github.com/paritytech/jsonrpsee#7144be544f6fbbb607a5df858b736a2b917edc10"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85dc3aea8bbb844dacc45cd98d01f624e4485184149a045761888c2e5fa5a0c6"
 dependencies = [
- "jsonrpsee-client-transport 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-core 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-types 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
+ "jsonrpsee-client-transport 0.17.1",
+ "jsonrpsee-core 0.17.1",
+ "jsonrpsee-types 0.17.1",
 ]
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.16.2"
-source = "git+https://github.com/paritytech/jsonrpsee#7144be544f6fbbb607a5df858b736a2b917edc10"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a69852133d549b07cb37ff2d0ec540eae0d20abb75ae923f5d39bc7536d987"
 dependencies = [
  "http",
- "jsonrpsee-client-transport 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-core 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
- "jsonrpsee-types 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
+ "jsonrpsee-client-transport 0.17.1",
+ "jsonrpsee-core 0.17.1",
+ "jsonrpsee-types 0.17.1",
 ]
 
 [[package]]
@@ -1762,9 +1882,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libm"
@@ -1836,6 +1956,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,11 +2015,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
+checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix",
+ "rustix 0.37.14",
 ]
 
 [[package]]
@@ -1916,12 +2042,11 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0c7cba9ce19ac7ffd2053ac9f49843bbd3f4318feedfd74e85c19d5fb0ba66"
+checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2075,12 +2200,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "owo-colors"
@@ -2242,34 +2361,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2357,7 +2452,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -2406,7 +2501,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
  "redox_syscall",
  "thiserror",
 ]
@@ -2428,7 +2523,7 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2445,13 +2540,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -2460,7 +2555,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2468,6 +2563,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "region"
@@ -2512,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -2530,16 +2631,30 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.36.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "3a38f9520be93aba504e8ca974197f46158de5dcaa9fa04b57c57cd6a679d658"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.4",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2552,6 +2667,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
 ]
 
 [[package]]
@@ -2576,6 +2703,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,7 +2727,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "log",
  "sp-core",
@@ -2595,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "lru",
  "parity-scale-codec",
@@ -2619,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -2632,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "log",
  "sc-allocator",
@@ -2645,14 +2788,14 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "anyhow",
  "cfg-if",
  "libc",
  "log",
  "once_cell",
- "rustix",
+ "rustix 0.36.13",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
@@ -2662,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61471dff9096de1d8b2319efed7162081e96793f5ebb147e50db10d50d648a4d"
+checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2676,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219580e803a66b3f05761fd06f1f879a872444e49ce23f73694d26e5a954c7e6"
+checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2804,29 +2947,29 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -2884,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -2965,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "hash-db",
  "log",
@@ -2983,9 +3126,11 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
+ "Inflector",
  "blake2",
+ "expander",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -2995,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3008,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -3022,13 +3167,13 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "array-bytes",
- "base58",
  "bitflags",
  "blake2",
  "bounded-collections",
+ "bs58",
  "dyn-clonable",
  "ed25519-zebra",
  "futures",
@@ -3065,9 +3210,9 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
- "blake2",
+ "blake2b_simd",
  "byteorder",
  "digest 0.10.6",
  "sha2 0.10.6",
@@ -3078,23 +3223,23 @@ dependencies = [
 
 [[package]]
 name = "sp-core-hashing"
-version = "6.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc2d1947252b7a4e403b0a260f596920443742791765ec111daa2bbf98eff25"
+checksum = "27449abdfbe41b473e625bce8113745e81d65777dd1d5a8462cf24137930dad8"
 dependencies = [
- "blake2",
+ "blake2b_simd",
  "byteorder",
  "digest 0.10.6",
  "sha2 0.10.6",
  "sha3",
- "sp-std 6.0.0",
+ "sp-std 7.0.0",
  "twox-hash",
 ]
 
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3105,7 +3250,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3115,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -3126,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "bytes",
  "ed25519",
@@ -3135,6 +3280,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "rustversion",
  "secp256k1",
  "sp-core",
  "sp-externalities",
@@ -3151,9 +3297,8 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
- "async-trait",
  "futures",
  "merlin",
  "parity-scale-codec",
@@ -3167,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "thiserror",
  "zstd",
@@ -3176,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3186,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -3208,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -3226,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -3238,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "hash-db",
  "log",
@@ -3258,18 +3403,18 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 
 [[package]]
 name = "sp-std"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0ee286f98455272f64ac5bb1384ff21ac029fbb669afbaf48477faff12760e"
+checksum = "1de8eef39962b5b97478719c493bed2926cf70cb621005bbf68ebe58252ff986"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3282,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "parity-scale-codec",
  "sp-std 5.0.0",
@@ -3294,11 +3439,11 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
  "lazy_static",
  "memory-db",
  "nohash-hasher",
@@ -3317,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3334,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -3345,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -3359,7 +3504,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-03#ad5399644aebc54e32a107ac37ae08e6cd1f0cfb"
+source = "git+https://github.com/paritytech/substrate?tag=monthly-2023-04#75dee3c6fc72f6399a43f498e0e42f94fb82a7bd"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3425,8 +3570,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-runtime-proposal-hash"
-version = "0.19.0"
-source = "git+https://github.com/chevdor/subwasm?branch=master#fd047d76d52beab8c062eb94141f8d14ddc0f59d"
+version = "0.19.1"
+source = "git+https://github.com/chevdor/subwasm?branch=master#04fd6218fb41c29d04b21db7e821810b25664d9b"
 dependencies = [
  "blake2",
  "hex",
@@ -3445,35 +3590,33 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt-codegen"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e86cb719003f1cedf2710a6e55ca4c37aba4c989bbd3b81dd1c52af9e4827e"
+version = "0.28.0"
+source = "git+https://github.com/paritytech/subxt?branch=master#e583aa987eb57ac6ce70c7166925189a663d0d31"
 dependencies = [
  "darling",
  "frame-metadata",
  "heck",
  "hex",
- "jsonrpsee 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpsee 0.16.2",
  "parity-scale-codec",
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "scale-info",
  "subxt-metadata",
  "syn 1.0.109",
+ "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "subxt-metadata"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593ab5f53435e6352675af4f9851342607f37785d84c7a3fb3139550d3c35f0"
+version = "0.28.0"
+source = "git+https://github.com/paritytech/subxt?branch=master#e583aa987eb57ac6ce70c7166925189a663d0d31"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
  "scale-info",
- "sp-core-hashing 6.0.0",
+ "sp-core-hashing 8.0.0",
 ]
 
 [[package]]
@@ -3489,25 +3632,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
 ]
 
 [[package]]
@@ -3518,9 +3649,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "termcolor"
@@ -3548,7 +3679,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3597,14 +3728,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -3612,18 +3742,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3632,16 +3762,26 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.12"
+name = "tokio-rustls"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.0",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cd2598a37719e3cd4c28af93f978506a97a2920ef4d96e4b12e38b8cbc8940"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3650,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3718,11 +3858,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3731,13 +3870,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3757,7 +3896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber 0.3.17",
 ]
 
 [[package]]
@@ -3805,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -3816,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.25.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3390c0409daaa6027d6681393316f4ccd3ff82e1590a1e4725014e3ae2bf1920"
+checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
@@ -3829,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "trie-root"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a36c5ca3911ed3c9a5416ee6c679042064b93fc637ded67e25f92e68d783891"
+checksum = "d4ed310ef5ab98f5fa467900ed906cb9232dd5376597e00fd4cba2a449d06c0b"
 dependencies = [
  "hash-db",
 ]
@@ -3921,6 +4060,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"
@@ -4033,11 +4178,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-loader"
-version = "0.19.0"
-source = "git+https://github.com/chevdor/subwasm?branch=master#fd047d76d52beab8c062eb94141f8d14ddc0f59d"
+version = "0.19.1"
+source = "git+https://github.com/chevdor/subwasm?branch=master#04fd6218fb41c29d04b21db7e821810b25664d9b"
 dependencies = [
  "hex",
- "jsonrpsee 0.16.2 (git+https://github.com/paritytech/jsonrpsee)",
+ "jsonrpsee 0.17.1",
  "log",
  "serde",
  "sp-maybe-compressed-blob",
@@ -4046,8 +4191,8 @@ dependencies = [
 
 [[package]]
 name = "wasm-testbed"
-version = "0.19.0"
-source = "git+https://github.com/chevdor/subwasm?branch=master#fd047d76d52beab8c062eb94141f8d14ddc0f59d"
+version = "0.19.1"
+source = "git+https://github.com/chevdor/subwasm?branch=master#04fd6218fb41c29d04b21db7e821810b25664d9b"
 dependencies = [
  "frame-metadata",
  "hex",
@@ -4158,7 +4303,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.36.13",
  "serde",
  "sha2 0.10.6",
  "toml",
@@ -4238,7 +4383,7 @@ checksum = "d0245e8a9347017c7185a72e215218a802ff561545c242953c11ba00fccc930f"
 dependencies = [
  "object 0.29.0",
  "once_cell",
- "rustix",
+ "rustix 0.36.13",
 ]
 
 [[package]]
@@ -4269,7 +4414,7 @@ dependencies = [
  "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
- "rustix",
+ "rustix 0.36.13",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -4318,6 +4463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4350,11 +4504,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4363,13 +4517,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4378,7 +4532,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4387,13 +4550,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4403,10 +4581,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4415,10 +4605,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4427,10 +4629,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4439,10 +4653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
-name = "winnow"
-version = "0.4.0"
+name = "windows_x86_64_msvc"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]
@@ -4458,23 +4678,22 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4498,9 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",

--- a/tools/runtime-codegen/Cargo.toml
+++ b/tools/runtime-codegen/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "4.0.8", features = ["derive", "cargo"] }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 color-eyre = "0.6.1"
 proc-macro2 = "1.0.51"
-subxt-codegen = "0.27.1"
 syn = "1.0"
+subxt-codegen = { git = "https://github.com/paritytech/subxt", branch = "master", default-features = false, features = [] }
 wasm-loader = { git = "https://github.com/chevdor/subwasm", branch = "master" }
 wasm-testbed = { git = "https://github.com/chevdor/subwasm", branch = "master" }


### PR DESCRIPTION
Closes #2045

The latest version of `subxt-codegen` exposes the possibility to:
- not add comments to the generated code
- only generate the runtime, without the subxt API
- not use the default derives

So we take advantage of this