### PR TITLE
Messages relay fixes

### DIFF
--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -561,6 +561,11 @@ where
 		self.strategy.source_nonces_updated(at_block, nonces)
 	}
 
+	fn reset_best_target_nonces(&mut self) {
+		self.target_nonces = None;
+		self.strategy.reset_best_target_nonces();
+	}
+
 	fn best_target_nonces_updated<RS: RaceState<SourceHeaderIdOf<P>, TargetHeaderIdOf<P>>>(
 		&mut self,
 		nonces: TargetClientNonces<DeliveryRaceTargetNoncesData>,

--- a/relays/messages/src/message_race_delivery.rs
+++ b/relays/messages/src/message_race_delivery.rs
@@ -343,31 +343,6 @@ where
 		// There's additional condition in the message delivery race: target would reject messages
 		// if there are too much unconfirmed messages at the inbound lane.
 
-		// The receiving race is responsible to deliver confirmations back to the source chain. So
-		// if there's a lot of unconfirmed messages, let's wait until it'll be able to do its job.
-		let latest_received_nonce_at_target = target_nonces.latest_nonce;
-		let confirmations_missing =
-			latest_received_nonce_at_target.checked_sub(latest_confirmed_nonce_at_source);
-		match confirmations_missing {
-			Some(confirmations_missing)
-				if confirmations_missing >= self.max_unconfirmed_nonces_at_target =>
-			{
-				log::debug!(
-					target: "bridge",
-					"Cannot deliver any more messages from {} to {}. Too many unconfirmed nonces \
-					at target: target.latest_received={:?}, source.latest_confirmed={:?}, max={:?}",
-					MessageDeliveryRace::<P>::source_name(),
-					MessageDeliveryRace::<P>::target_name(),
-					latest_received_nonce_at_target,
-					latest_confirmed_nonce_at_source,
-					self.max_unconfirmed_nonces_at_target,
-				);
-
-				return None
-			},
-			_ => (),
-		}
-
 		// Ok - we may have new nonces to deliver. But target may still reject new messages, because
 		// we haven't notified it that (some) messages have been confirmed. So we may want to
 		// include updated `source.latest_confirmed` in the proof.
@@ -375,6 +350,7 @@ where
 		// Important note: we're including outbound state lane proof whenever there are unconfirmed
 		// nonces on the target chain. Other strategy is to include it only if it's absolutely
 		// necessary.
+		let latest_received_nonce_at_target = target_nonces.latest_nonce;
 		let latest_confirmed_nonce_at_target = target_nonces.nonces_data.confirmed_nonce;
 		let outbound_state_proof_required =
 			latest_confirmed_nonce_at_target < latest_confirmed_nonce_at_source;
@@ -806,22 +782,6 @@ mod tests {
 			strategy.select_nonces_to_deliver(state).await,
 			Some(((20..=23), proof_parameters(false, 4)))
 		);
-	}
-
-	#[async_std::test]
-	async fn message_delivery_strategy_selects_nothing_if_too_many_confirmations_missing() {
-		let (state, mut strategy) = prepare_strategy();
-
-		// if there are already `max_unconfirmed_nonces_at_target` messages on target,
-		// we need to wait until confirmations will be delivered by receiving race
-		strategy.latest_confirmed_nonces_at_source = vec![(
-			header_id(1),
-			strategy.target_nonces.as_ref().unwrap().latest_nonce -
-				strategy.max_unconfirmed_nonces_at_target,
-		)]
-		.into_iter()
-		.collect();
-		assert_eq!(strategy.select_nonces_to_deliver(state).await, None);
 	}
 
 	#[async_std::test]

--- a/relays/messages/src/message_race_strategy.rs
+++ b/relays/messages/src/message_race_strategy.rs
@@ -276,7 +276,7 @@ impl<
 			.nonces_to_submit()
 			.map(|nonces| nonce >= *nonces.start())
 			.unwrap_or(false);
-		if need_to_select_new_nonces && race_state.nonces_to_submit().is_some() {
+		if need_to_select_new_nonces {
 			log::trace!(
 				target: "bridge",
 				"Latest nonce at target is {}. Clearing nonces to submit: {:?}",
@@ -293,7 +293,7 @@ impl<
 			.nonces_submitted()
 			.map(|nonces| nonce >= *nonces.start())
 			.unwrap_or(false);
-		if need_new_nonces_to_submit && race_state.nonces_submitted().is_some() {
+		if need_new_nonces_to_submit {
 			log::trace!(
 				target: "bridge",
 				"Latest nonce at target is {}. Clearing submitted nonces: {:?}",

--- a/relays/messages/src/message_race_strategy.rs
+++ b/relays/messages/src/message_race_strategy.rs
@@ -254,6 +254,10 @@ impl<
 		)
 	}
 
+	fn reset_best_target_nonces(&mut self) {
+		self.best_target_nonce = None;
+	}
+
 	fn best_target_nonces_updated<
 		RS: RaceState<
 			HeaderId<SourceHeaderHash, SourceHeaderNumber>,

--- a/relays/messages/src/message_race_strategy.rs
+++ b/relays/messages/src/message_race_strategy.rs
@@ -270,19 +270,37 @@ impl<
 	) {
 		let nonce = nonces.latest_nonce;
 
+		// if **some** of nonces that we have selected to submit already present at the
+		// target chain => select new nonces
 		let need_to_select_new_nonces = race_state
 			.nonces_to_submit()
-			.map(|nonces| *nonces.end() <= nonce)
+			.map(|nonces| nonce >= *nonces.start())
 			.unwrap_or(false);
-		if need_to_select_new_nonces {
+		if need_to_select_new_nonces && race_state.nonces_to_submit().is_some() {
+			log::trace!(
+				target: "bridge",
+				"Latest nonce at target is {}. Clearing nonces to submit: {:?}",
+				nonce,
+				race_state.nonces_to_submit(),
+			);
+
 			race_state.reset_nonces_to_submit();
 		}
 
+		// if **some** of nonces that we have submitted already present at the
+		// target chain => select new nonces
 		let need_new_nonces_to_submit = race_state
 			.nonces_submitted()
-			.map(|nonces| *nonces.end() <= nonce)
+			.map(|nonces| nonce >= *nonces.start())
 			.unwrap_or(false);
-		if need_new_nonces_to_submit {
+		if need_new_nonces_to_submit && race_state.nonces_submitted().is_some() {
+			log::trace!(
+				target: "bridge",
+				"Latest nonce at target is {}. Clearing submitted nonces: {:?}",
+				nonce,
+				race_state.nonces_submitted(),
+			);
+
 			race_state.reset_nonces_submitted();
 		}
 
@@ -419,10 +437,15 @@ mod tests {
 		let mut state = TestRaceStateImpl::default();
 		let mut strategy = BasicStrategy::<TestMessageLane>::new();
 		state.nonces_to_submit = Some((header_id(1), 5..=10, (5..=10, None)));
-		strategy.best_target_nonces_updated(target_nonces(7), &mut state);
+		// we are going to submit 5..=10, so having latest nonce 4 at target is fine
+		strategy.best_target_nonces_updated(target_nonces(4), &mut state);
 		assert!(state.nonces_to_submit.is_some());
-		strategy.best_target_nonces_updated(target_nonces(10), &mut state);
-		assert!(state.nonces_to_submit.is_none());
+		// any nonce larger than 4 invalidates the `nonces_to_submit`
+		for nonce in 5..=11 {
+			state.nonces_to_submit = Some((header_id(1), 5..=10, (5..=10, None)));
+			strategy.best_target_nonces_updated(target_nonces(nonce), &mut state);
+			assert!(state.nonces_to_submit.is_none());
+		}
 	}
 
 	#[test]
@@ -430,10 +453,15 @@ mod tests {
 		let mut state = TestRaceStateImpl::default();
 		let mut strategy = BasicStrategy::<TestMessageLane>::new();
 		state.nonces_submitted = Some(5..=10);
-		strategy.best_target_nonces_updated(target_nonces(7), &mut state);
+		// we have submitted 5..=10, so having latest nonce 4 at target is fine
+		strategy.best_target_nonces_updated(target_nonces(4), &mut state);
 		assert!(state.nonces_submitted.is_some());
-		strategy.best_target_nonces_updated(target_nonces(10), &mut state);
-		assert!(state.nonces_submitted.is_none());
+		// any nonce larger than 4 invalidates the `nonces_submitted`
+		for nonce in 5..=11 {
+			state.nonces_submitted = Some(5..=10);
+			strategy.best_target_nonces_updated(target_nonces(nonce), &mut state);
+			assert!(state.nonces_submitted.is_none());
+		}
 	}
 
 	#[async_std::test]


### PR DESCRIPTION
https://github.com/paritytech/parity-bridges-common/commit/3abd734e9c2666ff28d542d77d812c5129fbd700: removes check that is now wrong and breaks relay. It is now superseded by the lane unblock transaction and related stuff

https://github.com/paritytech/parity-bridges-common/commit/94dc4f805de41e721d39553b11cb632fefc0061a: if we have failed to submit nonces `1..=10`, that is probably because our transaction is already obsolete and there are new nonces at the target node. Let's wait until we read those nonces and continue. This decreases relay "sleep" time

https://github.com/paritytech/parity-bridges-common/commit/ec0ed529f567441373299c698867655f0a61b767: now we reject all transactions where at least one nonce is obsolete. This commit "shares" this knowledge with relay - if it sees that at least one of selected/submitted nonces is already at target node, it'll assume that we need to reselect and resubmit new nonces.