### PR TITLE
Fixed off-by-one when confirming rewards in messages pallet

### DIFF
--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -548,7 +548,7 @@ mod tests {
 	}
 
 	#[test]
-	fn no_off_by_one_when_first_message_of_single_relayer_is_confirmed() {
+	fn first_message_is_confirmed_correctly() {
 		run_test(|| {
 			let mut lane = inbound_lane::<TestRuntime, _>(TEST_LANE_ID);
 			receive_regular_message(&mut lane, 1);

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -153,7 +153,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		// Note: There will be max. 1 record to update as we don't allow messages from relayers to
 		// overlap.
 		match data.relayers.front_mut() {
-			Some(entry) if entry.messages.begin < new_confirmed_nonce => {
+			Some(entry) if entry.messages.begin <= new_confirmed_nonce => {
 				entry.messages.begin = new_confirmed_nonce + 1;
 			},
 			_ => {},
@@ -221,12 +221,13 @@ mod tests {
 	use crate::{
 		inbound_lane,
 		mock::{
-			dispatch_result, inbound_message_data, run_test, unrewarded_relayer,
-			TestMessageDispatch, TestRuntime, REGULAR_PAYLOAD, TEST_LANE_ID, TEST_RELAYER_A,
-			TEST_RELAYER_B, TEST_RELAYER_C,
+			dispatch_result, inbound_message_data, inbound_unrewarded_relayers_state, run_test,
+			unrewarded_relayer, TestMessageDispatch, TestRuntime, REGULAR_PAYLOAD, TEST_LANE_ID,
+			TEST_RELAYER_A, TEST_RELAYER_B, TEST_RELAYER_C,
 		},
 		RuntimeInboundLaneStorage,
 	};
+	use bp_messages::UnrewardedRelayersState;
 
 	fn receive_regular_message(
 		lane: &mut InboundLane<RuntimeInboundLaneStorage<TestRuntime, ()>>,
@@ -542,6 +543,31 @@ mod tests {
 					inbound_message_data(payload)
 				),
 				ReceivalResult::Dispatched(dispatch_result(1))
+			);
+		});
+	}
+
+	#[test]
+	fn no_off_by_one_when_first_message_of_single_relayer_is_confirmed() {
+		run_test(|| {
+			let mut lane = inbound_lane::<TestRuntime, _>(TEST_LANE_ID);
+			receive_regular_message(&mut lane, 1);
+			receive_regular_message(&mut lane, 2);
+			assert_eq!(
+				lane.receive_state_update(OutboundLaneData {
+					latest_received_nonce: 1,
+					..Default::default()
+				}),
+				Some(1),
+			);
+			assert_eq!(
+				inbound_unrewarded_relayers_state(TEST_LANE_ID),
+				UnrewardedRelayersState {
+					unrewarded_relayer_entries: 1,
+					messages_in_oldest_entry: 1,
+					total_messages: 1,
+					last_delivered_nonce: 2,
+				},
 			);
 		});
 	}

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -949,12 +949,12 @@ fn verify_and_decode_messages_proof<Chain: SourceHeaderChain, DispatchPayload: D
 mod tests {
 	use super::*;
 	use crate::mock::{
-		message, message_payload, run_test, unrewarded_relayer, AccountId, DbWeight,
-		RuntimeEvent as TestEvent, RuntimeOrigin, TestDeliveryConfirmationPayments,
-		TestDeliveryPayments, TestMessagesDeliveryProof, TestMessagesProof, TestRelayer,
-		TestRuntime, TestWeightInfo, MAX_OUTBOUND_PAYLOAD_SIZE, PAYLOAD_REJECTED_BY_TARGET_CHAIN,
-		REGULAR_PAYLOAD, TEST_LANE_ID, TEST_LANE_ID_2, TEST_LANE_ID_3, TEST_RELAYER_A,
-		TEST_RELAYER_B,
+		inbound_unrewarded_relayers_state, message, message_payload, run_test, unrewarded_relayer,
+		AccountId, DbWeight, RuntimeEvent as TestEvent, RuntimeOrigin,
+		TestDeliveryConfirmationPayments, TestDeliveryPayments, TestMessagesDeliveryProof,
+		TestMessagesProof, TestRelayer, TestRuntime, TestWeightInfo, MAX_OUTBOUND_PAYLOAD_SIZE,
+		PAYLOAD_REJECTED_BY_TARGET_CHAIN, REGULAR_PAYLOAD, TEST_LANE_ID, TEST_LANE_ID_2,
+		TEST_LANE_ID_3, TEST_RELAYER_A, TEST_RELAYER_B,
 	};
 	use bp_messages::{BridgeMessagesCall, UnrewardedRelayer, UnrewardedRelayersState};
 	use bp_test_utils::generate_owned_bridge_module_tests;
@@ -971,23 +971,6 @@ mod tests {
 	fn get_ready_for_events() {
 		System::<TestRuntime>::set_block_number(1);
 		System::<TestRuntime>::reset_events();
-	}
-
-	fn inbound_unrewarded_relayers_state(
-		lane: bp_messages::LaneId,
-	) -> bp_messages::UnrewardedRelayersState {
-		let inbound_lane_data = InboundLanes::<TestRuntime, ()>::get(lane).0;
-		let last_delivered_nonce = inbound_lane_data.last_delivered_nonce();
-		let relayers = inbound_lane_data.relayers;
-		bp_messages::UnrewardedRelayersState {
-			unrewarded_relayer_entries: relayers.len() as _,
-			messages_in_oldest_entry: relayers
-				.front()
-				.map(|entry| 1 + entry.messages.end - entry.messages.begin)
-				.unwrap_or(0),
-			total_messages: total_unrewarded_messages(&relayers).unwrap_or(MessageNonce::MAX),
-			last_delivered_nonce,
-		}
 	}
 
 	fn send_regular_message() {


### PR DESCRIPTION
For example when messages `235..=363` are delivered by single relayer and only message `235` reward is confirmed, then the `235` was not removed from delivered messages and total number unrewarded messages was above the limit (e.g. `129` vs `128`).