### PR TITLE
Add integrity tests to rialto parachain runtiime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10012,6 +10012,7 @@ dependencies = [
  "sp-std 5.0.0",
  "sp-transaction-pool",
  "sp-version",
+ "static_assertions",
  "substrate-wasm-builder",
  "xcm",
  "xcm-builder",

--- a/bin/rialto-parachain/runtime/Cargo.toml
+++ b/bin/rialto-parachain/runtime/Cargo.toml
@@ -76,6 +76,7 @@ pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "master"
 
 [dev-dependencies]
 bridge-runtime-common = { path = "../../runtime-common", features = ["integrity-test"] }
+static_assertions = "1.1"
 
 [features]
 default = ['std']

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -134,3 +134,65 @@ impl XcmBlobHauler for ToMillauXcmBlobHauler {
 		XCM_LANE
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{MillauGrandpaInstance, Runtime, WithMillauMessagesInstance};
+	use bridge_runtime_common::{
+		assert_complete_bridge_types,
+		integrity::{
+			assert_complete_bridge_constants, check_message_lane_weights,
+			AssertBridgeMessagesPalletConstants, AssertBridgePalletNames, AssertChainConstants,
+			AssertCompleteBridgeConstants,
+		},
+	};
+
+	#[test]
+	fn ensure_millau_message_lane_weights_are_correct() {
+		check_message_lane_weights::<bp_rialto_parachain::RialtoParachain, Runtime>(
+			bp_millau::EXTRA_STORAGE_PROOF_SIZE,
+			bp_rialto_parachain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
+			bp_rialto_parachain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
+			false,
+		);
+	}
+
+	#[test]
+	fn ensure_bridge_integrity() {
+		assert_complete_bridge_types!(
+			runtime: Runtime,
+			with_bridged_chain_grandpa_instance: MillauGrandpaInstance,
+			with_bridged_chain_messages_instance: WithMillauMessagesInstance,
+			bridge: WithMillauMessageBridge,
+			this_chain: bp_rialto_parachain::RialtoParachain,
+			bridged_chain: bp_millau::Millau,
+		);
+
+		assert_complete_bridge_constants::<
+			Runtime,
+			MillauGrandpaInstance,
+			WithMillauMessagesInstance,
+			WithMillauMessageBridge,
+		>(AssertCompleteBridgeConstants {
+			this_chain_constants: AssertChainConstants {
+				block_length: bp_rialto_parachain::BlockLength::get(),
+				block_weights: bp_rialto_parachain::BlockWeights::get(),
+			},
+			messages_pallet_constants: AssertBridgeMessagesPalletConstants {
+				max_unrewarded_relayers_in_bridged_confirmation_tx:
+					bp_millau::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
+				max_unconfirmed_messages_in_bridged_confirmation_tx:
+					bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
+				bridged_chain_id: bp_runtime::MILLAU_CHAIN_ID,
+			},
+			pallet_names: AssertBridgePalletNames {
+				with_this_chain_messages_pallet_name:
+					bp_rialto_parachain::WITH_RIALTO_PARACHAIN_MESSAGES_PALLET_NAME,
+				with_bridged_chain_grandpa_pallet_name: bp_millau::WITH_MILLAU_GRANDPA_PALLET_NAME,
+				with_bridged_chain_messages_pallet_name:
+					bp_millau::WITH_MILLAU_MESSAGES_PALLET_NAME,
+			},
+		});
+	}
+}

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -154,7 +154,6 @@ mod tests {
 			bp_millau::EXTRA_STORAGE_PROOF_SIZE,
 			bp_rialto_parachain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 			bp_rialto_parachain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
-			false,
 		);
 	}
 


### PR DESCRIPTION
extracted from #2089 

I've found that we are not currently doing weights/types assertions for `rialto-parachain` runtime. This PR adds that.