### PR TITLE
Naive fix for sending sized messages

### DIFF
--- a/bin/runtime-common/src/lib.rs
+++ b/bin/runtime-common/src/lib.rs
@@ -159,7 +159,21 @@ pub enum CustomNetworkId {
 	RialtoParachain,
 }
 
+impl TryFrom<bp_runtime::ChainId> for CustomNetworkId {
+	type Error = ();
+
+	fn try_from(chain: bp_runtime::ChainId) -> Result<Self, Self::Error> {
+		Ok(match chain {
+			bp_runtime::MILLAU_CHAIN_ID => Self::Millau,
+			bp_runtime::RIALTO_CHAIN_ID => Self::Rialto,
+			bp_runtime::RIALTO_PARACHAIN_CHAIN_ID => Self::RialtoParachain,
+			_ => return Err(()),
+		})
+	}
+}
+
 impl CustomNetworkId {
+	/// Converts self to XCM' network id.
 	pub const fn as_network_id(&self) -> NetworkId {
 		match *self {
 			CustomNetworkId::Millau => NetworkId::Kusama,

--- a/deployments/networks/millau.yml
+++ b/deployments/networks/millau.yml
@@ -11,7 +11,6 @@ services:
     image: ${MILLAU_BRIDGE_NODE_IMAGE:-paritytech/millau-bridge-node}
     entrypoint:
       - /home/user/millau-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/millau-node-bob/tcp/30333/p2p/12D3KooWM5LFR5ne4yTQ4sBSXJ75M4bDo2MAhAW2GhL3i8fe5aRb
       - --alice
@@ -32,7 +31,6 @@ services:
     <<: *millau-bridge-node
     entrypoint:
       - /home/user/millau-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/millau-node-alice/tcp/30333/p2p/12D3KooWFqiV73ipQ1jpfVmCfLqBCp8G9PLH3zPkY9EhmdrSGA4H
       - --bob
@@ -51,7 +49,6 @@ services:
     <<: *millau-bridge-node
     entrypoint:
       - /home/user/millau-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/millau-node-alice/tcp/30333/p2p/12D3KooWFqiV73ipQ1jpfVmCfLqBCp8G9PLH3zPkY9EhmdrSGA4H
       - --charlie
@@ -69,7 +66,6 @@ services:
     <<: *millau-bridge-node
     entrypoint:
       - /home/user/millau-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/millau-node-alice/tcp/30333/p2p/12D3KooWFqiV73ipQ1jpfVmCfLqBCp8G9PLH3zPkY9EhmdrSGA4H
       - --dave
@@ -87,7 +83,6 @@ services:
     <<: *millau-bridge-node
     entrypoint:
       - /home/user/millau-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/millau-node-alice/tcp/30333/p2p/12D3KooWFqiV73ipQ1jpfVmCfLqBCp8G9PLH3zPkY9EhmdrSGA4H
       - --eve

--- a/deployments/networks/rialto.yml
+++ b/deployments/networks/rialto.yml
@@ -11,7 +11,6 @@ services:
     image: ${RIALTO_BRIDGE_NODE_IMAGE:-paritytech/rialto-bridge-node}
     entrypoint:
       - /home/user/rialto-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/rialto-node-bob/tcp/30333/p2p/12D3KooWSEpHJj29HEzgPFcRYVc5X3sEuP3KgiUoqJNCet51NiMX
       - --alice
@@ -32,7 +31,6 @@ services:
     <<: *rialto-bridge-node
     entrypoint:
       - /home/user/rialto-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/rialto-node-alice/tcp/30333/p2p/12D3KooWMF6JvV319a7kJn5pqkKbhR3fcM2cvK5vCbYZHeQhYzFE
       - --bob
@@ -51,7 +49,6 @@ services:
     <<: *rialto-bridge-node
     entrypoint:
       - /home/user/rialto-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/rialto-node-alice/tcp/30333/p2p/12D3KooWMF6JvV319a7kJn5pqkKbhR3fcM2cvK5vCbYZHeQhYzFE
       - --charlie
@@ -69,7 +66,6 @@ services:
     <<: *rialto-bridge-node
     entrypoint:
       - /home/user/rialto-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/rialto-node-alice/tcp/30333/p2p/12D3KooWMF6JvV319a7kJn5pqkKbhR3fcM2cvK5vCbYZHeQhYzFE
       - --dave
@@ -87,7 +83,6 @@ services:
     <<: *rialto-bridge-node
     entrypoint:
       - /home/user/rialto-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/rialto-node-alice/tcp/30333/p2p/12D3KooWMF6JvV319a7kJn5pqkKbhR3fcM2cvK5vCbYZHeQhYzFE
       - --eve
@@ -105,7 +100,6 @@ services:
     <<: *rialto-bridge-node
     entrypoint:
       - /home/user/rialto-bridge-node
-      - --execution=Native
       - --chain=local
       - --bootnodes=/dns4/rialto-node-alice/tcp/30333/p2p/12D3KooWMF6JvV319a7kJn5pqkKbhR3fcM2cvK5vCbYZHeQhYzFE
       - --ferdie

--- a/relays/bin-substrate/src/chains/mod.rs
+++ b/relays/bin-substrate/src/chains/mod.rs
@@ -27,7 +27,7 @@ mod wococo;
 
 #[cfg(test)]
 mod tests {
-	use crate::cli::encode_message;
+	use crate::cli::{encode_message, encode_message::XCM_EXPORTER_OVERHEAD};
 	use bp_messages::source_chain::TargetHeaderChain;
 	use bp_runtime::Chain as _;
 	use codec::Encode;
@@ -42,7 +42,7 @@ mod tests {
 		let maximal_message_size = encode_message::compute_maximal_message_size(
 			bp_rialto::Rialto::max_extrinsic_size(),
 			bp_millau::Millau::max_extrinsic_size(),
-		);
+		) + XCM_EXPORTER_OVERHEAD;
 
 		let message = vec![42; maximal_message_size as _];
 		assert_eq!(MillauAsTargetHeaderChain::verify_message(&message), Ok(()));

--- a/relays/bin-substrate/src/cli/encode_message.rs
+++ b/relays/bin-substrate/src/cli/encode_message.rs
@@ -78,16 +78,13 @@ pub(crate) fn encode_message<Source: Chain, Target: Chain>(
 			// instruction, which has byte vector inside
 			let mut current_vec_size = expected_xcm_size;
 			let at_target_xcm = loop {
-				let xcm = xcm::v3::Xcm(
-					vec![xcm::v3::Instruction::ExpectPallet {
-						index: 0,
-						name: vec![42; current_vec_size as usize],
-						module_name: vec![],
-						crate_major: 0,
-						min_crate_minor: 0,
-					}]
-					.into(),
-				);
+				let xcm = xcm::v3::Xcm(vec![xcm::v3::Instruction::ExpectPallet {
+					index: 0,
+					name: vec![42; current_vec_size as usize],
+					module_name: vec![],
+					crate_major: 0,
+					min_crate_minor: 0,
+				}]);
 				if xcm.encode().len() <= expected_xcm_size as usize {
 					break xcm
 				}


### PR DESCRIPTION
Fix sized messages by adding an estimated xcm executor overhead.

This can be just a temporary fix, or if it's good enough we can leave it like this. @svyatonik what do you think ? How precise does the payload size need to be ? I see that we already have other estimation [here for example](https://github.com/paritytech/parity-bridges-common/blob/ae44c6b7a13ff6d2d14ac927f1d4189cdb0d81d5/relays/bin-substrate/src/cli/encode_message.rs#L104).