### PR TITLE
Add `MessagesPalletInstance` for integrity tests

### DIFF
--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -166,7 +166,7 @@ mod tests {
 
 	#[test]
 	fn ensure_millau_message_lane_weights_are_correct() {
-		check_message_lane_weights::<bp_millau::Millau, Runtime>(
+		check_message_lane_weights::<bp_millau::Millau, Runtime, WithRialtoMessagesInstance>(
 			bp_rialto::EXTRA_STORAGE_PROOF_SIZE,
 			bp_millau::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 			bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,

--- a/bin/millau/runtime/src/rialto_parachain_messages.rs
+++ b/bin/millau/runtime/src/rialto_parachain_messages.rs
@@ -172,7 +172,7 @@ mod tests {
 
 	#[test]
 	fn ensure_millau_message_lane_weights_are_correct() {
-		check_message_lane_weights::<bp_millau::Millau, Runtime>(
+		check_message_lane_weights::<bp_millau::Millau, Runtime, WithRialtoParachainMessagesInstance>(
 			bp_rialto_parachain::EXTRA_STORAGE_PROOF_SIZE,
 			bp_millau::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 			bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -150,7 +150,11 @@ mod tests {
 
 	#[test]
 	fn ensure_millau_message_lane_weights_are_correct() {
-		check_message_lane_weights::<bp_rialto_parachain::RialtoParachain, Runtime>(
+		check_message_lane_weights::<
+			bp_rialto_parachain::RialtoParachain,
+			Runtime,
+			WithMillauMessagesInstance,
+		>(
 			bp_millau::EXTRA_STORAGE_PROOF_SIZE,
 			bp_rialto_parachain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 			bp_rialto_parachain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -150,7 +150,7 @@ mod tests {
 
 	#[test]
 	fn ensure_millau_message_lane_weights_are_correct() {
-		check_message_lane_weights::<bp_rialto::Rialto, Runtime>(
+		check_message_lane_weights::<bp_rialto::Rialto, Runtime, WithMillauMessagesInstance>(
 			bp_millau::EXTRA_STORAGE_PROOF_SIZE,
 			bp_rialto::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 			bp_rialto::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,


### PR DESCRIPTION
we have multiple instance in Cumulus and without this it wont work