### PR TITLE
Remove some `expect()` statements

### DIFF
--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -40,7 +40,7 @@ pub trait InboundLaneStorage {
 	/// Return maximal number of unconfirmed messages in inbound lane.
 	fn max_unconfirmed_messages(&self) -> MessageNonce;
 	/// Get lane data from the storage.
-	fn data(&self) -> InboundLaneData<Self::Relayer>;
+	fn get_or_init_data(&mut self) -> InboundLaneData<Self::Relayer>;
 	/// Update lane data in the storage.
 	fn set_data(&mut self, data: InboundLaneData<Self::Relayer>);
 }
@@ -117,9 +117,9 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		InboundLane { storage }
 	}
 
-	/// Returns storage reference.
-	pub fn storage(&self) -> &S {
-		&self.storage
+	/// Returns mut storage reference.
+	pub fn storage_mut(&mut self) -> &mut S {
+		&mut self.storage
 	}
 
 	/// Receive state of the corresponding outbound lane.
@@ -127,7 +127,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		&mut self,
 		outbound_lane_data: OutboundLaneData,
 	) -> Option<MessageNonce> {
-		let mut data = self.storage.data();
+		let mut data = self.storage.get_or_init_data();
 		let last_delivered_nonce = data.last_delivered_nonce();
 
 		if outbound_lane_data.latest_received_nonce > last_delivered_nonce {
@@ -170,7 +170,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		nonce: MessageNonce,
 		message_data: DispatchMessageData<Dispatch::DispatchPayload>,
 	) -> ReceivalResult<Dispatch::DispatchLevelResult> {
-		let mut data = self.storage.data();
+		let mut data = self.storage.get_or_init_data();
 		let is_correct_message = nonce == data.last_delivered_nonce() + 1;
 		if !is_correct_message {
 			return ReceivalResult::InvalidNonce
@@ -252,7 +252,7 @@ mod tests {
 				None,
 			);
 
-			assert_eq!(lane.storage.data().last_confirmed_nonce, 0);
+			assert_eq!(lane.storage.get_or_init_data().last_confirmed_nonce, 0);
 		});
 	}
 
@@ -270,7 +270,7 @@ mod tests {
 				}),
 				Some(3),
 			);
-			assert_eq!(lane.storage.data().last_confirmed_nonce, 3);
+			assert_eq!(lane.storage.get_or_init_data().last_confirmed_nonce, 3);
 
 			assert_eq!(
 				lane.receive_state_update(OutboundLaneData {
@@ -279,7 +279,7 @@ mod tests {
 				}),
 				None,
 			);
-			assert_eq!(lane.storage.data().last_confirmed_nonce, 3);
+			assert_eq!(lane.storage.get_or_init_data().last_confirmed_nonce, 3);
 		});
 	}
 
@@ -290,9 +290,9 @@ mod tests {
 			receive_regular_message(&mut lane, 1);
 			receive_regular_message(&mut lane, 2);
 			receive_regular_message(&mut lane, 3);
-			assert_eq!(lane.storage.data().last_confirmed_nonce, 0);
+			assert_eq!(lane.storage.get_or_init_data().last_confirmed_nonce, 0);
 			assert_eq!(
-				lane.storage.data().relayers,
+				lane.storage.get_or_init_data().relayers,
 				vec![unrewarded_relayer(1, 3, TEST_RELAYER_A)]
 			);
 
@@ -303,9 +303,9 @@ mod tests {
 				}),
 				Some(2),
 			);
-			assert_eq!(lane.storage.data().last_confirmed_nonce, 2);
+			assert_eq!(lane.storage.get_or_init_data().last_confirmed_nonce, 2);
 			assert_eq!(
-				lane.storage.data().relayers,
+				lane.storage.get_or_init_data().relayers,
 				vec![unrewarded_relayer(3, 3, TEST_RELAYER_A)]
 			);
 
@@ -316,8 +316,8 @@ mod tests {
 				}),
 				Some(3),
 			);
-			assert_eq!(lane.storage.data().last_confirmed_nonce, 3);
-			assert_eq!(lane.storage.data().relayers, vec![]);
+			assert_eq!(lane.storage.get_or_init_data().last_confirmed_nonce, 3);
+			assert_eq!(lane.storage.get_or_init_data().relayers, vec![]);
 		});
 	}
 
@@ -325,7 +325,7 @@ mod tests {
 	fn receive_status_update_works_with_batches_from_relayers() {
 		run_test(|| {
 			let mut lane = inbound_lane::<TestRuntime, _>(TEST_LANE_ID);
-			let mut seed_storage_data = lane.storage.data();
+			let mut seed_storage_data = lane.storage.get_or_init_data();
 			// Prepare data
 			seed_storage_data.last_confirmed_nonce = 0;
 			seed_storage_data.relayers.push_back(unrewarded_relayer(1, 1, TEST_RELAYER_A));
@@ -341,9 +341,9 @@ mod tests {
 				}),
 				Some(3),
 			);
-			assert_eq!(lane.storage.data().last_confirmed_nonce, 3);
+			assert_eq!(lane.storage.get_or_init_data().last_confirmed_nonce, 3);
 			assert_eq!(
-				lane.storage.data().relayers,
+				lane.storage.get_or_init_data().relayers,
 				vec![
 					unrewarded_relayer(4, 4, TEST_RELAYER_B),
 					unrewarded_relayer(5, 5, TEST_RELAYER_C)
@@ -364,7 +364,7 @@ mod tests {
 				),
 				ReceivalResult::InvalidNonce
 			);
-			assert_eq!(lane.storage.data().last_delivered_nonce(), 0);
+			assert_eq!(lane.storage.get_or_init_data().last_delivered_nonce(), 0);
 		});
 	}
 
@@ -470,7 +470,7 @@ mod tests {
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
 			assert_eq!(
-				lane.storage.data().relayers,
+				lane.storage.get_or_init_data().relayers,
 				vec![
 					unrewarded_relayer(1, 1, TEST_RELAYER_A),
 					unrewarded_relayer(2, 2, TEST_RELAYER_B),
@@ -508,7 +508,7 @@ mod tests {
 		run_test(|| {
 			let mut lane = inbound_lane::<TestRuntime, _>(TEST_LANE_ID);
 			receive_regular_message(&mut lane, 1);
-			assert_eq!(lane.storage.data().last_delivered_nonce(), 1);
+			assert_eq!(lane.storage.get_or_init_data().last_delivered_nonce(), 1);
 		});
 	}
 

--- a/modules/messages/src/outbound_lane.rs
+++ b/modules/messages/src/outbound_lane.rs
@@ -20,6 +20,7 @@ use crate::Config;
 
 use bp_messages::{
 	DeliveredMessages, LaneId, MessageNonce, MessagePayload, OutboundLaneData, UnrewardedRelayer,
+	VerificationError,
 };
 use frame_support::{
 	weights::{RuntimeDbWeight, Weight},
@@ -40,7 +41,11 @@ pub trait OutboundLaneStorage {
 	#[cfg(test)]
 	fn message(&self, nonce: &MessageNonce) -> Option<MessagePayload>;
 	/// Save outbound message in the storage.
-	fn save_message(&mut self, nonce: MessageNonce, message_payload: MessagePayload);
+	fn save_message(
+		&mut self,
+		nonce: MessageNonce,
+		message_payload: MessagePayload,
+	) -> Result<(), VerificationError>;
 	/// Remove outbound message from the storage.
 	fn remove_message(&mut self, nonce: &MessageNonce);
 }
@@ -88,15 +93,18 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 	/// Send message over lane.
 	///
 	/// Returns new message nonce.
-	pub fn send_message(&mut self, message_payload: MessagePayload) -> MessageNonce {
+	pub fn send_message(
+		&mut self,
+		message_payload: MessagePayload,
+	) -> Result<MessageNonce, VerificationError> {
 		let mut data = self.storage.data();
 		let nonce = data.latest_generated_nonce + 1;
 		data.latest_generated_nonce = nonce;
 
-		self.storage.save_message(nonce, message_payload);
+		self.storage.save_message(nonce, message_payload)?;
 		self.storage.set_data(data);
 
-		nonce
+		Ok(nonce)
 	}
 
 	/// Confirm messages delivery.
@@ -213,7 +221,7 @@ mod tests {
 		},
 		outbound_lane,
 	};
-	use frame_support::weights::constants::RocksDbWeight;
+	use frame_support::{assert_ok, weights::constants::RocksDbWeight};
 	use sp_std::ops::RangeInclusive;
 
 	fn unrewarded_relayers(
@@ -234,9 +242,9 @@ mod tests {
 	) -> ReceivalConfirmationResult {
 		run_test(|| {
 			let mut lane = outbound_lane::<TestRuntime, _>(TEST_LANE_ID);
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 0);
 			let result = lane.confirm_delivery(3, latest_received_nonce, relayers);
@@ -251,7 +259,7 @@ mod tests {
 		run_test(|| {
 			let mut lane = outbound_lane::<TestRuntime, _>(TEST_LANE_ID);
 			assert_eq!(lane.storage.data().latest_generated_nonce, 0);
-			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), 1);
+			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), Ok(1));
 			assert!(lane.storage.message(&1).is_some());
 			assert_eq!(lane.storage.data().latest_generated_nonce, 1);
 		});
@@ -261,9 +269,9 @@ mod tests {
 	fn confirm_delivery_works() {
 		run_test(|| {
 			let mut lane = outbound_lane::<TestRuntime, _>(TEST_LANE_ID);
-			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), 1);
-			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), 2);
-			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), 3);
+			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), Ok(1));
+			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), Ok(2));
+			assert_eq!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)), Ok(3));
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 0);
 			assert_eq!(
@@ -279,9 +287,9 @@ mod tests {
 	fn confirm_delivery_rejects_nonce_lesser_than_latest_received() {
 		run_test(|| {
 			let mut lane = outbound_lane::<TestRuntime, _>(TEST_LANE_ID);
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 0);
 			assert_eq!(
@@ -369,9 +377,9 @@ mod tests {
 			);
 			assert_eq!(lane.storage.data().oldest_unpruned_nonce, 1);
 			// when nothing is confirmed, nothing is pruned
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
 			assert!(lane.storage.message(&1).is_some());
 			assert!(lane.storage.message(&2).is_some());
 			assert!(lane.storage.message(&3).is_some());
@@ -413,9 +421,9 @@ mod tests {
 	fn confirm_delivery_detects_when_more_than_expected_messages_are_confirmed() {
 		run_test(|| {
 			let mut lane = outbound_lane::<TestRuntime, _>(TEST_LANE_ID);
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
-			lane.send_message(outbound_message_data(REGULAR_PAYLOAD));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
+			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
 			assert_eq!(
 				lane.confirm_delivery(0, 3, &unrewarded_relayers(1..=3)),
 				ReceivalConfirmationResult::TryingToConfirmMoreMessagesThanExpected(3),


### PR DESCRIPTION
Related to #2038

Remove some `expect()` statements in order to avoid unpredictable failures.