### PR TITLE
Make client code generic over Client type

### DIFF
--- a/relays/bin-substrate/src/bridges/kusama_polkadot/kusama_headers_to_bridge_hub_polkadot.rs
+++ b/relays/bin-substrate/src/bridges/kusama_polkadot/kusama_headers_to_bridge_hub_polkadot.rs
@@ -19,7 +19,7 @@
 use crate::cli::bridge::{CliBridgeBase, RelayToRelayHeadersCliBridge};
 
 use async_trait::async_trait;
-use relay_substrate_client::{AccountKeyPairOf, Client, ClientT};
+use relay_substrate_client::{AccountKeyPairOf, Client};
 use substrate_relay_helper::{
 	finality::{engine::Grandpa as GrandpaFinalityEngine, SubstrateFinalitySyncPipeline},
 	TransactionParams,
@@ -45,7 +45,7 @@ impl SubstrateFinalitySyncPipeline for KusamaFinalityToBridgeHubPolkadot {
 	type SubmitFinalityProofCallBuilder = KusamaFinalityToBridgeHubPolkadotCallBuilder;
 
 	async fn start_relay_guards(
-		target_client: &Client<Self::TargetChain>,
+		target_client: &impl Client<Self::TargetChain>,
 		_transaction_params: &TransactionParams<AccountKeyPairOf<Self::TargetChain>>,
 		enable_version_guard: bool,
 	) -> relay_substrate_client::Result<()> {

--- a/relays/bin-substrate/src/bridges/kusama_polkadot/polkadot_headers_to_bridge_hub_kusama.rs
+++ b/relays/bin-substrate/src/bridges/kusama_polkadot/polkadot_headers_to_bridge_hub_kusama.rs
@@ -19,7 +19,7 @@
 use crate::cli::bridge::{CliBridgeBase, RelayToRelayHeadersCliBridge};
 
 use async_trait::async_trait;
-use relay_substrate_client::{AccountKeyPairOf, Client, ClientT};
+use relay_substrate_client::{AccountKeyPairOf, Client};
 use substrate_relay_helper::{
 	finality::{engine::Grandpa as GrandpaFinalityEngine, SubstrateFinalitySyncPipeline},
 	TransactionParams,
@@ -45,7 +45,7 @@ impl SubstrateFinalitySyncPipeline for PolkadotFinalityToBridgeHubKusama {
 	type SubmitFinalityProofCallBuilder = PolkadotFinalityToBridgeHubKusamaCallBuilder;
 
 	async fn start_relay_guards(
-		target_client: &Client<Self::TargetChain>,
+		target_client: &impl Client<Self::TargetChain>,
 		_transaction_params: &TransactionParams<AccountKeyPairOf<Self::TargetChain>>,
 		enable_version_guard: bool,
 	) -> relay_substrate_client::Result<()> {

--- a/relays/bin-substrate/src/bridges/rococo_wococo/rococo_headers_to_bridge_hub_wococo.rs
+++ b/relays/bin-substrate/src/bridges/rococo_wococo/rococo_headers_to_bridge_hub_wococo.rs
@@ -19,7 +19,7 @@
 use crate::cli::bridge::{CliBridgeBase, RelayToRelayHeadersCliBridge};
 
 use async_trait::async_trait;
-use relay_substrate_client::{AccountKeyPairOf, Client, ClientT};
+use relay_substrate_client::{AccountKeyPairOf, Client};
 use substrate_relay_helper::{
 	finality::{engine::Grandpa as GrandpaFinalityEngine, SubstrateFinalitySyncPipeline},
 	TransactionParams,
@@ -45,7 +45,7 @@ impl SubstrateFinalitySyncPipeline for RococoFinalityToBridgeHubWococo {
 	type SubmitFinalityProofCallBuilder = RococoFinalityToBridgeHubWococoCallBuilder;
 
 	async fn start_relay_guards(
-		target_client: &Client<Self::TargetChain>,
+		target_client: &impl Client<Self::TargetChain>,
 		_transaction_params: &TransactionParams<AccountKeyPairOf<Self::TargetChain>>,
 		enable_version_guard: bool,
 	) -> relay_substrate_client::Result<()> {

--- a/relays/bin-substrate/src/bridges/rococo_wococo/wococo_headers_to_bridge_hub_rococo.rs
+++ b/relays/bin-substrate/src/bridges/rococo_wococo/wococo_headers_to_bridge_hub_rococo.rs
@@ -19,7 +19,7 @@
 use crate::cli::bridge::{CliBridgeBase, RelayToRelayHeadersCliBridge};
 
 use async_trait::async_trait;
-use relay_substrate_client::{AccountKeyPairOf, Client, ClientT};
+use relay_substrate_client::{AccountKeyPairOf, Client};
 use substrate_relay_helper::{
 	finality::{engine::Grandpa as GrandpaFinalityEngine, SubstrateFinalitySyncPipeline},
 	TransactionParams,
@@ -45,7 +45,7 @@ impl SubstrateFinalitySyncPipeline for WococoFinalityToBridgeHubRococo {
 	type SubmitFinalityProofCallBuilder = WococoFinalityToBridgeHubRococoCallBuilder;
 
 	async fn start_relay_guards(
-		target_client: &Client<Self::TargetChain>,
+		target_client: &impl Client<Self::TargetChain>,
 		_transaction_params: &TransactionParams<AccountKeyPairOf<Self::TargetChain>>,
 		enable_version_guard: bool,
 	) -> relay_substrate_client::Result<()> {

--- a/relays/bin-substrate/src/cli/chain_schema.rs
+++ b/relays/bin-substrate/src/cli/chain_schema.rs
@@ -111,7 +111,7 @@ macro_rules! declare_chain_connection_params_cli_schema {
 				#[allow(dead_code)]
 				pub async fn into_client<Chain: CliChain>(
 					self,
-				) -> anyhow::Result<relay_substrate_client::Client<Chain>> {
+				) -> anyhow::Result<$crate::cli::DefaultClient<Chain>> {
 					let chain_runtime_version = self
 						.[<$chain_prefix _runtime_version>]
 						.into_runtime_version(Chain::RUNTIME_VERSION)?;

--- a/relays/bin-substrate/src/cli/mod.rs
+++ b/relays/bin-substrate/src/cli/mod.rs
@@ -46,6 +46,11 @@ mod resubmit_transactions;
 /// The target that will be used when publishing logs related to this pallet.
 pub const LOG_TARGET: &str = "bridge";
 
+/// Default Substrate client type that we are using. We'll use it all over the glue CLI code
+/// to avoid multiple level generic arguments and constraints. We still allow usage of other
+/// clients in the **core logic code**.
+pub type DefaultClient<C> = relay_substrate_client::RpcWithCachingClient<C>;
+
 /// Parse relay CLI args.
 pub fn parse_args() -> Command {
 	Command::from_args()

--- a/relays/bin-substrate/src/cli/register_parachain.rs
+++ b/relays/bin-substrate/src/cli/register_parachain.rs
@@ -26,7 +26,7 @@ use polkadot_runtime_common::{
 	paras_registrar::Call as ParaRegistrarCall, slots::Call as ParaSlotsCall,
 };
 use polkadot_runtime_parachains::paras::ParaLifecycle;
-use relay_substrate_client::{AccountIdOf, CallOf, Chain, Client, ClientT, UnsignedTransaction};
+use relay_substrate_client::{AccountIdOf, CallOf, Chain, Client, UnsignedTransaction};
 use relay_utils::{TrackedTransactionStatus, TransactionTracker};
 use rialto_runtime::SudoCall;
 use sp_core::{
@@ -230,7 +230,7 @@ impl RegisterParachain {
 
 /// Wait until parachain state is changed.
 async fn wait_para_state<Relaychain: Chain>(
-	relay_client: &Client<Relaychain>,
+	relay_client: &impl Client<Relaychain>,
 	para_state_key: &[u8],
 	from_states: &[ParaLifecycle],
 	to_state: ParaLifecycle,

--- a/relays/bin-substrate/src/cli/relay_headers.rs
+++ b/relays/bin-substrate/src/cli/relay_headers.rs
@@ -36,7 +36,7 @@ use crate::bridges::{
 	},
 	westend_millau::westend_headers_to_millau::WestendToMillauCliBridge,
 };
-use relay_substrate_client::ClientT;
+use relay_substrate_client::Client;
 use relay_utils::metrics::{GlobalMetrics, StandaloneMetric};
 use substrate_relay_helper::finality::SubstrateFinalitySyncPipeline;
 

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
@@ -64,7 +64,7 @@ use crate::{
 		},
 		chain_schema::*,
 		relay_headers_and_messages::parachain_to_parachain::ParachainToParachainBridge,
-		CliChain, HexLaneId, PrometheusParams,
+		CliChain, DefaultClient, HexLaneId, PrometheusParams,
 	},
 	declare_chain_cli_schema,
 };
@@ -72,7 +72,7 @@ use bp_messages::LaneId;
 use bp_runtime::BalanceOf;
 use relay_substrate_client::{
 	AccountIdOf, AccountKeyPairOf, Chain, ChainWithBalances, ChainWithMessages,
-	ChainWithTransactions, Client, Parachain,
+	ChainWithTransactions, Parachain,
 };
 use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
@@ -130,7 +130,7 @@ impl<Left: ChainWithTransactions + CliChain, Right: ChainWithTransactions + CliC
 /// Parameters that are associated with one side of the bridge.
 pub struct BridgeEndCommonParams<Chain: ChainWithTransactions + CliChain> {
 	/// Chain client.
-	pub client: Client<Chain>,
+	pub client: DefaultClient<Chain>,
 	/// Transactions signer.
 	pub sign: AccountKeyPairOf<Chain>,
 	/// Transactions mortality.
@@ -178,7 +178,7 @@ where
 		source_to_target_headers_relay: Arc<dyn OnDemandRelay<Source, Target>>,
 		target_to_source_headers_relay: Arc<dyn OnDemandRelay<Target, Source>>,
 		lane_id: LaneId,
-	) -> MessagesRelayParams<Bridge::MessagesLane> {
+	) -> MessagesRelayParams<Bridge::MessagesLane, DefaultClient<Source>, DefaultClient<Target>> {
 		MessagesRelayParams {
 			source_client: self.source.client.clone(),
 			source_transaction_params: TransactionParams {
@@ -374,6 +374,8 @@ where
 		for lane in lanes {
 			let left_to_right_messages = substrate_relay_helper::messages_lane::run::<
 				<Self::L2R as MessagesCliBridge>::MessagesLane,
+				_,
+				_,
 			>(self.left_to_right().messages_relay_params(
 				left_to_right_on_demand_headers.clone(),
 				right_to_left_on_demand_headers.clone(),
@@ -385,6 +387,8 @@ where
 
 			let right_to_left_messages = substrate_relay_helper::messages_lane::run::<
 				<Self::R2L as MessagesCliBridge>::MessagesLane,
+				_,
+				_,
 			>(self.right_to_left().messages_relay_params(
 				right_to_left_on_demand_headers.clone(),
 				left_to_right_on_demand_headers.clone(),

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/parachain_to_parachain.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/parachain_to_parachain.rs
@@ -20,12 +20,12 @@ use std::sync::Arc;
 use crate::cli::{
 	bridge::{CliBridgeBase, MessagesCliBridge, ParachainToRelayHeadersCliBridge},
 	relay_headers_and_messages::{Full2WayBridgeBase, Full2WayBridgeCommonParams},
-	CliChain,
+	CliChain, DefaultClient,
 };
 use bp_polkadot_core::parachains::ParaHash;
 use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumber};
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, ClientT, Parachain,
+	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, Parachain,
 };
 use sp_core::Pair;
 use substrate_relay_helper::{
@@ -51,9 +51,9 @@ pub struct ParachainToParachainBridge<
 	pub common:
 		Full2WayBridgeCommonParams<<R2L as CliBridgeBase>::Target, <L2R as CliBridgeBase>::Target>,
 	/// Client of the left relay chain.
-	pub left_relay: Client<<L2R as ParachainToRelayHeadersCliBridge>::SourceRelay>,
+	pub left_relay: DefaultClient<<L2R as ParachainToRelayHeadersCliBridge>::SourceRelay>,
 	/// Client of the right relay chain.
-	pub right_relay: Client<<R2L as ParachainToRelayHeadersCliBridge>::SourceRelay>,
+	pub right_relay: DefaultClient<<R2L as ParachainToRelayHeadersCliBridge>::SourceRelay>,
 
 	/// Override for right_relay->left headers signer.
 	pub right_headers_to_left_transaction_params:
@@ -233,25 +233,33 @@ where
 		)
 		.await?;
 
-		let left_relay_to_right_on_demand_headers =
-			OnDemandHeadersRelay::<<L2R as ParachainToRelayHeadersCliBridge>::RelayFinality>::new(
-				self.left_relay.clone(),
-				self.common.right.client.clone(),
-				self.left_headers_to_right_transaction_params.clone(),
-				self.common.shared.only_mandatory_headers,
-				Some(self.common.metrics_params.clone()),
-			);
-		let right_relay_to_left_on_demand_headers =
-			OnDemandHeadersRelay::<<R2L as ParachainToRelayHeadersCliBridge>::RelayFinality>::new(
-				self.right_relay.clone(),
-				self.common.left.client.clone(),
-				self.right_headers_to_left_transaction_params.clone(),
-				self.common.shared.only_mandatory_headers,
-				Some(self.common.metrics_params.clone()),
-			);
+		let left_relay_to_right_on_demand_headers = OnDemandHeadersRelay::<
+			<L2R as ParachainToRelayHeadersCliBridge>::RelayFinality,
+			_,
+			_,
+		>::new(
+			self.left_relay.clone(),
+			self.common.right.client.clone(),
+			self.left_headers_to_right_transaction_params.clone(),
+			self.common.shared.only_mandatory_headers,
+			Some(self.common.metrics_params.clone()),
+		);
+		let right_relay_to_left_on_demand_headers = OnDemandHeadersRelay::<
+			<R2L as ParachainToRelayHeadersCliBridge>::RelayFinality,
+			_,
+			_,
+		>::new(
+			self.right_relay.clone(),
+			self.common.left.client.clone(),
+			self.right_headers_to_left_transaction_params.clone(),
+			self.common.shared.only_mandatory_headers,
+			Some(self.common.metrics_params.clone()),
+		);
 
 		let left_to_right_on_demand_parachains = OnDemandParachainsRelay::<
 			<L2R as ParachainToRelayHeadersCliBridge>::ParachainFinality,
+			_,
+			_,
 		>::new(
 			self.left_relay.clone(),
 			self.common.right.client.clone(),
@@ -260,6 +268,8 @@ where
 		);
 		let right_to_left_on_demand_parachains = OnDemandParachainsRelay::<
 			<R2L as ParachainToRelayHeadersCliBridge>::ParachainFinality,
+			_,
+			_,
 		>::new(
 			self.right_relay.clone(),
 			self.common.left.client.clone(),

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_parachain.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_parachain.rs
@@ -23,12 +23,12 @@ use crate::cli::{
 		RelayToRelayHeadersCliBridge,
 	},
 	relay_headers_and_messages::{Full2WayBridgeBase, Full2WayBridgeCommonParams},
-	CliChain,
+	CliChain, DefaultClient,
 };
 use bp_polkadot_core::parachains::ParaHash;
 use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumber};
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, ClientT, Parachain,
+	AccountIdOf, AccountKeyPairOf, Chain, ChainWithTransactions, Client, Parachain,
 };
 use sp_core::Pair;
 use substrate_relay_helper::{
@@ -53,7 +53,7 @@ pub struct RelayToParachainBridge<
 	pub common:
 		Full2WayBridgeCommonParams<<R2L as CliBridgeBase>::Target, <L2R as CliBridgeBase>::Target>,
 	/// Client of the right relay chain.
-	pub right_relay: Client<<R2L as ParachainToRelayHeadersCliBridge>::SourceRelay>,
+	pub right_relay: DefaultClient<<R2L as ParachainToRelayHeadersCliBridge>::SourceRelay>,
 
 	/// Override for right_relay->left headers signer.
 	pub right_headers_to_left_transaction_params:
@@ -216,23 +216,28 @@ where
 		.await?;
 
 		let left_to_right_on_demand_headers =
-			OnDemandHeadersRelay::<<L2R as RelayToRelayHeadersCliBridge>::Finality>::new(
+			OnDemandHeadersRelay::<<L2R as RelayToRelayHeadersCliBridge>::Finality, _, _>::new(
 				self.common.left.client.clone(),
 				self.common.right.client.clone(),
 				self.left_headers_to_right_transaction_params.clone(),
 				self.common.shared.only_mandatory_headers,
 				None,
 			);
-		let right_relay_to_left_on_demand_headers =
-			OnDemandHeadersRelay::<<R2L as ParachainToRelayHeadersCliBridge>::RelayFinality>::new(
-				self.right_relay.clone(),
-				self.common.left.client.clone(),
-				self.right_headers_to_left_transaction_params.clone(),
-				self.common.shared.only_mandatory_headers,
-				Some(self.common.metrics_params.clone()),
-			);
+		let right_relay_to_left_on_demand_headers = OnDemandHeadersRelay::<
+			<R2L as ParachainToRelayHeadersCliBridge>::RelayFinality,
+			_,
+			_,
+		>::new(
+			self.right_relay.clone(),
+			self.common.left.client.clone(),
+			self.right_headers_to_left_transaction_params.clone(),
+			self.common.shared.only_mandatory_headers,
+			Some(self.common.metrics_params.clone()),
+		);
 		let right_to_left_on_demand_parachains = OnDemandParachainsRelay::<
 			<R2L as ParachainToRelayHeadersCliBridge>::ParachainFinality,
+			_,
+			_,
 		>::new(
 			self.right_relay.clone(),
 			self.common.left.client.clone(),

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_relay.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/relay_to_relay.rs
@@ -22,7 +22,7 @@ use crate::cli::{
 	relay_headers_and_messages::{Full2WayBridgeBase, Full2WayBridgeCommonParams},
 	CliChain,
 };
-use relay_substrate_client::{AccountIdOf, AccountKeyPairOf, ChainWithTransactions, ClientT};
+use relay_substrate_client::{AccountIdOf, AccountKeyPairOf, ChainWithTransactions, Client};
 use sp_core::Pair;
 use substrate_relay_helper::{
 	finality::SubstrateFinalitySyncPipeline,
@@ -168,7 +168,7 @@ where
 		.await?;
 
 		let left_to_right_on_demand_headers =
-			OnDemandHeadersRelay::<<L2R as RelayToRelayHeadersCliBridge>::Finality>::new(
+			OnDemandHeadersRelay::<<L2R as RelayToRelayHeadersCliBridge>::Finality, _, _>::new(
 				self.common.left.client.clone(),
 				self.common.right.client.clone(),
 				self.left_to_right_transaction_params.clone(),
@@ -176,7 +176,7 @@ where
 				None,
 			);
 		let right_to_left_on_demand_headers =
-			OnDemandHeadersRelay::<<R2L as RelayToRelayHeadersCliBridge>::Finality>::new(
+			OnDemandHeadersRelay::<<R2L as RelayToRelayHeadersCliBridge>::Finality, _, _>::new(
 				self.common.right.client.clone(),
 				self.common.left.client.clone(),
 				self.right_to_left_transaction_params.clone(),

--- a/relays/bin-substrate/src/cli/relay_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_messages.rs
@@ -79,22 +79,24 @@ where
 		let target_sign = data.target_sign.to_keypair::<Self::Target>()?;
 		let target_transactions_mortality = data.target_sign.transactions_mortality()?;
 
-		substrate_relay_helper::messages_lane::run::<Self::MessagesLane>(MessagesRelayParams {
-			source_client,
-			source_transaction_params: TransactionParams {
-				signer: source_sign,
-				mortality: source_transactions_mortality,
+		substrate_relay_helper::messages_lane::run::<Self::MessagesLane, _, _>(
+			MessagesRelayParams {
+				source_client,
+				source_transaction_params: TransactionParams {
+					signer: source_sign,
+					mortality: source_transactions_mortality,
+				},
+				target_client,
+				target_transaction_params: TransactionParams {
+					signer: target_sign,
+					mortality: target_transactions_mortality,
+				},
+				source_to_target_headers_relay: None,
+				target_to_source_headers_relay: None,
+				lane_id: data.lane.into(),
+				metrics_params: data.prometheus_params.into_metrics_params()?,
 			},
-			target_client,
-			target_transaction_params: TransactionParams {
-				signer: target_sign,
-				mortality: target_transactions_mortality,
-			},
-			source_to_target_headers_relay: None,
-			target_to_source_headers_relay: None,
-			lane_id: data.lane.into(),
-			metrics_params: data.prometheus_params.into_metrics_params()?,
-		})
+		)
 		.await
 		.map_err(|e| anyhow::format_err!("{}", e))
 	}

--- a/relays/bin-substrate/src/cli/resubmit_transactions.rs
+++ b/relays/bin-substrate/src/cli/resubmit_transactions.rs
@@ -20,7 +20,7 @@ use bp_runtime::HeaderIdProvider;
 use codec::{Decode, Encode};
 use num_traits::{One, Zero};
 use relay_substrate_client::{
-	AccountKeyPairOf, BlockWithJustification, Chain, ChainWithTransactions, Client, ClientT,
+	AccountKeyPairOf, BlockWithJustification, Chain, ChainWithTransactions, Client,
 	Error as SubstrateError, HeaderIdOf, HeaderOf, SignParam,
 };
 use relay_utils::FailedClient;
@@ -141,7 +141,7 @@ impl PrioritySelectionStrategy {
 	/// Select target priority.
 	async fn select_target_priority<C: ChainWithTransactions>(
 		&self,
-		client: &Client<C>,
+		client: &impl Client<C>,
 		context: &Context<C>,
 	) -> Result<Option<TransactionPriority>, SubstrateError> {
 		match *self {
@@ -202,7 +202,7 @@ impl<C: Chain> Context<C> {
 
 /// Run resubmit transactions loop.
 async fn run_until_connection_lost<C: ChainWithTransactions>(
-	client: Client<C>,
+	client: impl Client<C>,
 	transaction_params: TransactionParams<AccountKeyPairOf<C>>,
 	mut context: Context<C>,
 ) -> Result<(), FailedClient> {
@@ -227,7 +227,7 @@ async fn run_until_connection_lost<C: ChainWithTransactions>(
 
 /// Run single loop iteration.
 async fn run_loop_iteration<C: ChainWithTransactions>(
-	client: Client<C>,
+	client: impl Client<C>,
 	transaction_params: TransactionParams<AccountKeyPairOf<C>>,
 	mut context: Context<C>,
 ) -> Result<Context<C>, SubstrateError> {
@@ -302,7 +302,7 @@ async fn run_loop_iteration<C: ChainWithTransactions>(
 
 /// Search transaction pool for transaction, signed by given key pair.
 async fn lookup_signer_transaction<C: ChainWithTransactions>(
-	client: &Client<C>,
+	client: &impl Client<C>,
 	key_pair: &AccountKeyPairOf<C>,
 ) -> Result<Option<C::SignedTransaction>, SubstrateError> {
 	let pending_transactions = client.pending_extrinsics().await?;
@@ -321,7 +321,7 @@ async fn lookup_signer_transaction<C: ChainWithTransactions>(
 
 /// Read priority of best signed transaction of previous block.
 async fn read_previous_block_best_priority<C: ChainWithTransactions>(
-	client: &Client<C>,
+	client: &impl Client<C>,
 	context: &Context<C>,
 ) -> Result<Option<TransactionPriority>, SubstrateError> {
 	let best_block = client.block_by_hash(context.best_header.hash()).await?;
@@ -343,7 +343,7 @@ async fn read_previous_block_best_priority<C: ChainWithTransactions>(
 
 /// Select priority of some queued transaction.
 async fn select_priority_from_queue<C: ChainWithTransactions>(
-	client: &Client<C>,
+	client: &impl Client<C>,
 	context: &Context<C>,
 ) -> Result<Option<TransactionPriority>, SubstrateError> {
 	// select transaction from the queue
@@ -387,7 +387,7 @@ fn select_transaction_from_queue<C: Chain>(
 
 /// Try to find appropriate tip for transaction so that its priority is larger than given.
 async fn update_transaction_tip<C: ChainWithTransactions>(
-	client: &Client<C>,
+	client: &impl Client<C>,
 	transaction_params: &TransactionParams<AccountKeyPairOf<C>>,
 	at_block: HeaderIdOf<C>,
 	tx: C::SignedTransaction,

--- a/relays/bin-substrate/src/cli/send_message.rs
+++ b/relays/bin-substrate/src/cli/send_message.rs
@@ -35,7 +35,7 @@ use crate::{
 use async_trait::async_trait;
 use codec::{Decode, Encode};
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, Chain, ChainBase, ChainWithTransactions, ClientT,
+	AccountIdOf, AccountKeyPairOf, Chain, ChainBase, ChainWithTransactions, Client,
 	UnsignedTransaction,
 };
 use sp_core::Pair;

--- a/relays/client-substrate/src/guard.rs
+++ b/relays/client-substrate/src/guard.rs
@@ -98,7 +98,7 @@ fn conditions_check_delay<C: Chain>() -> Duration {
 }
 
 #[async_trait]
-impl<C: ChainWithBalances> Environment<C> for Client<C> {
+impl<C: ChainWithBalances, Clnt: Client<C>> Environment<C> for Clnt {
 	type Error = Error;
 
 	async fn runtime_version(&mut self) -> Result<RuntimeVersion, Self::Error> {

--- a/relays/client-substrate/src/lib.rs
+++ b/relays/client-substrate/src/lib.rs
@@ -39,9 +39,9 @@ pub use crate::{
 		SignedBlockOf, TransactionStatusOf, UnsignedTransaction, UtilityPallet,
 	},
 	client::{
-		is_ancient_block, rpc_with_caching as new, ChainRuntimeVersion, Client as ClientT,
-		OpaqueGrandpaAuthoritiesSet, RpcWithCachingClient as Client, SimpleRuntimeVersion,
-		Subscription, ANCIENT_BLOCK_THRESHOLD,
+		is_ancient_block, rpc_with_caching as new, ChainRuntimeVersion, Client,
+		OpaqueGrandpaAuthoritiesSet, RpcWithCachingClient, SimpleRuntimeVersion, Subscription,
+		ANCIENT_BLOCK_THRESHOLD,
 	},
 	error::{Error, Result},
 	sync_header::SyncHeader,

--- a/relays/lib-substrate-relay/src/finality/engine.rs
+++ b/relays/lib-substrate-relay/src/finality/engine.rs
@@ -27,8 +27,8 @@ use codec::{Decode, Encode};
 use finality_grandpa::voter_set::VoterSet;
 use num_traits::{One, Zero};
 use relay_substrate_client::{
-	BlockNumberOf, Chain, ChainWithGrandpa, Client, ClientT, Error as SubstrateError, HashOf,
-	HeaderOf, Subscription,
+	BlockNumberOf, Chain, ChainWithGrandpa, Client, Error as SubstrateError, HashOf, HeaderOf,
+	Subscription,
 };
 use sp_consensus_grandpa::{AuthorityList as GrandpaAuthoritiesSet, GRANDPA_ENGINE_ID};
 use sp_core::{storage::StorageKey, Bytes};
@@ -57,7 +57,7 @@ pub trait Engine<C: Chain>: Send {
 
 	/// Returns `Ok(true)` if finality pallet at the bridged chain has already been initialized.
 	async fn is_initialized<TargetChain: Chain>(
-		target_client: &Client<TargetChain>,
+		target_client: &impl Client<TargetChain>,
 	) -> Result<bool, SubstrateError> {
 		Ok(target_client
 			.raw_storage_value(target_client.best_header_hash().await?, Self::is_initialized_key())
@@ -71,7 +71,7 @@ pub trait Engine<C: Chain>: Send {
 
 	/// Returns `Ok(true)` if finality pallet at the bridged chain is halted.
 	async fn is_halted<TargetChain: Chain>(
-		target_client: &Client<TargetChain>,
+		target_client: &impl Client<TargetChain>,
 	) -> Result<bool, SubstrateError> {
 		Ok(target_client
 			.storage_value::<Self::OperatingMode>(
@@ -84,18 +84,20 @@ pub trait Engine<C: Chain>: Send {
 	}
 
 	/// A method to subscribe to encoded finality proofs, given source client.
-	async fn finality_proofs(client: &Client<C>) -> Result<Subscription<Bytes>, SubstrateError>;
+	async fn finality_proofs(
+		client: &impl Client<C>,
+	) -> Result<Subscription<Bytes>, SubstrateError>;
 
 	/// Optimize finality proof before sending it to the target node.
 	async fn optimize_proof<TargetChain: Chain>(
-		target_client: &Client<TargetChain>,
+		target_client: &impl Client<TargetChain>,
 		header: &C::Header,
 		proof: Self::FinalityProof,
 	) -> Result<Self::FinalityProof, SubstrateError>;
 
 	/// Prepare initialization data for the finality bridge pallet.
 	async fn prepare_initialization_data(
-		client: Client<C>,
+		client: impl Client<C>,
 	) -> Result<Self::InitializationData, Error<HashOf<C>, BlockNumberOf<C>>>;
 }
 
@@ -105,7 +107,7 @@ pub struct Grandpa<C>(PhantomData<C>);
 impl<C: ChainWithGrandpa> Grandpa<C> {
 	/// Read header by hash from the source client.
 	async fn source_header(
-		source_client: &Client<C>,
+		source_client: &impl Client<C>,
 		header_hash: C::Hash,
 	) -> Result<C::Header, Error<HashOf<C>, BlockNumberOf<C>>> {
 		source_client
@@ -116,7 +118,7 @@ impl<C: ChainWithGrandpa> Grandpa<C> {
 
 	/// Read GRANDPA authorities set at given header.
 	async fn source_authorities_set(
-		source_client: &Client<C>,
+		source_client: &impl Client<C>,
 		header_hash: C::Hash,
 	) -> Result<GrandpaAuthoritiesSet, Error<HashOf<C>, BlockNumberOf<C>>> {
 		const SUB_API_GRANDPA_AUTHORITIES: &str = "GrandpaApi_grandpa_authorities";
@@ -144,12 +146,14 @@ impl<C: ChainWithGrandpa> Engine<C> for Grandpa<C> {
 		bp_header_chain::storage_keys::pallet_operating_mode_key(C::WITH_CHAIN_GRANDPA_PALLET_NAME)
 	}
 
-	async fn finality_proofs(client: &Client<C>) -> Result<Subscription<Bytes>, SubstrateError> {
+	async fn finality_proofs(
+		client: &impl Client<C>,
+	) -> Result<Subscription<Bytes>, SubstrateError> {
 		client.subscribe_grandpa_finality_justifications().await
 	}
 
 	async fn optimize_proof<TargetChain: Chain>(
-		target_client: &Client<TargetChain>,
+		target_client: &impl Client<TargetChain>,
 		header: &C::Header,
 		proof: Self::FinalityProof,
 	) -> Result<Self::FinalityProof, SubstrateError> {
@@ -192,7 +196,7 @@ impl<C: ChainWithGrandpa> Engine<C> for Grandpa<C> {
 
 	/// Prepare initialization data for the GRANDPA verifier pallet.
 	async fn prepare_initialization_data(
-		source_client: Client<C>,
+		source_client: impl Client<C>,
 	) -> Result<Self::InitializationData, Error<HashOf<C>, BlockNumberOf<C>>> {
 		// In ideal world we just need to get best finalized header and then to read GRANDPA
 		// authorities set (`pallet_grandpa::CurrentSetId` + `GrandpaApi::grandpa_authorities()`) at

--- a/relays/lib-substrate-relay/src/finality/initialize.rs
+++ b/relays/lib-substrate-relay/src/finality/initialize.rs
@@ -26,7 +26,7 @@ use sp_core::Pair;
 
 use bp_runtime::HeaderIdOf;
 use relay_substrate_client::{
-	AccountKeyPairOf, Chain, ChainWithTransactions, Client, ClientT, Error as SubstrateError,
+	AccountKeyPairOf, Chain, ChainWithTransactions, Client, Error as SubstrateError,
 	UnsignedTransaction,
 };
 use relay_utils::{TrackedTransactionStatus, TransactionTracker};
@@ -39,8 +39,8 @@ pub async fn initialize<
 	TargetChain: ChainWithTransactions,
 	F,
 >(
-	source_client: Client<SourceChain>,
-	target_client: Client<TargetChain>,
+	source_client: impl Client<SourceChain>,
+	target_client: impl Client<TargetChain>,
 	target_signer: AccountKeyPairOf<TargetChain>,
 	prepare_initialize_transaction: F,
 	dry_run: bool,
@@ -101,8 +101,8 @@ async fn do_initialize<
 	TargetChain: ChainWithTransactions,
 	F,
 >(
-	source_client: Client<SourceChain>,
-	target_client: Client<TargetChain>,
+	source_client: impl Client<SourceChain>,
+	target_client: impl Client<TargetChain>,
 	target_signer: AccountKeyPairOf<TargetChain>,
 	prepare_initialize_transaction: F,
 	dry_run: bool,

--- a/relays/lib-substrate-relay/src/finality/mod.rs
+++ b/relays/lib-substrate-relay/src/finality/mod.rs
@@ -64,7 +64,7 @@ pub trait SubstrateFinalitySyncPipeline: 'static + Clone + Debug + Send + Sync {
 
 	/// Add relay guards if required.
 	async fn start_relay_guards(
-		_target_client: &Client<Self::TargetChain>,
+		_target_client: &impl Client<Self::TargetChain>,
 		_transaction_params: &TransactionParams<AccountKeyPairOf<Self::TargetChain>>,
 		_enable_version_guard: bool,
 	) -> relay_substrate_client::Result<()> {
@@ -168,8 +168,8 @@ macro_rules! generate_submit_finality_proof_call_builder {
 
 /// Run Substrate-to-Substrate finality sync loop.
 pub async fn run<P: SubstrateFinalitySyncPipeline>(
-	source_client: Client<P::SourceChain>,
-	target_client: Client<P::TargetChain>,
+	source_client: impl Client<P::SourceChain>,
+	target_client: impl Client<P::TargetChain>,
 	only_mandatory_headers: bool,
 	transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 	metrics_params: MetricsParams,
@@ -185,8 +185,8 @@ where
 	);
 
 	finality_relay::run(
-		SubstrateFinalitySource::<P>::new(source_client, None),
-		SubstrateFinalityTarget::<P>::new(target_client, transaction_params.clone()),
+		SubstrateFinalitySource::<P, _>::new(source_client, None),
+		SubstrateFinalityTarget::<P, _>::new(target_client, transaction_params.clone()),
 		finality_relay::FinalitySyncParams {
 			tick: std::cmp::max(
 				P::SourceChain::AVERAGE_BLOCK_INTERVAL,

--- a/relays/lib-substrate-relay/src/finality/source.rs
+++ b/relays/lib-substrate-relay/src/finality/source.rs
@@ -29,7 +29,7 @@ use futures::{
 };
 use num_traits::One;
 use relay_substrate_client::{
-	BlockNumberOf, BlockWithJustification, Chain, Client, ClientT, Error, HeaderOf,
+	BlockNumberOf, BlockWithJustification, Chain, Client, Error, HeaderOf,
 };
 use relay_utils::{relay_loop::Client as RelayClient, UniqueSaturatedInto};
 use std::pin::Pin;
@@ -48,22 +48,24 @@ pub type SubstrateFinalityProof<P> =
 	>>::FinalityProof;
 
 /// Substrate node as finality source.
-pub struct SubstrateFinalitySource<P: SubstrateFinalitySyncPipeline> {
-	client: Client<P::SourceChain>,
+pub struct SubstrateFinalitySource<P: SubstrateFinalitySyncPipeline, SourceClnt> {
+	client: SourceClnt,
 	maximal_header_number: Option<RequiredHeaderNumberRef<P::SourceChain>>,
 }
 
-impl<P: SubstrateFinalitySyncPipeline> SubstrateFinalitySource<P> {
+impl<P: SubstrateFinalitySyncPipeline, SourceClnt: Client<P::SourceChain>>
+	SubstrateFinalitySource<P, SourceClnt>
+{
 	/// Create new headers source using given client.
 	pub fn new(
-		client: Client<P::SourceChain>,
+		client: SourceClnt,
 		maximal_header_number: Option<RequiredHeaderNumberRef<P::SourceChain>>,
 	) -> Self {
 		SubstrateFinalitySource { client, maximal_header_number }
 	}
 
 	/// Returns reference to the underlying RPC client.
-	pub fn client(&self) -> &Client<P::SourceChain> {
+	pub fn client(&self) -> &SourceClnt {
 		&self.client
 	}
 
@@ -182,7 +184,9 @@ impl<P: SubstrateFinalitySyncPipeline> SubstrateFinalitySource<P> {
 	}
 }
 
-impl<P: SubstrateFinalitySyncPipeline> Clone for SubstrateFinalitySource<P> {
+impl<P: SubstrateFinalitySyncPipeline, SourceClnt: Clone> Clone
+	for SubstrateFinalitySource<P, SourceClnt>
+{
 	fn clone(&self) -> Self {
 		SubstrateFinalitySource {
 			client: self.client.clone(),
@@ -192,7 +196,9 @@ impl<P: SubstrateFinalitySyncPipeline> Clone for SubstrateFinalitySource<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateFinalitySyncPipeline> RelayClient for SubstrateFinalitySource<P> {
+impl<P: SubstrateFinalitySyncPipeline, SourceClnt: Client<P::SourceChain>> RelayClient
+	for SubstrateFinalitySource<P, SourceClnt>
+{
 	type Error = Error;
 
 	async fn reconnect(&mut self) -> Result<(), Error> {
@@ -201,8 +207,8 @@ impl<P: SubstrateFinalitySyncPipeline> RelayClient for SubstrateFinalitySource<P
 }
 
 #[async_trait]
-impl<P: SubstrateFinalitySyncPipeline> SourceClient<FinalitySyncPipelineAdapter<P>>
-	for SubstrateFinalitySource<P>
+impl<P: SubstrateFinalitySyncPipeline, SourceClnt: Client<P::SourceChain>>
+	SourceClient<FinalitySyncPipelineAdapter<P>> for SubstrateFinalitySource<P, SourceClnt>
 {
 	type FinalityProofsStream = SubstrateFinalityProofsStream<P>;
 
@@ -274,7 +280,7 @@ impl<P: SubstrateFinalitySyncPipeline> SourceClient<FinalitySyncPipelineAdapter<
 }
 
 async fn header_and_finality_proof<P: SubstrateFinalitySyncPipeline>(
-	client: &Client<P::SourceChain>,
+	client: &impl Client<P::SourceChain>,
 	number: BlockNumberOf<P::SourceChain>,
 ) -> Result<
 	(

--- a/relays/lib-substrate-relay/src/messages_lane.rs
+++ b/relays/lib-substrate-relay/src/messages_lane.rs
@@ -37,8 +37,8 @@ use messages_relay::{message_lane::MessageLane, message_lane_loop::BatchTransact
 use pallet_bridge_messages::{Call as BridgeMessagesCall, Config as BridgeMessagesConfig};
 use relay_substrate_client::{
 	transaction_stall_timeout, AccountKeyPairOf, BalanceOf, BlockNumberOf, CallOf, Chain,
-	ChainWithMessages, ChainWithTransactions, Client, ClientT, Error as SubstrateError, HashOf,
-	SignParam, UnsignedTransaction,
+	ChainWithMessages, ChainWithTransactions, Client, Error as SubstrateError, HashOf, SignParam,
+	UnsignedTransaction,
 };
 use relay_utils::{
 	metrics::{GlobalMetrics, MetricsParams, StandaloneMetric},
@@ -88,13 +88,13 @@ impl<P: SubstrateMessageLane> MessageLane for MessageLaneAdapter<P> {
 }
 
 /// Substrate <-> Substrate messages relay parameters.
-pub struct MessagesRelayParams<P: SubstrateMessageLane> {
+pub struct MessagesRelayParams<P: SubstrateMessageLane, SourceClnt, TargetClnt> {
 	/// Messages source client.
-	pub source_client: Client<P::SourceChain>,
+	pub source_client: SourceClnt,
 	/// Source transaction params.
 	pub source_transaction_params: TransactionParams<AccountKeyPairOf<P::SourceChain>>,
 	/// Messages target client.
-	pub target_client: Client<P::TargetChain>,
+	pub target_client: TargetClnt,
 	/// Target transaction params.
 	pub target_transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 	/// Optional on-demand source to target headers relay.
@@ -168,8 +168,13 @@ impl<SC: Chain, TC: Chain, B: BatchCallBuilderConstructor<CallOf<SC>>>
 }
 
 /// Run Substrate-to-Substrate messages sync loop.
-pub async fn run<P: SubstrateMessageLane>(params: MessagesRelayParams<P>) -> anyhow::Result<()>
+pub async fn run<P, SourceClnt, TargetClnt>(
+	params: MessagesRelayParams<P, SourceClnt, TargetClnt>,
+) -> anyhow::Result<()>
 where
+	P: SubstrateMessageLane,
+	SourceClnt: Client<P::SourceChain>,
+	TargetClnt: Client<P::TargetChain>,
 	AccountIdOf<P::SourceChain>: From<<AccountKeyPairOf<P::SourceChain> as Pair>::Public>,
 	AccountIdOf<P::TargetChain>: From<<AccountKeyPairOf<P::TargetChain> as Pair>::Public>,
 	BalanceOf<P::SourceChain>: TryFrom<BalanceOf<P::TargetChain>>,
@@ -179,7 +184,7 @@ where
 	// we don't know exact weights of the Polkadot runtime. So to guess weights we'll be using
 	// weights from Rialto and then simply dividing it by x2.
 	let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
-		select_delivery_transaction_limits_rpc::<P>(
+		select_delivery_transaction_limits_rpc(
 			&params,
 			P::TargetChain::max_extrinsic_weight(),
 			P::SourceChain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
@@ -238,14 +243,14 @@ where
 				max_messages_size_in_single_batch,
 			},
 		},
-		SubstrateMessagesSource::<P>::new(
+		SubstrateMessagesSource::<P, _, _>::new(
 			source_client.clone(),
 			target_client.clone(),
 			params.lane_id,
 			params.source_transaction_params,
 			params.target_to_source_headers_relay,
 		),
-		SubstrateMessagesTarget::<P>::new(
+		SubstrateMessagesTarget::<P, _, _>::new(
 			target_client,
 			source_client,
 			params.lane_id,
@@ -453,12 +458,15 @@ macro_rules! generate_receive_message_delivery_proof_call_builder {
 }
 
 /// Returns maximal number of messages and their maximal cumulative dispatch weight.
-async fn select_delivery_transaction_limits_rpc<P: SubstrateMessageLane>(
-	params: &MessagesRelayParams<P>,
+async fn select_delivery_transaction_limits_rpc<P, SourceClnt, TargetClnt>(
+	params: &MessagesRelayParams<P, SourceClnt, TargetClnt>,
 	max_extrinsic_weight: Weight,
 	max_unconfirmed_messages_at_inbound_lane: MessageNonce,
 ) -> anyhow::Result<(MessageNonce, Weight)>
 where
+	P: SubstrateMessageLane,
+	SourceClnt: Client<P::SourceChain>,
+	TargetClnt: Client<P::TargetChain>,
 	AccountIdOf<P::SourceChain>: From<<AccountKeyPairOf<P::SourceChain> as Pair>::Public>,
 {
 	// We may try to guess accurate value, based on maximal number of messages and per-message
@@ -475,7 +483,7 @@ where
 
 	// weight of empty message delivery with outbound lane state
 	let best_target_block_hash = params.target_client.best_header_hash().await?;
-	let delivery_tx_with_zero_messages = dummy_messages_delivery_transaction::<P>(params, 0)?;
+	let delivery_tx_with_zero_messages = dummy_messages_delivery_transaction::<P, _, _>(params, 0)?;
 	let delivery_tx_with_zero_messages_weight = params
 		.target_client
 		.estimate_extrinsic_weight(best_target_block_hash, delivery_tx_with_zero_messages)
@@ -485,7 +493,7 @@ where
 		})?;
 
 	// weight of single message delivery with outbound lane state
-	let delivery_tx_with_one_message = dummy_messages_delivery_transaction::<P>(params, 1)?;
+	let delivery_tx_with_one_message = dummy_messages_delivery_transaction::<P, _, _>(params, 1)?;
 	let delivery_tx_with_one_message_weight = params
 		.target_client
 		.estimate_extrinsic_weight(best_target_block_hash, delivery_tx_with_one_message)
@@ -520,8 +528,8 @@ where
 }
 
 /// Returns dummy message delivery transaction with zero messages and `1kb` proof.
-fn dummy_messages_delivery_transaction<P: SubstrateMessageLane>(
-	params: &MessagesRelayParams<P>,
+fn dummy_messages_delivery_transaction<P: SubstrateMessageLane, SourceClnt, TargetClnt>(
+	params: &MessagesRelayParams<P, SourceClnt, TargetClnt>,
 	messages: u32,
 ) -> anyhow::Result<<P::TargetChain as ChainWithTransactions>::SignedTransaction>
 where

--- a/relays/lib-substrate-relay/src/messages_metrics.rs
+++ b/relays/lib-substrate-relay/src/messages_metrics.rs
@@ -26,7 +26,7 @@ use frame_system::AccountInfo;
 use pallet_balances::AccountData;
 use relay_substrate_client::{
 	metrics::{FloatStorageValue, FloatStorageValueMetric},
-	AccountIdOf, BalanceOf, Chain, ChainWithBalances, ChainWithMessages, Client, ClientT,
+	AccountIdOf, BalanceOf, Chain, ChainWithBalances, ChainWithMessages, Client,
 	Error as SubstrateError, IndexOf,
 };
 use relay_utils::metrics::{MetricsParams, StandaloneMetric};
@@ -36,7 +36,7 @@ use std::{convert::TryFrom, fmt::Debug, marker::PhantomData};
 
 /// Add relay accounts balance metrics.
 pub async fn add_relay_balances_metrics<C: ChainWithBalances, BC: ChainWithMessages>(
-	client: Client<C>,
+	client: impl Client<C>,
 	metrics: &mut MetricsParams,
 	relay_accounts: &Vec<TaggedAccount<AccountIdOf<C>>>,
 	lanes: &[LaneId],

--- a/relays/lib-substrate-relay/src/messages_source.rs
+++ b/relays/lib-substrate-relay/src/messages_source.rs
@@ -478,7 +478,7 @@ where
 					peer_client.header_by_number(peer_on_self_best_finalized_id.number()).await?;
 				Some(actual_peer_on_self_best_finalized.id())
 			},
-			_ => client_state.best_finalized_peer_at_best_self.clone(),
+			_ => client_state.best_finalized_peer_at_best_self,
 		};
 	Ok(client_state)
 }

--- a/relays/lib-substrate-relay/src/messages_source.rs
+++ b/relays/lib-substrate-relay/src/messages_source.rs
@@ -47,7 +47,7 @@ use messages_relay::{
 };
 use num_traits::Zero;
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, BalanceOf, Chain, ChainWithMessages, Client, ClientT,
+	AccountIdOf, AccountKeyPairOf, BalanceOf, Chain, ChainWithMessages, Client,
 	Error as SubstrateError, HashOf, HeaderIdOf, TransactionEra, TransactionTracker,
 	UnsignedTransaction,
 };
@@ -62,19 +62,21 @@ pub type SubstrateMessagesProof<C> = (Weight, FromBridgedChainMessagesProof<Hash
 type MessagesToRefine<'a> = Vec<(MessagePayload, &'a mut OutboundMessageDetails)>;
 
 /// Substrate client as Substrate messages source.
-pub struct SubstrateMessagesSource<P: SubstrateMessageLane> {
-	source_client: Client<P::SourceChain>,
-	target_client: Client<P::TargetChain>,
+pub struct SubstrateMessagesSource<P: SubstrateMessageLane, SourceClnt, TargetClnt> {
+	source_client: SourceClnt,
+	target_client: TargetClnt,
 	lane_id: LaneId,
 	transaction_params: TransactionParams<AccountKeyPairOf<P::SourceChain>>,
 	target_to_source_headers_relay: Option<Arc<dyn OnDemandRelay<P::TargetChain, P::SourceChain>>>,
 }
 
-impl<P: SubstrateMessageLane> SubstrateMessagesSource<P> {
+impl<P: SubstrateMessageLane, SourceClnt: Client<P::SourceChain>, TargetClnt>
+	SubstrateMessagesSource<P, SourceClnt, TargetClnt>
+{
 	/// Create new Substrate headers source.
 	pub fn new(
-		source_client: Client<P::SourceChain>,
-		target_client: Client<P::TargetChain>,
+		source_client: SourceClnt,
+		target_client: TargetClnt,
 		lane_id: LaneId,
 		transaction_params: TransactionParams<AccountKeyPairOf<P::SourceChain>>,
 		target_to_source_headers_relay: Option<
@@ -108,11 +110,14 @@ impl<P: SubstrateMessageLane> SubstrateMessagesSource<P> {
 
 	/// Ensure that the messages pallet at source chain is active.
 	async fn ensure_pallet_active(&self) -> Result<(), SubstrateError> {
-		ensure_messages_pallet_active::<P::SourceChain, P::TargetChain>(&self.source_client).await
+		ensure_messages_pallet_active::<P::SourceChain, P::TargetChain, _>(&self.source_client)
+			.await
 	}
 }
 
-impl<P: SubstrateMessageLane> Clone for SubstrateMessagesSource<P> {
+impl<P: SubstrateMessageLane, SourceClnt: Clone, TargetClnt: Clone> Clone
+	for SubstrateMessagesSource<P, SourceClnt, TargetClnt>
+{
 	fn clone(&self) -> Self {
 		Self {
 			source_client: self.source_client.clone(),
@@ -125,7 +130,12 @@ impl<P: SubstrateMessageLane> Clone for SubstrateMessagesSource<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesSource<P> {
+impl<
+		P: SubstrateMessageLane,
+		SourceClnt: Client<P::SourceChain>,
+		TargetClnt: Client<P::TargetChain>,
+	> RelayClient for SubstrateMessagesSource<P, SourceClnt, TargetClnt>
+{
 	type Error = SubstrateError;
 
 	async fn reconnect(&mut self) -> Result<(), SubstrateError> {
@@ -149,13 +159,17 @@ impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesSource<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateMessageLane> SourceClient<MessageLaneAdapter<P>> for SubstrateMessagesSource<P>
+impl<
+		P: SubstrateMessageLane,
+		SourceClnt: Client<P::SourceChain>,
+		TargetClnt: Client<P::TargetChain>,
+	> SourceClient<MessageLaneAdapter<P>> for SubstrateMessagesSource<P, SourceClnt, TargetClnt>
 where
 	AccountIdOf<P::SourceChain>: From<<AccountKeyPairOf<P::SourceChain> as Pair>::Public>,
 {
 	type BatchTransaction =
 		BatchProofTransaction<P::SourceChain, P::TargetChain, P::SourceBatchCallBuilder>;
-	type TransactionTracker = TransactionTracker<P::SourceChain, Client<P::SourceChain>>;
+	type TransactionTracker = TransactionTracker<P::SourceChain, SourceClnt>;
 
 	async fn state(&self) -> Result<SourceClientState<MessageLaneAdapter<P>>, SubstrateError> {
 		// we can't continue to deliver confirmations if source node is out of sync, because
@@ -168,7 +182,7 @@ where
 		// we can't relay confirmations if messages pallet at source chain is halted
 		self.ensure_pallet_active().await?;
 
-		read_client_state(&self.source_client, Some(&self.target_client)).await
+		read_client_state_from_both_chains(&self.source_client, &self.target_client).await
 	}
 
 	async fn latest_generated_nonce(
@@ -387,12 +401,13 @@ where
 }
 
 /// Ensure that the messages pallet at source chain is active.
-pub(crate) async fn ensure_messages_pallet_active<AtChain, WithChain>(
-	client: &Client<AtChain>,
+pub(crate) async fn ensure_messages_pallet_active<AtChain, WithChain, AtChainClient>(
+	client: &AtChainClient,
 ) -> Result<(), SubstrateError>
 where
 	AtChain: ChainWithMessages,
 	WithChain: ChainWithMessages,
+	AtChainClient: Client<AtChain>,
 {
 	let operating_mode = client
 		.storage_value(
@@ -415,11 +430,10 @@ where
 /// bridge GRANDPA pallet deployed and it provides `best_finalized_header_id_method_name`
 /// runtime API to read the best finalized Bridged chain header.
 ///
-/// If `peer_client` is `None`, the value of `actual_best_finalized_peer_at_best_self` will
-/// always match the `best_finalized_peer_at_best_self`.
+/// The value of `actual_best_finalized_peer_at_best_self` will always match
+/// the `best_finalized_peer_at_best_self`.
 pub async fn read_client_state<SelfChain, PeerChain>(
-	self_client: &Client<SelfChain>,
-	peer_client: Option<&Client<PeerChain>>,
+	self_client: &impl Client<SelfChain>,
 ) -> Result<ClientState<HeaderIdOf<SelfChain>, HeaderIdOf<PeerChain>>, SubstrateError>
 where
 	SelfChain: Chain,
@@ -438,30 +452,42 @@ where
 		)
 		.await?;
 
-	// read actual header, matching the `peer_on_self_best_finalized_id` from the peer chain
-	let actual_peer_on_self_best_finalized_id =
-		match (peer_client, peer_on_self_best_finalized_id.as_ref()) {
-			(Some(peer_client), Some(peer_on_self_best_finalized_id)) => {
-				let actual_peer_on_self_best_finalized =
-					peer_client.header_by_number(peer_on_self_best_finalized_id.number()).await?;
-				Some(actual_peer_on_self_best_finalized.id())
-			},
-			_ => peer_on_self_best_finalized_id,
-		};
-
 	Ok(ClientState {
 		best_self: self_best_id,
 		best_finalized_self: self_best_finalized_id,
 		best_finalized_peer_at_best_self: peer_on_self_best_finalized_id,
-		actual_best_finalized_peer_at_best_self: actual_peer_on_self_best_finalized_id,
+		actual_best_finalized_peer_at_best_self: peer_on_self_best_finalized_id,
 	})
+}
+
+/// Does the same stuff as `read_client_state`, but properly fills the
+/// `actual_best_finalized_peer_at_best_self` field of the result.
+pub async fn read_client_state_from_both_chains<SelfChain, PeerChain>(
+	self_client: &impl Client<SelfChain>,
+	peer_client: &impl Client<PeerChain>,
+) -> Result<ClientState<HeaderIdOf<SelfChain>, HeaderIdOf<PeerChain>>, SubstrateError>
+where
+	SelfChain: Chain,
+	PeerChain: Chain,
+{
+	let mut client_state = read_client_state::<SelfChain, PeerChain>(self_client).await?;
+	client_state.actual_best_finalized_peer_at_best_self =
+		match client_state.best_finalized_peer_at_best_self.as_ref() {
+			Some(peer_on_self_best_finalized_id) => {
+				let actual_peer_on_self_best_finalized =
+					peer_client.header_by_number(peer_on_self_best_finalized_id.number()).await?;
+				Some(actual_peer_on_self_best_finalized.id())
+			},
+			_ => client_state.best_finalized_peer_at_best_self.clone(),
+		};
+	Ok(client_state)
 }
 
 /// Reads best `PeerChain` header known to the `SelfChain` using provided runtime API method.
 ///
 /// Method is supposed to be the `<PeerChain>FinalityApi::best_finalized()` method.
 pub async fn best_finalized_peer_header_at_self<SelfChain, PeerChain>(
-	self_client: &Client<SelfChain>,
+	self_client: &impl Client<SelfChain>,
 	at_self_hash: HashOf<SelfChain>,
 ) -> Result<Option<HeaderIdOf<PeerChain>>, SubstrateError>
 where

--- a/relays/lib-substrate-relay/src/messages_target.rs
+++ b/relays/lib-substrate-relay/src/messages_target.rs
@@ -23,7 +23,9 @@ use crate::{
 		BatchProofTransaction, MessageLaneAdapter, ReceiveMessagesProofCallBuilder,
 		SubstrateMessageLane,
 	},
-	messages_source::{ensure_messages_pallet_active, read_client_state, SubstrateMessagesProof},
+	messages_source::{
+		ensure_messages_pallet_active, read_client_state_from_both_chains, SubstrateMessagesProof,
+	},
 	on_demand::OnDemandRelay,
 	TransactionParams,
 };
@@ -40,7 +42,7 @@ use messages_relay::{
 	message_lane_loop::{NoncesSubmitArtifacts, TargetClient, TargetClientState},
 };
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, BalanceOf, CallOf, ChainWithMessages, Client, ClientT,
+	AccountIdOf, AccountKeyPairOf, BalanceOf, CallOf, ChainWithMessages, Client,
 	Error as SubstrateError, HashOf, TransactionEra, TransactionTracker, UnsignedTransaction,
 };
 use relay_utils::relay_loop::Client as RelayClient;
@@ -52,20 +54,24 @@ pub type SubstrateMessagesDeliveryProof<C> =
 	(UnrewardedRelayersState, FromBridgedChainMessagesDeliveryProof<HashOf<C>>);
 
 /// Substrate client as Substrate messages target.
-pub struct SubstrateMessagesTarget<P: SubstrateMessageLane> {
-	target_client: Client<P::TargetChain>,
-	source_client: Client<P::SourceChain>,
+pub struct SubstrateMessagesTarget<P: SubstrateMessageLane, SourceClnt, TargetClnt> {
+	target_client: TargetClnt,
+	source_client: SourceClnt,
 	lane_id: LaneId,
 	relayer_id_at_source: AccountIdOf<P::SourceChain>,
 	transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 	source_to_target_headers_relay: Option<Arc<dyn OnDemandRelay<P::SourceChain, P::TargetChain>>>,
 }
 
-impl<P: SubstrateMessageLane> SubstrateMessagesTarget<P> {
+impl<P, SourceClnt, TargetClnt> SubstrateMessagesTarget<P, SourceClnt, TargetClnt>
+where
+	P: SubstrateMessageLane,
+	TargetClnt: Client<P::TargetChain>,
+{
 	/// Create new Substrate headers target.
 	pub fn new(
-		target_client: Client<P::TargetChain>,
-		source_client: Client<P::SourceChain>,
+		target_client: TargetClnt,
+		source_client: SourceClnt,
 		lane_id: LaneId,
 		relayer_id_at_source: AccountIdOf<P::SourceChain>,
 		transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
@@ -101,11 +107,14 @@ impl<P: SubstrateMessageLane> SubstrateMessagesTarget<P> {
 
 	/// Ensure that the messages pallet at target chain is active.
 	async fn ensure_pallet_active(&self) -> Result<(), SubstrateError> {
-		ensure_messages_pallet_active::<P::TargetChain, P::SourceChain>(&self.target_client).await
+		ensure_messages_pallet_active::<P::TargetChain, P::SourceChain, _>(&self.target_client)
+			.await
 	}
 }
 
-impl<P: SubstrateMessageLane> Clone for SubstrateMessagesTarget<P> {
+impl<P: SubstrateMessageLane, SourceClnt: Clone, TargetClnt: Clone> Clone
+	for SubstrateMessagesTarget<P, SourceClnt, TargetClnt>
+{
 	fn clone(&self) -> Self {
 		Self {
 			target_client: self.target_client.clone(),
@@ -119,7 +128,12 @@ impl<P: SubstrateMessageLane> Clone for SubstrateMessagesTarget<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesTarget<P> {
+impl<
+		P: SubstrateMessageLane,
+		SourceClnt: Client<P::SourceChain>,
+		TargetClnt: Client<P::TargetChain>,
+	> RelayClient for SubstrateMessagesTarget<P, SourceClnt, TargetClnt>
+{
 	type Error = SubstrateError;
 
 	async fn reconnect(&mut self) -> Result<(), SubstrateError> {
@@ -143,14 +157,18 @@ impl<P: SubstrateMessageLane> RelayClient for SubstrateMessagesTarget<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateMessageLane> TargetClient<MessageLaneAdapter<P>> for SubstrateMessagesTarget<P>
+impl<
+		P: SubstrateMessageLane,
+		SourceClnt: Client<P::SourceChain>,
+		TargetClnt: Client<P::TargetChain>,
+	> TargetClient<MessageLaneAdapter<P>> for SubstrateMessagesTarget<P, SourceClnt, TargetClnt>
 where
 	AccountIdOf<P::TargetChain>: From<<AccountKeyPairOf<P::TargetChain> as Pair>::Public>,
 	BalanceOf<P::SourceChain>: TryFrom<BalanceOf<P::TargetChain>>,
 {
 	type BatchTransaction =
 		BatchProofTransaction<P::TargetChain, P::SourceChain, P::TargetBatchCallBuilder>;
-	type TransactionTracker = TransactionTracker<P::TargetChain, Client<P::TargetChain>>;
+	type TransactionTracker = TransactionTracker<P::TargetChain, TargetClnt>;
 
 	async fn state(&self) -> Result<TargetClientState<MessageLaneAdapter<P>>, SubstrateError> {
 		// we can't continue to deliver confirmations if source node is out of sync, because
@@ -163,7 +181,7 @@ where
 		// we can't relay messages if messages pallet at target chain is halted
 		self.ensure_pallet_active().await?;
 
-		read_client_state(&self.target_client, Some(&self.source_client)).await
+		read_client_state_from_both_chains(&self.target_client, &self.source_client).await
 	}
 
 	async fn latest_received_nonce(

--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -28,8 +28,8 @@ use sp_runtime::traits::Header;
 
 use finality_relay::{FinalitySyncParams, TargetClient as FinalityTargetClient};
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, BlockNumberOf, CallOf, Chain, Client, ClientT,
-	Error as SubstrateError, HeaderIdOf,
+	AccountIdOf, AccountKeyPairOf, BlockNumberOf, CallOf, Chain, Client, Error as SubstrateError,
+	HeaderIdOf,
 };
 use relay_utils::{
 	metrics::MetricsParams, relay_loop::Client as RelayClient, FailedClient, MaybeConnectionError,
@@ -53,25 +53,30 @@ use crate::{
 /// relay) needs it to continue its regular work. When enough headers are relayed, on-demand stops
 /// syncing headers.
 #[derive(Clone)]
-pub struct OnDemandHeadersRelay<P: SubstrateFinalitySyncPipeline> {
+pub struct OnDemandHeadersRelay<P: SubstrateFinalitySyncPipeline, SourceClnt, TargetClnt> {
 	/// Relay task name.
 	relay_task_name: String,
 	/// Shared reference to maximal required finalized header number.
 	required_header_number: RequiredHeaderNumberRef<P::SourceChain>,
 	/// Client of the source chain.
-	source_client: Client<P::SourceChain>,
+	source_client: SourceClnt,
 	/// Client of the target chain.
-	target_client: Client<P::TargetChain>,
+	target_client: TargetClnt,
 }
 
-impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
+impl<
+		P: SubstrateFinalitySyncPipeline,
+		SourceClnt: Client<P::SourceChain>,
+		TargetClnt: Client<P::TargetChain>,
+	> OnDemandHeadersRelay<P, SourceClnt, TargetClnt>
+{
 	/// Create new on-demand headers relay.
 	///
 	/// If `metrics_params` is `Some(_)`, the metrics of the finality relay are registered.
 	/// Otherwise, all required metrics must be exposed outside of this method.
 	pub fn new(
-		source_client: Client<P::SourceChain>,
-		target_client: Client<P::TargetChain>,
+		source_client: SourceClnt,
+		target_client: TargetClnt,
 		target_transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 		only_mandatory_headers: bool,
 		metrics_params: Option<MetricsParams>,
@@ -104,8 +109,12 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandHeadersRelay<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetChain>
-	for OnDemandHeadersRelay<P>
+impl<
+		P: SubstrateFinalitySyncPipeline,
+		SourceClnt: Client<P::SourceChain>,
+		TargetClnt: Client<P::TargetChain>,
+	> OnDemandRelay<P::SourceChain, P::TargetChain>
+	for OnDemandHeadersRelay<P, SourceClnt, TargetClnt>
 {
 	async fn reconnect(&self) -> Result<(), SubstrateError> {
 		// using clone is fine here (to avoid mut requirement), because clone on Client clones
@@ -134,7 +143,8 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 		required_header: BlockNumberOf<P::SourceChain>,
 	) -> Result<(HeaderIdOf<P::SourceChain>, Vec<CallOf<P::TargetChain>>), SubstrateError> {
 		// first find proper header (either `required_header`) or its descendant
-		let finality_source = SubstrateFinalitySource::<P>::new(self.source_client.clone(), None);
+		let finality_source =
+			SubstrateFinalitySource::<P, _>::new(self.source_client.clone(), None);
 		let (header, proof) = finality_source.prove_block_finality(required_header).await?;
 		let header_id = header.id();
 
@@ -161,8 +171,8 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 
 /// Background task that is responsible for starting headers relay.
 async fn background_task<P: SubstrateFinalitySyncPipeline>(
-	source_client: Client<P::SourceChain>,
-	target_client: Client<P::TargetChain>,
+	source_client: impl Client<P::SourceChain>,
+	target_client: impl Client<P::TargetChain>,
 	target_transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 	only_mandatory_headers: bool,
 	required_header_number: RequiredHeaderNumberRef<P::SourceChain>,
@@ -172,7 +182,7 @@ async fn background_task<P: SubstrateFinalitySyncPipeline>(
 {
 	let relay_task_name = on_demand_headers_relay_name::<P::SourceChain, P::TargetChain>();
 	let target_transactions_mortality = target_transaction_params.mortality;
-	let mut finality_source = SubstrateFinalitySource::<P>::new(
+	let mut finality_source = SubstrateFinalitySource::<P, _>::new(
 		source_client.clone(),
 		Some(required_header_number.clone()),
 	);
@@ -209,7 +219,8 @@ async fn background_task<P: SubstrateFinalitySyncPipeline>(
 
 		// read best finalized source header number from target
 		let best_finalized_source_header_at_target =
-			best_finalized_source_header_at_target::<P>(&finality_target, &relay_task_name).await;
+			best_finalized_source_header_at_target::<P, _>(&finality_target, &relay_task_name)
+				.await;
 		if matches!(best_finalized_source_header_at_target, Err(ref e) if e.is_connection_error()) {
 			relay_utils::relay_loop::reconnect_failed_client(
 				FailedClient::Target,
@@ -373,13 +384,17 @@ async fn mandatory_headers_scan_range<C: Chain>(
 /// it.
 ///
 /// Returns `true` if header was found and (asked to be) relayed and `false` otherwise.
-async fn relay_mandatory_header_from_range<P: SubstrateFinalitySyncPipeline>(
-	finality_source: &SubstrateFinalitySource<P>,
+async fn relay_mandatory_header_from_range<P, SourceClnt>(
+	finality_source: &SubstrateFinalitySource<P, SourceClnt>,
 	required_header_number: &RequiredHeaderNumberRef<P::SourceChain>,
 	best_finalized_source_header_at_target: String,
 	range: (BlockNumberOf<P::SourceChain>, BlockNumberOf<P::SourceChain>),
 	relay_task_name: &str,
-) -> Result<bool, relay_substrate_client::Error> {
+) -> Result<bool, relay_substrate_client::Error>
+where
+	P: SubstrateFinalitySyncPipeline,
+	SourceClnt: Client<P::SourceChain>,
+{
 	// search for mandatory header first
 	let mandatory_source_header_number =
 		find_mandatory_header_in_range(finality_source, range).await?;
@@ -414,10 +429,14 @@ async fn relay_mandatory_header_from_range<P: SubstrateFinalitySyncPipeline>(
 /// Read best finalized source block number from source client.
 ///
 /// Returns `None` if we have failed to read the number.
-async fn best_finalized_source_header_at_source<P: SubstrateFinalitySyncPipeline>(
-	finality_source: &SubstrateFinalitySource<P>,
+async fn best_finalized_source_header_at_source<P, SourceClnt>(
+	finality_source: &SubstrateFinalitySource<P, SourceClnt>,
 	relay_task_name: &str,
-) -> Result<BlockNumberOf<P::SourceChain>, relay_substrate_client::Error> {
+) -> Result<BlockNumberOf<P::SourceChain>, relay_substrate_client::Error>
+where
+	P: SubstrateFinalitySyncPipeline,
+	SourceClnt: Client<P::SourceChain>,
+{
 	finality_source.on_chain_best_finalized_block_number().await.map_err(|error| {
 		log::error!(
 			target: "bridge",
@@ -433,11 +452,16 @@ async fn best_finalized_source_header_at_source<P: SubstrateFinalitySyncPipeline
 /// Read best finalized source block number from target client.
 ///
 /// Returns `None` if we have failed to read the number.
-async fn best_finalized_source_header_at_target<P: SubstrateFinalitySyncPipeline>(
-	finality_target: &SubstrateFinalityTarget<P>,
+async fn best_finalized_source_header_at_target<P, TargetClnt>(
+	finality_target: &SubstrateFinalityTarget<P, TargetClnt>,
 	relay_task_name: &str,
-) -> Result<BlockNumberOf<P::SourceChain>, <SubstrateFinalityTarget<P> as RelayClient>::Error>
+) -> Result<
+	BlockNumberOf<P::SourceChain>,
+	<SubstrateFinalityTarget<P, TargetClnt> as RelayClient>::Error,
+>
 where
+	P: SubstrateFinalitySyncPipeline,
+	TargetClnt: Client<P::TargetChain>,
 	AccountIdOf<P::TargetChain>: From<<AccountKeyPairOf<P::TargetChain> as sp_core::Pair>::Public>,
 {
 	finality_target
@@ -459,10 +483,14 @@ where
 /// Read first mandatory header in given inclusive range.
 ///
 /// Returns `Ok(None)` if there were no mandatory headers in the range.
-async fn find_mandatory_header_in_range<P: SubstrateFinalitySyncPipeline>(
-	finality_source: &SubstrateFinalitySource<P>,
+async fn find_mandatory_header_in_range<P, SourceClnt>(
+	finality_source: &SubstrateFinalitySource<P, SourceClnt>,
 	range: (BlockNumberOf<P::SourceChain>, BlockNumberOf<P::SourceChain>),
-) -> Result<Option<BlockNumberOf<P::SourceChain>>, relay_substrate_client::Error> {
+) -> Result<Option<BlockNumberOf<P::SourceChain>>, relay_substrate_client::Error>
+where
+	P: SubstrateFinalitySyncPipeline,
+	SourceClnt: Client<P::SourceChain>,
+{
 	let mut current = range.0;
 	while current <= range.1 {
 		let header = finality_source.client().header_by_number(current).await?;

--- a/relays/lib-substrate-relay/src/on_demand/parachains.rs
+++ b/relays/lib-substrate-relay/src/on_demand/parachains.rs
@@ -38,7 +38,7 @@ use num_traits::Zero;
 use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumber};
 use parachains_relay::parachains_loop::{AvailableHeader, SourceClient, TargetClient};
 use relay_substrate_client::{
-	is_ancient_block, AccountIdOf, AccountKeyPairOf, BlockNumberOf, CallOf, Chain, Client, ClientT,
+	is_ancient_block, AccountIdOf, AccountKeyPairOf, BlockNumberOf, CallOf, Chain, Client,
 	Error as SubstrateError, HashOf, HeaderIdOf, ParachainBase,
 };
 use relay_utils::{
@@ -53,29 +53,34 @@ use std::fmt::Debug;
 /// (e.g. messages relay) needs it to continue its regular work. When enough parachain headers
 /// are relayed, on-demand stops syncing headers.
 #[derive(Clone)]
-pub struct OnDemandParachainsRelay<P: SubstrateParachainsPipeline> {
+pub struct OnDemandParachainsRelay<P: SubstrateParachainsPipeline, SourceRelayClnt, TargetClnt> {
 	/// Relay task name.
 	relay_task_name: String,
 	/// Channel used to communicate with background task and ask for relay of parachain heads.
 	required_header_number_sender: Sender<BlockNumberOf<P::SourceParachain>>,
 	/// Source relay chain client.
-	source_relay_client: Client<P::SourceRelayChain>,
+	source_relay_client: SourceRelayClnt,
 	/// Target chain client.
-	target_client: Client<P::TargetChain>,
+	target_client: TargetClnt,
 	/// On-demand relay chain relay.
 	on_demand_source_relay_to_target_headers:
 		Arc<dyn OnDemandRelay<P::SourceRelayChain, P::TargetChain>>,
 }
 
-impl<P: SubstrateParachainsPipeline> OnDemandParachainsRelay<P> {
+impl<
+		P: SubstrateParachainsPipeline,
+		SourceRelayClnt: Client<P::SourceRelayChain>,
+		TargetClnt: Client<P::TargetChain>,
+	> OnDemandParachainsRelay<P, SourceRelayClnt, TargetClnt>
+{
 	/// Create new on-demand parachains relay.
 	///
 	/// Note that the argument is the source relay chain client, not the parachain client.
 	/// That's because parachain finality is determined by the relay chain and we don't
 	/// need to connect to the parachain itself here.
 	pub fn new(
-		source_relay_client: Client<P::SourceRelayChain>,
-		target_client: Client<P::TargetChain>,
+		source_relay_client: SourceRelayClnt,
+		target_client: TargetClnt,
 		target_transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 		on_demand_source_relay_to_target_headers: Arc<
 			dyn OnDemandRelay<P::SourceRelayChain, P::TargetChain>,
@@ -114,10 +119,13 @@ impl<P: SubstrateParachainsPipeline> OnDemandParachainsRelay<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateParachainsPipeline> OnDemandRelay<P::SourceParachain, P::TargetChain>
-	for OnDemandParachainsRelay<P>
+impl<P: SubstrateParachainsPipeline, SourceRelayClnt, TargetClnt>
+	OnDemandRelay<P::SourceParachain, P::TargetChain>
+	for OnDemandParachainsRelay<P, SourceRelayClnt, TargetClnt>
 where
 	P::SourceParachain: Chain<Hash = ParaHash>,
+	SourceRelayClnt: Client<P::SourceRelayChain>,
+	TargetClnt: Client<P::TargetChain>,
 {
 	async fn reconnect(&self) -> Result<(), SubstrateError> {
 		// using clone is fine here (to avoid mut requirement), because clone on Client clones
@@ -147,7 +155,7 @@ where
 		required_parachain_header: BlockNumberOf<P::SourceParachain>,
 	) -> Result<(HeaderIdOf<P::SourceParachain>, Vec<CallOf<P::TargetChain>>), SubstrateError> {
 		// select headers to prove
-		let parachains_source = ParachainsSource::<P>::new(
+		let parachains_source = ParachainsSource::<P, _>::new(
 			self.source_relay_client.clone(),
 			Arc::new(Mutex::new(AvailableHeader::Missing)),
 		);
@@ -230,8 +238,8 @@ where
 
 /// Background task that is responsible for starting parachain headers relay.
 async fn background_task<P: SubstrateParachainsPipeline>(
-	source_relay_client: Client<P::SourceRelayChain>,
-	target_client: Client<P::TargetChain>,
+	source_relay_client: impl Client<P::SourceRelayChain>,
+	target_client: impl Client<P::TargetChain>,
 	target_transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 	on_demand_source_relay_to_target_headers: Arc<
 		dyn OnDemandRelay<P::SourceRelayChain, P::TargetChain>,
@@ -254,10 +262,12 @@ async fn background_task<P: SubstrateParachainsPipeline>(
 	let parachains_relay_task = futures::future::Fuse::terminated();
 	futures::pin_mut!(parachains_relay_task);
 
-	let mut parachains_source =
-		ParachainsSource::<P>::new(source_relay_client.clone(), required_para_header_ref.clone());
+	let mut parachains_source = ParachainsSource::<P, _>::new(
+		source_relay_client.clone(),
+		required_para_header_ref.clone(),
+	);
 	let mut parachains_target =
-		ParachainsTarget::<P>::new(target_client.clone(), target_transaction_params.clone());
+		ParachainsTarget::<P, _>::new(target_client.clone(), target_transaction_params.clone());
 
 	loop {
 		select! {
@@ -440,9 +450,9 @@ struct RelayData<ParaHash, ParaNumber, RelayNumber> {
 }
 
 /// Read required data from source and target clients.
-async fn read_relay_data<P: SubstrateParachainsPipeline>(
-	source: &ParachainsSource<P>,
-	target: &ParachainsTarget<P>,
+async fn read_relay_data<P: SubstrateParachainsPipeline, SourceRelayClnt, TargetClnt>(
+	source: &ParachainsSource<P, SourceRelayClnt>,
+	target: &ParachainsTarget<P, TargetClnt>,
 	required_header_number: BlockNumberOf<P::SourceParachain>,
 ) -> Result<
 	RelayData<
@@ -453,7 +463,9 @@ async fn read_relay_data<P: SubstrateParachainsPipeline>(
 	FailedClient,
 >
 where
-	ParachainsTarget<P>:
+	SourceRelayClnt: Client<P::SourceRelayChain>,
+	TargetClnt: Client<P::TargetChain>,
+	ParachainsTarget<P, TargetClnt>:
 		TargetClient<ParachainsPipelineAdapter<P>> + RelayClient<Error = SubstrateError>,
 {
 	let map_target_err = |e| {
@@ -636,13 +648,19 @@ trait SelectHeadersToProveEnvironment<RBN, RBH, PBN, PBH> {
 }
 
 #[async_trait]
-impl<'a, P: SubstrateParachainsPipeline>
+impl<'a, P: SubstrateParachainsPipeline, SourceRelayClnt, TargetClnt>
 	SelectHeadersToProveEnvironment<
 		BlockNumberOf<P::SourceRelayChain>,
 		HashOf<P::SourceRelayChain>,
 		BlockNumberOf<P::SourceParachain>,
 		HashOf<P::SourceParachain>,
-	> for (&'a OnDemandParachainsRelay<P>, &'a ParachainsSource<P>)
+	>
+	for (
+		&'a OnDemandParachainsRelay<P, SourceRelayClnt, TargetClnt>,
+		&'a ParachainsSource<P, SourceRelayClnt>,
+	) where
+	SourceRelayClnt: Client<P::SourceRelayChain>,
+	TargetClnt: Client<P::TargetChain>,
 {
 	fn parachain_id(&self) -> ParaId {
 		ParaId(P::SourceParachain::PARACHAIN_ID)
@@ -659,7 +677,6 @@ impl<'a, P: SubstrateParachainsPipeline>
 	) -> Result<HeaderIdOf<P::SourceRelayChain>, SubstrateError> {
 		Ok(crate::messages_source::read_client_state::<P::TargetChain, P::SourceRelayChain>(
 			&self.0.target_client,
-			None,
 		)
 		.await?
 		.best_finalized_peer_at_best_self

--- a/relays/lib-substrate-relay/src/parachains/target.rs
+++ b/relays/lib-substrate-relay/src/parachains/target.rs
@@ -28,34 +28,34 @@ use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
 use bp_runtime::HeaderIdProvider;
 use parachains_relay::parachains_loop::TargetClient;
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, Chain, Client, ClientT, Error as SubstrateError, HeaderIdOf,
+	AccountIdOf, AccountKeyPairOf, Chain, Client, Error as SubstrateError, HeaderIdOf,
 	ParachainBase, TransactionEra, TransactionTracker, UnsignedTransaction,
 };
 use relay_utils::relay_loop::Client as RelayClient;
 use sp_core::Pair;
 
 /// Substrate client as parachain heads source.
-pub struct ParachainsTarget<P: SubstrateParachainsPipeline> {
-	client: Client<P::TargetChain>,
+pub struct ParachainsTarget<P: SubstrateParachainsPipeline, TargetClnt> {
+	client: TargetClnt,
 	transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 }
 
-impl<P: SubstrateParachainsPipeline> ParachainsTarget<P> {
+impl<P: SubstrateParachainsPipeline, TargetClnt> ParachainsTarget<P, TargetClnt> {
 	/// Creates new parachains target client.
 	pub fn new(
-		client: Client<P::TargetChain>,
+		client: TargetClnt,
 		transaction_params: TransactionParams<AccountKeyPairOf<P::TargetChain>>,
 	) -> Self {
 		ParachainsTarget { client, transaction_params }
 	}
 
 	/// Returns reference to the underlying RPC client.
-	pub fn client(&self) -> &Client<P::TargetChain> {
+	pub fn client(&self) -> &TargetClnt {
 		&self.client
 	}
 }
 
-impl<P: SubstrateParachainsPipeline> Clone for ParachainsTarget<P> {
+impl<P: SubstrateParachainsPipeline, TargetClnt: Clone> Clone for ParachainsTarget<P, TargetClnt> {
 	fn clone(&self) -> Self {
 		ParachainsTarget {
 			client: self.client.clone(),
@@ -65,7 +65,9 @@ impl<P: SubstrateParachainsPipeline> Clone for ParachainsTarget<P> {
 }
 
 #[async_trait]
-impl<P: SubstrateParachainsPipeline> RelayClient for ParachainsTarget<P> {
+impl<P: SubstrateParachainsPipeline, TargetClnt: Client<P::TargetChain>> RelayClient
+	for ParachainsTarget<P, TargetClnt>
+{
 	type Error = SubstrateError;
 
 	async fn reconnect(&mut self) -> Result<(), SubstrateError> {
@@ -74,12 +76,13 @@ impl<P: SubstrateParachainsPipeline> RelayClient for ParachainsTarget<P> {
 }
 
 #[async_trait]
-impl<P> TargetClient<ParachainsPipelineAdapter<P>> for ParachainsTarget<P>
+impl<P, TargetClnt> TargetClient<ParachainsPipelineAdapter<P>> for ParachainsTarget<P, TargetClnt>
 where
 	P: SubstrateParachainsPipeline,
+	TargetClnt: Client<P::TargetChain>,
 	AccountIdOf<P::TargetChain>: From<<AccountKeyPairOf<P::TargetChain> as Pair>::Public>,
 {
-	type TransactionTracker = TransactionTracker<P::TargetChain, Client<P::TargetChain>>;
+	type TransactionTracker = TransactionTracker<P::TargetChain, TargetClnt>;
 
 	async fn best_block(&self) -> Result<HeaderIdOf<P::TargetChain>, Self::Error> {
 		let best_header = self.client.best_header().await?;


### PR DESCRIPTION
closes #2133. Writing tests and proper `TestingClient` is not trivial, so I've extracted this to a separate issue #2145 2145. So let's this PR will be just about making relayer code generic over the `Client` type.

Please note that the code in `substrate-relay` folder still uses the `CachingClient<RpcClient<C>>` everywhere. That's because most of code there contains no any logic and there's nothing to test there. So only code in `lib-substrate-relay` is generic.