### PR TITLE
Do not wait for reader when sending subscription items

### DIFF
--- a/relays/client-substrate/src/client/subscription.rs
+++ b/relays/client-substrate/src/client/subscription.rs
@@ -157,7 +157,7 @@ async fn background_worker<T: 'static + Clone + DeserializeOwned + Send>(
 		let mut i = 0;
 		while i < subscribers.len() {
 			let result_to_send = result_to_send.clone();
-			let send_result = subscribers[i].send(result_to_send).await;
+			let send_result = subscribers[i].try_send(result_to_send);
 			match send_result {
 				Ok(_) => {
 					i += 1;


### PR DESCRIPTION
Found this during code review. When sending subscription items to readers, we shall not wait block - if reader is not reading items (and the channel is full), we shall just drop the reader. It doesn't causes any issues now, but still this is a code bug.