### PR TITLE
Get rid of LaneMessageVerifier

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -457,7 +457,6 @@ impl pallet_bridge_messages::Config<WithRialtoMessagesInstance> for Runtime {
 	type DeliveryPayments = ();
 
 	type TargetHeaderChain = crate::rialto_messages::RialtoAsTargetHeaderChain;
-	type LaneMessageVerifier = crate::rialto_messages::ToRialtoMessageVerifier;
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithRialtoMessagesInstance,
@@ -488,7 +487,6 @@ impl pallet_bridge_messages::Config<WithRialtoParachainMessagesInstance> for Run
 	type DeliveryPayments = ();
 
 	type TargetHeaderChain = crate::rialto_parachain_messages::RialtoParachainAsTargetHeaderChain;
-	type LaneMessageVerifier = crate::rialto_parachain_messages::ToRialtoParachainMessageVerifier;
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithRialtoParachainMessagesInstance,

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -27,7 +27,6 @@ use bridge_runtime_common::{
 };
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
 use pallet_bridge_relayers::WeightInfoExt as _;
-use xcm::latest::prelude::*;
 use xcm_builder::HaulBlobExporter;
 
 /// Default lane that is used to send messages to Rialto.
@@ -47,10 +46,6 @@ parameter_types! {
 
 /// Message payload for Millau -> Rialto messages.
 pub type ToRialtoMessagePayload = messages::source::FromThisChainMessagePayload;
-
-/// Message verifier for Millau -> Rialto messages.
-pub type ToRialtoMessageVerifier =
-	messages::source::FromThisChainMessageVerifier<WithRialtoMessageBridge>;
 
 /// Message payload for Rialto -> Millau messages.
 pub type FromRialtoMessagePayload = messages::target::FromBridgedChainMessagePayload;
@@ -124,12 +119,6 @@ pub struct ToRialtoXcmBlobHauler;
 
 impl XcmBlobHauler for ToRialtoXcmBlobHauler {
 	type MessageSender = pallet_bridge_messages::Pallet<Runtime, WithRialtoMessagesInstance>;
-	type MessageSenderOrigin = RuntimeOrigin;
-
-	fn message_sender_origin() -> RuntimeOrigin {
-		pallet_xcm::Origin::from(MultiLocation::new(1, crate::xcm_config::UniversalLocation::get()))
-			.into()
-	}
 
 	fn xcm_lane() -> LaneId {
 		XCM_LANE

--- a/bin/millau/runtime/src/rialto_parachain_messages.rs
+++ b/bin/millau/runtime/src/rialto_parachain_messages.rs
@@ -29,7 +29,6 @@ use bridge_runtime_common::{
 };
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
 use pallet_bridge_relayers::WeightInfoExt as _;
-use xcm::latest::prelude::*;
 use xcm_builder::HaulBlobExporter;
 
 /// Default lane that is used to send messages to Rialto parachain.
@@ -49,10 +48,6 @@ parameter_types! {
 
 /// Message payload for Millau -> RialtoParachain messages.
 pub type ToRialtoParachainMessagePayload = messages::source::FromThisChainMessagePayload;
-
-/// Message verifier for Millau -> RialtoParachain messages.
-pub type ToRialtoParachainMessageVerifier =
-	messages::source::FromThisChainMessageVerifier<WithRialtoParachainMessageBridge>;
 
 /// Message payload for RialtoParachain -> Millau messages.
 pub type FromRialtoParachainMessagePayload = messages::target::FromBridgedChainMessagePayload;
@@ -125,12 +120,6 @@ pub struct ToRialtoParachainXcmBlobHauler;
 impl XcmBlobHauler for ToRialtoParachainXcmBlobHauler {
 	type MessageSender =
 		pallet_bridge_messages::Pallet<Runtime, WithRialtoParachainMessagesInstance>;
-	type MessageSenderOrigin = RuntimeOrigin;
-
-	fn message_sender_origin() -> RuntimeOrigin {
-		pallet_xcm::Origin::from(MultiLocation::new(1, crate::xcm_config::UniversalLocation::get()))
-			.into()
-	}
 
 	fn xcm_lane() -> LaneId {
 		XCM_LANE

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -577,7 +577,6 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type DeliveryPayments = ();
 
 	type TargetHeaderChain = crate::millau_messages::MillauAsTargetHeaderChain;
-	type LaneMessageVerifier = crate::millau_messages::ToMillauMessageVerifier;
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithMillauMessagesInstance,

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -29,7 +29,6 @@ use bridge_runtime_common::{
 	messages_xcm_extension::{XcmBlobHauler, XcmBlobHaulerAdapter},
 };
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
-use xcm::latest::prelude::*;
 use xcm_builder::HaulBlobExporter;
 
 /// Default lane that is used to send messages to Millau.
@@ -49,10 +48,6 @@ parameter_types! {
 
 /// Message payload for RialtoParachain -> Millau messages.
 pub type ToMillauMessagePayload = messages::source::FromThisChainMessagePayload;
-
-/// Message verifier for RialtoParachain -> Millau messages.
-pub type ToMillauMessageVerifier =
-	messages::source::FromThisChainMessageVerifier<WithMillauMessageBridge>;
 
 /// Message payload for Millau -> RialtoParachain messages.
 pub type FromMillauMessagePayload = messages::target::FromBridgedChainMessagePayload;
@@ -124,11 +119,6 @@ pub struct ToMillauXcmBlobHauler;
 
 impl XcmBlobHauler for ToMillauXcmBlobHauler {
 	type MessageSender = pallet_bridge_messages::Pallet<Runtime, WithMillauMessagesInstance>;
-	type MessageSenderOrigin = RuntimeOrigin;
-
-	fn message_sender_origin() -> RuntimeOrigin {
-		pallet_xcm::Origin::from(MultiLocation::new(1, crate::UniversalLocation::get())).into()
-	}
 
 	fn xcm_lane() -> LaneId {
 		XCM_LANE

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -434,7 +434,6 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type DeliveryPayments = ();
 
 	type TargetHeaderChain = crate::millau_messages::MillauAsTargetHeaderChain;
-	type LaneMessageVerifier = crate::millau_messages::ToMillauMessageVerifier;
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithMillauMessagesInstance,

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -26,7 +26,6 @@ use bridge_runtime_common::{
 	messages_xcm_extension::{XcmBlobHauler, XcmBlobHaulerAdapter},
 };
 use frame_support::{parameter_types, weights::Weight, RuntimeDebug};
-use xcm::latest::prelude::*;
 use xcm_builder::HaulBlobExporter;
 
 /// Lane that is used for XCM messages exchange.
@@ -46,10 +45,6 @@ parameter_types! {
 
 /// Message payload for Rialto -> Millau messages.
 pub type ToMillauMessagePayload = messages::source::FromThisChainMessagePayload;
-
-/// Message verifier for Rialto -> Millau messages.
-pub type ToMillauMessageVerifier =
-	messages::source::FromThisChainMessageVerifier<WithMillauMessageBridge>;
 
 /// Message payload for Millau -> Rialto messages.
 pub type FromMillauMessagePayload = messages::target::FromBridgedChainMessagePayload;
@@ -123,12 +118,6 @@ pub struct ToMillauXcmBlobHauler;
 
 impl XcmBlobHauler for ToMillauXcmBlobHauler {
 	type MessageSender = pallet_bridge_messages::Pallet<Runtime, WithMillauMessagesInstance>;
-	type MessageSenderOrigin = RuntimeOrigin;
-
-	fn message_sender_origin() -> RuntimeOrigin {
-		pallet_xcm::Origin::from(MultiLocation::new(1, crate::xcm_config::UniversalLocation::get()))
-			.into()
-	}
 
 	fn xcm_lane() -> LaneId {
 		XCM_LANE

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -22,7 +22,7 @@
 
 use bp_header_chain::HeaderChain;
 use bp_messages::{
-	source_chain::{LaneMessageVerifier, TargetHeaderChain},
+	source_chain::TargetHeaderChain,
 	target_chain::{ProvedLaneMessages, ProvedMessages, SourceHeaderChain},
 	InboundLaneData, LaneId, Message, MessageKey, MessageNonce, MessagePayload, OutboundLaneData,
 	VerificationError,
@@ -121,48 +121,6 @@ pub mod source {
 	pub type ParsedMessagesDeliveryProofFromBridgedChain<B> =
 		(LaneId, InboundLaneData<AccountIdOf<ThisChain<B>>>);
 
-	/// Message verifier that is doing all basic checks.
-	///
-	/// This verifier assumes following:
-	///
-	/// - all message lanes are equivalent, so all checks are the same;
-	///
-	/// Following checks are made:
-	///
-	/// - message is rejected if its lane is currently blocked;
-	/// - message is rejected if there are too many pending (undelivered) messages at the outbound
-	///   lane;
-	/// - check that the sender has rights to dispatch the call on target chain using provided
-	///   dispatch origin;
-	/// - check that the sender has paid enough funds for both message delivery and dispatch.
-	#[derive(RuntimeDebug)]
-	pub struct FromThisChainMessageVerifier<B>(PhantomData<B>);
-
-	impl<B> LaneMessageVerifier<OriginOf<ThisChain<B>>, FromThisChainMessagePayload>
-		for FromThisChainMessageVerifier<B>
-	where
-		B: MessageBridge,
-		// matches requirements from the `frame_system::Config::Origin`
-		OriginOf<ThisChain<B>>: Clone
-			+ Into<Result<frame_system::RawOrigin<AccountIdOf<ThisChain<B>>>, OriginOf<ThisChain<B>>>>,
-		AccountIdOf<ThisChain<B>>: PartialEq + Clone,
-	{
-		fn verify_message(
-			_submitter: &OriginOf<ThisChain<B>>,
-			_lane: &LaneId,
-			_lane_outbound_data: &OutboundLaneData,
-			_payload: &FromThisChainMessagePayload,
-		) -> Result<(), VerificationError> {
-			// IMPORTANT: any error that is returned here is fatal for the bridge, because
-			// this code is executed at the bridge hub and message sender actually lives
-			// at some sibling parachain. So we are failing **after** the message has been
-			// sent and we can't report it back to sender (unless error report mechanism is
-			// embedded into message and its dispatcher).
-
-			Ok(())
-		}
-	}
-
 	/// Return maximal message size of This -> Bridged chain message.
 	pub fn maximal_message_size<B: MessageBridge>() -> u32 {
 		super::target::maximal_incoming_message_size(
@@ -192,8 +150,7 @@ pub mod source {
 	/// Do basic Bridged-chain specific verification of This -> Bridged chain message.
 	///
 	/// Ok result from this function means that the delivery transaction with this message
-	/// may be 'mined' by the target chain. But the lane may have its own checks (e.g. fee
-	/// check) that would reject message (see `FromThisChainMessageVerifier`).
+	/// may be 'mined' by the target chain.
 	pub fn verify_chain_message<B: MessageBridge>(
 		payload: &FromThisChainMessagePayload,
 	) -> Result<(), VerificationError> {

--- a/bin/runtime-common/src/mock.rs
+++ b/bin/runtime-common/src/mock.rs
@@ -26,7 +26,7 @@
 use crate::messages::{
 	source::{
 		FromThisChainMaximalOutboundPayloadSize, FromThisChainMessagePayload,
-		FromThisChainMessageVerifier, TargetHeaderChainAdapter,
+		TargetHeaderChainAdapter,
 	},
 	target::{FromBridgedChainMessagePayload, SourceHeaderChainAdapter},
 	BridgedChainWithMessages, HashOf, MessageBridge, ThisChainWithMessages,
@@ -246,7 +246,6 @@ impl pallet_bridge_messages::Config for TestRuntime {
 	type DeliveryPayments = ();
 
 	type TargetHeaderChain = TargetHeaderChainAdapter<OnThisChainBridge>;
-	type LaneMessageVerifier = FromThisChainMessageVerifier<OnThisChainBridge>;
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		TestRuntime,
 		(),

--- a/modules/messages/README.md
+++ b/modules/messages/README.md
@@ -132,23 +132,6 @@ implementation must be able to parse and verify the proof of messages delivery. 
 reuse the same (configurable) type on all chains that are sending messages to the same bridged
 chain.
 
-The `pallet_bridge_messages::Config::LaneMessageVerifier` defines a single callback to verify outbound
-messages. The simplest callback may just accept all messages. But in this case you'll need to answer
-many questions first. Who will pay for the delivery and confirmation transaction? Are we sure that
-someone will ever deliver this message to the bridged chain? Are we sure that we don't bloat our
-runtime storage by accepting this message? What if the message is improperly encoded or has some
-fields set to invalid values? Answering all those (and similar) questions would lead to correct
-implementation.
-
-There's another thing to consider when implementing type for use in
-`pallet_bridge_messages::Config::LaneMessageVerifier`. It is whether we treat all message lanes
-identically, or they'll have different sets of verification rules? For example, you may reserve
-lane#1 for messages coming from some 'wrapped-token' pallet - then you may verify in your
-implementation that the origin is associated with this pallet. Lane#2 may be reserved for 'system'
-messages and you may charge zero fee for such messages. You may have some rate limiting for messages
-sent over the lane#3. Or you may just verify the same rules set for all outbound messages - it is
-all up to the `pallet_bridge_messages::Config::LaneMessageVerifier` implementation.
-
 The last type is the `pallet_bridge_messages::Config::DeliveryConfirmationPayments`. When confirmation
 transaction is received, we call the `pay_reward()` method, passing the range of delivered messages.
 You may use the [`pallet-bridge-relayers`](../relayers/) pallet and its

--- a/modules/messages/src/outbound_lane.rs
+++ b/modules/messages/src/outbound_lane.rs
@@ -83,6 +83,7 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 	}
 
 	/// Get this lane data.
+	#[cfg(test)]
 	pub fn data(&self) -> OutboundLaneData {
 		self.storage.data()
 	}

--- a/primitives/messages/src/source_chain.rs
+++ b/primitives/messages/src/source_chain.rs
@@ -16,7 +16,7 @@
 
 //! Primitives of messages module, that are used on the source chain.
 
-use crate::{InboundLaneData, LaneId, MessageNonce, OutboundLaneData, VerificationError};
+use crate::{InboundLaneData, LaneId, MessageNonce, VerificationError};
 
 use crate::UnrewardedRelayer;
 use bp_runtime::Size;
@@ -63,25 +63,6 @@ pub trait TargetHeaderChain<Payload, AccountId> {
 	) -> Result<(LaneId, InboundLaneData<AccountId>), VerificationError>;
 }
 
-/// Lane message verifier.
-///
-/// Runtime developer may implement any additional validation logic over message-lane mechanism.
-/// E.g. if lanes should have some security (e.g. you can only accept Lane1 messages from
-/// Submitter1, Lane2 messages for those who has submitted first message to this lane, disable
-/// Lane3 until some block, ...), then it may be built using this verifier.
-///
-/// Any fee requirements should also be enforced here.
-pub trait LaneMessageVerifier<SenderOrigin, Payload> {
-	/// Verify message payload and return Ok(()) if message is valid and allowed to be sent over the
-	/// lane.
-	fn verify_message(
-		submitter: &SenderOrigin,
-		lane: &LaneId,
-		outbound_data: &OutboundLaneData,
-		payload: &Payload,
-	) -> Result<(), VerificationError>;
-}
-
 /// Manages payments that are happening at the source chain during delivery confirmation
 /// transaction.
 pub trait DeliveryConfirmationPayments<AccountId> {
@@ -124,37 +105,29 @@ pub struct SendMessageArtifacts {
 }
 
 /// Messages bridge API to be used from other pallets.
-pub trait MessagesBridge<SenderOrigin, Payload> {
+pub trait MessagesBridge<Payload> {
 	/// Error type.
 	type Error: Debug;
 
 	/// Send message over the bridge.
 	///
 	/// Returns unique message nonce or error if send has failed.
-	fn send_message(
-		sender: SenderOrigin,
-		lane: LaneId,
-		message: Payload,
-	) -> Result<SendMessageArtifacts, Self::Error>;
+	fn send_message(lane: LaneId, message: Payload) -> Result<SendMessageArtifacts, Self::Error>;
 }
 
 /// Bridge that does nothing when message is being sent.
 #[derive(Eq, RuntimeDebug, PartialEq)]
 pub struct NoopMessagesBridge;
 
-impl<SenderOrigin, Payload> MessagesBridge<SenderOrigin, Payload> for NoopMessagesBridge {
+impl<Payload> MessagesBridge<Payload> for NoopMessagesBridge {
 	type Error = &'static str;
 
-	fn send_message(
-		_sender: SenderOrigin,
-		_lane: LaneId,
-		_message: Payload,
-	) -> Result<SendMessageArtifacts, Self::Error> {
+	fn send_message(_lane: LaneId, _message: Payload) -> Result<SendMessageArtifacts, Self::Error> {
 		Ok(SendMessageArtifacts { nonce: 0 })
 	}
 }
 
-/// Structure that may be used in place of `TargetHeaderChain`, `LaneMessageVerifier` and
+/// Structure that may be used in place of `TargetHeaderChain` and
 /// `MessageDeliveryAndDispatchPayment` on chains, where outbound messages are forbidden.
 pub struct ForbidOutboundMessages;
 
@@ -172,17 +145,6 @@ impl<Payload, AccountId> TargetHeaderChain<Payload, AccountId> for ForbidOutboun
 	fn verify_messages_delivery_proof(
 		_proof: Self::MessagesDeliveryProof,
 	) -> Result<(LaneId, InboundLaneData<AccountId>), VerificationError> {
-		Err(VerificationError::Other(ALL_OUTBOUND_MESSAGES_REJECTED))
-	}
-}
-
-impl<SenderOrigin, Payload> LaneMessageVerifier<SenderOrigin, Payload> for ForbidOutboundMessages {
-	fn verify_message(
-		_submitter: &SenderOrigin,
-		_lane: &LaneId,
-		_outbound_data: &OutboundLaneData,
-		_payload: &Payload,
-	) -> Result<(), VerificationError> {
 		Err(VerificationError::Other(ALL_OUTBOUND_MESSAGES_REJECTED))
 	}
 }


### PR DESCRIPTION
First commit for resolving #1666

`LaneMessageVerifier` concept is no longer actual - lanes are just transport, without any logic, so it should be removed. No audit required (no actual code removed - just trait and noop implementations).