### PR TITLE
Introduce bp_messages::ChainWithMessages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9692,7 +9692,6 @@ dependencies = [
  "bp-bridge-hub-kusama",
  "bp-bridge-hub-polkadot",
  "bp-header-chain",
- "bp-messages",
  "bp-parachains",
  "bp-polkadot",
  "bp-runtime",
@@ -9712,7 +9711,6 @@ dependencies = [
  "bp-bridge-hub-polkadot",
  "bp-header-chain",
  "bp-kusama",
- "bp-messages",
  "bp-parachains",
  "bp-polkadot-core",
  "bp-runtime",
@@ -9754,7 +9752,6 @@ dependencies = [
  "bp-bridge-hub-rococo",
  "bp-bridge-hub-wococo",
  "bp-header-chain",
- "bp-messages",
  "bp-parachains",
  "bp-polkadot-core",
  "bp-rococo",
@@ -9786,7 +9783,6 @@ dependencies = [
 name = "relay-millau-client"
 version = "0.1.0"
 dependencies = [
- "bp-messages",
  "bp-millau",
  "bp-runtime",
  "frame-support",
@@ -9815,7 +9811,6 @@ dependencies = [
 name = "relay-rialto-client"
 version = "0.1.0"
 dependencies = [
- "bp-messages",
  "bp-rialto",
  "bp-runtime",
  "frame-support",

--- a/primitives/chain-bridge-hub-kusama/src/lib.rs
+++ b/primitives/chain-bridge-hub-kusama/src/lib.rs
@@ -64,6 +64,15 @@ impl Parachain for BridgeHubKusama {
 	const PARACHAIN_ID: u32 = BRIDGE_HUB_KUSAMA_PARACHAIN_ID;
 }
 
+impl ChainWithMessages for BridgeHubKusama {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
+		WITH_BRIDGE_HUB_KUSAMA_MESSAGES_PALLET_NAME;
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
+}
+
 /// Public key of the chain account that may be used to verify signatures.
 pub type AccountSigner = MultiSigner;
 

--- a/primitives/chain-bridge-hub-polkadot/src/lib.rs
+++ b/primitives/chain-bridge-hub-polkadot/src/lib.rs
@@ -60,6 +60,16 @@ impl Parachain for BridgeHubPolkadot {
 	const PARACHAIN_ID: u32 = BRIDGE_HUB_POLKADOT_PARACHAIN_ID;
 }
 
+impl ChainWithMessages for BridgeHubPolkadot {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
+		WITH_BRIDGE_HUB_POLKADOT_MESSAGES_PALLET_NAME;
+
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
+}
+
 /// Identifier of BridgeHubPolkadot in the Polkadot relay chain.
 pub const BRIDGE_HUB_POLKADOT_PARACHAIN_ID: u32 = 1002;
 

--- a/primitives/chain-bridge-hub-rococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-rococo/src/lib.rs
@@ -64,6 +64,16 @@ impl Parachain for BridgeHubRococo {
 	const PARACHAIN_ID: u32 = BRIDGE_HUB_ROCOCO_PARACHAIN_ID;
 }
 
+impl ChainWithMessages for BridgeHubRococo {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
+		WITH_BRIDGE_HUB_ROCOCO_MESSAGES_PALLET_NAME;
+
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
+}
+
 /// Public key of the chain account that may be used to verify signatures.
 pub type AccountSigner = MultiSigner;
 

--- a/primitives/chain-bridge-hub-wococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-wococo/src/lib.rs
@@ -60,6 +60,16 @@ impl Parachain for BridgeHubWococo {
 	const PARACHAIN_ID: u32 = BRIDGE_HUB_WOCOCO_PARACHAIN_ID;
 }
 
+impl ChainWithMessages for BridgeHubWococo {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
+		WITH_BRIDGE_HUB_WOCOCO_MESSAGES_PALLET_NAME;
+
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
+}
+
 /// Identifier of BridgeHubWococo in the Wococo relay chain.
 pub const BRIDGE_HUB_WOCOCO_PARACHAIN_ID: u32 = 1014;
 

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -23,7 +23,8 @@ mod millau_hash;
 use bp_beefy::ChainWithBeefy;
 use bp_header_chain::ChainWithGrandpa;
 use bp_messages::{
-	InboundMessageDetails, LaneId, MessageNonce, MessagePayload, OutboundMessageDetails,
+	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
+	OutboundMessageDetails,
 };
 use bp_runtime::{decl_bridge_runtime_apis, Chain};
 use frame_support::{
@@ -196,6 +197,15 @@ impl ChainWithBeefy for Millau {
 	type BeefyMmrLeafExtra = ();
 	type AuthorityId = bp_beefy::EcdsaValidatorId;
 	type AuthorityIdToMerkleLeaf = bp_beefy::BeefyEcdsaToEthereum;
+}
+
+impl ChainWithMessages for Millau {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str = WITH_MILLAU_MESSAGES_PALLET_NAME;
+
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 /// Millau Hasher (Blake2-256 ++ Keccak-256) implementation.

--- a/primitives/chain-rialto-parachain/src/lib.rs
+++ b/primitives/chain-rialto-parachain/src/lib.rs
@@ -19,7 +19,8 @@
 #![allow(clippy::too_many_arguments)]
 
 use bp_messages::{
-	InboundMessageDetails, LaneId, MessageNonce, MessagePayload, OutboundMessageDetails,
+	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
+	OutboundMessageDetails,
 };
 use bp_runtime::{decl_bridge_runtime_apis, Chain, Parachain};
 use frame_support::{
@@ -133,6 +134,15 @@ impl Chain for RialtoParachain {
 
 impl Parachain for RialtoParachain {
 	const PARACHAIN_ID: u32 = RIALTO_PARACHAIN_ID;
+}
+
+impl ChainWithMessages for RialtoParachain {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
+		WITH_RIALTO_PARACHAIN_MESSAGES_PALLET_NAME;
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 // Technically this is incorrect, because rialto-parachain isn't a bridge hub, but we're

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -20,7 +20,8 @@
 
 use bp_header_chain::ChainWithGrandpa;
 use bp_messages::{
-	InboundMessageDetails, LaneId, MessageNonce, MessagePayload, OutboundMessageDetails,
+	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
+	OutboundMessageDetails,
 };
 use bp_runtime::{decl_bridge_runtime_apis, Chain};
 use frame_support::{
@@ -191,6 +192,14 @@ impl ChainWithGrandpa for Rialto {
 		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
 	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
 	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
+
+impl ChainWithMessages for Rialto {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str = WITH_RIALTO_MESSAGES_PALLET_NAME;
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 frame_support::parameter_types! {

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -22,8 +22,8 @@
 
 use bp_header_chain::HeaderChainError;
 use bp_runtime::{
-	messages::MessageDispatchResult, BasicOperatingMode, OperatingMode, RangeInclusiveExt,
-	StorageProofError, VecDbError,
+	messages::MessageDispatchResult, BasicOperatingMode, Chain, OperatingMode, RangeInclusiveExt,
+	StorageProofError, UnderlyingChainOf, UnderlyingChainProvider, VecDbError,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{PalletError, RuntimeDebug};
@@ -37,6 +37,36 @@ use sp_std::{collections::vec_deque::VecDeque, ops::RangeInclusive, prelude::*};
 pub mod source_chain;
 pub mod storage_keys;
 pub mod target_chain;
+
+/// Substrate-based chain with messaging support.
+pub trait ChainWithMessages: Chain {
+	/// Name of the bridge messages pallet (used in `construct_runtime` macro call) that is
+	/// deployed at some other chain to bridge with this `ChainWithMessages`.
+	///
+	/// We assume that all chains that are bridging with this `ChainWithMessages` are using
+	/// the same name.
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str;
+
+	/// Maximal number of unrewarded relayers in a single confirmation transaction at this
+	/// `ChainWithMessages`.
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce;
+	/// Maximal number of unconfirmed messages in a single confirmation transaction at this
+	/// `ChainWithMessages`.
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce;
+}
+
+impl<T> ChainWithMessages for T
+where
+	T: Chain + UnderlyingChainProvider,
+	UnderlyingChainOf<T>: ChainWithMessages,
+{
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
+		UnderlyingChainOf::<T>::WITH_CHAIN_MESSAGES_PALLET_NAME;
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		UnderlyingChainOf::<T>::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		UnderlyingChainOf::<T>::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
+}
 
 /// Messages pallet operating mode.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]

--- a/relays/client-bridge-hub-kusama/Cargo.toml
+++ b/relays/client-bridge-hub-kusama/Cargo.toml
@@ -15,7 +15,6 @@ relay-substrate-client = { path = "../client-substrate" }
 bp-bridge-hub-kusama = { path = "../../primitives/chain-bridge-hub-kusama" }
 bp-bridge-hub-polkadot = { path = "../../primitives/chain-bridge-hub-polkadot" }
 bp-header-chain = { path = "../../primitives/header-chain" }
-bp-messages = { path = "../../primitives/messages" }
 bp-parachains = { path = "../../primitives/parachains" }
 bp-runtime = { path = "../../primitives/runtime" }
 bp-polkadot = { path = "../../primitives/chain-polkadot" }

--- a/relays/client-bridge-hub-kusama/src/lib.rs
+++ b/relays/client-bridge-hub-kusama/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the BridgeHub-Kusama-Substrate parachain.
 
 use bp_bridge_hub_kusama::{BridgeHubSignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_messages::MessageNonce;
 use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
@@ -114,8 +113,6 @@ impl ChainWithTransactions for BridgeHubKusama {
 }
 
 impl ChainWithMessages for BridgeHubKusama {
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
-		bp_bridge_hub_kusama::WITH_BRIDGE_HUB_KUSAMA_MESSAGES_PALLET_NAME;
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_kusama::WITH_BRIDGE_HUB_KUSAMA_RELAYERS_PALLET_NAME);
 
@@ -123,11 +120,6 @@ impl ChainWithMessages for BridgeHubKusama {
 		bp_bridge_hub_kusama::TO_BRIDGE_HUB_KUSAMA_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_kusama::FROM_BRIDGE_HUB_KUSAMA_MESSAGE_DETAILS_METHOD;
-
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_kusama::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_kusama::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 #[cfg(test)]

--- a/relays/client-bridge-hub-polkadot/Cargo.toml
+++ b/relays/client-bridge-hub-polkadot/Cargo.toml
@@ -15,7 +15,6 @@ relay-substrate-client = { path = "../client-substrate" }
 bp-bridge-hub-kusama = { path = "../../primitives/chain-bridge-hub-kusama" }
 bp-bridge-hub-polkadot = { path = "../../primitives/chain-bridge-hub-polkadot" }
 bp-header-chain = { path = "../../primitives/header-chain" }
-bp-messages = { path = "../../primitives/messages" }
 bp-parachains = { path = "../../primitives/parachains" }
 bp-kusama = { path = "../../primitives/chain-kusama" }
 bp-runtime = { path = "../../primitives/runtime" }

--- a/relays/client-bridge-hub-polkadot/src/lib.rs
+++ b/relays/client-bridge-hub-polkadot/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the BridgeHub-Polkadot-Substrate parachain.
 
 use bp_bridge_hub_polkadot::{BridgeHubSignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_messages::MessageNonce;
 use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
@@ -114,8 +113,6 @@ impl ChainWithTransactions for BridgeHubPolkadot {
 }
 
 impl ChainWithMessages for BridgeHubPolkadot {
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
-		bp_bridge_hub_polkadot::WITH_BRIDGE_HUB_POLKADOT_MESSAGES_PALLET_NAME;
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_polkadot::WITH_BRIDGE_HUB_POLKADOT_RELAYERS_PALLET_NAME);
 
@@ -123,11 +120,6 @@ impl ChainWithMessages for BridgeHubPolkadot {
 		bp_bridge_hub_polkadot::TO_BRIDGE_HUB_POLKADOT_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_polkadot::FROM_BRIDGE_HUB_POLKADOT_MESSAGE_DETAILS_METHOD;
-
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_polkadot::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_polkadot::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 #[cfg(test)]

--- a/relays/client-bridge-hub-rococo/src/lib.rs
+++ b/relays/client-bridge-hub-rococo/src/lib.rs
@@ -19,7 +19,6 @@
 pub mod codegen_runtime;
 
 use bp_bridge_hub_rococo::{BridgeHubSignedExtension, SignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_messages::MessageNonce;
 use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
@@ -130,8 +129,6 @@ impl ChainWithTransactions for BridgeHubRococo {
 }
 
 impl ChainWithMessages for BridgeHubRococo {
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
-		bp_bridge_hub_rococo::WITH_BRIDGE_HUB_ROCOCO_MESSAGES_PALLET_NAME;
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_rococo::WITH_BRIDGE_HUB_ROCOCO_RELAYERS_PALLET_NAME);
 
@@ -139,11 +136,6 @@ impl ChainWithMessages for BridgeHubRococo {
 		bp_bridge_hub_rococo::TO_BRIDGE_HUB_ROCOCO_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_rococo::FROM_BRIDGE_HUB_ROCOCO_MESSAGE_DETAILS_METHOD;
-
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_rococo::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_rococo::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 #[cfg(test)]

--- a/relays/client-bridge-hub-wococo/Cargo.toml
+++ b/relays/client-bridge-hub-wococo/Cargo.toml
@@ -15,7 +15,6 @@ subxt = { version = "0.28.0", default-features = false, features = [] }
 bp-bridge-hub-rococo = { path = "../../primitives/chain-bridge-hub-rococo" }
 bp-bridge-hub-wococo = { path = "../../primitives/chain-bridge-hub-wococo" }
 bp-header-chain = { path = "../../primitives/header-chain" }
-bp-messages = { path = "../../primitives/messages" }
 bp-parachains = { path = "../../primitives/parachains" }
 bp-polkadot-core = { path = "../../primitives/polkadot-core" }
 bp-rococo = { path = "../../primitives/chain-rococo" }

--- a/relays/client-bridge-hub-wococo/src/lib.rs
+++ b/relays/client-bridge-hub-wococo/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the BridgeHub-Wococo-Substrate parachain.
 
 use bp_bridge_hub_wococo::{BridgeHubSignedExtension, SignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_messages::MessageNonce;
 use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
@@ -119,8 +118,6 @@ impl ChainWithTransactions for BridgeHubWococo {
 }
 
 impl ChainWithMessages for BridgeHubWococo {
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
-		bp_bridge_hub_wococo::WITH_BRIDGE_HUB_WOCOCO_MESSAGES_PALLET_NAME;
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_wococo::WITH_BRIDGE_HUB_WOCOCO_RELAYERS_PALLET_NAME);
 
@@ -128,11 +125,6 @@ impl ChainWithMessages for BridgeHubWococo {
 		bp_bridge_hub_wococo::TO_BRIDGE_HUB_WOCOCO_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_wococo::FROM_BRIDGE_HUB_WOCOCO_MESSAGE_DETAILS_METHOD;
-
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_wococo::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
-		bp_bridge_hub_wococo::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 #[cfg(test)]

--- a/relays/client-millau/Cargo.toml
+++ b/relays/client-millau/Cargo.toml
@@ -12,7 +12,6 @@ relay-utils = { path = "../utils" }
 
 # Supported Chains
 
-bp-messages = { path = "../../primitives/messages" }
 bp-millau = { path = "../../primitives/chain-millau" }
 bp-runtime = { path = "../../primitives/runtime" }
 millau-runtime = { path = "../../bin/millau/runtime" }

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Types used to connect to the Millau-Substrate chain.
 
-use bp_messages::MessageNonce;
 use bp_runtime::ChainId;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
@@ -40,18 +39,12 @@ impl UnderlyingChainProvider for Millau {
 }
 
 impl ChainWithMessages for Millau {
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
-		bp_millau::WITH_MILLAU_MESSAGES_PALLET_NAME;
 	// TODO (https://github.com/paritytech/parity-bridges-common/issues/1692): change the name
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> = Some("BridgeRelayers");
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_millau::TO_MILLAU_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_millau::FROM_MILLAU_MESSAGE_DETAILS_METHOD;
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
-		bp_millau::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
-		bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 impl Chain for Millau {

--- a/relays/client-rialto-parachain/src/lib.rs
+++ b/relays/client-rialto-parachain/src/lib.rs
@@ -19,7 +19,6 @@
 pub mod codegen_runtime;
 
 use bp_bridge_hub_cumulus::BridgeHubSignedExtension;
-use bp_messages::MessageNonce;
 use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
@@ -66,18 +65,12 @@ impl ChainWithBalances for RialtoParachain {
 }
 
 impl ChainWithMessages for RialtoParachain {
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
-		bp_rialto_parachain::WITH_RIALTO_PARACHAIN_MESSAGES_PALLET_NAME;
 	// TODO (https://github.com/paritytech/parity-bridges-common/issues/1692): change the name
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> = Some("BridgeRelayers");
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_rialto_parachain::TO_RIALTO_PARACHAIN_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_rialto_parachain::FROM_RIALTO_PARACHAIN_MESSAGE_DETAILS_METHOD;
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
-		bp_rialto_parachain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
-		bp_rialto_parachain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 impl ChainWithTransactions for RialtoParachain {

--- a/relays/client-rialto/Cargo.toml
+++ b/relays/client-rialto/Cargo.toml
@@ -12,7 +12,6 @@ relay-utils = { path = "../utils" }
 
 # Bridge dependencies
 
-bp-messages = { path = "../../primitives/messages" }
 bp-rialto = { path = "../../primitives/chain-rialto" }
 bp-runtime = { path = "../../primitives/runtime" }
 rialto-runtime = { path = "../../bin/rialto/runtime" }

--- a/relays/client-rialto/src/lib.rs
+++ b/relays/client-rialto/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Types used to connect to the Rialto-Substrate chain.
 
-use bp_messages::MessageNonce;
 use bp_runtime::ChainId;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
@@ -57,18 +56,12 @@ impl RelayChain for Rialto {
 }
 
 impl ChainWithMessages for Rialto {
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
-		bp_rialto::WITH_RIALTO_MESSAGES_PALLET_NAME;
 	// TODO (https://github.com/paritytech/parity-bridges-common/issues/1692): change the name
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> = Some("BridgeRelayers");
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_rialto::TO_RIALTO_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_rialto::FROM_RIALTO_MESSAGE_DETAILS_METHOD;
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
-		bp_rialto::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
-		bp_rialto::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 impl ChainWithBalances for Rialto {

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -16,7 +16,7 @@
 
 use crate::calls::UtilityCall;
 
-use bp_messages::MessageNonce;
+use bp_messages::ChainWithMessages as ChainWithMessagesBase;
 use bp_runtime::{
 	Chain as ChainBase, ChainId, EncodedOrDecodedCall, HashOf, Parachain as ParachainBase,
 	TransactionEra, TransactionEraOf, UnderlyingChainProvider,
@@ -104,14 +104,7 @@ pub trait Parachain: Chain + ParachainBase {}
 impl<T> Parachain for T where T: UnderlyingChainProvider + Chain + ParachainBase {}
 
 /// Substrate-based chain with messaging support from minimal relay-client point of view.
-pub trait ChainWithMessages: Chain {
-	/// Name of the bridge messages pallet (used in `construct_runtime` macro call) that is deployed
-	/// at some other chain to bridge with this `ChainWithMessages`.
-	///
-	/// We assume that all chains that are bridging with this `ChainWithMessages` are using
-	/// the same name.
-	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str;
-
+pub trait ChainWithMessages: Chain + ChainWithMessagesBase {
 	// TODO (https://github.com/paritytech/parity-bridges-common/issues/1692): check all the names
 	// after the issue is fixed - all names must be changed
 
@@ -129,13 +122,6 @@ pub trait ChainWithMessages: Chain {
 	/// Name of the `From<ChainWithMessages>InboundLaneApi::message_details` runtime API method.
 	/// The method is provided by the runtime that is bridged with this `ChainWithMessages`.
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str;
-
-	/// Maximal number of unrewarded relayers in a single confirmation transaction at this
-	/// `ChainWithMessages`.
-	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce;
-	/// Maximal number of unconfirmed messages in a single confirmation transaction at this
-	/// `ChainWithMessages`.
-	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce;
 }
 
 /// Call type used by the chain.

--- a/relays/lib-substrate-relay/src/messages_lane.rs
+++ b/relays/lib-substrate-relay/src/messages_lane.rs
@@ -26,7 +26,7 @@ use crate::{
 use async_std::sync::Arc;
 use bp_messages::{
 	source_chain::FromBridgedChainMessagesDeliveryProof,
-	target_chain::FromBridgedChainMessagesProof, LaneId, MessageNonce,
+	target_chain::FromBridgedChainMessagesProof, ChainWithMessages as _, LaneId, MessageNonce,
 };
 use bp_runtime::{
 	AccountIdOf, Chain as _, EncodedOrDecodedCall, HeaderIdOf, TransactionEra, WeightExtraOps,

--- a/relays/lib-substrate-relay/src/messages_source.rs
+++ b/relays/lib-substrate-relay/src/messages_source.rs
@@ -32,8 +32,8 @@ use async_trait::async_trait;
 use bp_messages::{
 	storage_keys::{operating_mode_key, outbound_lane_data_key},
 	target_chain::FromBridgedChainMessagesProof,
-	InboundMessageDetails, LaneId, MessageNonce, MessagePayload, MessagesOperatingMode,
-	OutboundLaneData, OutboundMessageDetails,
+	ChainWithMessages as _, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
+	MessagesOperatingMode, OutboundLaneData, OutboundMessageDetails,
 };
 use bp_runtime::{
 	BasicOperatingMode, HasherOf, HeaderIdProvider, RangeInclusiveExt, UntrustedVecDb,

--- a/relays/lib-substrate-relay/src/messages_target.rs
+++ b/relays/lib-substrate-relay/src/messages_target.rs
@@ -34,15 +34,15 @@ use async_std::sync::Arc;
 use async_trait::async_trait;
 use bp_messages::{
 	source_chain::FromBridgedChainMessagesDeliveryProof, storage_keys::inbound_lane_data_key,
-	InboundLaneData, LaneId, MessageNonce, UnrewardedRelayersState,
+	ChainWithMessages as _, InboundLaneData, LaneId, MessageNonce, UnrewardedRelayersState,
 };
 use messages_relay::{
 	message_lane::{MessageLane, SourceHeaderIdOf, TargetHeaderIdOf},
 	message_lane_loop::{NoncesSubmitArtifacts, TargetClient, TargetClientState},
 };
 use relay_substrate_client::{
-	AccountIdOf, AccountKeyPairOf, BalanceOf, CallOf, ChainWithMessages, Client,
-	Error as SubstrateError, HashOf, TransactionEra, TransactionTracker, UnsignedTransaction,
+	AccountIdOf, AccountKeyPairOf, BalanceOf, CallOf, Client, Error as SubstrateError, HashOf,
+	TransactionEra, TransactionTracker, UnsignedTransaction,
 };
 use relay_utils::relay_loop::Client as RelayClient;
 use sp_core::Pair;


### PR DESCRIPTION
continue https://github.com/paritytech/parity-bridges-common/issues/1666

Why: right now those constants are part of `bridge_runtime_common::MessageBridge` trait. I'm planning to remove this trait, so we need some analog in the `bp_messages` to be able to use it in the pallet configuration (like `trat Config<I> { type BridgedChain: ChainWithMessages; }`)
Audit: not required because no logic is not changed
Compatibility with `polkadot-staging`: compatible