### PR TITLE
Improve receive_messages_proof benchmarks accuracy

### DIFF
--- a/bin/millau/runtime/src/weights/pallet_bridge_messages_messages_bench_runtime_with_rialto_messages_instance.rs
+++ b/bin/millau/runtime/src/weights/pallet_bridge_messages_messages_bench_runtime_with_rialto_messages_instance.rs
@@ -42,8 +42,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 35_366_000 picoseconds.
-		Weight::from_parts(38_231_000, 0)
+		// Minimum execution time: 34_747_000 picoseconds.
+		Weight::from_parts(36_222_000, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -54,13 +54,17 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68), added: 2048, mode: MaxEncodedLen)
 	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added: 51655, mode: MaxEncodedLen)
-	fn receive_two_messages_proof() -> Weight {
+	/// The range of component `n` is `[1, 1004]`.
+	/// The range of component `n` is `[1, 1004]`.
+	fn receive_n_messages_proof(n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 45_776_000 picoseconds.
-		Weight::from_parts(49_241_000, 0)
+		// Minimum execution time: 34_644_000 picoseconds.
+		Weight::from_parts(17_835_495, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
+			// Standard Error: 4_354
+			.saturating_add(Weight::from_parts(7_517_907, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -74,8 +78,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 41_194_000 picoseconds.
-		Weight::from_parts(44_475_000, 0)
+		// Minimum execution time: 40_916_000 picoseconds.
+		Weight::from_parts(42_815_000, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -92,11 +96,11 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 36_326_000 picoseconds.
-		Weight::from_parts(39_241_295, 0)
+		// Minimum execution time: 36_255_000 picoseconds.
+		Weight::from_parts(37_098_233, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
-			// Standard Error: 10_280
-			.saturating_add(Weight::from_parts(1_214_604, 0).saturating_mul(n.into()))
+			// Standard Error: 4_401
+			.saturating_add(Weight::from_parts(1_186_679, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -112,8 +116,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `515`
 		//  Estimated: `3530`
-		// Minimum execution time: 34_481_000 picoseconds.
-		Weight::from_parts(35_471_000, 0)
+		// Minimum execution time: 34_098_000 picoseconds.
+		Weight::from_parts(35_428_000, 0)
 			.saturating_add(Weight::from_parts(0, 3530))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
@@ -130,8 +134,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `532`
 		//  Estimated: `3530`
-		// Minimum execution time: 33_471_000 picoseconds.
-		Weight::from_parts(34_446_000, 0)
+		// Minimum execution time: 33_381_000 picoseconds.
+		Weight::from_parts(34_557_000, 0)
 			.saturating_add(Weight::from_parts(0, 3530))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
@@ -148,8 +152,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `532`
 		//  Estimated: `6070`
-		// Minimum execution time: 36_077_000 picoseconds.
-		Weight::from_parts(37_235_000, 0)
+		// Minimum execution time: 36_060_000 picoseconds.
+		Weight::from_parts(37_322_000, 0)
 			.saturating_add(Weight::from_parts(0, 6070))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
@@ -166,11 +170,11 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 74_819_000 picoseconds.
-		Weight::from_parts(74_915_515, 0)
+		// Minimum execution time: 74_472_000 picoseconds.
+		Weight::from_parts(66_563_335, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
-			// Standard Error: 1_393
-			.saturating_add(Weight::from_parts(303_406, 0).saturating_mul(n.into()))
+			// Standard Error: 2_202
+			.saturating_add(Weight::from_parts(352_276, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/bin/millau/runtime/src/weights/pallet_bridge_messages_messages_bench_runtime_with_rialto_parachain_messages_instance.rs
+++ b/bin/millau/runtime/src/weights/pallet_bridge_messages_messages_bench_runtime_with_rialto_parachain_messages_instance.rs
@@ -42,8 +42,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `428`
 		//  Estimated: `52645`
-		// Minimum execution time: 33_154_000 picoseconds.
-		Weight::from_parts(36_293_000, 0)
+		// Minimum execution time: 33_092_000 picoseconds.
+		Weight::from_parts(34_474_000, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -54,13 +54,17 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size: Some(196), added: 1681, mode: MaxEncodedLen)
 	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
 	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180), added: 51655, mode: MaxEncodedLen)
-	fn receive_two_messages_proof() -> Weight {
+	/// The range of component `n` is `[1, 1004]`.
+	/// The range of component `n` is `[1, 1004]`.
+	fn receive_n_messages_proof(n: u32, ) -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `428`
 		//  Estimated: `52645`
-		// Minimum execution time: 45_093_000 picoseconds.
-		Weight::from_parts(47_694_000, 0)
+		// Minimum execution time: 34_026_000 picoseconds.
+		Weight::from_parts(14_732_760, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
+			// Standard Error: 4_476
+			.saturating_add(Weight::from_parts(7_326_060, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -74,8 +78,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `428`
 		//  Estimated: `52645`
-		// Minimum execution time: 39_801_000 picoseconds.
-		Weight::from_parts(43_062_000, 0)
+		// Minimum execution time: 39_779_000 picoseconds.
+		Weight::from_parts(41_716_000, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
@@ -92,11 +96,11 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `428`
 		//  Estimated: `52645`
-		// Minimum execution time: 34_641_000 picoseconds.
-		Weight::from_parts(36_810_210, 0)
+		// Minimum execution time: 35_279_000 picoseconds.
+		Weight::from_parts(35_429_607, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
-			// Standard Error: 8_559
-			.saturating_add(Weight::from_parts(1_322_389, 0).saturating_mul(n.into()))
+			// Standard Error: 3_367
+			.saturating_add(Weight::from_parts(1_271_388, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -112,8 +116,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `453`
 		//  Estimated: `3530`
-		// Minimum execution time: 33_150_000 picoseconds.
-		Weight::from_parts(34_823_000, 0)
+		// Minimum execution time: 33_210_000 picoseconds.
+		Weight::from_parts(34_302_000, 0)
 			.saturating_add(Weight::from_parts(0, 3530))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
@@ -130,8 +134,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `470`
 		//  Estimated: `3530`
-		// Minimum execution time: 32_065_000 picoseconds.
-		Weight::from_parts(33_329_000, 0)
+		// Minimum execution time: 32_096_000 picoseconds.
+		Weight::from_parts(33_223_000, 0)
 			.saturating_add(Weight::from_parts(0, 3530))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
@@ -148,8 +152,8 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `470`
 		//  Estimated: `6070`
-		// Minimum execution time: 35_065_000 picoseconds.
-		Weight::from_parts(36_428_000, 0)
+		// Minimum execution time: 34_795_000 picoseconds.
+		Weight::from_parts(36_118_000, 0)
 			.saturating_add(Weight::from_parts(0, 6070))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
@@ -166,11 +170,11 @@ impl<T: frame_system::Config> pallet_bridge_messages::WeightInfo for WeightInfo<
 		// Proof Size summary in bytes:
 		//  Measured:  `428`
 		//  Estimated: `52645`
-		// Minimum execution time: 73_280_000 picoseconds.
-		Weight::from_parts(73_762_167, 0)
+		// Minimum execution time: 73_041_000 picoseconds.
+		Weight::from_parts(62_429_611, 0)
 			.saturating_add(Weight::from_parts(0, 52645))
-			// Standard Error: 1_436
-			.saturating_add(Weight::from_parts(301_526, 0).saturating_mul(n.into()))
+			// Standard Error: 2_126
+			.saturating_add(Weight::from_parts(358_085, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -33,7 +33,7 @@ use codec::Decode;
 use frame_benchmarking::{account, v2::*};
 use frame_support::weights::Weight;
 use frame_system::RawOrigin;
-use sp_runtime::traits::TrailingZeroInput;
+use sp_runtime::traits::{Get, TrailingZeroInput};
 use sp_std::{ops::RangeInclusive, prelude::*};
 
 const SEED: u32 = 0;
@@ -186,14 +186,17 @@ mod benchmarks {
 	// Benchmarks that are used directly by the runtime calls weight formulae.
 	//
 
+	fn max_msgs<T: Config<I>, I: 'static>() -> u32 {
+		T::MaxUnconfirmedMessagesAtInboundLane::get() as u32 -
+			ReceiveMessagesProofSetup::<T, I>::LATEST_RECEIVED_NONCE as u32
+	}
+
 	// Benchmark `receive_messages_proof` extrinsic with single minimal-weight message and following
 	// conditions:
 	// * proof does not include outbound lane state proof;
 	// * inbound lane already has state, so it needs to be read and decoded;
 	// * message is dispatched (reminder: dispatch weight should be minimal);
 	// * message requires all heavy checks done by dispatcher.
-	//
-	// This is base benchmark for all other message delivery benchmarks.
 	#[benchmark]
 	fn receive_single_message_proof() {
 		// setup code
@@ -219,21 +222,16 @@ mod benchmarks {
 		setup.check_last_nonce();
 	}
 
-	// Benchmark `receive_messages_proof` extrinsic with two minimal-weight messages and following
+	// Benchmark `receive_messages_proof` extrinsic with `n` minimal-weight messages and following
 	// conditions:
 	// * proof does not include outbound lane state proof;
 	// * inbound lane already has state, so it needs to be read and decoded;
 	// * message is dispatched (reminder: dispatch weight should be minimal);
 	// * message requires all heavy checks done by dispatcher.
-	//
-	// The weight of single message delivery could be approximated as
-	// `weight(receive_two_messages_proof) - weight(receive_single_message_proof)`.
-	// This won't be super-accurate if message has non-zero dispatch weight, but estimation should
-	// be close enough to real weight.
 	#[benchmark]
-	fn receive_two_messages_proof() {
+	fn receive_n_messages_proof(n: Linear<1, { max_msgs::<T, I>() }>) {
 		// setup code
-		let setup = ReceiveMessagesProofSetup::<T, I>::new(2);
+		let setup = ReceiveMessagesProofSetup::<T, I>::new(n);
 		let (proof, dispatch_weight) = T::prepare_message_proof(MessageProofParams {
 			lane: T::bench_lane_id(),
 			message_nonces: setup.nonces(),
@@ -489,6 +487,7 @@ mod benchmarks {
 	// * inbound lane already has state, so it needs to be read and decoded;
 	// * message is **SUCCESSFULLY** dispatched;
 	// * message requires all heavy checks done by dispatcher.
+	// #[benchmark(extra)]
 	#[benchmark]
 	fn receive_single_message_n_bytes_proof_with_dispatch(
 		/// Proof size in bytes

--- a/modules/messages/src/weights.rs
+++ b/modules/messages/src/weights.rs
@@ -51,7 +51,7 @@ use sp_std::marker::PhantomData;
 /// Weight functions needed for pallet_bridge_messages.
 pub trait WeightInfo {
 	fn receive_single_message_proof() -> Weight;
-	fn receive_two_messages_proof() -> Weight;
+	fn receive_n_messages_proof(n: u32) -> Weight;
 	fn receive_single_message_proof_with_outbound_lane_state() -> Weight;
 	fn receive_single_message_n_kb_proof(n: u32) -> Weight;
 	fn receive_delivery_proof_for_single_message() -> Weight;
@@ -65,118 +65,124 @@ pub trait WeightInfo {
 /// Those weights are test only and must never be used in production.
 pub struct BridgeWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for BridgeWeight<T> {
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	fn receive_single_message_proof() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 32_573 nanoseconds.
-		Weight::from_parts(35_227_000, 52645)
+		// Minimum execution time: 34_644 nanoseconds.
+		Weight::from_parts(36_135_000, 52645)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
-	fn receive_two_messages_proof() -> Weight {
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
+	///
+	/// The range of component `n` is `[1, 1004]`.
+	///
+	/// The range of component `n` is `[1, 1004]`.
+	fn receive_n_messages_proof(n: u32) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 43_726 nanoseconds.
-		Weight::from_parts(47_518_000, 52645)
+		// Minimum execution time: 35_330 nanoseconds.
+		Weight::from_parts(27_526_047, 52645)
+			// Standard Error: 2_681
+			.saturating_add(Weight::from_parts(7_412_923, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	fn receive_single_message_proof_with_outbound_lane_state() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 40_091 nanoseconds.
-		Weight::from_parts(43_639_000, 52645)
+		// Minimum execution time: 41_123 nanoseconds.
+		Weight::from_parts(43_023_000, 52645)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	///
 	/// The range of component `n` is `[1, 16]`.
 	///
 	/// The range of component `n` is `[1, 16]`.
 	fn receive_single_message_n_kb_proof(n: u32) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 34_578 nanoseconds.
-		Weight::from_parts(36_723_095, 52645)
-			// Standard Error: 8_197
-			.saturating_add(Weight::from_parts(1_317_904, 0).saturating_mul(n.into()))
+		// Minimum execution time: 36_301 nanoseconds.
+		Weight::from_parts(37_103_459, 52645)
+			// Standard Error: 4_645
+			.saturating_add(Weight::from_parts(1_172_720, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages OutboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages OutboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages OutboundLanes (max_values: Some(1), max_size: Some(44),
-	/// added: 539, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages OutboundLanes (max_values: Some(1), max_size: Some(44), added:
+	/// 539, mode: MaxEncodedLen)
 	///
 	/// Storage: BridgeRelayers RelayerRewards (r:1 w:1)
 	///
@@ -184,27 +190,27 @@ impl<T: frame_system::Config> WeightInfo for BridgeWeight<T> {
 	/// mode: MaxEncodedLen)
 	fn receive_delivery_proof_for_single_message() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `453`
+		//  Measured:  `515`
 		//  Estimated: `3530`
-		// Minimum execution time: 32_635 nanoseconds.
-		Weight::from_parts(33_711_000, 3530)
+		// Minimum execution time: 33_941 nanoseconds.
+		Weight::from_parts(35_252_000, 3530)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages OutboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages OutboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages OutboundLanes (max_values: Some(1), max_size: Some(44),
-	/// added: 539, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages OutboundLanes (max_values: Some(1), max_size: Some(44), added:
+	/// 539, mode: MaxEncodedLen)
 	///
 	/// Storage: BridgeRelayers RelayerRewards (r:1 w:1)
 	///
@@ -212,27 +218,27 @@ impl<T: frame_system::Config> WeightInfo for BridgeWeight<T> {
 	/// mode: MaxEncodedLen)
 	fn receive_delivery_proof_for_two_messages_by_single_relayer() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `470`
+		//  Measured:  `532`
 		//  Estimated: `3530`
-		// Minimum execution time: 31_808 nanoseconds.
-		Weight::from_parts(33_071_000, 3530)
+		// Minimum execution time: 33_259 nanoseconds.
+		Weight::from_parts(34_558_000, 3530)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages OutboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages OutboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages OutboundLanes (max_values: Some(1), max_size: Some(44),
-	/// added: 539, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages OutboundLanes (max_values: Some(1), max_size: Some(44), added:
+	/// 539, mode: MaxEncodedLen)
 	///
 	/// Storage: BridgeRelayers RelayerRewards (r:2 w:2)
 	///
@@ -240,39 +246,39 @@ impl<T: frame_system::Config> WeightInfo for BridgeWeight<T> {
 	/// mode: MaxEncodedLen)
 	fn receive_delivery_proof_for_two_messages_by_two_relayers() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `470`
+		//  Measured:  `532`
 		//  Estimated: `6070`
-		// Minimum execution time: 34_171 nanoseconds.
-		Weight::from_parts(35_591_000, 6070)
+		// Minimum execution time: 35_199 nanoseconds.
+		Weight::from_parts(36_989_000, 6070)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	///
 	/// The range of component `n` is `[128, 2048]`.
 	///
 	/// The range of component `n` is `[128, 2048]`.
 	fn receive_single_message_n_bytes_proof_with_dispatch(n: u32) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 76_504 nanoseconds.
-		Weight::from_parts(75_331_522, 52645)
-			// Standard Error: 1_440
-			.saturating_add(Weight::from_parts(302_158, 0).saturating_mul(n.into()))
+		// Minimum execution time: 75_228 nanoseconds.
+		Weight::from_parts(62_255_691, 52645)
+			// Standard Error: 2_005
+			.saturating_add(Weight::from_parts(353_141, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -280,118 +286,124 @@ impl<T: frame_system::Config> WeightInfo for BridgeWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	fn receive_single_message_proof() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 32_573 nanoseconds.
-		Weight::from_parts(35_227_000, 52645)
+		// Minimum execution time: 34_644 nanoseconds.
+		Weight::from_parts(36_135_000, 52645)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
-	fn receive_two_messages_proof() -> Weight {
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
+	///
+	/// The range of component `n` is `[1, 1004]`.
+	///
+	/// The range of component `n` is `[1, 1004]`.
+	fn receive_n_messages_proof(n: u32) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 43_726 nanoseconds.
-		Weight::from_parts(47_518_000, 52645)
+		// Minimum execution time: 35_330 nanoseconds.
+		Weight::from_parts(27_526_047, 52645)
+			// Standard Error: 2_681
+			.saturating_add(Weight::from_parts(7_412_923, 0).saturating_mul(n.into()))
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	fn receive_single_message_proof_with_outbound_lane_state() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 40_091 nanoseconds.
-		Weight::from_parts(43_639_000, 52645)
+		// Minimum execution time: 41_123 nanoseconds.
+		Weight::from_parts(43_023_000, 52645)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	///
 	/// The range of component `n` is `[1, 16]`.
 	///
 	/// The range of component `n` is `[1, 16]`.
 	fn receive_single_message_n_kb_proof(n: u32) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 34_578 nanoseconds.
-		Weight::from_parts(36_723_095, 52645)
-			// Standard Error: 8_197
-			.saturating_add(Weight::from_parts(1_317_904, 0).saturating_mul(n.into()))
+		// Minimum execution time: 36_301 nanoseconds.
+		Weight::from_parts(37_103_459, 52645)
+			// Standard Error: 4_645
+			.saturating_add(Weight::from_parts(1_172_720, 0).saturating_mul(n.into()))
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages OutboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages OutboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages OutboundLanes (max_values: Some(1), max_size: Some(44),
-	/// added: 539, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages OutboundLanes (max_values: Some(1), max_size: Some(44), added:
+	/// 539, mode: MaxEncodedLen)
 	///
 	/// Storage: BridgeRelayers RelayerRewards (r:1 w:1)
 	///
@@ -399,27 +411,27 @@ impl WeightInfo for () {
 	/// mode: MaxEncodedLen)
 	fn receive_delivery_proof_for_single_message() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `453`
+		//  Measured:  `515`
 		//  Estimated: `3530`
-		// Minimum execution time: 32_635 nanoseconds.
-		Weight::from_parts(33_711_000, 3530)
+		// Minimum execution time: 33_941 nanoseconds.
+		Weight::from_parts(35_252_000, 3530)
 			.saturating_add(RocksDbWeight::get().reads(4_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages OutboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages OutboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages OutboundLanes (max_values: Some(1), max_size: Some(44),
-	/// added: 539, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages OutboundLanes (max_values: Some(1), max_size: Some(44), added:
+	/// 539, mode: MaxEncodedLen)
 	///
 	/// Storage: BridgeRelayers RelayerRewards (r:1 w:1)
 	///
@@ -427,27 +439,27 @@ impl WeightInfo for () {
 	/// mode: MaxEncodedLen)
 	fn receive_delivery_proof_for_two_messages_by_single_relayer() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `470`
+		//  Measured:  `532`
 		//  Estimated: `3530`
-		// Minimum execution time: 31_808 nanoseconds.
-		Weight::from_parts(33_071_000, 3530)
+		// Minimum execution time: 33_259 nanoseconds.
+		Weight::from_parts(34_558_000, 3530)
 			.saturating_add(RocksDbWeight::get().reads(4_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages OutboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages OutboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages OutboundLanes (max_values: Some(1), max_size: Some(44),
-	/// added: 539, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages OutboundLanes (max_values: Some(1), max_size: Some(44), added:
+	/// 539, mode: MaxEncodedLen)
 	///
 	/// Storage: BridgeRelayers RelayerRewards (r:2 w:2)
 	///
@@ -455,39 +467,39 @@ impl WeightInfo for () {
 	/// mode: MaxEncodedLen)
 	fn receive_delivery_proof_for_two_messages_by_two_relayers() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `470`
+		//  Measured:  `532`
 		//  Estimated: `6070`
-		// Minimum execution time: 34_171 nanoseconds.
-		Weight::from_parts(35_591_000, 6070)
+		// Minimum execution time: 35_199 nanoseconds.
+		Weight::from_parts(36_989_000, 6070)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
-	/// Storage: BridgeRialtoParachainMessages PalletOperatingMode (r:1 w:0)
+	/// Storage: BridgeRialtoMessages PalletOperatingMode (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachainMessages PalletOperatingMode (max_values: Some(1), max_size:
-	/// Some(2), added: 497, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages PalletOperatingMode (max_values: Some(1), max_size: Some(2),
+	/// added: 497, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachains ImportedParaHeads (r:1 w:0)
+	/// Storage: BridgeRialtoGrandpa ImportedHeaders (r:1 w:0)
 	///
-	/// Proof: BridgeRialtoParachains ImportedParaHeads (max_values: Some(1024), max_size:
-	/// Some(196), added: 1681, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoGrandpa ImportedHeaders (max_values: Some(14400), max_size: Some(68),
+	/// added: 2048, mode: MaxEncodedLen)
 	///
-	/// Storage: BridgeRialtoParachainMessages InboundLanes (r:1 w:1)
+	/// Storage: BridgeRialtoMessages InboundLanes (r:1 w:1)
 	///
-	/// Proof: BridgeRialtoParachainMessages InboundLanes (max_values: None, max_size: Some(49180),
-	/// added: 51655, mode: MaxEncodedLen)
+	/// Proof: BridgeRialtoMessages InboundLanes (max_values: None, max_size: Some(49180), added:
+	/// 51655, mode: MaxEncodedLen)
 	///
 	/// The range of component `n` is `[128, 2048]`.
 	///
 	/// The range of component `n` is `[128, 2048]`.
 	fn receive_single_message_n_bytes_proof_with_dispatch(n: u32) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `428`
+		//  Measured:  `490`
 		//  Estimated: `52645`
-		// Minimum execution time: 76_504 nanoseconds.
-		Weight::from_parts(75_331_522, 52645)
-			// Standard Error: 1_440
-			.saturating_add(Weight::from_parts(302_158, 0).saturating_mul(n.into()))
+		// Minimum execution time: 75_228 nanoseconds.
+		Weight::from_parts(62_255_691, 52645)
+			// Standard Error: 2_005
+			.saturating_add(Weight::from_parts(353_141, 0).saturating_mul(n.into()))
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}

--- a/modules/messages/src/weights_ext.rs
+++ b/modules/messages/src/weights_ext.rs
@@ -40,13 +40,6 @@ pub fn ensure_weights_are_correct<W: WeightInfoExt>() {
 	// benchmarked using `MaxEncodedLen` approach and there are no components that cause additional
 	// db reads
 
-	// verify `receive_messages_proof` weight components
-	assert_ne!(W::receive_messages_proof_overhead().ref_time(), 0);
-	assert_ne!(W::receive_messages_proof_overhead().proof_size(), 0);
-	// W::receive_messages_proof_messages_overhead(1).ref_time() may be zero because:
-	// the message processing code (`InboundLane::receive_message`) is minimal and may not be
-	// accounted by our benchmarks
-	assert_eq!(W::receive_messages_proof_messages_overhead(1).proof_size(), 0);
 	// W::receive_messages_proof_outbound_lane_state_overhead().ref_time() may be zero because:
 	// the outbound lane state processing code (`InboundLane::receive_state_update`) is minimal and
 	// may not be accounted by our benchmarks
@@ -296,13 +289,11 @@ pub trait WeightInfoExt: WeightInfo {
 		dispatch_weight: Weight,
 	) -> Weight {
 		// basic components of extrinsic weight
-		let transaction_overhead = Self::receive_messages_proof_overhead();
+		let base_weight = Self::receive_n_messages_proof(messages_count);
 		let transaction_overhead_from_runtime =
 			Self::receive_messages_proof_overhead_from_runtime();
 		let outbound_state_delivery_weight =
 			Self::receive_messages_proof_outbound_lane_state_overhead();
-		let messages_delivery_weight =
-			Self::receive_messages_proof_messages_overhead(MessageNonce::from(messages_count));
 		let messages_dispatch_weight = dispatch_weight;
 
 		// proof size overhead weight
@@ -314,10 +305,9 @@ pub trait WeightInfoExt: WeightInfo {
 			actual_proof_size.saturating_sub(expected_proof_size),
 		);
 
-		transaction_overhead
+		base_weight
 			.saturating_add(transaction_overhead_from_runtime)
 			.saturating_add(outbound_state_delivery_weight)
-			.saturating_add(messages_delivery_weight)
 			.saturating_add(messages_dispatch_weight)
 			.saturating_add(proof_size_overhead)
 	}
@@ -353,20 +343,11 @@ pub trait WeightInfoExt: WeightInfo {
 
 	// Functions that are used by extrinsics weights formulas.
 
-	/// Returns weight overhead of message delivery transaction (`receive_messages_proof`).
-	fn receive_messages_proof_overhead() -> Weight {
-		let weight_of_two_messages_and_two_tx_overheads =
-			Self::receive_single_message_proof().saturating_mul(2);
-		let weight_of_two_messages_and_single_tx_overhead = Self::receive_two_messages_proof();
-		weight_of_two_messages_and_two_tx_overheads
-			.saturating_sub(weight_of_two_messages_and_single_tx_overhead)
-	}
-
 	/// Returns weight that needs to be accounted when receiving given a number of messages with
 	/// message delivery transaction (`receive_messages_proof`).
 	fn receive_messages_proof_messages_overhead(messages: MessageNonce) -> Weight {
-		let weight_of_two_messages_and_single_tx_overhead = Self::receive_two_messages_proof();
-		let weight_of_single_message_and_single_tx_overhead = Self::receive_single_message_proof();
+		let weight_of_two_messages_and_single_tx_overhead = Self::receive_n_messages_proof(2);
+		let weight_of_single_message_and_single_tx_overhead = Self::receive_n_messages_proof(1);
 		weight_of_two_messages_and_single_tx_overhead
 			.saturating_sub(weight_of_single_message_and_single_tx_overhead)
 			.saturating_mul(messages as _)

--- a/modules/messages/src/weights_ext.rs
+++ b/modules/messages/src/weights_ext.rs
@@ -343,16 +343,6 @@ pub trait WeightInfoExt: WeightInfo {
 
 	// Functions that are used by extrinsics weights formulas.
 
-	/// Returns weight that needs to be accounted when receiving given a number of messages with
-	/// message delivery transaction (`receive_messages_proof`).
-	fn receive_messages_proof_messages_overhead(messages: MessageNonce) -> Weight {
-		let weight_of_two_messages_and_single_tx_overhead = Self::receive_n_messages_proof(2);
-		let weight_of_single_message_and_single_tx_overhead = Self::receive_n_messages_proof(1);
-		weight_of_two_messages_and_single_tx_overhead
-			.saturating_sub(weight_of_single_message_and_single_tx_overhead)
-			.saturating_mul(messages as _)
-	}
-
 	/// Returns weight that needs to be accounted when message delivery transaction
 	/// (`receive_messages_proof`) is carrying outbound lane state proof.
 	fn receive_messages_proof_outbound_lane_state_overhead() -> Weight {

--- a/scripts/update-weights.sh
+++ b/scripts/update-weights.sh
@@ -3,6 +3,8 @@
 # Runtime benchmarks for the `pallet-bridge-messages` and `pallet-bridge-grandpa` pallets.
 #
 # Run this script from root of the repo.
+# Redirecting the output to a file gives much more consistent results
+# e.g. `./scripts/update-weights.sh > /tmp/benchmarks 2>&1`
 
 set -eux
 


### PR DESCRIPTION
Fixes #2165 

For the record, with the previous code without compact proofs, the new benchmark outputs:

```
	fn receive_n_messages_proof(n: u32, ) -> Weight {
		// Proof Size summary in bytes:
		//  Measured:  `490`
		//  Estimated: `52645`
		// Minimum execution time: 36_973_000 picoseconds.
		Weight::from_parts(38_623_000, 0)
			.saturating_add(Weight::from_parts(0, 52645))
			// Standard Error: 11_632
			.saturating_add(Weight::from_parts(11_585_692, 0).saturating_mul(n.into()))
			.saturating_add(T::DbWeight::get().reads(3))
			.saturating_add(T::DbWeight::get().writes(1))
	}
```

vs

```
	fn receive_n_messages_proof(n: u32, ) -> Weight {
		// Proof Size summary in bytes:
		//  Measured:  `490`
		//  Estimated: `52645`
		// Minimum execution time: 34_644_000 picoseconds.
		Weight::from_parts(17_835_495, 0)
			.saturating_add(Weight::from_parts(0, 52645))
			// Standard Error: 4_354
			.saturating_add(Weight::from_parts(7_517_907, 0).saturating_mul(n.into()))
			.saturating_add(T::DbWeight::get().reads(3))
			.saturating_add(T::DbWeight::get().writes(1))
	}
```

now. So the performance improvement is more noticeable. 