### PR TITLE
Move Chain::ID from relay-level Chain to primitives-level Chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9826,7 +9826,6 @@ dependencies = [
  "bp-header-chain",
  "bp-parachains",
  "bp-polkadot",
- "bp-runtime",
  "bridge-runtime-common",
  "parity-scale-codec",
  "relay-substrate-client",
@@ -9865,7 +9864,6 @@ dependencies = [
  "bp-messages",
  "bp-parachains",
  "bp-polkadot-core",
- "bp-runtime",
  "bp-wococo",
  "bridge-runtime-common",
  "parity-scale-codec",
@@ -9887,7 +9885,6 @@ dependencies = [
  "bp-parachains",
  "bp-polkadot-core",
  "bp-rococo",
- "bp-runtime",
  "bridge-runtime-common",
  "parity-scale-codec",
  "relay-bridge-hub-rococo-client",
@@ -9905,7 +9902,6 @@ name = "relay-kusama-client"
 version = "0.1.0"
 dependencies = [
  "bp-kusama",
- "bp-runtime",
  "relay-substrate-client",
  "relay-utils",
  "sp-core",
@@ -9916,7 +9912,6 @@ name = "relay-millau-client"
 version = "0.1.0"
 dependencies = [
  "bp-millau",
- "bp-runtime",
  "frame-support",
  "frame-system",
  "millau-runtime",
@@ -9933,7 +9928,6 @@ name = "relay-polkadot-client"
 version = "0.1.0"
 dependencies = [
  "bp-polkadot",
- "bp-runtime",
  "relay-substrate-client",
  "relay-utils",
  "sp-core",
@@ -9944,7 +9938,6 @@ name = "relay-rialto-client"
 version = "0.1.0"
 dependencies = [
  "bp-rialto",
- "bp-runtime",
  "frame-support",
  "frame-system",
  "pallet-transaction-payment",
@@ -9966,7 +9959,6 @@ dependencies = [
  "bp-millau",
  "bp-polkadot-core",
  "bp-rialto-parachain",
- "bp-runtime",
  "bridge-runtime-common",
  "parity-scale-codec",
  "relay-substrate-client",
@@ -9982,7 +9974,6 @@ name = "relay-rococo-client"
 version = "0.1.0"
 dependencies = [
  "bp-rococo",
- "bp-runtime",
  "relay-substrate-client",
  "relay-utils",
  "sp-core",
@@ -10058,7 +10049,6 @@ dependencies = [
 name = "relay-westend-client"
 version = "0.1.0"
 dependencies = [
- "bp-runtime",
  "bp-westend",
  "relay-substrate-client",
  "relay-utils",
@@ -10069,7 +10059,6 @@ dependencies = [
 name = "relay-wococo-client"
 version = "0.1.0"
 dependencies = [
- "bp-runtime",
  "bp-wococo",
  "relay-substrate-client",
  "relay-utils",

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -36,7 +36,7 @@ pub mod xcm_config;
 use bp_parachains::SingleParaStoredHeaderDataBuilder;
 #[cfg(feature = "runtime-benchmarks")]
 use bp_relayers::{RewardsAccountOwner, RewardsAccountParams};
-use bp_runtime::HeaderId;
+use bp_runtime::{Chain, HeaderId};
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -432,8 +432,8 @@ parameter_types! {
 	pub const MaxUnconfirmedMessagesAtInboundLane: bp_messages::MessageNonce =
 		bp_rialto::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 	pub const RootAccountForPayments: Option<AccountId> = None;
-	pub const RialtoChainId: bp_runtime::ChainId = bp_runtime::RIALTO_CHAIN_ID;
-	pub const RialtoParachainChainId: bp_runtime::ChainId = bp_runtime::RIALTO_PARACHAIN_CHAIN_ID;
+	pub const RialtoChainId: bp_runtime::ChainId = bp_rialto::Rialto::ID;
+	pub const RialtoParachainChainId: bp_runtime::ChainId = bp_rialto_parachain::RialtoParachain::ID;
 	pub RialtoActiveOutboundLanes: &'static [bp_messages::LaneId] = &[rialto_messages::XCM_LANE];
 	pub RialtoParachainActiveOutboundLanes: &'static [bp_messages::LaneId] = &[rialto_parachain_messages::XCM_LANE];
 }
@@ -1045,7 +1045,7 @@ impl_runtime_apis! {
 
 				fn is_relayer_rewarded(relayer: &Self::AccountId) -> bool {
 					let lane = <Self as MessagesConfig<WithRialtoParachainMessagesInstance>>::bench_lane_id();
-					let bridged_chain_id = bp_runtime::RIALTO_PARACHAIN_CHAIN_ID;
+					let bridged_chain_id = bp_rialto_parachain::RialtoParachain::ID;
 					pallet_bridge_relayers::Pallet::<Runtime>::relayer_reward(
 						relayer,
 						RewardsAccountParams::new(lane, bridged_chain_id, RewardsAccountOwner::BridgedChain)
@@ -1076,7 +1076,7 @@ impl_runtime_apis! {
 
 				fn is_relayer_rewarded(relayer: &Self::AccountId) -> bool {
 					let lane = <Self as MessagesConfig<WithRialtoMessagesInstance>>::bench_lane_id();
-					let bridged_chain_id = bp_runtime::RIALTO_CHAIN_ID;
+					let bridged_chain_id = bp_rialto::Rialto::ID;
 					pallet_bridge_relayers::Pallet::<Runtime>::relayer_reward(
 						relayer,
 						RewardsAccountParams::new(lane, bridged_chain_id, RewardsAccountOwner::BridgedChain)

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -137,6 +137,7 @@ mod tests {
 	use super::*;
 	use crate::{Runtime, WithRialtoMessagesInstance};
 
+	use bp_runtime::Chain;
 	use bridge_runtime_common::{
 		assert_complete_bridge_types,
 		integrity::{
@@ -182,7 +183,7 @@ mod tests {
 					bp_rialto::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 				max_unconfirmed_messages_in_bridged_confirmation_tx:
 					bp_rialto::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
-				bridged_chain_id: bp_runtime::RIALTO_CHAIN_ID,
+				bridged_chain_id: bp_rialto::Rialto::ID,
 			},
 			pallet_names: AssertBridgePalletNames {
 				with_this_chain_messages_pallet_name: bp_millau::WITH_MILLAU_MESSAGES_PALLET_NAME,

--- a/bin/millau/runtime/src/rialto_parachain_messages.rs
+++ b/bin/millau/runtime/src/rialto_parachain_messages.rs
@@ -150,6 +150,7 @@ mod tests {
 		WithRialtoParachainMessagesInstance,
 	};
 
+	use bp_runtime::Chain;
 	use bridge_runtime_common::{
 		assert_complete_bridge_types,
 		integrity::{
@@ -195,7 +196,7 @@ mod tests {
 					bp_rialto_parachain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 				max_unconfirmed_messages_in_bridged_confirmation_tx:
 					bp_rialto_parachain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
-				bridged_chain_id: bp_runtime::RIALTO_PARACHAIN_CHAIN_ID,
+				bridged_chain_id: bp_rialto_parachain::RialtoParachain::ID,
 			},
 			pallet_names: AssertBridgePalletNames {
 				with_this_chain_messages_pallet_name: bp_millau::WITH_MILLAU_MESSAGES_PALLET_NAME,

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -26,6 +26,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use bp_runtime::Chain;
 use bridge_runtime_common::generate_bridge_reject_obsolete_headers_and_messages;
 use codec::{Decode, Encode};
 use cumulus_pallet_parachain_system::AnyRelayNumber;
@@ -556,7 +557,7 @@ parameter_types! {
 	pub const MaxUnconfirmedMessagesAtInboundLane: bp_messages::MessageNonce =
 		bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 	pub const RootAccountForPayments: Option<AccountId> = None;
-	pub const BridgedChainId: bp_runtime::ChainId = bp_runtime::MILLAU_CHAIN_ID;
+	pub const BridgedChainId: bp_runtime::ChainId = bp_millau::Millau::ID;
 	pub ActiveOutboundLanes: &'static [bp_messages::LaneId] = &[millau_messages::XCM_LANE];
 }
 

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -122,6 +122,7 @@ impl XcmBlobHauler for ToMillauXcmBlobHauler {
 mod tests {
 	use super::*;
 	use crate::{MillauGrandpaInstance, Runtime, WithMillauMessagesInstance};
+	use bp_runtime::Chain;
 	use bridge_runtime_common::{
 		assert_complete_bridge_types,
 		integrity::{
@@ -171,7 +172,7 @@ mod tests {
 					bp_millau::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 				max_unconfirmed_messages_in_bridged_confirmation_tx:
 					bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
-				bridged_chain_id: bp_runtime::MILLAU_CHAIN_ID,
+				bridged_chain_id: bp_millau::Millau::ID,
 			},
 			pallet_names: AssertBridgePalletNames {
 				with_this_chain_messages_pallet_name:

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -32,7 +32,7 @@ pub mod millau_messages;
 pub mod parachains;
 pub mod xcm_config;
 
-use bp_runtime::HeaderId;
+use bp_runtime::{Chain, HeaderId};
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -412,7 +412,7 @@ parameter_types! {
 	pub const MaxUnconfirmedMessagesAtInboundLane: bp_messages::MessageNonce =
 		bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 	pub const RootAccountForPayments: Option<AccountId> = None;
-	pub const BridgedChainId: bp_runtime::ChainId = bp_runtime::MILLAU_CHAIN_ID;
+	pub const BridgedChainId: bp_runtime::ChainId = bp_millau::Millau::ID;
 	pub ActiveOutboundLanes: &'static [bp_messages::LaneId] = &[millau_messages::XCM_LANE];
 }
 

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -121,6 +121,7 @@ impl XcmBlobHauler for ToMillauXcmBlobHauler {
 mod tests {
 	use super::*;
 	use crate::{MillauGrandpaInstance, Runtime, WithMillauMessagesInstance};
+	use bp_runtime::Chain;
 	use bridge_runtime_common::{
 		assert_complete_bridge_types,
 		integrity::{
@@ -166,7 +167,7 @@ mod tests {
 					bp_millau::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
 				max_unconfirmed_messages_in_bridged_confirmation_tx:
 					bp_millau::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
-				bridged_chain_id: bp_runtime::MILLAU_CHAIN_ID,
+				bridged_chain_id: bp_millau::Millau::ID,
 			},
 			pallet_names: AssertBridgePalletNames {
 				with_this_chain_messages_pallet_name: bp_rialto::WITH_RIALTO_MESSAGES_PALLET_NAME,

--- a/bin/runtime-common/src/lib.rs
+++ b/bin/runtime-common/src/lib.rs
@@ -162,12 +162,17 @@ impl TryFrom<bp_runtime::ChainId> for CustomNetworkId {
 	type Error = ();
 
 	fn try_from(chain: bp_runtime::ChainId) -> Result<Self, Self::Error> {
-		Ok(match chain {
-			bp_runtime::MILLAU_CHAIN_ID => Self::Millau,
-			bp_runtime::RIALTO_CHAIN_ID => Self::Rialto,
-			bp_runtime::RIALTO_PARACHAIN_CHAIN_ID => Self::RialtoParachain,
-			_ => return Err(()),
-		})
+		// TODO: this code needs to be removed or fixed (use constants) in the
+		// https://github.com/paritytech/parity-bridges-common/issues/2068
+		if chain == *b"mlau" {
+			Ok(Self::Millau)
+		} else if chain == *b"rlto" {
+			Ok(Self::Rialto)
+		} else if chain == *b"rlpa" {
+			Ok(Self::RialtoParachain)
+		} else {
+			Err(())
+		}
 	}
 }
 

--- a/bin/runtime-common/src/mock.rs
+++ b/bin/runtime-common/src/mock.rs
@@ -318,6 +318,8 @@ impl From<BridgedChainOrigin>
 pub struct ThisUnderlyingChain;
 
 impl Chain for ThisUnderlyingChain {
+	const ID: ChainId = *b"tuch";
+
 	type BlockNumber = ThisChainBlockNumber;
 	type Hash = ThisChainHash;
 	type Hasher = ThisChainHasher;
@@ -367,6 +369,8 @@ pub struct BridgedUnderlyingParachain;
 pub struct BridgedChainCall;
 
 impl Chain for BridgedUnderlyingChain {
+	const ID: ChainId = *b"buch";
+
 	type BlockNumber = BridgedChainBlockNumber;
 	type Hash = BridgedChainHash;
 	type Hasher = BridgedChainHasher;
@@ -395,6 +399,8 @@ impl ChainWithGrandpa for BridgedUnderlyingChain {
 }
 
 impl Chain for BridgedUnderlyingParachain {
+	const ID: ChainId = *b"bupc";
+
 	type BlockNumber = BridgedChainBlockNumber;
 	type Hash = BridgedChainHash;
 	type Hasher = BridgedChainHasher;

--- a/modules/beefy/src/mock.rs
+++ b/modules/beefy/src/mock.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 use bp_beefy::{BeefyValidatorSignatureOf, ChainWithBeefy, Commitment, MmrDataOrHash};
-use bp_runtime::{BasicOperatingMode, Chain};
+use bp_runtime::{BasicOperatingMode, Chain, ChainId};
 use codec::Encode;
 use frame_support::{
 	construct_runtime, parameter_types, traits::ConstU64, weights::Weight, StateVersion,
@@ -116,6 +116,8 @@ impl beefy::Config for TestRuntime {
 pub struct TestBridgedChain;
 
 impl Chain for TestBridgedChain {
+	const ID: ChainId = *b"tbch";
+
 	type BlockNumber = TestBridgedBlockNumber;
 	type Hash = H256;
 	type Hasher = BlakeTwo256;

--- a/modules/grandpa/src/mock.rs
+++ b/modules/grandpa/src/mock.rs
@@ -18,7 +18,7 @@
 #![allow(clippy::from_over_into)]
 
 use bp_header_chain::ChainWithGrandpa;
-use bp_runtime::Chain;
+use bp_runtime::{Chain, ChainId};
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{ConstU32, ConstU64, Hooks},
@@ -106,6 +106,8 @@ impl grandpa::Config for TestRuntime {
 pub struct TestBridgedChain;
 
 impl Chain for TestBridgedChain {
+	const ID: ChainId = *b"tbch";
+
 	type BlockNumber = <TestRuntime as frame_system::Config>::BlockNumber;
 	type Hash = <TestRuntime as frame_system::Config>::Hash;
 	type Hasher = <TestRuntime as frame_system::Config>::Hashing;

--- a/modules/messages/src/tests/pallet_tests.rs
+++ b/modules/messages/src/tests/pallet_tests.rs
@@ -1,3 +1,21 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Pallet-level tests.
+
 use crate::{
 	outbound_lane,
 	outbound_lane::ReceivalConfirmationError,

--- a/modules/parachains/src/mock.rs
+++ b/modules/parachains/src/mock.rs
@@ -16,7 +16,7 @@
 
 use bp_header_chain::ChainWithGrandpa;
 use bp_polkadot_core::parachains::ParaId;
-use bp_runtime::{Chain, Parachain};
+use bp_runtime::{Chain, ChainId, Parachain};
 use frame_support::{
 	construct_runtime, parameter_types, traits::ConstU32, weights::Weight, StateVersion,
 };
@@ -51,6 +51,8 @@ pub type BigParachainHeader = sp_runtime::generic::Header<u128, BlakeTwo256>;
 pub struct Parachain1;
 
 impl Chain for Parachain1 {
+	const ID: ChainId = *b"pch1";
+
 	type BlockNumber = u64;
 	type Hash = H256;
 	type Hasher = RegularParachainHasher;
@@ -77,6 +79,8 @@ impl Parachain for Parachain1 {
 pub struct Parachain2;
 
 impl Chain for Parachain2 {
+	const ID: ChainId = *b"pch2";
+
 	type BlockNumber = u64;
 	type Hash = H256;
 	type Hasher = RegularParachainHasher;
@@ -103,6 +107,8 @@ impl Parachain for Parachain2 {
 pub struct Parachain3;
 
 impl Chain for Parachain3 {
+	const ID: ChainId = *b"pch3";
+
 	type BlockNumber = u64;
 	type Hash = H256;
 	type Hasher = RegularParachainHasher;
@@ -130,6 +136,8 @@ impl Parachain for Parachain3 {
 pub struct BigParachain;
 
 impl Chain for BigParachain {
+	const ID: ChainId = *b"bpch";
+
 	type BlockNumber = u128;
 	type Hash = H256;
 	type Hasher = RegularParachainHasher;
@@ -273,6 +281,8 @@ impl pallet_bridge_parachains::benchmarking::Config<()> for TestRuntime {
 pub struct TestBridgedChain;
 
 impl Chain for TestBridgedChain {
+	const ID: ChainId = *b"tbch";
+
 	type BlockNumber = crate::RelayBlockNumber;
 	type Hash = crate::RelayBlockHash;
 	type Hasher = crate::RelayBlockHasher;
@@ -306,6 +316,8 @@ impl ChainWithGrandpa for TestBridgedChain {
 pub struct OtherBridgedChain;
 
 impl Chain for OtherBridgedChain {
+	const ID: ChainId = *b"obch";
+
 	type BlockNumber = u64;
 	type Hash = crate::RelayBlockHash;
 	type Hasher = crate::RelayBlockHasher;

--- a/primitives/chain-bridge-hub-kusama/src/lib.rs
+++ b/primitives/chain-bridge-hub-kusama/src/lib.rs
@@ -36,7 +36,7 @@ use sp_std::prelude::*;
 pub struct BridgeHubKusama;
 
 impl Chain for BridgeHubKusama {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_KUSAMA_CHAIN_ID;
+	const ID: ChainId = *b"bhks";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-bridge-hub-kusama/src/lib.rs
+++ b/primitives/chain-bridge-hub-kusama/src/lib.rs
@@ -22,7 +22,7 @@
 pub use bp_bridge_hub_cumulus::*;
 use bp_messages::*;
 use bp_runtime::{
-	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, Parachain,
+	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, ChainId, Parachain,
 };
 use frame_support::{
 	dispatch::DispatchClass,
@@ -36,6 +36,8 @@ use sp_std::prelude::*;
 pub struct BridgeHubKusama;
 
 impl Chain for BridgeHubKusama {
+	const ID: ChainId = bp_runtime::BRIDGE_HUB_KUSAMA_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-bridge-hub-polkadot/src/lib.rs
+++ b/primitives/chain-bridge-hub-polkadot/src/lib.rs
@@ -32,7 +32,7 @@ use sp_std::prelude::*;
 pub struct BridgeHubPolkadot;
 
 impl Chain for BridgeHubPolkadot {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_POLKADOT_CHAIN_ID;
+	const ID: ChainId = *b"bhpd";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-bridge-hub-polkadot/src/lib.rs
+++ b/primitives/chain-bridge-hub-polkadot/src/lib.rs
@@ -22,7 +22,7 @@
 pub use bp_bridge_hub_cumulus::*;
 use bp_messages::*;
 use bp_runtime::{
-	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, Parachain,
+	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, ChainId, Parachain,
 };
 use frame_support::{dispatch::DispatchClass, RuntimeDebug, StateVersion};
 use sp_std::prelude::*;
@@ -32,6 +32,8 @@ use sp_std::prelude::*;
 pub struct BridgeHubPolkadot;
 
 impl Chain for BridgeHubPolkadot {
+	const ID: ChainId = bp_runtime::BRIDGE_HUB_POLKADOT_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-bridge-hub-rococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-rococo/src/lib.rs
@@ -36,7 +36,7 @@ use sp_std::prelude::*;
 pub struct BridgeHubRococo;
 
 impl Chain for BridgeHubRococo {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_ROCOCO_CHAIN_ID;
+	const ID: ChainId = *b"bhro";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-bridge-hub-rococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-rococo/src/lib.rs
@@ -22,7 +22,7 @@
 pub use bp_bridge_hub_cumulus::*;
 use bp_messages::*;
 use bp_runtime::{
-	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, Parachain,
+	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, ChainId, Parachain,
 };
 use frame_support::{
 	dispatch::DispatchClass,
@@ -36,6 +36,8 @@ use sp_std::prelude::*;
 pub struct BridgeHubRococo;
 
 impl Chain for BridgeHubRococo {
+	const ID: ChainId = bp_runtime::BRIDGE_HUB_ROCOCO_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-bridge-hub-wococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-wococo/src/lib.rs
@@ -22,7 +22,7 @@
 pub use bp_bridge_hub_cumulus::*;
 use bp_messages::*;
 use bp_runtime::{
-	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, Parachain,
+	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, ChainId, Parachain,
 };
 use frame_support::{dispatch::DispatchClass, RuntimeDebug, StateVersion};
 use sp_std::prelude::*;
@@ -32,6 +32,8 @@ use sp_std::prelude::*;
 pub struct BridgeHubWococo;
 
 impl Chain for BridgeHubWococo {
+	const ID: ChainId = bp_runtime::BRIDGE_HUB_WOCOCO_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-bridge-hub-wococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-wococo/src/lib.rs
@@ -32,7 +32,7 @@ use sp_std::prelude::*;
 pub struct BridgeHubWococo;
 
 impl Chain for BridgeHubWococo {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_WOCOCO_CHAIN_ID;
+	const ID: ChainId = *b"bhwo";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::weights::Weight;
 pub struct Kusama;
 
 impl Chain for Kusama {
-	const ID: ChainId = bp_runtime::KUSAMA_CHAIN_ID;
+	const ID: ChainId = *b"ksma";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -22,31 +22,33 @@ pub use bp_polkadot_core::*;
 use frame_support::StateVersion;
 
 use bp_header_chain::ChainWithGrandpa;
-use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId};
 use frame_support::weights::Weight;
 
 /// Kusama Chain
 pub struct Kusama;
 
 impl Chain for Kusama {
-	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
-	type Hash = <PolkadotLike as Chain>::Hash;
-	type Hasher = <PolkadotLike as Chain>::Hasher;
-	type Header = <PolkadotLike as Chain>::Header;
+	const ID: ChainId = bp_runtime::KUSAMA_CHAIN_ID;
 
-	type AccountId = <PolkadotLike as Chain>::AccountId;
-	type Balance = <PolkadotLike as Chain>::Balance;
-	type Index = <PolkadotLike as Chain>::Index;
-	type Signature = <PolkadotLike as Chain>::Signature;
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+
+	type AccountId = AccountId;
+	type Balance = Balance;
+	type Index = Index;
+	type Signature = Signature;
 
 	const STATE_VERSION: StateVersion = StateVersion::V0;
 
 	fn max_extrinsic_size() -> u32 {
-		PolkadotLike::max_extrinsic_size()
+		max_extrinsic_size()
 	}
 
 	fn max_extrinsic_weight() -> Weight {
-		PolkadotLike::max_extrinsic_weight()
+		max_extrinsic_weight()
 	}
 }
 

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -26,7 +26,7 @@ use bp_messages::{
 	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
 	OutboundMessageDetails,
 };
-use bp_runtime::{decl_bridge_runtime_apis, Chain};
+use bp_runtime::{decl_bridge_runtime_apis, Chain, ChainId};
 use frame_support::{
 	dispatch::DispatchClass,
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, IdentityFee, Weight},
@@ -157,6 +157,8 @@ pub type WeightToFee = IdentityFee<Balance>;
 pub struct Millau;
 
 impl Chain for Millau {
+	const ID: ChainId = bp_runtime::MILLAU_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -157,7 +157,7 @@ pub type WeightToFee = IdentityFee<Balance>;
 pub struct Millau;
 
 impl Chain for Millau {
-	const ID: ChainId = bp_runtime::MILLAU_CHAIN_ID;
+	const ID: ChainId = *b"mlau";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -22,31 +22,33 @@ pub use bp_polkadot_core::*;
 use frame_support::StateVersion;
 
 use bp_header_chain::ChainWithGrandpa;
-use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId};
 use frame_support::weights::Weight;
 
 /// Polkadot Chain
 pub struct Polkadot;
 
 impl Chain for Polkadot {
-	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
-	type Hash = <PolkadotLike as Chain>::Hash;
-	type Hasher = <PolkadotLike as Chain>::Hasher;
-	type Header = <PolkadotLike as Chain>::Header;
+	const ID: ChainId = bp_runtime::POLKADOT_CHAIN_ID;
 
-	type AccountId = <PolkadotLike as Chain>::AccountId;
-	type Balance = <PolkadotLike as Chain>::Balance;
-	type Index = <PolkadotLike as Chain>::Index;
-	type Signature = <PolkadotLike as Chain>::Signature;
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+
+	type AccountId = AccountId;
+	type Balance = Balance;
+	type Index = Index;
+	type Signature = Signature;
 
 	const STATE_VERSION: StateVersion = StateVersion::V0;
 
 	fn max_extrinsic_size() -> u32 {
-		PolkadotLike::max_extrinsic_size()
+		max_extrinsic_size()
 	}
 
 	fn max_extrinsic_weight() -> Weight {
-		PolkadotLike::max_extrinsic_weight()
+		max_extrinsic_weight()
 	}
 }
 

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::weights::Weight;
 pub struct Polkadot;
 
 impl Chain for Polkadot {
-	const ID: ChainId = bp_runtime::POLKADOT_CHAIN_ID;
+	const ID: ChainId = *b"pdot";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-rialto-parachain/src/lib.rs
+++ b/primitives/chain-rialto-parachain/src/lib.rs
@@ -22,7 +22,7 @@ use bp_messages::{
 	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
 	OutboundMessageDetails,
 };
-use bp_runtime::{decl_bridge_runtime_apis, Chain, Parachain};
+use bp_runtime::{decl_bridge_runtime_apis, Chain, ChainId, Parachain};
 use frame_support::{
 	dispatch::DispatchClass,
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, IdentityFee, Weight},
@@ -108,6 +108,8 @@ pub type WeightToFee = IdentityFee<Balance>;
 pub struct RialtoParachain;
 
 impl Chain for RialtoParachain {
+	const ID: ChainId = bp_runtime::RIALTO_PARACHAIN_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-rialto-parachain/src/lib.rs
+++ b/primitives/chain-rialto-parachain/src/lib.rs
@@ -108,7 +108,7 @@ pub type WeightToFee = IdentityFee<Balance>;
 pub struct RialtoParachain;
 
 impl Chain for RialtoParachain {
-	const ID: ChainId = bp_runtime::RIALTO_PARACHAIN_CHAIN_ID;
+	const ID: ChainId = *b"rlpa";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -161,7 +161,7 @@ pub type WeightToFee = IdentityFee<Balance>;
 pub struct Rialto;
 
 impl Chain for Rialto {
-	const ID: ChainId = bp_runtime::RIALTO_CHAIN_ID;
+	const ID: ChainId = *b"rlto";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -23,7 +23,7 @@ use bp_messages::{
 	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
 	OutboundMessageDetails,
 };
-use bp_runtime::{decl_bridge_runtime_apis, Chain};
+use bp_runtime::{decl_bridge_runtime_apis, Chain, ChainId};
 use frame_support::{
 	dispatch::DispatchClass,
 	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, IdentityFee, Weight},
@@ -161,6 +161,8 @@ pub type WeightToFee = IdentityFee<Balance>;
 pub struct Rialto;
 
 impl Chain for Rialto {
+	const ID: ChainId = bp_runtime::RIALTO_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -21,31 +21,33 @@
 pub use bp_polkadot_core::*;
 
 use bp_header_chain::ChainWithGrandpa;
-use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId};
 use frame_support::{parameter_types, weights::Weight, StateVersion};
 
 /// Rococo Chain
 pub struct Rococo;
 
 impl Chain for Rococo {
-	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
-	type Hash = <PolkadotLike as Chain>::Hash;
-	type Hasher = <PolkadotLike as Chain>::Hasher;
-	type Header = <PolkadotLike as Chain>::Header;
+	const ID: ChainId = bp_runtime::ROCOCO_CHAIN_ID;
 
-	type AccountId = <PolkadotLike as Chain>::AccountId;
-	type Balance = <PolkadotLike as Chain>::Balance;
-	type Index = <PolkadotLike as Chain>::Index;
-	type Signature = <PolkadotLike as Chain>::Signature;
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+
+	type AccountId = AccountId;
+	type Balance = Balance;
+	type Index = Index;
+	type Signature = Signature;
 
 	const STATE_VERSION: StateVersion = StateVersion::V1;
 
 	fn max_extrinsic_size() -> u32 {
-		PolkadotLike::max_extrinsic_size()
+		max_extrinsic_size()
 	}
 
 	fn max_extrinsic_weight() -> Weight {
-		PolkadotLike::max_extrinsic_weight()
+		max_extrinsic_weight()
 	}
 }
 

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -28,7 +28,7 @@ use frame_support::{parameter_types, weights::Weight, StateVersion};
 pub struct Rococo;
 
 impl Chain for Rococo {
-	const ID: ChainId = bp_runtime::ROCOCO_CHAIN_ID;
+	const ID: ChainId = *b"roco";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -22,31 +22,33 @@ pub use bp_polkadot_core::*;
 use frame_support::StateVersion;
 
 use bp_header_chain::ChainWithGrandpa;
-use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, Parachain};
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId, Parachain};
 use frame_support::weights::Weight;
 
 /// Westend Chain
 pub struct Westend;
 
 impl Chain for Westend {
-	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
-	type Hash = <PolkadotLike as Chain>::Hash;
-	type Hasher = <PolkadotLike as Chain>::Hasher;
-	type Header = <PolkadotLike as Chain>::Header;
+	const ID: ChainId = bp_runtime::WESTEND_CHAIN_ID;
 
-	type AccountId = <PolkadotLike as Chain>::AccountId;
-	type Balance = <PolkadotLike as Chain>::Balance;
-	type Index = <PolkadotLike as Chain>::Index;
-	type Signature = <PolkadotLike as Chain>::Signature;
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+
+	type AccountId = AccountId;
+	type Balance = Balance;
+	type Index = Index;
+	type Signature = Signature;
 
 	const STATE_VERSION: StateVersion = StateVersion::V1;
 
 	fn max_extrinsic_size() -> u32 {
-		PolkadotLike::max_extrinsic_size()
+		max_extrinsic_size()
 	}
 
 	fn max_extrinsic_weight() -> Weight {
-		PolkadotLike::max_extrinsic_weight()
+		max_extrinsic_weight()
 	}
 }
 
@@ -66,6 +68,8 @@ pub struct Westmint;
 // Westmint seems to use the same configuration as all Polkadot-like chains, so we'll use Westend
 // primitives here.
 impl Chain for Westmint {
+	const ID: ChainId = bp_runtime::WESTMINT_CHAIN_ID;
+
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
 	type Hasher = Hasher;

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::weights::Weight;
 pub struct Westend;
 
 impl Chain for Westend {
-	const ID: ChainId = bp_runtime::WESTEND_CHAIN_ID;
+	const ID: ChainId = *b"wend";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;
@@ -68,7 +68,7 @@ pub struct Westmint;
 // Westmint seems to use the same configuration as all Polkadot-like chains, so we'll use Westend
 // primitives here.
 impl Chain for Westmint {
-	const ID: ChainId = bp_runtime::WESTMINT_CHAIN_ID;
+	const ID: ChainId = *b"wmnt";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-wococo/src/lib.rs
+++ b/primitives/chain-wococo/src/lib.rs
@@ -32,7 +32,7 @@ use frame_support::weights::Weight;
 pub struct Wococo;
 
 impl Chain for Wococo {
-	const ID: ChainId = bp_runtime::WOCOCO_CHAIN_ID;
+	const ID: ChainId = *b"woco";
 
 	type BlockNumber = BlockNumber;
 	type Hash = Hash;

--- a/primitives/chain-wococo/src/lib.rs
+++ b/primitives/chain-wococo/src/lib.rs
@@ -25,31 +25,33 @@ pub use bp_rococo::{
 use frame_support::StateVersion;
 
 use bp_header_chain::ChainWithGrandpa;
-use bp_runtime::{decl_bridge_finality_runtime_apis, Chain};
+use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId};
 use frame_support::weights::Weight;
 
 /// Wococo Chain
 pub struct Wococo;
 
 impl Chain for Wococo {
-	type BlockNumber = <PolkadotLike as Chain>::BlockNumber;
-	type Hash = <PolkadotLike as Chain>::Hash;
-	type Hasher = <PolkadotLike as Chain>::Hasher;
-	type Header = <PolkadotLike as Chain>::Header;
+	const ID: ChainId = bp_runtime::WOCOCO_CHAIN_ID;
 
-	type AccountId = <PolkadotLike as Chain>::AccountId;
-	type Balance = <PolkadotLike as Chain>::Balance;
-	type Index = <PolkadotLike as Chain>::Index;
-	type Signature = <PolkadotLike as Chain>::Signature;
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+
+	type AccountId = AccountId;
+	type Balance = Balance;
+	type Index = Index;
+	type Signature = Signature;
 
 	const STATE_VERSION: StateVersion = StateVersion::V1;
 
 	fn max_extrinsic_size() -> u32 {
-		PolkadotLike::max_extrinsic_size()
+		max_extrinsic_size()
 	}
 
 	fn max_extrinsic_weight() -> Weight {
-		PolkadotLike::max_extrinsic_weight()
+		max_extrinsic_weight()
 	}
 }
 

--- a/primitives/polkadot-core/src/lib.rs
+++ b/primitives/polkadot-core/src/lib.rs
@@ -17,7 +17,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use bp_messages::MessageNonce;
-use bp_runtime::{Chain, EncodedOrDecodedCall, StorageMapKeyProvider};
+use bp_runtime::{EncodedOrDecodedCall, StorageMapKeyProvider};
 use frame_support::{
 	dispatch::DispatchClass,
 	parameter_types,
@@ -25,7 +25,7 @@ use frame_support::{
 		constants::{BlockExecutionWeight, WEIGHT_REF_TIME_PER_SECOND},
 		Weight,
 	},
-	Blake2_128Concat, RuntimeDebug, StateVersion,
+	Blake2_128Concat,
 };
 use frame_system::limits;
 use sp_core::{storage::StorageKey, Hasher as HasherT};
@@ -224,33 +224,17 @@ pub type UncheckedExtrinsic<Call, SignedExt> =
 /// Account address, used by the Polkadot-like chain.
 pub type Address = MultiAddress<AccountId, ()>;
 
-/// Polkadot-like chain.
-#[derive(RuntimeDebug)]
-pub struct PolkadotLike;
+/// Returns maximal extrinsic size on all Polkadot-like chains.
+pub fn max_extrinsic_size() -> u32 {
+	*BlockLength::get().max.get(DispatchClass::Normal)
+}
 
-impl Chain for PolkadotLike {
-	type BlockNumber = BlockNumber;
-	type Hash = Hash;
-	type Hasher = Hasher;
-	type Header = Header;
-
-	type AccountId = AccountId;
-	type Balance = Balance;
-	type Index = Index;
-	type Signature = Signature;
-
-	const STATE_VERSION: StateVersion = StateVersion::V0;
-
-	fn max_extrinsic_size() -> u32 {
-		*BlockLength::get().max.get(DispatchClass::Normal)
-	}
-
-	fn max_extrinsic_weight() -> Weight {
-		BlockWeights::get()
-			.get(DispatchClass::Normal)
-			.max_extrinsic
-			.unwrap_or(Weight::MAX)
-	}
+/// Returns maximal extrinsic weight on all Polkadot-like chains.
+pub fn max_extrinsic_weight() -> Weight {
+	BlockWeights::get()
+		.get(DispatchClass::Normal)
+		.max_extrinsic
+		.unwrap_or(Weight::MAX)
 }
 
 /// Provides a storage key for account data.

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::HeaderIdProvider;
+use crate::{ChainId, HeaderIdProvider};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{weights::Weight, Parameter, StateVersion};
 use num_traits::{AsPrimitive, Bounded, CheckedSub, Saturating, SaturatingAdd, Zero};
@@ -91,6 +91,9 @@ impl<ChainCall: Encode> Encode for EncodedOrDecodedCall<ChainCall> {
 
 /// Minimal Substrate-based chain representation that may be used from no_std environment.
 pub trait Chain: Send + Sync + 'static {
+	/// Chain id.
+	const ID: ChainId;
+
 	/// A type that fulfills the abstract idea of what a Substrate block number is.
 	// Constraits come from the associated Number type of `sp_runtime::traits::Header`
 	// See here for more info:
@@ -204,6 +207,8 @@ impl<T> Chain for T
 where
 	T: Send + Sync + 'static + UnderlyingChainProvider,
 {
+	const ID: ChainId = <T::Chain as Chain>::ID;
+
 	type BlockNumber = <T::Chain as Chain>::BlockNumber;
 	type Hash = <T::Chain as Chain>::Hash;
 	type Hasher = <T::Chain as Chain>::Hasher;

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -60,45 +60,6 @@ pub use sp_runtime::paste;
 /// Use this when something must be shared among all instances.
 pub const NO_INSTANCE_ID: ChainId = [0, 0, 0, 0];
 
-/// Rialto chain id.
-pub const RIALTO_CHAIN_ID: ChainId = *b"rlto";
-
-/// RialtoParachain chain id.
-pub const RIALTO_PARACHAIN_CHAIN_ID: ChainId = *b"rlpa";
-
-/// Millau chain id.
-pub const MILLAU_CHAIN_ID: ChainId = *b"mlau";
-
-/// Polkadot chain id.
-pub const POLKADOT_CHAIN_ID: ChainId = *b"pdot";
-
-/// Kusama chain id.
-pub const KUSAMA_CHAIN_ID: ChainId = *b"ksma";
-
-/// Westend chain id.
-pub const WESTEND_CHAIN_ID: ChainId = *b"wend";
-
-/// Westend chain id.
-pub const WESTMINT_CHAIN_ID: ChainId = *b"wmnt";
-
-/// Rococo chain id.
-pub const ROCOCO_CHAIN_ID: ChainId = *b"roco";
-
-/// Wococo chain id.
-pub const WOCOCO_CHAIN_ID: ChainId = *b"woco";
-
-/// BridgeHubRococo chain id.
-pub const BRIDGE_HUB_ROCOCO_CHAIN_ID: ChainId = *b"bhro";
-
-/// BridgeHubWococo chain id.
-pub const BRIDGE_HUB_WOCOCO_CHAIN_ID: ChainId = *b"bhwo";
-
-/// BridgeHubKusama chain id.
-pub const BRIDGE_HUB_KUSAMA_CHAIN_ID: ChainId = *b"bhks";
-
-/// BridgeHubPolkadot chain id.
-pub const BRIDGE_HUB_POLKADOT_CHAIN_ID: ChainId = *b"bhpd";
-
 /// Generic header Id.
 #[derive(
 	RuntimeDebug,

--- a/relays/client-bridge-hub-kusama/Cargo.toml
+++ b/relays/client-bridge-hub-kusama/Cargo.toml
@@ -16,7 +16,6 @@ bp-bridge-hub-kusama = { path = "../../primitives/chain-bridge-hub-kusama" }
 bp-bridge-hub-polkadot = { path = "../../primitives/chain-bridge-hub-polkadot" }
 bp-header-chain = { path = "../../primitives/header-chain" }
 bp-parachains = { path = "../../primitives/parachains" }
-bp-runtime = { path = "../../primitives/runtime" }
 bp-polkadot = { path = "../../primitives/chain-polkadot" }
 
 bridge-runtime-common = { path = "../../bin/runtime-common" }

--- a/relays/client-bridge-hub-kusama/src/lib.rs
+++ b/relays/client-bridge-hub-kusama/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the BridgeHub-Kusama-Substrate parachain.
 
 use bp_bridge_hub_kusama::{BridgeHubSignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions, ChainWithUtilityPallet,
@@ -41,7 +40,6 @@ impl UnderlyingChainProvider for BridgeHubKusama {
 }
 
 impl Chain for BridgeHubKusama {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_KUSAMA_CHAIN_ID;
 	const NAME: &'static str = "BridgeHubKusama";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_kusama::BEST_FINALIZED_BRIDGE_HUB_KUSAMA_HEADER_METHOD;

--- a/relays/client-bridge-hub-polkadot/src/lib.rs
+++ b/relays/client-bridge-hub-polkadot/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the BridgeHub-Polkadot-Substrate parachain.
 
 use bp_bridge_hub_polkadot::{BridgeHubSignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions, ChainWithUtilityPallet,
@@ -41,7 +40,6 @@ impl UnderlyingChainProvider for BridgeHubPolkadot {
 }
 
 impl Chain for BridgeHubPolkadot {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_POLKADOT_CHAIN_ID;
 	const NAME: &'static str = "BridgeHubPolkadot";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_polkadot::BEST_FINALIZED_BRIDGE_HUB_POLKADOT_HEADER_METHOD;

--- a/relays/client-bridge-hub-rococo/Cargo.toml
+++ b/relays/client-bridge-hub-rococo/Cargo.toml
@@ -18,7 +18,6 @@ bp-header-chain = { path = "../../primitives/header-chain" }
 bp-messages = { path = "../../primitives/messages" }
 bp-parachains = { path = "../../primitives/parachains" }
 bp-polkadot-core = { path = "../../primitives/polkadot-core" }
-bp-runtime = { path = "../../primitives/runtime" }
 bp-wococo = { path = "../../primitives/chain-wococo" }
 
 bridge-runtime-common = { path = "../../bin/runtime-common" }

--- a/relays/client-bridge-hub-rococo/src/lib.rs
+++ b/relays/client-bridge-hub-rococo/src/lib.rs
@@ -19,7 +19,6 @@
 pub mod codegen_runtime;
 
 use bp_bridge_hub_rococo::{BridgeHubSignedExtension, SignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
 	calls::UtilityCall as MockUtilityCall, Chain, ChainWithBalances, ChainWithMessages,
@@ -48,7 +47,6 @@ impl UnderlyingChainProvider for BridgeHubRococo {
 }
 
 impl Chain for BridgeHubRococo {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_ROCOCO_CHAIN_ID;
 	const NAME: &'static str = "BridgeHubRococo";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_rococo::BEST_FINALIZED_BRIDGE_HUB_ROCOCO_HEADER_METHOD;

--- a/relays/client-bridge-hub-wococo/Cargo.toml
+++ b/relays/client-bridge-hub-wococo/Cargo.toml
@@ -18,7 +18,6 @@ bp-header-chain = { path = "../../primitives/header-chain" }
 bp-parachains = { path = "../../primitives/parachains" }
 bp-polkadot-core = { path = "../../primitives/polkadot-core" }
 bp-rococo = { path = "../../primitives/chain-rococo" }
-bp-runtime = { path = "../../primitives/runtime" }
 
 bridge-runtime-common = { path = "../../bin/runtime-common" }
 relay-bridge-hub-rococo-client = { path = "../client-bridge-hub-rococo" }

--- a/relays/client-bridge-hub-wococo/src/lib.rs
+++ b/relays/client-bridge-hub-wococo/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the BridgeHub-Wococo-Substrate parachain.
 
 use bp_bridge_hub_wococo::{BridgeHubSignedExtension, SignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions, ChainWithUtilityPallet,
@@ -46,7 +45,6 @@ impl UnderlyingChainProvider for BridgeHubWococo {
 }
 
 impl Chain for BridgeHubWococo {
-	const ID: ChainId = bp_runtime::BRIDGE_HUB_WOCOCO_CHAIN_ID;
 	const NAME: &'static str = "BridgeHubWococo";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_wococo::BEST_FINALIZED_BRIDGE_HUB_WOCOCO_HEADER_METHOD;

--- a/relays/client-kusama/Cargo.toml
+++ b/relays/client-kusama/Cargo.toml
@@ -12,7 +12,6 @@ relay-utils = { path = "../utils" }
 # Bridge dependencies
 
 bp-kusama = { path = "../../primitives/chain-kusama" }
-bp-runtime = { path = "../../primitives/runtime" }
 
 # Substrate Dependencies
 

--- a/relays/client-kusama/src/lib.rs
+++ b/relays/client-kusama/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the Kusama chain.
 
 use bp_kusama::AccountInfoStorageMapKeyProvider;
-use bp_runtime::ChainId;
 use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
@@ -37,7 +36,6 @@ impl UnderlyingChainProvider for Kusama {
 }
 
 impl Chain for Kusama {
-	const ID: ChainId = bp_runtime::KUSAMA_CHAIN_ID;
 	const NAME: &'static str = "Kusama";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_kusama::BEST_FINALIZED_KUSAMA_HEADER_METHOD;

--- a/relays/client-millau/Cargo.toml
+++ b/relays/client-millau/Cargo.toml
@@ -13,7 +13,6 @@ relay-utils = { path = "../utils" }
 # Supported Chains
 
 bp-millau = { path = "../../primitives/chain-millau" }
-bp-runtime = { path = "../../primitives/runtime" }
 millau-runtime = { path = "../../bin/millau/runtime" }
 
 # Substrate Dependencies

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Types used to connect to the Millau-Substrate chain.
 
-use bp_runtime::ChainId;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
 	BalanceOf, Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions,
@@ -48,7 +47,6 @@ impl ChainWithMessages for Millau {
 }
 
 impl Chain for Millau {
-	const ID: ChainId = bp_runtime::MILLAU_CHAIN_ID;
 	const NAME: &'static str = "Millau";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_millau::BEST_FINALIZED_MILLAU_HEADER_METHOD;

--- a/relays/client-polkadot/Cargo.toml
+++ b/relays/client-polkadot/Cargo.toml
@@ -12,7 +12,6 @@ relay-utils = { path = "../utils" }
 # Bridge dependencies
 
 bp-polkadot = { path = "../../primitives/chain-polkadot" }
-bp-runtime = { path = "../../primitives/runtime" }
 
 # Substrate Dependencies
 

--- a/relays/client-polkadot/src/lib.rs
+++ b/relays/client-polkadot/src/lib.rs
@@ -17,7 +17,6 @@
 //! Types used to connect to the Polkadot chain.
 
 use bp_polkadot::AccountInfoStorageMapKeyProvider;
-use bp_runtime::ChainId;
 use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
@@ -37,7 +36,6 @@ impl UnderlyingChainProvider for Polkadot {
 }
 
 impl Chain for Polkadot {
-	const ID: ChainId = bp_runtime::POLKADOT_CHAIN_ID;
 	const NAME: &'static str = "Polkadot";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_polkadot::BEST_FINALIZED_POLKADOT_HEADER_METHOD;

--- a/relays/client-rialto-parachain/Cargo.toml
+++ b/relays/client-rialto-parachain/Cargo.toml
@@ -18,7 +18,6 @@ bp-messages = { path = "../../primitives/messages" }
 bp-millau = { path = "../../primitives/chain-millau" }
 bp-polkadot-core = { path = "../../primitives/polkadot-core" }
 bp-rialto-parachain = { path = "../../primitives/chain-rialto-parachain" }
-bp-runtime = { path = "../../primitives/runtime" }
 
 bridge-runtime-common = { path = "../../bin/runtime-common" }
 relay-substrate-client = { path = "../client-substrate" }

--- a/relays/client-rialto-parachain/src/lib.rs
+++ b/relays/client-rialto-parachain/src/lib.rs
@@ -19,7 +19,6 @@
 pub mod codegen_runtime;
 
 use bp_bridge_hub_cumulus::BridgeHubSignedExtension;
-use bp_runtime::ChainId;
 use codec::Encode;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions, Error as SubstrateError,
@@ -48,7 +47,6 @@ impl UnderlyingChainProvider for RialtoParachain {
 }
 
 impl Chain for RialtoParachain {
-	const ID: ChainId = bp_runtime::RIALTO_PARACHAIN_CHAIN_ID;
 	const NAME: &'static str = "RialtoParachain";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_rialto_parachain::BEST_FINALIZED_RIALTO_PARACHAIN_HEADER_METHOD;

--- a/relays/client-rialto/Cargo.toml
+++ b/relays/client-rialto/Cargo.toml
@@ -13,7 +13,6 @@ relay-utils = { path = "../utils" }
 # Bridge dependencies
 
 bp-rialto = { path = "../../primitives/chain-rialto" }
-bp-runtime = { path = "../../primitives/runtime" }
 rialto-runtime = { path = "../../bin/rialto/runtime" }
 
 # Substrate Dependencies

--- a/relays/client-rialto/src/lib.rs
+++ b/relays/client-rialto/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Types used to connect to the Rialto-Substrate chain.
 
-use bp_runtime::ChainId;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
 	BalanceOf, Chain, ChainWithBalances, ChainWithMessages, ChainWithTransactions,
@@ -39,7 +38,6 @@ impl UnderlyingChainProvider for Rialto {
 }
 
 impl Chain for Rialto {
-	const ID: ChainId = bp_runtime::RIALTO_CHAIN_ID;
 	const NAME: &'static str = "Rialto";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_rialto::BEST_FINALIZED_RIALTO_HEADER_METHOD;

--- a/relays/client-rococo/Cargo.toml
+++ b/relays/client-rococo/Cargo.toml
@@ -12,7 +12,6 @@ relay-utils = { path = "../utils" }
 # Bridge dependencies
 
 bp-rococo = { path = "../../primitives/chain-rococo" }
-bp-runtime = { path = "../../primitives/runtime" }
 
 # Substrate Dependencies
 

--- a/relays/client-rococo/src/lib.rs
+++ b/relays/client-rococo/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Types used to connect to the Rococo-Substrate chain.
 
-use bp_runtime::ChainId;
 use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
@@ -36,7 +35,6 @@ impl UnderlyingChainProvider for Rococo {
 }
 
 impl Chain for Rococo {
-	const ID: ChainId = bp_runtime::ROCOCO_CHAIN_ID;
 	const NAME: &'static str = "Rococo";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_rococo::BEST_FINALIZED_ROCOCO_HEADER_METHOD;

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -18,8 +18,8 @@ use crate::calls::UtilityCall;
 
 use bp_messages::ChainWithMessages as ChainWithMessagesBase;
 use bp_runtime::{
-	Chain as ChainBase, ChainId, EncodedOrDecodedCall, HashOf, Parachain as ParachainBase,
-	TransactionEra, TransactionEraOf, UnderlyingChainProvider,
+	Chain as ChainBase, EncodedOrDecodedCall, HashOf, Parachain as ParachainBase, TransactionEra,
+	TransactionEraOf, UnderlyingChainProvider,
 };
 use codec::{Codec, Encode};
 use jsonrpsee::core::{DeserializeOwned, Serialize};
@@ -38,8 +38,6 @@ pub type SignedBlockOf<C> = <C as Chain>::SignedBlock;
 
 /// Substrate-based chain from minimal relay-client point of view.
 pub trait Chain: ChainBase + Clone {
-	/// Chain id.
-	const ID: ChainId;
 	/// Chain name.
 	const NAME: &'static str;
 	/// Name of the runtime API method that is returning best known finalized header number

--- a/relays/client-substrate/src/test_chain.rs
+++ b/relays/client-substrate/src/test_chain.rs
@@ -31,6 +31,8 @@ use std::time::Duration;
 pub struct TestChain;
 
 impl bp_runtime::Chain for TestChain {
+	const ID: ChainId = *b"test";
+
 	type BlockNumber = u32;
 	type Hash = sp_core::H256;
 	type Hasher = sp_runtime::traits::BlakeTwo256;
@@ -53,7 +55,6 @@ impl bp_runtime::Chain for TestChain {
 }
 
 impl Chain for TestChain {
-	const ID: ChainId = *b"test";
 	const NAME: &'static str = "Test";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str = "TestMethod";
 	const AVERAGE_BLOCK_INTERVAL: Duration = Duration::from_millis(0);
@@ -75,6 +76,8 @@ impl ChainWithBalances for TestChain {
 pub struct TestParachainBase;
 
 impl bp_runtime::Chain for TestParachainBase {
+	const ID: ChainId = *b"tstp";
+
 	type BlockNumber = u32;
 	type Hash = sp_core::H256;
 	type Hasher = sp_runtime::traits::BlakeTwo256;
@@ -109,7 +112,6 @@ impl bp_runtime::UnderlyingChainProvider for TestParachain {
 }
 
 impl Chain for TestParachain {
-	const ID: ChainId = *b"test";
 	const NAME: &'static str = "TestParachain";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str = "TestParachainMethod";
 	const AVERAGE_BLOCK_INTERVAL: Duration = Duration::from_millis(0);

--- a/relays/client-westend/Cargo.toml
+++ b/relays/client-westend/Cargo.toml
@@ -11,7 +11,6 @@ relay-utils = { path = "../utils" }
 
 # Bridge dependencies
 
-bp-runtime = { path = "../../primitives/runtime" }
 bp-westend = { path = "../../primitives/chain-westend" }
 
 # Substrate Dependencies

--- a/relays/client-westend/src/lib.rs
+++ b/relays/client-westend/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Types used to connect to the Westend chain.
 
-use bp_runtime::ChainId;
 use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
@@ -36,7 +35,6 @@ impl UnderlyingChainProvider for Westend {
 }
 
 impl Chain for Westend {
-	const ID: ChainId = bp_runtime::WESTEND_CHAIN_ID;
 	const NAME: &'static str = "Westend";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_westend::BEST_FINALIZED_WESTEND_HEADER_METHOD;
@@ -69,7 +67,6 @@ impl UnderlyingChainProvider for Westmint {
 // Westmint seems to use the same configuration as all Polkadot-like chains, so we'll use Westend
 // primitives here.
 impl Chain for Westmint {
-	const ID: ChainId = bp_runtime::WESTMINT_CHAIN_ID;
 	const NAME: &'static str = "Westmint";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_westend::BEST_FINALIZED_WESTMINT_HEADER_METHOD;

--- a/relays/client-wococo/Cargo.toml
+++ b/relays/client-wococo/Cargo.toml
@@ -11,7 +11,6 @@ relay-utils = { path = "../utils" }
 
 # Bridge dependencies
 
-bp-runtime = { path = "../../primitives/runtime" }
 bp-wococo = { path = "../../primitives/chain-wococo" }
 
 # Substrate Dependencies

--- a/relays/client-wococo/src/lib.rs
+++ b/relays/client-wococo/src/lib.rs
@@ -16,7 +16,6 @@
 
 //! Types used to connect to the Wococo-Substrate chain.
 
-use bp_runtime::ChainId;
 use relay_substrate_client::{Chain, ChainWithBalances, RelayChain, UnderlyingChainProvider};
 use sp_core::storage::StorageKey;
 use std::time::Duration;
@@ -36,7 +35,6 @@ impl UnderlyingChainProvider for Wococo {
 }
 
 impl Chain for Wococo {
-	const ID: ChainId = bp_runtime::WOCOCO_CHAIN_ID;
 	const NAME: &'static str = "Wococo";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_wococo::BEST_FINALIZED_WOCOCO_HEADER_METHOD;


### PR DESCRIPTION
related to #1666 

Since we're adding `type BridgedChain: Chain` to the messages pallet configuration, we may use `BridgedChain::ID` instead of the dedicated pallet constant (`type BridgedChainId: Get<ChainId>`).

This PR moves this field from the relay-chain level `Chain` definition to the primitives level `Chain` definition. Logic is not changed