### PR TITLE
Use compact proofs for messages delivery confirmation

### DIFF
--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -162,7 +162,7 @@ pub mod source {
 		let FromBridgedChainMessagesDeliveryProof { bridged_header_hash, storage_proof, lane } =
 			proof;
 		let mut storage =
-			B::BridgedHeaderChain::storage_proof_checker(bridged_header_hash, storage_proof)
+			B::BridgedHeaderChain::verify_vec_db_storage(bridged_header_hash, storage_proof)
 				.map_err(VerificationError::HeaderChain)?;
 		// Messages delivery proof is just proof of single storage key read => any error
 		// is fatal.
@@ -171,11 +171,11 @@ pub mod source {
 			&lane,
 		);
 		let inbound_lane_data = storage
-			.read_and_decode_mandatory_value(storage_inbound_lane_data_key.0.as_ref())
+			.get_and_decode_mandatory(&storage_inbound_lane_data_key)
 			.map_err(VerificationError::InboundLaneStorage)?;
 
 		// check that the storage proof doesn't have any untouched trie nodes
-		storage.ensure_no_unused_nodes().map_err(VerificationError::StorageProof)?;
+		storage.ensure_no_unused_keys().map_err(VerificationError::VecDb)?;
 
 		Ok((lane, inbound_lane_data))
 	}

--- a/bin/runtime-common/src/messages_call_ext.rs
+++ b/bin/runtime-common/src/messages_call_ext.rs
@@ -488,7 +488,7 @@ mod tests {
 			pallet_bridge_messages::Call::<TestRuntime>::receive_messages_delivery_proof {
 				proof: FromBridgedChainMessagesDeliveryProof {
 					bridged_header_hash: Default::default(),
-					storage_proof: Vec::new(),
+					storage_proof: Default::default(),
 					lane: LaneId([0, 0, 0, 0]),
 				},
 				relayers_state: UnrewardedRelayersState {

--- a/bin/runtime-common/src/refund_relayer_extension.rs
+++ b/bin/runtime-common/src/refund_relayer_extension.rs
@@ -817,7 +817,7 @@ mod tests {
 		RuntimeCall::BridgeMessages(MessagesCall::receive_messages_delivery_proof {
 			proof: FromBridgedChainMessagesDeliveryProof {
 				bridged_header_hash: Default::default(),
-				storage_proof: vec![],
+				storage_proof: Default::default(),
 				lane: TestLaneId::get(),
 			},
 			relayers_state: UnrewardedRelayersState {

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -23,7 +23,7 @@
 use bp_header_chain::HeaderChainError;
 use bp_runtime::{
 	messages::MessageDispatchResult, BasicOperatingMode, Chain, OperatingMode, RangeInclusiveExt,
-	StorageProofError, UnderlyingChainOf, UnderlyingChainProvider, VecDbError,
+	UnderlyingChainOf, UnderlyingChainProvider, VecDbError,
 };
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{PalletError, RuntimeDebug};
@@ -454,7 +454,7 @@ pub enum VerificationError {
 	/// Error returned by the bridged header chain.
 	HeaderChain(HeaderChainError),
 	/// Error returned while reading/decoding inbound lane data from the storage proof.
-	InboundLaneStorage(StorageProofError),
+	InboundLaneStorage(VecDbError),
 	/// The declared message weight is incorrect.
 	InvalidMessageWeight,
 	/// Declared messages count doesn't match actual value.
@@ -465,8 +465,6 @@ pub enum VerificationError {
 	MessageTooLarge,
 	/// Error returned while reading/decoding outbound lane data from the `VecDb`.
 	OutboundLaneStorage(VecDbError),
-	/// Storage proof related error.
-	StorageProof(StorageProofError),
 	/// `VecDb` related error.
 	VecDb(VecDbError),
 	/// Custom error

--- a/primitives/messages/src/source_chain.rs
+++ b/primitives/messages/src/source_chain.rs
@@ -18,7 +18,7 @@
 
 use crate::{InboundLaneData, LaneId, MessageNonce, UnrewardedRelayer, VerificationError};
 
-use bp_runtime::{RawStorageProof, Size};
+use bp_runtime::{Size, UntrustedVecDb};
 use codec::{Decode, Encode};
 use frame_support::{Parameter, RuntimeDebug};
 use scale_info::TypeInfo;
@@ -43,19 +43,14 @@ pub struct FromBridgedChainMessagesDeliveryProof<BridgedHeaderHash> {
 	/// Hash of the bridge header the proof is for.
 	pub bridged_header_hash: BridgedHeaderHash,
 	/// Storage trie proof generated for [`Self::bridged_header_hash`].
-	pub storage_proof: RawStorageProof,
+	pub storage_proof: UntrustedVecDb,
 	/// Lane id of which messages were delivered and the proof is for.
 	pub lane: LaneId,
 }
 
 impl<BridgedHeaderHash> Size for FromBridgedChainMessagesDeliveryProof<BridgedHeaderHash> {
 	fn size(&self) -> u32 {
-		u32::try_from(
-			self.storage_proof
-				.iter()
-				.fold(0usize, |sum, node| sum.saturating_add(node.len())),
-		)
-		.unwrap_or(u32::MAX)
+		self.storage_proof.size()
 	}
 }
 

--- a/relays/lib-substrate-relay/src/messages/target.rs
+++ b/relays/lib-substrate-relay/src/messages/target.rs
@@ -37,6 +37,7 @@ use bp_messages::{
 	source_chain::FromBridgedChainMessagesDeliveryProof, storage_keys::inbound_lane_data_key,
 	ChainWithMessages as _, InboundLaneData, LaneId, MessageNonce, UnrewardedRelayersState,
 };
+use bp_runtime::{HasherOf, UntrustedVecDb};
 use messages_relay::{
 	message_lane::{MessageLane, SourceHeaderIdOf, TargetHeaderIdOf},
 	message_lane_loop::{NoncesSubmitArtifacts, TargetClient, TargetClientState},
@@ -47,6 +48,7 @@ use relay_substrate_client::{
 };
 use relay_utils::relay_loop::Client as RelayClient;
 use sp_core::Pair;
+use sp_runtime::traits::Header;
 use std::{convert::TryFrom, ops::RangeInclusive};
 
 /// Message receiving proof returned by the target Substrate node.
@@ -231,19 +233,24 @@ where
 		SubstrateError,
 	> {
 		let (id, relayers_state) = self.unrewarded_relayers_state(id).await?;
-		let inbound_data_key = bp_messages::storage_keys::inbound_lane_data_key(
+		let storage_keys = vec![inbound_lane_data_key(
 			P::SourceChain::WITH_CHAIN_MESSAGES_PALLET_NAME,
 			&self.lane_id,
-		);
-		let proof = self
-			.target_client
-			.prove_storage(id.hash(), vec![inbound_data_key])
-			.await?
-			.into_iter_nodes()
-			.collect();
+		)];
+
+		let root = *self.target_client.header_by_hash(id.hash()).await?.state_root();
+		let read_proof = self.target_client.prove_storage(id.hash(), storage_keys.clone()).await?;
+		let storage_proof =
+			UntrustedVecDb::try_new::<HasherOf<P::TargetChain>>(read_proof, root, storage_keys)
+				.map_err(|e| {
+					SubstrateError::Custom(format!(
+						"Error generating messages delivery confirmation storage: {:?}",
+						e
+					))
+				})?;
 		let proof = FromBridgedChainMessagesDeliveryProof {
 			bridged_header_hash: id.1,
-			storage_proof: proof,
+			storage_proof,
 			lane: self.lane_id,
 		};
 		Ok((id, (relayers_state, proof)))


### PR DESCRIPTION
Closes #2179

No need to adjust the benchmarks since in the case of messages delivery confirmation we only attach the storage proof for a single key (the inbound lane).