### PR TITLE
Remove MaximalOutboundPayloadSize and use BridgedChain::maximal_incomging_message_size instead

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -445,7 +445,6 @@ impl pallet_bridge_messages::Config<WithRialtoMessagesInstance> for Runtime {
 
 	type ActiveOutboundLanes = RialtoActiveOutboundLanes;
 
-	type MaximalOutboundPayloadSize = crate::rialto_messages::ToRialtoMaximalOutboundPayloadSize;
 	type OutboundPayload = crate::rialto_messages::ToRialtoMessagePayload;
 
 	type InboundPayload = crate::rialto_messages::FromRialtoMessagePayload;
@@ -478,8 +477,6 @@ impl pallet_bridge_messages::Config<WithRialtoParachainMessagesInstance> for Run
 
 	type ActiveOutboundLanes = RialtoParachainActiveOutboundLanes;
 
-	type MaximalOutboundPayloadSize =
-		crate::rialto_parachain_messages::ToRialtoParachainMaximalOutboundPayloadSize;
 	type OutboundPayload = crate::rialto_parachain_messages::ToRialtoParachainMessagePayload;
 
 	type InboundPayload = crate::rialto_parachain_messages::FromRialtoParachainMessagePayload;

--- a/bin/millau/runtime/src/rialto_messages.rs
+++ b/bin/millau/runtime/src/rialto_messages.rs
@@ -55,10 +55,6 @@ pub type FromRialtoMessageDispatch =
 		(),
 	>;
 
-/// Maximal outbound payload size of Millau -> Rialto messages.
-pub type ToRialtoMaximalOutboundPayloadSize =
-	messages::source::FromThisChainMaximalOutboundPayloadSize<WithRialtoMessageBridge>;
-
 /// Millau <-> Rialto message bridge.
 #[derive(RuntimeDebug, Clone, Copy)]
 pub struct WithRialtoMessageBridge;

--- a/bin/millau/runtime/src/rialto_parachain_messages.rs
+++ b/bin/millau/runtime/src/rialto_parachain_messages.rs
@@ -57,10 +57,6 @@ pub type FromRialtoParachainMessageDispatch =
 		(),
 	>;
 
-/// Maximal outbound payload size of Millau -> RialtoParachain messages.
-pub type ToRialtoParachainMaximalOutboundPayloadSize =
-	messages::source::FromThisChainMaximalOutboundPayloadSize<WithRialtoParachainMessageBridge>;
-
 /// Millau <-> RialtoParachain message bridge.
 #[derive(RuntimeDebug, Clone, Copy)]
 pub struct WithRialtoParachainMessageBridge;

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -568,7 +568,6 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 
 	type ActiveOutboundLanes = ActiveOutboundLanes;
 
-	type MaximalOutboundPayloadSize = crate::millau_messages::ToMillauMaximalOutboundPayloadSize;
 	type OutboundPayload = crate::millau_messages::ToMillauMessagePayload;
 
 	type InboundPayload = crate::millau_messages::FromMillauMessagePayload;

--- a/bin/rialto-parachain/runtime/src/millau_messages.rs
+++ b/bin/rialto-parachain/runtime/src/millau_messages.rs
@@ -57,10 +57,6 @@ pub type FromMillauMessageDispatch =
 		(),
 	>;
 
-/// Maximal outbound payload size of Rialto -> Millau messages.
-pub type ToMillauMaximalOutboundPayloadSize =
-	messages::source::FromThisChainMaximalOutboundPayloadSize<WithMillauMessageBridge>;
-
 /// Millau <-> RialtoParachain message bridge.
 #[derive(RuntimeDebug, Clone, Copy)]
 pub struct WithMillauMessageBridge;

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -424,7 +424,6 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 
 	type ActiveOutboundLanes = ActiveOutboundLanes;
 
-	type MaximalOutboundPayloadSize = crate::millau_messages::ToMillauMaximalOutboundPayloadSize;
 	type OutboundPayload = crate::millau_messages::ToMillauMessagePayload;
 
 	type InboundPayload = crate::millau_messages::FromMillauMessagePayload;

--- a/bin/rialto/runtime/src/millau_messages.rs
+++ b/bin/rialto/runtime/src/millau_messages.rs
@@ -54,10 +54,6 @@ pub type FromMillauMessageDispatch =
 		(),
 	>;
 
-/// Maximal outbound payload size of Rialto -> Millau messages.
-pub type ToMillauMaximalOutboundPayloadSize =
-	messages::source::FromThisChainMaximalOutboundPayloadSize<WithMillauMessageBridge>;
-
 /// Millau <-> Rialto message bridge.
 #[derive(RuntimeDebug, Clone, Copy)]
 pub struct WithMillauMessageBridge;

--- a/bin/runtime-common/src/messages.rs
+++ b/bin/runtime-common/src/messages.rs
@@ -26,8 +26,6 @@ pub use bp_runtime::{
 	Chain, RangeInclusiveExt, RawStorageProof, Size, TrustedVecDb, UnderlyingChainOf,
 	UnderlyingChainProvider, UntrustedVecDb,
 };
-use frame_support::traits::Get;
-use sp_std::marker::PhantomData;
 
 /// Bidirectional message bridge.
 pub trait MessageBridge {
@@ -70,24 +68,8 @@ pub type OriginOf<C> = <C as ThisChainWithMessages>::RuntimeOrigin;
 
 /// Sub-module that is declaring types required for processing This -> Bridged chain messages.
 pub mod source {
-	use super::*;
-
 	/// Message payload for This -> Bridged chain messages.
 	pub type FromThisChainMessagePayload = crate::messages_xcm_extension::XcmAsPlainPayload;
-
-	// TODO: https://github.com/paritytech/parity-bridges-common/issues/1666 remove me
-	/// Maximal size of outbound message payload.
-	pub struct FromThisChainMaximalOutboundPayloadSize<B>(PhantomData<B>);
-
-	impl<B: MessageBridge> Get<u32> for FromThisChainMaximalOutboundPayloadSize<B>
-	where
-		UnderlyingChainOf<BridgedChain<B>>: bp_messages::ChainWithMessages,
-	{
-		fn get() -> u32 {
-			use bp_messages::ChainWithMessages;
-			UnderlyingChainOf::<BridgedChain<B>>::maximal_incoming_message_size()
-		}
-	}
 }
 
 /// Sub-module that is declaring types required for processing Bridged -> This chain messages.

--- a/bin/runtime-common/src/mock.rs
+++ b/bin/runtime-common/src/mock.rs
@@ -24,8 +24,8 @@
 #![cfg(test)]
 
 use crate::messages::{
-	source::{FromThisChainMaximalOutboundPayloadSize, FromThisChainMessagePayload},
-	BridgedChainWithMessages, HashOf, MessageBridge, ThisChainWithMessages,
+	source::FromThisChainMessagePayload, BridgedChainWithMessages, HashOf, MessageBridge,
+	ThisChainWithMessages,
 };
 
 use bp_header_chain::{ChainWithGrandpa, HeaderChain};
@@ -227,7 +227,6 @@ impl pallet_bridge_messages::Config for TestRuntime {
 	type WeightInfo = pallet_bridge_messages::weights::BridgeWeight<TestRuntime>;
 	type ActiveOutboundLanes = ActiveOutboundLanes;
 
-	type MaximalOutboundPayloadSize = FromThisChainMaximalOutboundPayloadSize<OnThisChainBridge>;
 	type OutboundPayload = FromThisChainMessagePayload;
 
 	type InboundPayload = Vec<u8>;

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -116,10 +116,6 @@ pub mod pallet {
 		/// Get all active outbound lanes that the message pallet is serving.
 		type ActiveOutboundLanes: Get<&'static [LaneId]>;
 
-		// TODO: https://github.com/paritytech/parity-bridges-common/issues/1666 - use method from `ChainWithMessages` instead
-		/// Maximal encoded size of the outbound payload.
-		#[pallet::constant]
-		type MaximalOutboundPayloadSize: Get<u32>;
 		/// Payload type of outbound messages. This payload is dispatched on the bridged chain.
 		type OutboundPayload: Parameter + Size;
 

--- a/modules/messages/src/tests/mock.rs
+++ b/modules/messages/src/tests/mock.rs
@@ -122,7 +122,7 @@ impl Chain for BridgedChain {
 	const STATE_VERSION: StateVersion = StateVersion::V1;
 
 	fn max_extrinsic_size() -> u32 {
-		u32::MAX
+		4096
 	}
 
 	fn max_extrinsic_weight() -> Weight {
@@ -242,7 +242,6 @@ impl Config for TestRuntime {
 
 	type ActiveOutboundLanes = ActiveOutboundLanes;
 
-	type MaximalOutboundPayloadSize = frame_support::traits::ConstU32<MAX_OUTBOUND_PAYLOAD_SIZE>;
 	type OutboundPayload = TestPayload;
 
 	type InboundPayload = TestPayload;
@@ -294,9 +293,6 @@ impl Size for TestPayload {
 		16 + self.extra.len() as u32
 	}
 }
-
-/// Maximal outbound payload size.
-pub const MAX_OUTBOUND_PAYLOAD_SIZE: u32 = 4096;
 
 /// Account that has balance to use in tests.
 pub const ENDOWED_ACCOUNT: AccountId = 0xDEAD;

--- a/modules/messages/src/tests/pallet_tests.rs
+++ b/modules/messages/src/tests/pallet_tests.rs
@@ -217,20 +217,21 @@ fn send_message_rejects_too_large_message() {
 	run_test(|| {
 		let mut message_payload = message_payload(1, 0);
 		// the payload isn't simply extra, so it'll definitely overflow
-		// `MAX_OUTBOUND_PAYLOAD_SIZE` if we add `MAX_OUTBOUND_PAYLOAD_SIZE` bytes to extra
+		// `max_outbound_payload_size` if we add `max_outbound_payload_size` bytes to extra
+		let max_outbound_payload_size = BridgedChain::maximal_incoming_message_size();
 		message_payload
 			.extra
-			.extend_from_slice(&[0u8; MAX_OUTBOUND_PAYLOAD_SIZE as usize]);
+			.extend_from_slice(&vec![0u8; max_outbound_payload_size as usize]);
 		assert_noop!(
 			send_message::<TestRuntime, ()>(TEST_LANE_ID, message_payload.clone(),),
 			Error::<TestRuntime, ()>::MessageRejectedByPallet(VerificationError::MessageTooLarge),
 		);
 
-		// let's check that we're able to send `MAX_OUTBOUND_PAYLOAD_SIZE` messages
-		while message_payload.encoded_size() as u32 > MAX_OUTBOUND_PAYLOAD_SIZE {
+		// let's check that we're able to send `max_outbound_payload_size` messages
+		while message_payload.encoded_size() as u32 > max_outbound_payload_size {
 			message_payload.extra.pop();
 		}
-		assert_eq!(message_payload.encoded_size() as u32, MAX_OUTBOUND_PAYLOAD_SIZE);
+		assert_eq!(message_payload.encoded_size() as u32, max_outbound_payload_size);
 		assert_ok!(send_message::<TestRuntime, ()>(TEST_LANE_ID, message_payload,),);
 	})
 }


### PR DESCRIPTION
related to #1666 

We can use `BridgedChain::maximal_incomging_message_size()` instead of `MaximalOutboundPayloadSize`. No logic changes