### PR TITLE
Use BridgedChain::Account instead of InbundRelayer

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -446,11 +446,9 @@ impl pallet_bridge_messages::Config<WithRialtoMessagesInstance> for Runtime {
 	type ActiveOutboundLanes = RialtoActiveOutboundLanes;
 
 	type OutboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-
 	type InboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-	type InboundRelayer = bp_rialto::AccountId;
-	type DeliveryPayments = ();
 
+	type DeliveryPayments = ();
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithRialtoMessagesInstance,
@@ -478,11 +476,9 @@ impl pallet_bridge_messages::Config<WithRialtoParachainMessagesInstance> for Run
 	type ActiveOutboundLanes = RialtoParachainActiveOutboundLanes;
 
 	type OutboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-
 	type InboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-	type InboundRelayer = bp_rialto_parachain::AccountId;
-	type DeliveryPayments = ();
 
+	type DeliveryPayments = ();
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithRialtoParachainMessagesInstance,

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -569,11 +569,9 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type ActiveOutboundLanes = ActiveOutboundLanes;
 
 	type OutboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-
 	type InboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-	type InboundRelayer = bp_millau::AccountId;
-	type DeliveryPayments = ();
 
+	type DeliveryPayments = ();
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithMillauMessagesInstance,

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -425,11 +425,9 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type ActiveOutboundLanes = ActiveOutboundLanes;
 
 	type OutboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-
 	type InboundPayload = bridge_runtime_common::messages_xcm_extension::XcmAsPlainPayload;
-	type InboundRelayer = bp_millau::AccountId;
-	type DeliveryPayments = ();
 
+	type DeliveryPayments = ();
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithMillauMessagesInstance,

--- a/bin/runtime-common/src/messages_call_ext.rs
+++ b/bin/runtime-common/src/messages_call_ext.rs
@@ -15,8 +15,9 @@
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
 use bp_messages::{ChainWithMessages, InboundLaneData, LaneId, MessageNonce};
+use bp_runtime::AccountIdOf;
 use frame_support::{dispatch::CallableCallFor, traits::IsSubType, RuntimeDebug};
-use pallet_bridge_messages::{Config, Pallet};
+use pallet_bridge_messages::{BridgedChainOf, Config, Pallet};
 use sp_runtime::transaction_validity::TransactionValidity;
 use sp_std::ops::RangeInclusive;
 
@@ -287,7 +288,7 @@ impl<
 
 /// Returns occupation state of unrewarded relayers vector.
 fn unrewarded_relayers_occupation<T: Config<I>, I: 'static>(
-	inbound_lane_data: &InboundLaneData<T::InboundRelayer>,
+	inbound_lane_data: &InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>>,
 ) -> UnrewardedRelayerOccupation {
 	UnrewardedRelayerOccupation {
 		free_relayer_slots: T::BridgedChain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX

--- a/bin/runtime-common/src/mock.rs
+++ b/bin/runtime-common/src/mock.rs
@@ -224,7 +224,6 @@ impl pallet_bridge_messages::Config for TestRuntime {
 	type OutboundPayload = XcmAsPlainPayload;
 
 	type InboundPayload = Vec<u8>;
-	type InboundRelayer = BridgedChainAccountId;
 	type DeliveryPayments = ();
 
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<

--- a/deployments/types-millau.json
+++ b/deployments/types-millau.json
@@ -77,7 +77,6 @@
     "lane_id": "LaneId",
     "nonce:": "MessageNonce"
   },
-  "InboundRelayer": "AccountId",
   "InboundLaneData": {
     "relayers": "Vec<UnrewardedRelayer>",
     "last_confirmed_nonce": "MessageNonce"

--- a/deployments/types-rialto.json
+++ b/deployments/types-rialto.json
@@ -77,7 +77,6 @@
     "lane_id": "LaneId",
     "nonce:": "MessageNonce"
   },
-  "InboundRelayer": "AccountId",
   "InboundLaneData": {
     "relayers": "Vec<UnrewardedRelayer>",
     "last_confirmed_nonce": "MessageNonce"

--- a/deployments/types/common.json
+++ b/deployments/types/common.json
@@ -23,7 +23,6 @@
 		"lane_id": "LaneId",
 		"nonce:": "MessageNonce"
 	},
-	"InboundRelayer": "AccountId",
 	"InboundLaneData": {
 		"relayers": "Vec<UnrewardedRelayer>",
 		"last_confirmed_nonce": "MessageNonce"

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -29,7 +29,7 @@ use bp_messages::{
 	InboundLaneData, LaneId, MessageNonce, OutboundLaneData, UnrewardedRelayer,
 	UnrewardedRelayersState,
 };
-use bp_runtime::{HashOf, StorageProofSize};
+use bp_runtime::{AccountIdOf, HashOf, StorageProofSize};
 use codec::Decode;
 use frame_benchmarking::{account, v2::*};
 use frame_support::weights::Weight;
@@ -83,8 +83,8 @@ pub trait Config<I: 'static>: crate::Config<I> {
 	/// Return id of relayer account at the bridged chain.
 	///
 	/// By default, zero account is returned.
-	fn bridged_relayer_id() -> Self::InboundRelayer {
-		Self::InboundRelayer::decode(&mut TrailingZeroInput::zeroes()).unwrap()
+	fn bridged_relayer_id() -> AccountIdOf<BridgedChainOf<Self, I>> {
+		Decode::decode(&mut TrailingZeroInput::zeroes()).unwrap()
 	}
 
 	/// Create given account and give it enough balance for test purposes. Used to create
@@ -132,7 +132,7 @@ fn receive_messages<T: Config<I>, I: 'static>(nonce: MessageNonce) {
 }
 
 struct ReceiveMessagesProofSetup<T: Config<I>, I: 'static> {
-	relayer_id_on_src: T::InboundRelayer,
+	relayer_id_on_src: AccountIdOf<BridgedChainOf<T, I>>,
 	relayer_id_on_tgt: T::AccountId,
 	msgs_count: u32,
 	_phantom_data: sp_std::marker::PhantomData<I>,
@@ -155,7 +155,7 @@ impl<T: Config<I>, I: 'static> ReceiveMessagesProofSetup<T, I> {
 		setup
 	}
 
-	fn relayer_id_on_src(&self) -> T::InboundRelayer {
+	fn relayer_id_on_src(&self) -> AccountIdOf<BridgedChainOf<T, I>> {
 		self.relayer_id_on_src.clone()
 	}
 

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -23,6 +23,7 @@ use bp_messages::{
 	ChainWithMessages, DeliveredMessages, InboundLaneData, LaneId, MessageKey, MessageNonce,
 	OutboundLaneData, ReceivalResult, UnrewardedRelayer,
 };
+use bp_runtime::AccountIdOf;
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
 use frame_support::RuntimeDebug;
 use scale_info::{Type, TypeInfo};
@@ -54,10 +55,12 @@ pub trait InboundLaneStorage {
 ///
 /// The encoding of this type matches encoding of the corresponding `MessageData`.
 #[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq)]
-pub struct StoredInboundLaneData<T: Config<I>, I: 'static>(pub InboundLaneData<T::InboundRelayer>);
+pub struct StoredInboundLaneData<T: Config<I>, I: 'static>(
+	pub InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>>,
+);
 
 impl<T: Config<I>, I: 'static> sp_std::ops::Deref for StoredInboundLaneData<T, I> {
-	type Target = InboundLaneData<T::InboundRelayer>;
+	type Target = InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>>;
 
 	fn deref(&self) -> &Self::Target {
 		&self.0
@@ -77,7 +80,7 @@ impl<T: Config<I>, I: 'static> Default for StoredInboundLaneData<T, I> {
 }
 
 impl<T: Config<I>, I: 'static> From<StoredInboundLaneData<T, I>>
-	for InboundLaneData<T::InboundRelayer>
+	for InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>>
 {
 	fn from(data: StoredInboundLaneData<T, I>) -> Self {
 		data.0
@@ -85,7 +88,7 @@ impl<T: Config<I>, I: 'static> From<StoredInboundLaneData<T, I>>
 }
 
 impl<T: Config<I>, I: 'static> EncodeLike<StoredInboundLaneData<T, I>>
-	for InboundLaneData<T::InboundRelayer>
+	for InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>>
 {
 }
 
@@ -93,13 +96,13 @@ impl<T: Config<I>, I: 'static> TypeInfo for StoredInboundLaneData<T, I> {
 	type Identity = Self;
 
 	fn type_info() -> Type {
-		InboundLaneData::<T::InboundRelayer>::type_info()
+		InboundLaneData::<AccountIdOf<BridgedChainOf<T, I>>>::type_info()
 	}
 }
 
 impl<T: Config<I>, I: 'static> MaxEncodedLen for StoredInboundLaneData<T, I> {
 	fn max_encoded_len() -> usize {
-		InboundLaneData::<T::InboundRelayer>::encoded_size_hint(
+		InboundLaneData::<AccountIdOf<BridgedChainOf<T, I>>>::encoded_size_hint(
 			BridgedChainOf::<T, I>::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX as usize,
 		)
 		.unwrap_or(usize::MAX)

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -64,7 +64,9 @@ use bp_messages::{
 	MessageKey, MessageNonce, MessagePayload, MessagesOperatingMode, OutboundLaneData,
 	OutboundMessageDetails, UnrewardedRelayersState, VerificationError,
 };
-use bp_runtime::{BasicOperatingMode, HashOf, OwnedBridgeModule, PreComputedSize, Size};
+use bp_runtime::{
+	AccountIdOf, BasicOperatingMode, HashOf, OwnedBridgeModule, PreComputedSize, Size,
+};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{dispatch::PostDispatchInfo, ensure, fail, traits::Get, DefaultNoBound};
 use sp_runtime::traits::UniqueSaturatedFrom;
@@ -118,24 +120,17 @@ pub mod pallet {
 
 		/// Payload type of outbound messages. This payload is dispatched on the bridged chain.
 		type OutboundPayload: Parameter + Size;
-
 		/// Payload type of inbound messages. This payload is dispatched on this chain.
 		type InboundPayload: Decode;
-		/// Identifier of relayer that deliver messages to this chain. Relayer reward is paid on the
-		/// bridged chain.
-		type InboundRelayer: Parameter + MaxEncodedLen;
 
-		// Types that are used by outbound_lane (on source chain).
-
-		/// Delivery confirmation payments.
+		/// Handler for relayer payments that happen during message delivery transaction.
+		type DeliveryPayments: DeliveryPayments<Self::AccountId>;
+		/// Handler for relayer payments that happen during message delivery confirmation
+		/// transaction.
 		type DeliveryConfirmationPayments: DeliveryConfirmationPayments<Self::AccountId>;
 
-		// Types that are used by inbound_lane (on target chain).
-
-		/// Message dispatch.
+		/// Message dispatch handler.
 		type MessageDispatch: MessageDispatch<DispatchPayload = Self::InboundPayload>;
-		/// Delivery payments.
-		type DeliveryPayments: DeliveryPayments<Self::AccountId>;
 	}
 
 	/// Shortcut to this chain type for Config.
@@ -237,7 +232,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::receive_messages_proof_weight(proof, *messages_count, *dispatch_weight))]
 		pub fn receive_messages_proof(
 			origin: OriginFor<T>,
-			relayer_id_at_bridged_chain: T::InboundRelayer,
+			relayer_id_at_bridged_chain: AccountIdOf<BridgedChainOf<T, I>>,
 			proof: FromBridgedChainMessagesProof<HashOf<BridgedChainOf<T, I>>>,
 			messages_count: u32,
 			dispatch_weight: Weight,
@@ -596,7 +591,9 @@ pub mod pallet {
 		}
 
 		/// Return inbound lane data.
-		pub fn inbound_lane_data(lane: LaneId) -> InboundLaneData<T::InboundRelayer> {
+		pub fn inbound_lane_data(
+			lane: LaneId,
+		) -> InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>> {
 			InboundLanes::<T, I>::get(lane).0
 		}
 	}
@@ -702,7 +699,7 @@ fn outbound_lane<T: Config<I>, I: 'static>(
 /// Runtime inbound lane storage.
 struct RuntimeInboundLaneStorage<T: Config<I>, I: 'static = ()> {
 	lane_id: LaneId,
-	cached_data: Option<InboundLaneData<T::InboundRelayer>>,
+	cached_data: Option<InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>>>,
 	_phantom: PhantomData<I>,
 }
 
@@ -726,14 +723,14 @@ impl<T: Config<I>, I: 'static> RuntimeInboundLaneStorage<T, I> {
 		let max_encoded_len = StoredInboundLaneData::<T, I>::max_encoded_len();
 		let relayers_count = self.get_or_init_data().relayers.len();
 		let actual_encoded_len =
-			InboundLaneData::<T::InboundRelayer>::encoded_size_hint(relayers_count)
+			InboundLaneData::<AccountIdOf<BridgedChainOf<T, I>>>::encoded_size_hint(relayers_count)
 				.unwrap_or(usize::MAX);
 		max_encoded_len.saturating_sub(actual_encoded_len) as _
 	}
 }
 
 impl<T: Config<I>, I: 'static> InboundLaneStorage for RuntimeInboundLaneStorage<T, I> {
-	type Relayer = T::InboundRelayer;
+	type Relayer = AccountIdOf<BridgedChainOf<T, I>>;
 
 	fn id(&self) -> LaneId {
 		self.lane_id
@@ -747,11 +744,11 @@ impl<T: Config<I>, I: 'static> InboundLaneStorage for RuntimeInboundLaneStorage<
 		BridgedChainOf::<T, I>::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX
 	}
 
-	fn get_or_init_data(&mut self) -> InboundLaneData<T::InboundRelayer> {
+	fn get_or_init_data(&mut self) -> InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>> {
 		match self.cached_data {
 			Some(ref data) => data.clone(),
 			None => {
-				let data: InboundLaneData<T::InboundRelayer> =
+				let data: InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>> =
 					InboundLanes::<T, I>::get(self.lane_id).into();
 				self.cached_data = Some(data.clone());
 				data
@@ -759,7 +756,7 @@ impl<T: Config<I>, I: 'static> InboundLaneStorage for RuntimeInboundLaneStorage<
 		}
 	}
 
-	fn set_data(&mut self, data: InboundLaneData<T::InboundRelayer>) {
+	fn set_data(&mut self, data: InboundLaneData<AccountIdOf<BridgedChainOf<T, I>>>) {
 		self.cached_data = Some(data.clone());
 		InboundLanes::<T, I>::insert(self.lane_id, StoredInboundLaneData::<T, I>(data))
 	}

--- a/modules/messages/src/tests/mock.rs
+++ b/modules/messages/src/tests/mock.rs
@@ -115,7 +115,7 @@ impl Chain for BridgedChain {
 	type Hash = BridgedHeaderHash;
 	type Hasher = BlakeTwo256;
 	type Header = BridgedChainHeader;
-	type AccountId = AccountId;
+	type AccountId = TestRelayer;
 	type Balance = Balance;
 	type Index = u64;
 	type Signature = sp_runtime::MultiSignature;
@@ -245,7 +245,6 @@ impl Config for TestRuntime {
 	type OutboundPayload = TestPayload;
 
 	type InboundPayload = TestPayload;
-	type InboundRelayer = TestRelayer;
 	type DeliveryPayments = TestDeliveryPayments;
 
 	type DeliveryConfirmationPayments = TestDeliveryConfirmationPayments;

--- a/relays/lib-substrate-relay/src/messages/mod.rs
+++ b/relays/lib-substrate-relay/src/messages/mod.rs
@@ -295,9 +295,10 @@ pub struct DirectReceiveMessagesProofCallBuilder<P, R, I> {
 impl<P, R, I> ReceiveMessagesProofCallBuilder<P> for DirectReceiveMessagesProofCallBuilder<P, R, I>
 where
 	P: SubstrateMessageLane,
-	R: BridgeMessagesConfig<I, InboundRelayer = AccountIdOf<P::SourceChain>>,
+	R: BridgeMessagesConfig<I>,
 	I: 'static,
-	R::BridgedChain: bp_runtime::Chain<Hash = HashOf<P::SourceChain>>,
+	R::BridgedChain:
+		bp_runtime::Chain<AccountId = AccountIdOf<P::SourceChain>, Hash = HashOf<P::SourceChain>>,
 	CallOf<P::TargetChain>: From<BridgeMessagesCall<R, I>> + GetDispatchInfo,
 {
 	fn build_receive_messages_proof_call(


### PR DESCRIPTION
related to #1666 

The PR just changes the way we get a type, so no audit required.