### PR TITLE
Polish the Subscription API

### DIFF
--- a/relays/client-substrate/src/client/caching.rs
+++ b/relays/client-substrate/src/client/caching.rs
@@ -18,12 +18,13 @@
 //! method calls.
 
 use crate::{
-	client::{Client, SharedSubscriptionFactory},
+	client::{Client, SubscriptionBroadcaster},
 	error::{Error, Result},
 	AccountIdOf, AccountKeyPairOf, BlockNumberOf, Chain, ChainWithGrandpa, ChainWithTransactions,
 	HashOf, HeaderIdOf, HeaderOf, IndexOf, SignedBlockOf, SimpleRuntimeVersion, Subscription,
 	TransactionTracker, UnsignedTransaction, ANCIENT_BLOCK_THRESHOLD,
 };
+use std::future::Future;
 
 use async_std::sync::{Arc, Mutex, RwLock};
 use async_trait::async_trait;
@@ -53,8 +54,8 @@ pub struct CachingClient<C: Chain, B: Client<C>> {
 
 /// Client data, shared by all `CachingClient` clones.
 struct ClientData<C: Chain> {
-	grandpa_justifications: Arc<Mutex<Option<SharedSubscriptionFactory<Bytes>>>>,
-	beefy_justifications: Arc<Mutex<Option<SharedSubscriptionFactory<Bytes>>>>,
+	grandpa_justifications: Arc<Mutex<Option<SubscriptionBroadcaster<Bytes>>>>,
+	beefy_justifications: Arc<Mutex<Option<SubscriptionBroadcaster<Bytes>>>>,
 	// `quick_cache::sync::Cache` has the `get_or_insert_async` method, which fits our needs,
 	// but it uses synchronization primitives that are not aware of async execution. They
 	// can block the executor threads and cause deadlocks => let's use primitives from
@@ -110,6 +111,26 @@ impl<C: Chain, B: Client<C>> CachingClient<C, B> {
 		// insert/update the value in the cache
 		cache.write().await.insert(key.clone(), value.clone());
 		Ok(value)
+	}
+
+	async fn subscribe_finality_justifications<'a>(
+		&'a self,
+		maybe_broadcaster: &Mutex<Option<SubscriptionBroadcaster<Bytes>>>,
+		do_subscribe: impl Future<Output = Result<Subscription<Bytes>>> + 'a,
+	) -> Result<Subscription<Bytes>> {
+		let mut maybe_broadcaster = maybe_broadcaster.lock().await;
+		let broadcaster = match maybe_broadcaster.as_ref() {
+			Some(justifications) => justifications,
+			None => {
+				let broadcaster = match SubscriptionBroadcaster::new(do_subscribe.await?) {
+					Ok(broadcaster) => broadcaster,
+					Err(subscription) => return Ok(subscription),
+				};
+				maybe_broadcaster.get_or_insert(broadcaster)
+			},
+		};
+
+		broadcaster.subscribe().await
 	}
 }
 
@@ -191,25 +212,19 @@ impl<C: Chain, B: Client<C>> Client<C> for CachingClient<C, B> {
 	where
 		C: ChainWithGrandpa,
 	{
-		let mut grandpa_justifications = self.data.grandpa_justifications.lock().await;
-		if let Some(ref grandpa_justifications) = *grandpa_justifications {
-			grandpa_justifications.subscribe().await
-		} else {
-			let subscription = self.backend.subscribe_grandpa_finality_justifications().await?;
-			*grandpa_justifications = Some(subscription.factory());
-			Ok(subscription)
-		}
+		self.subscribe_finality_justifications(
+			&self.data.grandpa_justifications,
+			self.backend.subscribe_grandpa_finality_justifications(),
+		)
+		.await
 	}
 
 	async fn subscribe_beefy_finality_justifications(&self) -> Result<Subscription<Bytes>> {
-		let mut beefy_justifications = self.data.beefy_justifications.lock().await;
-		if let Some(ref beefy_justifications) = *beefy_justifications {
-			beefy_justifications.subscribe().await
-		} else {
-			let subscription = self.backend.subscribe_beefy_finality_justifications().await?;
-			*beefy_justifications = Some(subscription.factory());
-			Ok(subscription)
-		}
+		self.subscribe_finality_justifications(
+			&self.data.beefy_justifications,
+			self.backend.subscribe_beefy_finality_justifications(),
+		)
+		.await
 	}
 
 	async fn token_decimals(&self) -> Result<Option<u64>> {

--- a/relays/client-substrate/src/client/mod.rs
+++ b/relays/client-substrate/src/client/mod.rs
@@ -33,7 +33,7 @@ mod rpc_api;
 mod subscription;
 
 pub use client::Client;
-pub use subscription::{SharedSubscriptionFactory, Subscription, UnderlyingSubscription};
+pub use subscription::{StreamDescription, Subscription, SubscriptionBroadcaster};
 
 /// Type of RPC client with caching support.
 pub type RpcWithCachingClient<C> = CachingClient<C, RpcClient<C>>;

--- a/relays/client-substrate/src/client/rpc.rs
+++ b/relays/client-substrate/src/client/rpc.rs
@@ -24,7 +24,7 @@ use crate::{
 			SubstrateFrameSystemClient, SubstrateGrandpaClient, SubstrateStateClient,
 			SubstrateSystemClient,
 		},
-		subscription::{Subscription, Unwrap},
+		subscription::{StreamDescription, Subscription},
 		Client,
 	},
 	error::{Error, Result},
@@ -39,8 +39,11 @@ use async_trait::async_trait;
 use bp_runtime::{HasherOf, HeaderIdProvider, UnverifiedStorageProof};
 use codec::Encode;
 use frame_support::weights::Weight;
-use futures::{TryFutureExt, TryStreamExt};
-use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
+use futures::TryFutureExt;
+use jsonrpsee::{
+	core::{client::Subscription as RpcSubscription, RpcResult},
+	ws_client::{WsClient, WsClientBuilder},
+};
 use num_traits::Zero;
 use pallet_transaction_payment::RuntimeDispatchInfo;
 use relay_utils::{relay_loop::RECONNECT_DELAY, STALL_TIMEOUT};
@@ -194,6 +197,25 @@ impl<C: Chain> RpcClient<C> {
 		})
 		.await
 	}
+
+	async fn subscribe_finality_justifications<Fut>(
+		&self,
+		gadget_name: &str,
+		do_subscribe: impl FnOnce(Arc<WsClient>) -> Fut + Send + 'static,
+	) -> Result<Subscription<Bytes>>
+	where
+		Fut: Future<Output = RpcResult<RpcSubscription<Bytes>>> + Send,
+	{
+		let subscription = self
+			.jsonrpsee_execute(move |client| async move { Ok(do_subscribe(client).await?) })
+			.map_err(|e| Error::failed_to_subscribe_justification::<C>(e))
+			.await?;
+
+		Ok(Subscription::new_forwarded(
+			StreamDescription::new(format!("{} justifications", gadget_name), C::NAME.into()),
+			subscription,
+		))
+	}
 }
 
 impl<C: Chain> Clone for RpcClient<C> {
@@ -282,36 +304,16 @@ impl<C: Chain> Client<C> for RpcClient<C> {
 	where
 		C: ChainWithGrandpa,
 	{
-		Subscription::new(
-			C::NAME.into(),
-			"GRANDPA justifications".into(),
-			self.jsonrpsee_execute(move |client| async move {
-				Ok(Box::new(
-					SubstrateGrandpaClient::<C>::subscribe_justifications(&*client)
-						.await?
-						.map_err(Into::into),
-				))
-			})
-			.map_err(|e| Error::failed_to_subscribe_justification::<C>(e))
-			.await?,
-		)
+		self.subscribe_finality_justifications("GRANDPA", move |client| async move {
+			SubstrateGrandpaClient::<C>::subscribe_justifications(&*client).await
+		})
 		.await
 	}
 
 	async fn subscribe_beefy_finality_justifications(&self) -> Result<Subscription<Bytes>> {
-		Subscription::new(
-			C::NAME.into(),
-			"BEEFY justifications".into(),
-			self.jsonrpsee_execute(move |client| async move {
-				Ok(Box::new(
-					SubstrateBeefyClient::<C>::subscribe_justifications(&*client)
-						.await?
-						.map_err(Into::into),
-				))
-			})
-			.map_err(|e| Error::failed_to_subscribe_justification::<C>(e))
-			.await?,
-		)
+		self.subscribe_finality_justifications("BEEFY", move |client| async move {
+			SubstrateBeefyClient::<C>::subscribe_justifications(&*client).await
+		})
 		.await
 	}
 
@@ -450,7 +452,10 @@ impl<C: Chain> Client<C> for RpcClient<C> {
 				self_clone,
 				stall_timeout,
 				tx_hash,
-				Box::new(Unwrap::new(C::NAME.into(), "transaction events".into(), subscription)),
+				Subscription::new_forwarded(
+					StreamDescription::new("transaction events".into(), C::NAME.into()),
+					subscription,
+				),
 			))
 		})
 		.await

--- a/relays/client-substrate/src/client/subscription.rs
+++ b/relays/client-substrate/src/client/subscription.rs
@@ -14,70 +14,85 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::error::Result;
+use crate::error::Result as ClientResult;
 
 use async_std::{
 	channel::{bounded, Receiver, Sender},
 	stream::StreamExt,
 };
 use futures::{FutureExt, Stream};
+use jsonrpsee::core::RpcResult;
 use sp_runtime::DeserializeOwned;
 use std::{
 	fmt::Debug,
 	pin::Pin,
+	result::Result as StdResult,
 	task::{Context, Poll},
 };
 
 /// Once channel reaches this capacity, the subscription breaks.
 const CHANNEL_CAPACITY: usize = 128;
 
-/// Underlying subscription type.
-pub type UnderlyingSubscription<T> = Box<dyn Stream<Item = T> + Unpin + Send>;
+/// Structure describing a stream.
+#[derive(Clone)]
+pub struct StreamDescription {
+	stream_name: String,
+	chain_name: String,
+}
+
+impl StreamDescription {
+	/// Create a new instance of `StreamDescription`.
+	pub fn new(stream_name: String, chain_name: String) -> Self {
+		Self { stream_name, chain_name }
+	}
+
+	/// Get a stream description.
+	fn get(&self) -> String {
+		format!("{} stream of {}", self.stream_name, self.chain_name)
+	}
+}
 
 /// Chainable stream that transforms items of type `Result<T, E>` to items of type `T`.
 ///
 /// If it encounters an item of type `Err`, it returns `Poll::Ready(None)`
 /// and terminates the underlying stream.
-pub struct Unwrap<S: Stream<Item = std::result::Result<T, E>>, T, E> {
-	chain_name: String,
-	item_type: String,
-	subscription: Option<S>,
+struct Unwrap<S: Stream<Item = StdResult<T, E>>, T, E> {
+	desc: StreamDescription,
+	stream: Option<S>,
 }
 
-impl<S: Stream<Item = std::result::Result<T, E>>, T, E> Unwrap<S, T, E> {
+impl<S: Stream<Item = StdResult<T, E>>, T, E> Unwrap<S, T, E> {
 	/// Create a new instance of `Unwrap`.
-	pub fn new(chain_name: String, item_type: String, subscription: S) -> Self {
-		Self { chain_name, item_type, subscription: Some(subscription) }
+	pub fn new(desc: StreamDescription, stream: S) -> Self {
+		Self { desc, stream: Some(stream) }
 	}
 }
 
-impl<S: Stream<Item = std::result::Result<T, E>> + Unpin, T: DeserializeOwned, E: Debug> Stream
+impl<S: Stream<Item = StdResult<T, E>> + Unpin, T: DeserializeOwned, E: Debug> Stream
 	for Unwrap<S, T, E>
 {
 	type Item = T;
 
 	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-		Poll::Ready(match self.subscription.as_mut() {
+		Poll::Ready(match self.stream.as_mut() {
 			Some(subscription) => match futures::ready!(Pin::new(subscription).poll_next(cx)) {
 				Some(Ok(item)) => Some(item),
 				Some(Err(e)) => {
-					self.subscription.take();
+					self.stream.take();
 					log::debug!(
 						target: "bridge",
-						"{} stream of {} has returned error: {:?}. It may need to be restarted",
-						self.item_type,
-						self.chain_name,
+						"{} has returned error: {:?}. It may need to be restarted",
+						self.desc.get(),
 						e,
 					);
 					None
 				},
 				None => {
-					self.subscription.take();
+					self.stream.take();
 					log::debug!(
 						target: "bridge",
-						"{} stream of {} has returned `None`. It may need to be restarted",
-						self.item_type,
-						self.chain_name,
+						"{} has returned `None`. It may need to be restarted",
+						self.desc.get()
 					);
 					None
 				},
@@ -89,71 +104,73 @@ impl<S: Stream<Item = std::result::Result<T, E>> + Unpin, T: DeserializeOwned, E
 
 /// Subscription factory that produces subscriptions, sharing the same background thread.
 #[derive(Clone)]
-pub struct SharedSubscriptionFactory<T> {
-	subscribers_sender: Sender<Sender<Option<T>>>,
+pub struct SubscriptionBroadcaster<T> {
+	desc: StreamDescription,
+	subscribers_sender: Sender<Sender<T>>,
 }
 
-impl<T: 'static + Clone + DeserializeOwned + Send> SharedSubscriptionFactory<T> {
+impl<T: 'static + Clone + DeserializeOwned + Send> SubscriptionBroadcaster<T> {
 	/// Create new subscription factory.
-	pub async fn new(
-		chain_name: String,
-		item_type: String,
-		subscription: UnderlyingSubscription<std::result::Result<T, jsonrpsee::core::Error>>,
-	) -> Self {
+	pub fn new(subscription: Subscription<T>) -> StdResult<Self, Subscription<T>> {
+		// It doesn't make sense to further broadcast a broadcasted subscription.
+		if subscription.is_broadcasted {
+			return Err(subscription)
+		}
+
+		let desc = subscription.desc().clone();
 		let (subscribers_sender, subscribers_receiver) = bounded(CHANNEL_CAPACITY);
-		async_std::task::spawn(background_worker(
-			chain_name.clone(),
-			item_type.clone(),
-			Box::new(Unwrap::new(chain_name, item_type, subscription)),
-			subscribers_receiver,
-		));
-		Self { subscribers_sender }
+		async_std::task::spawn(background_worker(subscription, subscribers_receiver));
+		Ok(Self { desc, subscribers_sender })
 	}
 
 	/// Produce new subscription.
-	pub async fn subscribe(&self) -> Result<Subscription<T>> {
+	pub async fn subscribe(&self) -> ClientResult<Subscription<T>> {
 		let (items_sender, items_receiver) = bounded(CHANNEL_CAPACITY);
 		self.subscribers_sender.try_send(items_sender)?;
 
-		Ok(Subscription { items_receiver, subscribers_sender: self.subscribers_sender.clone() })
+		Ok(Subscription::new_broadcasted(self.desc.clone(), items_receiver))
 	}
 }
 
 /// Subscription to some chain events.
 pub struct Subscription<T> {
-	items_receiver: Receiver<Option<T>>,
-	subscribers_sender: Sender<Sender<Option<T>>>,
+	desc: StreamDescription,
+	subscription: Box<dyn Stream<Item = T> + Unpin + Send>,
+	is_broadcasted: bool,
 }
 
 impl<T: 'static + Clone + DeserializeOwned + Send> Subscription<T> {
-	/// Create new subscription.
-	pub async fn new(
-		chain_name: String,
-		item_type: String,
-		subscription: UnderlyingSubscription<std::result::Result<T, jsonrpsee::core::Error>>,
-	) -> Result<Self> {
-		SharedSubscriptionFactory::<T>::new(chain_name, item_type, subscription)
-			.await
-			.subscribe()
-			.await
+	/// Create new forwarded subscription.
+	pub fn new_forwarded(
+		desc: StreamDescription,
+		subscription: impl Stream<Item = RpcResult<T>> + Unpin + Send + 'static,
+	) -> Self {
+		Self {
+			desc: desc.clone(),
+			subscription: Box::new(Unwrap::new(desc, subscription)),
+			is_broadcasted: false,
+		}
 	}
 
-	/// Return subscription factory for this subscription.
-	pub fn factory(&self) -> SharedSubscriptionFactory<T> {
-		SharedSubscriptionFactory { subscribers_sender: self.subscribers_sender.clone() }
+	/// Create new broadcasted subscription.
+	pub fn new_broadcasted(
+		desc: StreamDescription,
+		subscription: impl Stream<Item = T> + Unpin + Send + 'static,
+	) -> Self {
+		Self { desc, subscription: Box::new(subscription), is_broadcasted: true }
 	}
 
-	/// Consumes subscription and returns future items stream.
-	pub fn into_stream(self) -> impl Stream<Item = T> {
-		futures::stream::unfold(self, |mut this| async {
-			let item = this.items_receiver.next().await.unwrap_or(None);
-			item.map(|i| (i, this))
-		})
+	/// Get the description of the underlying stream
+	pub fn desc(&self) -> &StreamDescription {
+		&self.desc
 	}
+}
 
-	/// Return next item from the subscription.
-	pub async fn next(&self) -> Result<Option<T>> {
-		Ok(self.items_receiver.recv().await?)
+impl<T> Stream for Subscription<T> {
+	type Item = T;
+
+	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		Poll::Ready(futures::ready!(Pin::new(&mut self.subscription).poll_next(cx)))
 	}
 }
 
@@ -163,17 +180,14 @@ impl<T: 'static + Clone + DeserializeOwned + Send> Subscription<T> {
 /// message (`Err` or `None`) to all known listeners. Also, when it stops, all
 /// subsequent reads and new subscribers will get the connection error (`ChannelError`).
 async fn background_worker<T: 'static + Clone + DeserializeOwned + Send>(
-	chain_name: String,
-	item_type: String,
-	mut subscription: UnderlyingSubscription<T>,
-	mut subscribers_receiver: Receiver<Sender<Option<T>>>,
+	mut subscription: Subscription<T>,
+	mut subscribers_receiver: Receiver<Sender<T>>,
 ) {
-	fn log_task_exit(chain_name: &str, item_type: &str, reason: &str) {
+	fn log_task_exit(desc: &StreamDescription, reason: &str) {
 		log::debug!(
 			target: "bridge",
-			"Background task of {} subscription of {} has stopped: {}",
-			item_type,
-			chain_name,
+			"Background task of subscription broadcaster for {} has stopped: {}",
+			desc.get(),
 			reason,
 		);
 	}
@@ -184,7 +198,7 @@ async fn background_worker<T: 'static + Clone + DeserializeOwned + Send>(
 		None => {
 			// it means that the last subscriber/factory has been dropped, so we need to
 			// exit too
-			return log_task_exit(&chain_name, &item_type, "client has stopped")
+			return log_task_exit(subscription.desc(), "client has stopped")
 		},
 	};
 
@@ -200,22 +214,24 @@ async fn background_worker<T: 'static + Clone + DeserializeOwned + Send>(
 					None => {
 						// it means that the last subscriber/factory has been dropped, so we need to
 						// exit too
-						return log_task_exit(&chain_name, &item_type, "client has stopped")
+						return log_task_exit(subscription.desc(), "client has stopped")
 					},
 				}
 			},
-			item = subscription.next().fuse() => {
-				let is_stream_finished = item.is_none();
-				// notify subscribers
-				subscribers.retain(|subscriber| {
-					let send_result = subscriber.try_send(item.clone());
-					send_result.is_ok()
-				});
-
-				// it means that the underlying client has dropped, so we can't do anything here
-				// and need to stop the task
-				if is_stream_finished {
-					return log_task_exit(&chain_name, &item_type, "stream has finished");
+			maybe_item = subscription.subscription.next().fuse() => {
+				match maybe_item {
+					Some(item) => {
+						// notify subscribers
+						subscribers.retain(|subscriber| {
+							let send_result = subscriber.try_send(item.clone());
+							send_result.is_ok()
+						});
+					}
+					None => {
+						// The underlying client has dropped, so we can't do anything here
+						// and need to stop the task.
+						return log_task_exit(subscription.desc(), "stream has finished");
+					}
 				}
 			},
 		}

--- a/relays/client-substrate/src/lib.rs
+++ b/relays/client-substrate/src/lib.rs
@@ -40,8 +40,8 @@ pub use crate::{
 	},
 	client::{
 		is_ancient_block, rpc_with_caching as new, ChainRuntimeVersion, Client,
-		OpaqueGrandpaAuthoritiesSet, RpcWithCachingClient, SimpleRuntimeVersion, Subscription,
-		ANCIENT_BLOCK_THRESHOLD,
+		OpaqueGrandpaAuthoritiesSet, RpcWithCachingClient, SimpleRuntimeVersion, StreamDescription,
+		Subscription, ANCIENT_BLOCK_THRESHOLD,
 	},
 	error::{Error, Result},
 	sync_header::SyncHeader,

--- a/relays/lib-substrate-relay/src/finality/engine.rs
+++ b/relays/lib-substrate-relay/src/finality/engine.rs
@@ -25,6 +25,7 @@ use bp_header_chain::{
 use bp_runtime::{BasicOperatingMode, HeaderIdProvider, OperatingMode};
 use codec::{Decode, Encode};
 use finality_grandpa::voter_set::VoterSet;
+use futures::stream::StreamExt;
 use num_traits::{One, Zero};
 use relay_substrate_client::{
 	BlockNumberOf, Chain, ChainWithGrandpa, Client, Error as SubstrateError, HashOf, HeaderOf,
@@ -205,17 +206,14 @@ impl<C: ChainWithGrandpa> Engine<C> for Grandpa<C> {
 		// But now there are problems with this approach - `CurrentSetId` may return invalid value.
 		// So here we're waiting for the next justification, read the authorities set and then try
 		// to figure out the set id with bruteforce.
-		let justifications = Self::finality_proofs(&source_client)
+		let mut justifications = Self::finality_proofs(&source_client)
 			.await
 			.map_err(|err| Error::Subscribe(C::NAME, err))?;
 		// Read next justification - the header that it finalizes will be used as initial header.
 		let justification = justifications
 			.next()
 			.await
-			.map_err(|e| Error::ReadJustification(C::NAME, e))
-			.and_then(|justification| {
-				justification.ok_or(Error::ReadJustificationStreamEnded(C::NAME))
-			})?;
+			.ok_or(Error::ReadJustificationStreamEnded(C::NAME))?;
 
 		// Read initial header.
 		let justification: GrandpaJustification<C::Header> =


### PR DESCRIPTION
Fixes #2137 

- Decouple `SharedSubscriptionFactory` (now renamed to `SubscriptionBroadcaster`) from `Subscription`
- Avoid using extra background workers for normal, not broadcasted subscriptions
- Some deduplication