### PR TITLE
Box messages proof argument in receive_messages_proof call

### DIFF
--- a/bin/runtime-common/src/messages_call_ext.rs
+++ b/bin/runtime-common/src/messages_call_ext.rs
@@ -378,13 +378,13 @@ mod tests {
 				messages_count: nonces_end.checked_sub(nonces_start).map(|x| x + 1).unwrap_or(0)
 					as u32,
 				dispatch_weight: frame_support::weights::Weight::zero(),
-				proof: FromBridgedChainMessagesProof {
+				proof: Box::new(FromBridgedChainMessagesProof {
 					bridged_header_hash: Default::default(),
 					storage: Default::default(),
 					lane: TEST_LANE_ID,
 					nonces_start,
 					nonces_end,
-				},
+				}),
 			},
 		)
 		.check_obsolete_call()

--- a/bin/runtime-common/src/refund_relayer_extension.rs
+++ b/bin/runtime-common/src/refund_relayer_extension.rs
@@ -799,7 +799,7 @@ mod tests {
 	fn message_delivery_call(best_message: MessageNonce) -> RuntimeCall {
 		RuntimeCall::BridgeMessages(MessagesCall::receive_messages_proof {
 			relayer_id_at_bridged_chain: relayer_account_at_bridged_chain(),
-			proof: FromBridgedChainMessagesProof {
+			proof: Box::new(FromBridgedChainMessagesProof {
 				bridged_header_hash: Default::default(),
 				storage: Default::default(),
 				lane: TestLaneId::get(),
@@ -810,7 +810,7 @@ mod tests {
 				.last_delivered_nonce() +
 					1,
 				nonces_end: best_message,
-			},
+			}),
 			messages_count: 1,
 			dispatch_weight: Weight::zero(),
 		})

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -224,7 +224,7 @@ mod benchmarks {
 		receive_messages_proof(
 			RawOrigin::Signed(setup.relayer_id_on_tgt()),
 			setup.relayer_id_on_src(),
-			proof,
+			Box::new(proof),
 			setup.msgs_count,
 			dispatch_weight,
 		);
@@ -255,7 +255,7 @@ mod benchmarks {
 		receive_messages_proof(
 			RawOrigin::Signed(setup.relayer_id_on_tgt()),
 			setup.relayer_id_on_src(),
-			proof,
+			Box::new(proof),
 			setup.msgs_count,
 			dispatch_weight,
 		);
@@ -296,7 +296,7 @@ mod benchmarks {
 		receive_messages_proof(
 			RawOrigin::Signed(setup.relayer_id_on_tgt()),
 			setup.relayer_id_on_src(),
-			proof,
+			Box::new(proof),
 			setup.msgs_count,
 			dispatch_weight,
 		);
@@ -331,7 +331,7 @@ mod benchmarks {
 		receive_messages_proof(
 			RawOrigin::Signed(setup.relayer_id_on_tgt()),
 			setup.relayer_id_on_src(),
-			proof,
+			Box::new(proof),
 			setup.msgs_count,
 			dispatch_weight,
 		);
@@ -531,7 +531,7 @@ mod benchmarks {
 		receive_messages_proof(
 			RawOrigin::Signed(setup.relayer_id_on_tgt()),
 			setup.relayer_id_on_src(),
-			proof,
+			Box::new(proof),
 			setup.msgs_count,
 			dispatch_weight,
 		);

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -191,11 +191,11 @@ pub mod pallet {
 		/// The call may succeed, but some messages may not be delivered e.g. if they are not fit
 		/// into the unrewarded relayers vector.
 		#[pallet::call_index(2)]
-		#[pallet::weight(T::WeightInfo::receive_messages_proof_weight(proof, *messages_count, *dispatch_weight))]
+		#[pallet::weight(T::WeightInfo::receive_messages_proof_weight(&**proof, *messages_count, *dispatch_weight))]
 		pub fn receive_messages_proof(
 			origin: OriginFor<T>,
 			relayer_id_at_bridged_chain: AccountIdOf<BridgedChainOf<T, I>>,
-			proof: FromBridgedChainMessagesProof<HashOf<BridgedChainOf<T, I>>>,
+			proof: Box<FromBridgedChainMessagesProof<HashOf<BridgedChainOf<T, I>>>>,
 			messages_count: u32,
 			dispatch_weight: Weight,
 		) -> DispatchResultWithPostInfo {
@@ -220,14 +220,14 @@ pub mod pallet {
 			// The DeclaredWeight is exactly what's computed here. Unfortunately it is impossible
 			// to get pre-computed value (and it has been already computed by the executive).
 			let declared_weight = T::WeightInfo::receive_messages_proof_weight(
-				&proof,
+				&*proof,
 				messages_count,
 				dispatch_weight,
 			);
 			let mut actual_weight = declared_weight;
 
 			// verify messages proof && convert proof into messages
-			let messages = verify_and_decode_messages_proof::<T, I>(proof, messages_count)
+			let messages = verify_and_decode_messages_proof::<T, I>(*proof, messages_count)
 				.map_err(|err| {
 					log::trace!(target: LOG_TARGET, "Rejecting invalid messages proof: {:?}", err,);
 

--- a/modules/messages/src/tests/mock.rs
+++ b/modules/messages/src/tests/mock.rs
@@ -483,7 +483,7 @@ pub fn run_test<T>(test: impl FnOnce() -> T) -> T {
 pub fn prepare_messages_proof(
 	messages: Vec<Message>,
 	outbound_lane_data: Option<OutboundLaneData>,
-) -> FromBridgedChainMessagesProof<BridgedHeaderHash> {
+) -> Box<FromBridgedChainMessagesProof<BridgedHeaderHash>> {
 	// first - let's generate storage proof
 	let lane = messages.first().unwrap().key.lane_id;
 	let nonces_start = messages.first().unwrap().key.nonce;
@@ -507,13 +507,13 @@ pub fn prepare_messages_proof(
 		StoredHeaderData { number: 0, state_root: storage_root },
 	);
 
-	FromBridgedChainMessagesProof::<BridgedHeaderHash> {
+	Box::new(FromBridgedChainMessagesProof::<BridgedHeaderHash> {
 		bridged_header_hash,
 		storage,
 		lane,
 		nonces_start,
 		nonces_end,
-	}
+	})
 }
 
 /// Prepare valid storage proof for given messages and insert appropriate header to the

--- a/modules/messages/src/tests/mock.rs
+++ b/modules/messages/src/tests/mock.rs
@@ -263,7 +263,7 @@ impl crate::benchmarking::Config<()> for TestRuntime {
 		let dispatch_weight =
 			REGULAR_PAYLOAD.declared_weight * params.message_nonces.checked_len().unwrap_or(0);
 		(
-			prepare_messages_proof(
+			*prepare_messages_proof(
 				params.message_nonces.into_iter().map(|n| message(n, REGULAR_PAYLOAD)).collect(),
 				params.outbound_lane_data,
 			),

--- a/modules/messages/src/tests/pallet_tests.rs
+++ b/modules/messages/src/tests/pallet_tests.rs
@@ -661,7 +661,7 @@ fn ref_time_refund_from_receive_messages_proof_works() {
 			let messages_count = 1;
 			let pre_dispatch_weight =
 				<TestRuntime as Config>::WeightInfo::receive_messages_proof_weight(
-					&proof,
+					&*proof,
 					messages_count,
 					REGULAR_PAYLOAD.declared_weight,
 				);
@@ -716,7 +716,7 @@ fn proof_size_refund_from_receive_messages_proof_works() {
 		let messages_count = 1;
 		let pre_dispatch_weight =
 			<TestRuntime as Config>::WeightInfo::receive_messages_proof_weight(
-				&proof,
+				&*proof,
 				messages_count,
 				REGULAR_PAYLOAD.declared_weight,
 			);
@@ -893,7 +893,7 @@ fn test_bridge_messages_call_is_correctly_defined() {
 			FromBridgedChainMessagesDeliveryProof<BridgedHeaderHash>,
 		>::receive_messages_proof {
 			relayer_id_at_bridged_chain: account_id,
-			proof: message_proof,
+			proof: *message_proof,
 			messages_count: 1,
 			dispatch_weight: REGULAR_PAYLOAD.declared_weight,
 		};

--- a/relays/lib-substrate-relay/src/messages/mod.rs
+++ b/relays/lib-substrate-relay/src/messages/mod.rs
@@ -310,7 +310,7 @@ where
 	) -> CallOf<P::TargetChain> {
 		let call: CallOf<P::TargetChain> = BridgeMessagesCall::<R, I>::receive_messages_proof {
 			relayer_id_at_bridged_chain: relayer_id_at_source,
-			proof: proof.1,
+			proof: Box::new(proof.1),
 			messages_count,
 			dispatch_weight,
 		}


### PR DESCRIPTION
#2221 makes this argument a bit larger (additional `32 - 4 = 28` bytes) and it is larger than `200` bytes now. So it needs to go to heap. No actual code changes, so no audit required