### PR TITLE
Use host Ubuntu version to build images with prebuilt binaries

### DIFF
--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -11,7 +11,8 @@
 # You may use `scripts/build-containers.sh` to build all binaries and images at once.
 
 # This image needs to be binary compatible with the host machine (where images are built).
-FROM docker.io/library/ubuntu:20.04 as runtime
+ARG UBUNTU_RELEASE=20.04
+FROM docker.io/library/ubuntu:${UBUNTU_RELEASE} as runtime
 
 USER root
 WORKDIR /home/root

--- a/scripts/build-containers.sh
+++ b/scripts/build-containers.sh
@@ -11,9 +11,20 @@ else
         time cargo build -p substrate-relay -p rialto-bridge-node -p millau-bridge-node -p rialto-parachain-collator --release
     fi
 
+    # (try to) use docker image matching the host os
+    export UBUNTU_RELEASE=`lsb_release -r -s`
+
     # following (using DOCKER_BUILDKIT) requires docker 19.03 or above
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/substrate-relay --build-arg=PROJECT=substrate-relay
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-bridge-node --build-arg=PROJECT=rialto-bridge-node
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/millau-bridge-node --build-arg=PROJECT=millau-bridge-node
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-parachain-collator --build-arg=PROJECT=rialto-parachain-collator
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/substrate-relay \
+        --build-arg=PROJECT=substrate-relay \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-bridge-node \
+        --build-arg=PROJECT=rialto-bridge-node \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/millau-bridge-node \
+        --build-arg=PROJECT=millau-bridge-node \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-parachain-collator \
+        --build-arg=PROJECT=rialto-parachain-collator \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
 fi


### PR DESCRIPTION
(to avoid using `20.04` on `22.04` and so on)