### PR TITLE
Define generate_grandpa_key_ownership_proof()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10052,6 +10052,7 @@ dependencies = [
  "sc-rpc-api",
  "sc-transaction-pool-api",
  "scale-info",
+ "sp-consensus-grandpa",
  "sp-core",
  "sp-rpc",
  "sp-runtime",

--- a/relays/client-substrate/Cargo.toml
+++ b/relays/client-substrate/Cargo.toml
@@ -40,6 +40,7 @@ pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "ma
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-rpc = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/relays/client-substrate/src/client/caching.rs
+++ b/relays/client-substrate/src/client/caching.rs
@@ -219,6 +219,17 @@ impl<C: Chain, B: Client<C>> Client<C> for CachingClient<C, B> {
 		.await
 	}
 
+	async fn generate_grandpa_key_ownership_proof(
+		&self,
+		at: HashOf<C>,
+		set_id: sp_consensus_grandpa::SetId,
+		authority_id: sp_consensus_grandpa::AuthorityId,
+	) -> Result<Option<sp_consensus_grandpa::OpaqueKeyOwnershipProof>> {
+		self.backend
+			.generate_grandpa_key_ownership_proof(at, set_id, authority_id)
+			.await
+	}
+
 	async fn subscribe_beefy_finality_justifications(&self) -> Result<Subscription<Bytes>> {
 		self.subscribe_finality_justifications(
 			&self.data.beefy_justifications,

--- a/relays/client-substrate/src/client/client.rs
+++ b/relays/client-substrate/src/client/client.rs
@@ -78,6 +78,14 @@ pub trait Client<C: Chain>: 'static + Send + Sync + Clone + Debug {
 	async fn subscribe_grandpa_finality_justifications(&self) -> Result<Subscription<Bytes>>
 	where
 		C: ChainWithGrandpa;
+	/// Generates a proof of key ownership for the given authority in the given set.
+	async fn generate_grandpa_key_ownership_proof(
+		&self,
+		at: HashOf<C>,
+		set_id: sp_consensus_grandpa::SetId,
+		authority_id: sp_consensus_grandpa::AuthorityId,
+	) -> Result<Option<sp_consensus_grandpa::OpaqueKeyOwnershipProof>>;
+
 	/// Subscribe to BEEFY finality justifications.
 	async fn subscribe_beefy_finality_justifications(&self) -> Result<Subscription<Bytes>>;
 

--- a/relays/client-substrate/src/client/rpc.rs
+++ b/relays/client-substrate/src/client/rpc.rs
@@ -60,6 +60,8 @@ const MAX_SUBSCRIPTION_CAPACITY: usize = 4096;
 
 const SUB_API_TXPOOL_VALIDATE_TRANSACTION: &str = "TaggedTransactionQueue_validate_transaction";
 const SUB_API_TX_PAYMENT_QUERY_INFO: &str = "TransactionPaymentApi_query_info";
+const SUB_API_GRANDPA_GENERATE_KEY_OWNERSHIP_PROOF: &str =
+	"GrandpaApi_generate_key_ownership_proof";
 
 /// Client implementation that connects to the Substrate node over `ws`/`wss` connection
 /// and is using RPC methods to get required data and submit transactions.
@@ -307,6 +309,20 @@ impl<C: Chain> Client<C> for RpcClient<C> {
 		self.subscribe_finality_justifications("GRANDPA", move |client| async move {
 			SubstrateGrandpaClient::<C>::subscribe_justifications(&*client).await
 		})
+		.await
+	}
+
+	async fn generate_grandpa_key_ownership_proof(
+		&self,
+		at: HashOf<C>,
+		set_id: sp_consensus_grandpa::SetId,
+		authority_id: sp_consensus_grandpa::AuthorityId,
+	) -> Result<Option<sp_consensus_grandpa::OpaqueKeyOwnershipProof>> {
+		self.state_call(
+			at,
+			SUB_API_GRANDPA_GENERATE_KEY_OWNERSHIP_PROOF.into(),
+			(set_id, authority_id),
+		)
 		.await
 	}
 


### PR DESCRIPTION
No matter what solution we chose for #39, we need to generate a key ownership proof in order to send an equivocation report