### PR TITLE
run-millau-node.sh fails to run

### DIFF
--- a/deployments/local-scripts/run-millau-node.sh
+++ b/deployments/local-scripts/run-millau-node.sh
@@ -7,5 +7,5 @@ MILLAU_PORT="${MILLAU_PORT:-9945}"
 
 RUST_LOG=runtime=trace \
 ./target/debug/millau-bridge-node --dev --tmp \
-    --rpc-cors=all --unsafe-rpc-external --unsafe-rpc-external \
+    --rpc-cors=all --unsafe-rpc-external \
     --port 33044 --rpc-port $MILLAU_PORT \


### PR DESCRIPTION
This PR fix the following error:
```
➜  parity-bridges-common git:(master) ./deployments/local-scripts/run-millau-node.sh
error: the argument '--unsafe-rpc-external' cannot be used multiple times

Usage: millau-bridge-node [OPTIONS]
       millau-bridge-node <COMMAND>

For more information, try '--help'.
```
