### PR TITLE
(Suggestion) Ability to externalize configuration for `ExporterFor`

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -548,7 +548,7 @@ impl pallet_utility::Config for Runtime {
 // this config is totally incorrect - the pallet is not actually used at this runtime. We need
 // it only to be able to run benchmarks and make required traits (and default weights for tests).
 parameter_types! {
-	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
+	pub BridgeTable: Vec<(xcm::prelude::NetworkId, xcm::prelude::MultiLocation, Option<xcm::prelude::MultiAsset>)>
 		= vec![(xcm_config::RialtoNetwork::get(), xcm_config::TokenLocation::get(), None)];
 }
 impl pallet_xcm_bridge_hub_router::Config for Runtime {

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -549,7 +549,7 @@ impl pallet_utility::Config for Runtime {
 // it only to be able to run benchmarks and make required traits (and default weights for tests).
 parameter_types! {
 	pub BridgeTable: Vec<(xcm::prelude::NetworkId, xcm::prelude::MultiLocation, Option<xcm::prelude::MultiAsset>)>
-		= vec![(xcm_config::RialtoNetwork::get(), xcm_config::TokenLocation::get(), None)];
+		= vec![(xcm_config::RialtoNetwork::get(), xcm_config::TokenLocation::get(), Some((xcm_config::TokenAssetId::get(), 1_000_000_000_u128).into()))];
 }
 impl pallet_xcm_bridge_hub_router::Config for Runtime {
 	type WeightInfo = ();
@@ -561,7 +561,6 @@ impl pallet_xcm_bridge_hub_router::Config for Runtime {
 	type ToBridgeHubSender = xcm_config::XcmRouter;
 	type WithBridgeHubChannel = xcm_config::EmulatedSiblingXcmpChannel;
 
-	type BaseFee = ConstU128<1_000_000_000>;
 	type ByteFee = ConstU128<1_000>;
 	type FeeAsset = xcm_config::TokenAssetId;
 }

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -555,6 +555,7 @@ impl pallet_xcm_bridge_hub_router::Config for Runtime {
 	type WeightInfo = ();
 
 	type UniversalLocation = xcm_config::UniversalLocation;
+	type BridgedNetworkId = xcm_config::RialtoNetwork;
 	type Bridges = NetworkExportTable<BridgeTable>;
 
 	type ToBridgeHubSender = xcm_config::XcmRouter;

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -55,6 +55,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+use xcm_builder::NetworkExportTable;
 
 // to be able to use Millau runtime in `bridge-runtime-common` tests
 pub use bridge_runtime_common;
@@ -546,12 +547,15 @@ impl pallet_utility::Config for Runtime {
 
 // this config is totally incorrect - the pallet is not actually used at this runtime. We need
 // it only to be able to run benchmarks and make required traits (and default weights for tests).
+parameter_types! {
+	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
+		= vec![(xcm_config::RialtoNetwork::get(), xcm_config::TokenLocation::get(), None)];
+}
 impl pallet_xcm_bridge_hub_router::Config for Runtime {
 	type WeightInfo = ();
 
 	type UniversalLocation = xcm_config::UniversalLocation;
-	type SiblingBridgeHubLocation = xcm_config::TokenLocation;
-	type BridgedNetworkId = xcm_config::RialtoNetwork;
+	type Bridges = NetworkExportTable<BridgeTable>;
 
 	type ToBridgeHubSender = xcm_config::XcmRouter;
 	type WithBridgeHubChannel = xcm_config::EmulatedSiblingXcmpChannel;

--- a/modules/xcm-bridge-hub-router/src/lib.rs
+++ b/modules/xcm-bridge-hub-router/src/lib.rs
@@ -207,7 +207,7 @@ impl<T: Config<I>, I: 'static> ExporterFor for Pallet<T, I> {
 			return None
 		};
 
-		// take `base_fee` from `T::Brides`, but have to be the same `T::FeeAsset`
+		// take `base_fee` from `T::Brides`, but it has to be the same `T::FeeAsset`
 		let base_fee = match maybe_payment {
 			Some(payment) => match payment {
 				MultiAsset { fun: Fungible(amount), id } if id.eq(&T::FeeAsset::get()) => amount,

--- a/modules/xcm-bridge-hub-router/src/mock.rs
+++ b/modules/xcm-bridge-hub-router/src/mock.rs
@@ -26,6 +26,7 @@ use sp_runtime::{
 	BuildStorage,
 };
 use xcm::prelude::*;
+use xcm_builder::NetworkExportTable;
 
 pub type AccountId = u64;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
@@ -51,6 +52,8 @@ parameter_types! {
 	pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(ThisNetworkId::get()), Parachain(1000));
 	pub SiblingBridgeHubLocation: MultiLocation = ParentThen(X1(Parachain(1002))).into();
 	pub BridgeFeeAsset: AssetId = MultiLocation::parent().into();
+	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
+		= vec![(BridgedNetworkId::get(), SiblingBridgeHubLocation::get(), None)];
 }
 
 impl frame_system::Config for TestRuntime {
@@ -83,8 +86,7 @@ impl pallet_xcm_bridge_hub_router::Config<()> for TestRuntime {
 	type WeightInfo = ();
 
 	type UniversalLocation = UniversalLocation;
-	type SiblingBridgeHubLocation = SiblingBridgeHubLocation;
-	type BridgedNetworkId = BridgedNetworkId;
+	type Bridges = NetworkExportTable<BridgeTable>;
 
 	type ToBridgeHubSender = TestToBridgeHubSender;
 	type WithBridgeHubChannel = TestWithBridgeHubChannel;

--- a/modules/xcm-bridge-hub-router/src/mock.rs
+++ b/modules/xcm-bridge-hub-router/src/mock.rs
@@ -86,6 +86,7 @@ impl pallet_xcm_bridge_hub_router::Config<()> for TestRuntime {
 	type WeightInfo = ();
 
 	type UniversalLocation = UniversalLocation;
+	type BridgedNetworkId = BridgedNetworkId;
 	type Bridges = NetworkExportTable<BridgeTable>;
 
 	type ToBridgeHubSender = TestToBridgeHubSender;

--- a/modules/xcm-bridge-hub-router/src/mock.rs
+++ b/modules/xcm-bridge-hub-router/src/mock.rs
@@ -53,7 +53,7 @@ parameter_types! {
 	pub SiblingBridgeHubLocation: MultiLocation = ParentThen(X1(Parachain(1002))).into();
 	pub BridgeFeeAsset: AssetId = MultiLocation::parent().into();
 	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)>
-		= vec![(BridgedNetworkId::get(), SiblingBridgeHubLocation::get(), None)];
+		= vec![(BridgedNetworkId::get(), SiblingBridgeHubLocation::get(), Some((BridgeFeeAsset::get(), BASE_FEE).into()))];
 }
 
 impl frame_system::Config for TestRuntime {
@@ -92,7 +92,6 @@ impl pallet_xcm_bridge_hub_router::Config<()> for TestRuntime {
 	type ToBridgeHubSender = TestToBridgeHubSender;
 	type WithBridgeHubChannel = TestWithBridgeHubChannel;
 
-	type BaseFee = ConstU128<BASE_FEE>;
 	type ByteFee = ConstU128<BYTE_FEE>;
 	type FeeAsset = BridgeFeeAsset;
 }


### PR DESCRIPTION
(Replaced `BridgedNetworkId/SiblingBridgeHubLocation` with `Bridges: ExporterFor`)

actual `ExportFor` impl for Pallet matches only bridged newtork, which is not enough,
e.g. if we use `pallet_xcm::reserve_transfer_assets` on AssetHubKusama and we set destination as polkadot-collectives `MultiLocation { parents: 2, X2(GlobalConsensus(Polkadot), Parachain(1001))}`,
nothing stops to send this message over bridge to polkadot-collectives,
so for AssetHub we need to control exactly where we allow to send assets,

so for AssetHubs few days ago I added implementation for `ExportFor` which matches also remote destination:
https://github.com/paritytech/cumulus/pull/2762/commits/5103de8d3e9ee22df559b337a94c79f6428e2eb5


**TODO:**
- [x] how to handle `maybe_payment`? subsume with `(T::FeeAsset::get(), fee)`?
- [x] fix compiling other runtimes (millau, ...) :)