### PR TITLE
Grandpa: Store the authority set changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,7 @@ dependencies = [
  "bp-header-chain",
  "bp-messages",
  "bp-runtime",
- "fixed-hash",
+ "fixed-hash 0.8.0 (git+https://github.com/paritytech/parity-common?branch=master)",
  "frame-support",
  "frame-system",
  "hash256-std-hasher",
@@ -3269,7 +3269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
@@ -3282,7 +3282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
- "fixed-hash",
+ "fixed-hash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-rlp",
  "impl-serde",
  "primitive-types",
@@ -3486,6 +3486,17 @@ name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/parity-common?branch=master#d3a9327124a66e52ca1114bb8640c02c18c134b8"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -9612,7 +9623,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-codec",
  "impl-rlp",
  "impl-serde",

--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -885,9 +885,9 @@ impl_runtime_apis! {
 			BridgeRialtoGrandpa::best_finalized()
 		}
 
-		fn accepted_grandpa_finality_proofs(
-		) -> Vec<bp_header_chain::justification::GrandpaJustification<bp_rialto::Header>> {
-			BridgeRialtoGrandpa::accepted_finality_proofs()
+		fn synced_headers_grandpa_info(
+		) -> Vec<bp_header_chain::HeaderGrandpaInfo<bp_rialto::Header>> {
+			BridgeRialtoGrandpa::synced_headers_grandpa_info()
 		}
 	}
 
@@ -896,9 +896,9 @@ impl_runtime_apis! {
 			BridgeWestendGrandpa::best_finalized()
 		}
 
-		fn accepted_grandpa_finality_proofs(
-		) -> Vec<bp_header_chain::justification::GrandpaJustification<bp_westend::Header>> {
-			BridgeWestendGrandpa::accepted_finality_proofs()
+		fn synced_headers_grandpa_info(
+		) -> Vec<bp_header_chain::HeaderGrandpaInfo<bp_westend::Header>> {
+			BridgeWestendGrandpa::synced_headers_grandpa_info()
 		}
 	}
 

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -735,9 +735,9 @@ impl_runtime_apis! {
 			BridgeMillauGrandpa::best_finalized()
 		}
 
-		fn accepted_grandpa_finality_proofs(
-		) -> Vec<bp_header_chain::justification::GrandpaJustification<bp_millau::Header>> {
-			BridgeMillauGrandpa::accepted_finality_proofs()
+		fn synced_headers_grandpa_info(
+		) -> Vec<bp_header_chain::HeaderGrandpaInfo<bp_millau::Header>> {
+			BridgeMillauGrandpa::synced_headers_grandpa_info()
 		}
 	}
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -683,9 +683,9 @@ impl_runtime_apis! {
 			BridgeMillauGrandpa::best_finalized()
 		}
 
-		fn accepted_grandpa_finality_proofs(
-		) -> Vec<bp_header_chain::justification::GrandpaJustification<bp_millau::Header>> {
-			BridgeMillauGrandpa::accepted_finality_proofs()
+		fn synced_headers_grandpa_info(
+		) -> Vec<bp_header_chain::HeaderGrandpaInfo<bp_millau::Header>> {
+			BridgeMillauGrandpa::synced_headers_grandpa_info()
 		}
 	}
 

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -38,8 +38,8 @@
 pub use storage_types::StoredAuthoritySet;
 
 use bp_header_chain::{
-	justification::GrandpaJustification, ChainWithGrandpa, GrandpaConsensusLogReader, HeaderChain,
-	InitializationData, StoredHeaderData, StoredHeaderDataBuilder,
+	justification::GrandpaJustification, AuthoritySet, ChainWithGrandpa, GrandpaConsensusLogReader,
+	HeaderChain, HeaderGrandpaInfo, InitializationData, StoredHeaderData, StoredHeaderDataBuilder,
 };
 use bp_runtime::{BlockNumberOf, HashOf, HasherOf, HeaderId, HeaderOf, OwnedBridgeModule};
 use finality_grandpa::voter_set::VoterSet;
@@ -193,11 +193,12 @@ pub mod pallet {
 			let authority_set = <CurrentAuthoritySet<T, I>>::get();
 			let unused_proof_size = authority_set.unused_proof_size();
 			let set_id = authority_set.set_id;
-			verify_justification::<T, I>(&justification, hash, number, authority_set.into())?;
+			let authority_set: AuthoritySet = authority_set.into();
+			verify_justification::<T, I>(&justification, hash, number, authority_set)?;
 
-			let is_authorities_change_enacted =
+			let maybe_new_authority_set =
 				try_enact_authority_change::<T, I>(&finality_target, set_id)?;
-			let may_refund_call_fee = is_authorities_change_enacted &&
+			let may_refund_call_fee = maybe_new_authority_set.is_some() &&
 				// if we have seen too many mandatory headers in this block, we don't want to refund
 				Self::free_mandatory_headers_remaining() > 0 &&
 				// if arguments out of expected bounds, we don't want to refund
@@ -236,7 +237,14 @@ pub mod pallet {
 			let actual_weight = pre_dispatch_weight
 				.set_proof_size(pre_dispatch_weight.proof_size().saturating_sub(unused_proof_size));
 
-			Self::deposit_event(Event::UpdatedBestFinalizedHeader { number, hash, justification });
+			Self::deposit_event(Event::UpdatedBestFinalizedHeader {
+				number,
+				hash,
+				grandpa_info: HeaderGrandpaInfo {
+					justification,
+					authority_set: maybe_new_authority_set,
+				},
+			});
 
 			Ok(PostDispatchInfo { actual_weight: Some(actual_weight), pays_fee })
 		}
@@ -403,8 +411,8 @@ pub mod pallet {
 			number: BridgedBlockNumber<T, I>,
 			/// Hash of the new best finalized header.
 			hash: BridgedBlockHash<T, I>,
-			/// Justification.
-			justification: GrandpaJustification<BridgedHeader<T, I>>,
+			/// The Grandpa info associated to the new best finalized header.
+			grandpa_info: HeaderGrandpaInfo<BridgedHeader<T, I>>,
 		},
 	}
 
@@ -440,9 +448,7 @@ pub mod pallet {
 	pub(crate) fn try_enact_authority_change<T: Config<I>, I: 'static>(
 		header: &BridgedHeader<T, I>,
 		current_set_id: sp_consensus_grandpa::SetId,
-	) -> Result<bool, sp_runtime::DispatchError> {
-		let mut change_enacted = false;
-
+	) -> Result<Option<AuthoritySet>, DispatchError> {
 		// We don't support forced changes - at that point governance intervention is required.
 		ensure!(
 			GrandpaConsensusLogReader::<BridgedBlockNumber<T, I>>::find_forced_change(
@@ -471,7 +477,6 @@ pub mod pallet {
 			// Since our header schedules a change and we know the delay is 0, it must also enact
 			// the change.
 			<CurrentAuthoritySet<T, I>>::put(&next_authorities);
-			change_enacted = true;
 
 			log::info!(
 				target: LOG_TARGET,
@@ -480,9 +485,11 @@ pub mod pallet {
 				current_set_id + 1,
 				next_authorities,
 			);
+
+			return Ok(Some(next_authorities.into()))
 		};
 
-		Ok(change_enacted)
+		Ok(None)
 	}
 
 	/// Verify a GRANDPA justification (finality proof) for a given header.
@@ -611,13 +618,13 @@ where
 	<T as frame_system::Config>::RuntimeEvent: TryInto<Event<T, I>>,
 {
 	/// Get the GRANDPA justifications accepted in the current block.
-	pub fn accepted_finality_proofs() -> Vec<GrandpaJustification<BridgedHeader<T, I>>> {
+	pub fn synced_headers_grandpa_info() -> Vec<HeaderGrandpaInfo<BridgedHeader<T, I>>> {
 		frame_system::Pallet::<T>::read_events_no_consensus()
 			.filter_map(|event| {
-				if let Event::<T, I>::UpdatedBestFinalizedHeader { justification, .. } =
+				if let Event::<T, I>::UpdatedBestFinalizedHeader { grandpa_info, .. } =
 					event.event.try_into().ok()?
 				{
-					return Some(justification)
+					return Some(grandpa_info)
 				}
 				None
 			})
@@ -928,12 +935,18 @@ mod tests {
 					event: TestEvent::Grandpa(Event::UpdatedBestFinalizedHeader {
 						number: *header.number(),
 						hash: header.hash(),
-						justification: justification.clone(),
+						grandpa_info: HeaderGrandpaInfo {
+							justification: justification.clone(),
+							authority_set: None,
+						},
 					}),
 					topics: vec![],
 				}],
 			);
-			assert_eq!(Pallet::<TestRuntime>::accepted_finality_proofs(), vec![justification]);
+			assert_eq!(
+				Pallet::<TestRuntime>::synced_headers_grandpa_info(),
+				vec![HeaderGrandpaInfo { justification, authority_set: None }]
+			);
 		})
 	}
 
@@ -1039,7 +1052,7 @@ mod tests {
 			let result = Pallet::<TestRuntime>::submit_finality_proof(
 				RuntimeOrigin::signed(1),
 				Box::new(header.clone()),
-				justification,
+				justification.clone(),
 			);
 			assert_ok!(result);
 			assert_eq!(result.unwrap().pays_fee, frame_support::dispatch::Pays::No);
@@ -1053,6 +1066,30 @@ mod tests {
 				<CurrentAuthoritySet<TestRuntime>>::get(),
 				StoredAuthoritySet::<TestRuntime, ()>::try_new(next_authorities, next_set_id)
 					.unwrap(),
+			);
+
+			// Here
+			assert_eq!(
+				System::events(),
+				vec![EventRecord {
+					phase: Phase::Initialization,
+					event: TestEvent::Grandpa(Event::UpdatedBestFinalizedHeader {
+						number: *header.number(),
+						hash: header.hash(),
+						grandpa_info: HeaderGrandpaInfo {
+							justification: justification.clone(),
+							authority_set: Some(<CurrentAuthoritySet<TestRuntime>>::get().into()),
+						},
+					}),
+					topics: vec![],
+				}],
+			);
+			assert_eq!(
+				Pallet::<TestRuntime>::synced_headers_grandpa_info(),
+				vec![HeaderGrandpaInfo {
+					justification,
+					authority_set: Some(<CurrentAuthoritySet<TestRuntime>>::get().into()),
+				}]
 			);
 		})
 	}

--- a/modules/grandpa/src/storage_types.rs
+++ b/modules/grandpa/src/storage_types.rs
@@ -20,7 +20,7 @@ use crate::{Config, Error};
 
 use bp_header_chain::{AuthoritySet, ChainWithGrandpa};
 use codec::{Decode, Encode, MaxEncodedLen};
-use frame_support::{traits::Get, BoundedVec, RuntimeDebugNoBound};
+use frame_support::{traits::Get, BoundedVec, CloneNoBound, RuntimeDebugNoBound};
 use scale_info::TypeInfo;
 use sp_consensus_grandpa::{AuthorityId, AuthorityList, AuthorityWeight, SetId};
 use sp_std::marker::PhantomData;
@@ -39,7 +39,7 @@ impl<T: Config<I>, I: 'static> Get<u32> for StoredAuthorityListLimit<T, I> {
 }
 
 /// A bounded GRANDPA Authority List and ID.
-#[derive(Clone, Decode, Encode, Eq, TypeInfo, MaxEncodedLen, RuntimeDebugNoBound)]
+#[derive(CloneNoBound, Decode, Encode, Eq, TypeInfo, MaxEncodedLen, RuntimeDebugNoBound)]
 #[scale_info(skip_type_params(T, I))]
 pub struct StoredAuthoritySet<T: Config<I>, I: 'static> {
 	/// List of GRANDPA authorities for the current round.

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -721,7 +721,7 @@ pub(crate) mod tests {
 	use bp_test_utils::prepare_parachain_heads_proof;
 	use codec::Encode;
 
-	use bp_header_chain::justification::GrandpaJustification;
+	use bp_header_chain::{justification::GrandpaJustification, HeaderGrandpaInfo};
 	use bp_parachains::{
 		BestParaHeadHash, BridgeParachainCall, ImportedParaHeadsKeyProvider, ParasInfoKeyProvider,
 	};
@@ -1060,7 +1060,10 @@ pub(crate) mod tests {
 							pallet_bridge_grandpa::Event::UpdatedBestFinalizedHeader {
 								number: 1,
 								hash: relay_1_hash,
-								justification
+								grandpa_info: HeaderGrandpaInfo {
+									justification,
+									authority_set: None,
+								},
 							}
 						),
 						topics: vec![],
@@ -1198,7 +1201,10 @@ pub(crate) mod tests {
 							pallet_bridge_grandpa::Event::UpdatedBestFinalizedHeader {
 								number: 1,
 								hash: relay_1_hash,
-								justification
+								grandpa_info: HeaderGrandpaInfo {
+									justification,
+									authority_set: None,
+								}
 							}
 						),
 						topics: vec![],
@@ -1248,7 +1254,10 @@ pub(crate) mod tests {
 							pallet_bridge_grandpa::Event::UpdatedBestFinalizedHeader {
 								number: 1,
 								hash: relay_1_hash,
-								justification: justification.clone()
+								grandpa_info: HeaderGrandpaInfo {
+									justification: justification.clone(),
+									authority_set: None,
+								}
 							}
 						),
 						topics: vec![],
@@ -1286,7 +1295,10 @@ pub(crate) mod tests {
 							pallet_bridge_grandpa::Event::UpdatedBestFinalizedHeader {
 								number: 1,
 								hash: relay_1_hash,
-								justification
+								grandpa_info: HeaderGrandpaInfo {
+									justification,
+									authority_set: None,
+								}
 							}
 						),
 						topics: vec![],

--- a/primitives/chain-millau/Cargo.toml
+++ b/primitives/chain-millau/Cargo.toml
@@ -8,6 +8,9 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 
+# TODO: Consume `fixed-hash` from crates.io when the following fix is published:
+# https://github.com/paritytech/parity-common/commit/d3a9327124a66e52ca1114bb8640c02c18c134b8
+# Expected in a version > 0.8.0
 fixed-hash = { git = "https://github.com/paritytech/parity-common", branch = "master", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 impl-codec = { version = "0.6", default-features = false }

--- a/primitives/chain-millau/Cargo.toml
+++ b/primitives/chain-millau/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 
-fixed-hash = { version = "0.8.0", default-features = false }
+fixed-hash = { git = "https://github.com/paritytech/parity-common", branch = "master", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 impl-codec = { version = "0.6", default-features = false }
 impl-serde = { version = "0.4.0", default-features = false }

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -190,6 +190,15 @@ impl<Number: Codec> ConsensusLogReader for GrandpaConsensusLogReader<Number> {
 	}
 }
 
+/// The Grandpa-related info associated to a header.
+#[derive(Encode, Decode, Debug, PartialEq, Clone, TypeInfo)]
+pub struct HeaderGrandpaInfo<Header: HeaderT> {
+	/// The header justification
+	pub justification: justification::GrandpaJustification<Header>,
+	/// The authority set introduced by the header.
+	pub authority_set: Option<AuthoritySet>,
+}
+
 /// A minimized version of `pallet-bridge-grandpa::Call` that can be used without a runtime.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
 #[allow(non_camel_case_types)]

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -306,8 +306,8 @@ macro_rules! decl_bridge_finality_runtime_apis {
 				$(
 					/// Name of the `<ThisChain>FinalityApi::accepted_<consensus>_finality_proofs`
 					/// runtime method.
-					pub const [<$chain:upper _ACCEPTED_ $consensus:upper _FINALITY_PROOFS_METHOD>]: &str =
-						stringify!([<$chain:camel FinalityApi_accepted_ $consensus:lower _finality_proofs>]);
+					pub const [<$chain:upper _SYNCED_HEADERS_ $consensus:upper _INFO_METHOD>]: &str =
+						stringify!([<$chain:camel FinalityApi_synced_headers_ $consensus:lower _info>]);
 				)?
 
 				sp_api::decl_runtime_apis! {
@@ -321,7 +321,7 @@ macro_rules! decl_bridge_finality_runtime_apis {
 
 						$(
 							/// Returns the justifications accepted in the current block.
-							fn [<accepted_ $consensus:lower _finality_proofs>](
+							fn [<synced_headers_ $consensus:lower _info>](
 							) -> Vec<$justification_type>;
 						)?
 					}
@@ -332,7 +332,7 @@ macro_rules! decl_bridge_finality_runtime_apis {
 		}
 	};
 	($chain: ident, grandpa) => {
-		decl_bridge_finality_runtime_apis!($chain, grandpa => bp_header_chain::justification::GrandpaJustification<Header>);
+		decl_bridge_finality_runtime_apis!($chain, grandpa => bp_header_chain::HeaderGrandpaInfo<Header>);
 	};
 }
 

--- a/relays/client-kusama/src/lib.rs
+++ b/relays/client-kusama/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Types used to connect to the Kusama chain.
 
-use bp_kusama::{AccountInfoStorageMapKeyProvider, KUSAMA_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD};
+use bp_kusama::{AccountInfoStorageMapKeyProvider, KUSAMA_SYNCED_HEADERS_GRANDPA_INFO_METHOD};
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
 };
@@ -48,8 +48,8 @@ impl Chain for Kusama {
 }
 
 impl ChainWithGrandpa for Kusama {
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str =
-		KUSAMA_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str =
+		KUSAMA_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 }
 
 impl ChainWithBalances for Kusama {

--- a/relays/client-millau/src/lib.rs
+++ b/relays/client-millau/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Types used to connect to the Millau-Substrate chain.
 
-use bp_millau::MILLAU_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+use bp_millau::MILLAU_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
 	BalanceOf, Chain, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
@@ -58,8 +58,8 @@ impl Chain for Millau {
 }
 
 impl ChainWithGrandpa for Millau {
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str =
-		MILLAU_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str =
+		MILLAU_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 }
 
 impl ChainWithBalances for Millau {

--- a/relays/client-polkadot/src/lib.rs
+++ b/relays/client-polkadot/src/lib.rs
@@ -16,9 +16,7 @@
 
 //! Types used to connect to the Polkadot chain.
 
-use bp_polkadot::{
-	AccountInfoStorageMapKeyProvider, POLKADOT_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD,
-};
+use bp_polkadot::{AccountInfoStorageMapKeyProvider, POLKADOT_SYNCED_HEADERS_GRANDPA_INFO_METHOD};
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
 };
@@ -50,8 +48,8 @@ impl Chain for Polkadot {
 }
 
 impl ChainWithGrandpa for Polkadot {
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str =
-		POLKADOT_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str =
+		POLKADOT_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 }
 
 impl ChainWithBalances for Polkadot {

--- a/relays/client-rialto/src/lib.rs
+++ b/relays/client-rialto/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Types used to connect to the Rialto-Substrate chain.
 
-use bp_rialto::RIALTO_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+use bp_rialto::RIALTO_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 use codec::{Compact, Decode, Encode};
 use relay_substrate_client::{
 	BalanceOf, Chain, ChainWithBalances, ChainWithGrandpa, ChainWithMessages,
@@ -49,8 +49,8 @@ impl Chain for Rialto {
 }
 
 impl ChainWithGrandpa for Rialto {
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str =
-		RIALTO_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str =
+		RIALTO_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 }
 
 impl RelayChain for Rialto {

--- a/relays/client-rococo/src/lib.rs
+++ b/relays/client-rococo/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Types used to connect to the Rococo-Substrate chain.
 
-use bp_rococo::ROCOCO_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+use bp_rococo::ROCOCO_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
 };
@@ -48,8 +48,8 @@ impl Chain for Rococo {
 }
 
 impl ChainWithGrandpa for Rococo {
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str =
-		ROCOCO_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str =
+		ROCOCO_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 }
 
 impl ChainWithBalances for Rococo {

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -80,12 +80,12 @@ pub trait RelayChain: Chain {
 /// Keep in mind that parachains are relying on relay chain GRANDPA, so they should not implement
 /// this trait.
 pub trait ChainWithGrandpa: Chain + UnderlyingChainWithGrandpaProvider {
-	/// Name of the runtime API method that is returning the GRANDPA justifications accepted
-	/// by the `submit_finality_proofs` extrinsic in the queried block.
+	/// Name of the runtime API method that is returning the GRANDPA info associated with the
+	/// headers accepted by the `submit_finality_proofs` extrinsic in the queried block.
 	///
 	/// Keep in mind that this method is normally provided by the other chain, which is
 	/// bridged with this chain.
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str;
 }
 
 /// Substrate-based parachain from minimal relay-client point of view.

--- a/relays/client-westend/src/lib.rs
+++ b/relays/client-westend/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Types used to connect to the Westend chain.
 
-use bp_westend::WESTEND_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+use bp_westend::WESTEND_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
 };
@@ -48,8 +48,8 @@ impl Chain for Westend {
 }
 
 impl ChainWithGrandpa for Westend {
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str =
-		WESTEND_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str =
+		WESTEND_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 }
 
 impl RelayChain for Westend {

--- a/relays/client-wococo/src/lib.rs
+++ b/relays/client-wococo/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Types used to connect to the Wococo-Substrate chain.
 
-use bp_wococo::WOCOCO_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+use bp_wococo::WOCOCO_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithGrandpa, RelayChain, UnderlyingChainProvider,
 };
@@ -48,8 +48,8 @@ impl Chain for Wococo {
 }
 
 impl ChainWithGrandpa for Wococo {
-	const ACCEPTED_FINALITY_PROOFS_METHOD: &'static str =
-		WOCOCO_ACCEPTED_GRANDPA_FINALITY_PROOFS_METHOD;
+	const SYNCED_HEADERS_GRANDPA_INFO_METHOD: &'static str =
+		WOCOCO_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 }
 
 impl ChainWithBalances for Wococo {


### PR DESCRIPTION
Related to #2296

Together with each justification we have to also store the authority set that verified it. Otherwise, if multiple justifications that enact an authority set change are accepted in the same block via `submit_finality_proof()`, we can only check for equivocations the justifications before the first authority set change.