### PR TITLE
Try dependabot for multiple branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,6 @@ updates:
     versions:
     - ">= 0"
   rebase-strategy: disabled
+  target-branch:
+    - "master"
+    - "polkadot-staging"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,65 @@ updates:
     versions:
     - ">= 0"
   rebase-strategy: disabled
-  target-branch:
-    - "master"
-    - "polkadot-staging"
+  target-branch: "master"
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"
+    timezone: Europe/Berlin
+  open-pull-requests-limit: 20
+  ignore:
+  # Substrate (+ Polkadot/Cumulus pallets) dependencies
+  - dependency-name: beefy-*
+    versions:
+    - ">= 0"
+  - dependency-name: frame-*
+    versions:
+    - ">= 0"
+  - dependency-name: fork-tree
+    versions:
+    - ">= 0"
+  - dependency-name: mmr-*
+    versions:
+    - ">= 0"
+  - dependency-name: node-inspect
+    versions:
+    - ">= 0"
+  - dependency-name: pallet-*
+    versions:
+    - ">= 0"
+  - dependency-name: sc-*
+    versions:
+    - ">= 0"
+  - dependency-name: sp-*
+    versions:
+    - ">= 0"
+  - dependency-name: substrate-*
+    versions:
+    - ">= 0"
+  - dependency-name: try-runtime-cli
+    versions:
+    - ">= 0"
+  - dependency-name: binary-merkle-tree
+    versions:
+    - ">= 0"
+  # Polkadot dependencies
+  - dependency-name: kusama-*
+    versions:
+    - ">= 0"
+  - dependency-name: polkadot-*
+    versions:
+    - ">= 0"
+  - dependency-name: xcm*
+    versions:
+    - ">= 0"
+  # Cumulus dependencies
+  - dependency-name: cumulus-*
+    versions:
+    - ">= 0"
+  - dependency-name: parachain-info
+    versions:
+    - ">= 0"
+  rebase-strategy: disabled
+  target-branch: "polkadot-staging"


### PR DESCRIPTION
related to https://github.com/paritytech/parity-bridges-common/issues/2399
ref: https://github.com/dependabot/dependabot-core/issues/2159 + https://github.com/dependabot/dependabot-core/issues/2511

Not sure if that will work, so probably someone from @paritytech/ci could check. What we need is to run dependabot for two branches - `master` and `polkadot-staging`  to avoid manually cherry-picking updates. I was thinking about adding two values to `target-branch`, but https://github.com/dependabot/dependabot-core/issues/2511. So duplication seems like the only option. However I'm not sure if it works (there are some comments that say it works and other saying it does not).