### PR TITLE
Backport latest relevant dynamic fees changes from v1 to v2

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -55,6 +55,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+use xcm_builder::NetworkExportTable;
 
 // to be able to use Millau runtime in `bridge-runtime-common` tests
 pub use bridge_runtime_common;
@@ -529,17 +530,27 @@ impl pallet_utility::Config for Runtime {
 
 // this config is totally incorrect - the pallet is not actually used at this runtime. We need
 // it only to be able to run benchmarks and make required traits (and default weights for tests).
+
+parameter_types! {
+	pub BridgeTable: Vec<(xcm::prelude::NetworkId, xcm::prelude::MultiLocation, Option<xcm::prelude::MultiAsset>)>
+		= vec![(
+			xcm_config::RialtoNetwork::get(),
+			xcm_config::TokenLocation::get(),
+			Some((xcm_config::TokenAssetId::get(), 1_000_000_000_u128).into()),
+		)];
+}
+
 impl pallet_xcm_bridge_hub_router::Config for Runtime {
 	type WeightInfo = ();
 
 	type UniversalLocation = xcm_config::UniversalLocation;
 	type SiblingBridgeHubLocation = xcm_config::TokenLocation;
 	type BridgedNetworkId = xcm_config::RialtoNetwork;
+	type Bridges = NetworkExportTable<BridgeTable>;
 
 	type ToBridgeHubSender = xcm_config::XcmRouter;
 	type LocalXcmChannelManager = xcm_config::EmulatedSiblingXcmpChannel;
 
-	type BaseFee = ConstU128<1_000_000_000>;
 	type ByteFee = ConstU128<1_000>;
 	type FeeAsset = xcm_config::TokenAssetId;
 }

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -416,7 +416,7 @@ pub mod pallet {
 			// notify others about messages delivery
 			T::OnMessagesDelivered::on_messages_delivered(
 				lane_id,
-				lane.queued_messages().checked_len().unwrap_or(0),
+				lane.queued_messages().saturating_len(),
 			);
 
 			// because of lags, the inbound lane state (`lane_data`) may have entries for

--- a/modules/xcm-bridge-hub-router/src/benchmarking.rs
+++ b/modules/xcm-bridge-hub-router/src/benchmarking.rs
@@ -18,7 +18,7 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
-use crate::{DeliveryFeeFactor, InitialFactor};
+use crate::{DeliveryFeeFactor, InitialFactor, MINIMAL_DELIVERY_FEE_FACTOR};
 
 use frame_benchmarking::benchmarks_instance_pallet;
 use frame_support::traits::{Get, Hooks};
@@ -35,13 +35,13 @@ pub trait Config<I: 'static>: crate::Config<I> {
 
 benchmarks_instance_pallet! {
 	on_initialize_when_non_congested {
-		DeliveryFeeFactor::<T, I>::put(InitialFactor::get() + InitialFactor::get());
+		DeliveryFeeFactor::<T, I>::put(MINIMAL_DELIVERY_FEE_FACTOR + MINIMAL_DELIVERY_FEE_FACTOR);
 	}: {
 		crate::Pallet::<T, I>::on_initialize(Zero::zero())
 	}
 
 	on_initialize_when_congested {
-		DeliveryFeeFactor::<T, I>::put(InitialFactor::get() + InitialFactor::get());
+		DeliveryFeeFactor::<T, I>::put(MINIMAL_DELIVERY_FEE_FACTOR + MINIMAL_DELIVERY_FEE_FACTOR);
 		T::make_congested();
 	}: {
 		crate::Pallet::<T, I>::on_initialize(Zero::zero())

--- a/modules/xcm-bridge-hub-router/src/lib.rs
+++ b/modules/xcm-bridge-hub-router/src/lib.rs
@@ -114,7 +114,7 @@ pub mod pallet {
 				return T::WeightInfo::on_initialize_when_congested()
 			}
 
-			// if bridge has reported congestion, we don't change anything
+			// if we can't decrease the delivery fee factor anymore, we don't change anything
 			let mut delivery_fee_factor = Self::delivery_fee_factor();
 			if delivery_fee_factor == MINIMAL_DELIVERY_FEE_FACTOR {
 				return T::WeightInfo::on_initialize_when_congested()

--- a/modules/xcm-bridge-hub-router/src/mock.rs
+++ b/modules/xcm-bridge-hub-router/src/mock.rs
@@ -26,6 +26,7 @@ use sp_runtime::{
 	BuildStorage,
 };
 use xcm::prelude::*;
+use xcm_builder::NetworkExportTable;
 
 pub type AccountId = u64;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
@@ -51,6 +52,11 @@ parameter_types! {
 	pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(ThisNetworkId::get()), Parachain(1000));
 	pub SiblingBridgeHubLocation: MultiLocation = ParentThen(X1(Parachain(1002))).into();
 	pub BridgeFeeAsset: AssetId = MultiLocation::parent().into();
+	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)> = vec![(
+		BridgedNetworkId::get(),
+		SiblingBridgeHubLocation::get(),
+		Some((BridgeFeeAsset::get(), BASE_FEE).into()),
+	)];
 }
 
 impl frame_system::Config for TestRuntime {
@@ -85,11 +91,11 @@ impl pallet_xcm_bridge_hub_router::Config<()> for TestRuntime {
 	type UniversalLocation = UniversalLocation;
 	type SiblingBridgeHubLocation = SiblingBridgeHubLocation;
 	type BridgedNetworkId = BridgedNetworkId;
+	type Bridges = NetworkExportTable<BridgeTable>;
 
 	type ToBridgeHubSender = TestToBridgeHubSender;
 	type LocalXcmChannelManager = TestLocalXcmChannelManager;
 
-	type BaseFee = ConstU128<BASE_FEE>;
 	type ByteFee = ConstU128<BYTE_FEE>;
 	type FeeAsset = BridgeFeeAsset;
 }


### PR DESCRIPTION
follow up for #2371 

This PR backports all relevant dynamic fees changes from `polkadot-staging`. Relevant means that we are still not sending XCM messages to the source chain to pause the bridge and will be relying on #2324 in the future.

One change to `polkadot-staging` is that I've reverted removal of `SiblingBridgeHubLocation` from `pallet-xcm-bridge-hub-router` config, because it is required now to check whether the channel is congested or no. This must also be revisited in a context of #2358 - maybe we'll need to remove this `BridgeTable` at all in v2.