### PR TITLE
Pre-support logical HRMP channels in pallet-xcm-bridge-hub-router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-xcm-bridge-hub-router"
+version = "0.1.0"
+dependencies = [
+ "bp-xcm-bridge-hub",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
 dependencies = [
@@ -7977,7 +7987,7 @@ dependencies = [
 name = "pallet-xcm-bridge-hub-router"
 version = "0.1.0"
 dependencies = [
- "bp-xcm-bridge-hub",
+ "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
 	"primitives/runtime",
 	"primitives/test-utils",
 	"primitives/xcm-bridge-hub",
+	"primitives/xcm-bridge-hub-router",
 	"relays/bin-substrate",
 	"relays/client-bridge-hub-kusama",
 	"relays/client-bridge-hub-polkadot",

--- a/modules/xcm-bridge-hub-router/Cargo.toml
+++ b/modules/xcm-bridge-hub-router/Cargo.toml
@@ -13,7 +13,7 @@ scale-info = { version = "2.8.0", default-features = false, features = ["bit-vec
 
 # Bridge dependencies
 
-bp-xcm-bridge-hub = { path = "../../primitives/xcm-bridge-hub", default-features = false }
+bp-xcm-bridge-hub-router = { path = "../../primitives/xcm-bridge-hub-router", default-features = false }
 
 # Substrate Dependencies
 
@@ -36,7 +36,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "master" }
 [features]
 default = ["std"]
 std = [
-	"bp-xcm-bridge-hub/std",
+	"bp-xcm-bridge-hub-router/std",
 	"codec/std",
 	"frame-benchmarking/std",
 	"frame-support/std",

--- a/modules/xcm-bridge-hub-router/src/mock.rs
+++ b/modules/xcm-bridge-hub-router/src/mock.rs
@@ -18,15 +18,14 @@
 
 use crate as pallet_xcm_bridge_hub_router;
 
-use bp_xcm_bridge_hub::{BridgeId, LocalXcmChannelManager};
+use bp_xcm_bridge_hub_router::{BridgeId, LocalXcmChannelManager};
 use frame_support::{construct_runtime, parameter_types};
-use sp_core::H256;
+use sp_core::{ConstU32, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, ConstU128, IdentityLookup},
 	BuildStorage,
 };
 use xcm::prelude::*;
-use xcm_builder::NetworkExportTable;
 
 pub type AccountId = u64;
 type Block = frame_system::mocking::MockBlock<TestRuntime>;
@@ -52,11 +51,6 @@ parameter_types! {
 	pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(ThisNetworkId::get()), Parachain(1000));
 	pub SiblingBridgeHubLocation: MultiLocation = ParentThen(X1(Parachain(1002))).into();
 	pub BridgeFeeAsset: AssetId = MultiLocation::parent().into();
-	pub BridgeTable: Vec<(NetworkId, MultiLocation, Option<MultiAsset>)> = vec![(
-		BridgedNetworkId::get(),
-		SiblingBridgeHubLocation::get(),
-		Some((BridgeFeeAsset::get(), BASE_FEE).into()),
-	)];
 }
 
 impl frame_system::Config for TestRuntime {
@@ -88,14 +82,16 @@ impl frame_system::Config for TestRuntime {
 impl pallet_xcm_bridge_hub_router::Config<()> for TestRuntime {
 	type WeightInfo = ();
 
+	type MaxSuspendedBridges = ConstU32<1>;
+
 	type UniversalLocation = UniversalLocation;
 	type SiblingBridgeHubLocation = SiblingBridgeHubLocation;
 	type BridgedNetworkId = BridgedNetworkId;
-	type Bridges = NetworkExportTable<BridgeTable>;
 
 	type ToBridgeHubSender = TestToBridgeHubSender;
 	type LocalXcmChannelManager = TestLocalXcmChannelManager;
 
+	type BaseFee = ConstU128<BASE_FEE>;
 	type ByteFee = ConstU128<BYTE_FEE>;
 	type FeeAsset = BridgeFeeAsset;
 }

--- a/modules/xcm-bridge-hub/src/exporter.rs
+++ b/modules/xcm-bridge-hub/src/exporter.rs
@@ -165,8 +165,8 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		// check if the lane is already suspended. If it is, do nothing. We still accept new
 		// messages to the suspended bridge, hoping that it'll be actually suspended soon
-		let is_already_congested = SuspendedBridges::<T, I>::get().contains(&locations.bridge_id);
-		if is_already_congested {
+		let is_already_suspended = SuspendedBridges::<T, I>::get().contains(&locations.bridge_id);
+		if is_already_suspended {
 			return
 		}
 

--- a/primitives/xcm-bridge-hub-router/Cargo.toml
+++ b/primitives/xcm-bridge-hub-router/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bp-xcm-bridge-hub-router"
+description = "Primitives of the pallet-xcm-bridge-hub-router."
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6.0", default-features = false, features = ["derive"] }
+
+# Bridge Dependencies
+
+bp-xcm-bridge-hub = { path = "../xcm-bridge-hub", default-features = false }
+
+# Substrate Dependencies
+
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"bp-xcm-bridge-hub/std",
+	"sp-runtime/std",
+]

--- a/primitives/xcm-bridge-hub-router/src/lib.rs
+++ b/primitives/xcm-bridge-hub-router/src/lib.rs
@@ -1,0 +1,35 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Primitives of the `pallet-xcm-bridge-hub-router` pallet.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_runtime::{FixedU128, RuntimeDebug};
+
+pub use bp_xcm_bridge_hub::{
+	bridge_id_from_locations, bridge_locations, BridgeId, LocalXcmChannelManager,
+};
+
+/// All required bridge details, known to the chain that uses XCM bridge hub for
+/// sending messages.
+#[derive(Clone, Decode, Encode, Eq, PartialEq, TypeInfo, MaxEncodedLen, RuntimeDebug)]
+pub struct Bridge {
+	/// The number to multiply the base delivery fee by.
+	pub delivery_fee_factor: FixedU128,
+}

--- a/primitives/xcm-bridge-hub/src/lib.rs
+++ b/primitives/xcm-bridge-hub/src/lib.rs
@@ -266,9 +266,9 @@ pub fn bridge_locations(
 	// `GlobalConsensus` and we know that the `bridge_origin_universal_location`
 	// is also within the `GlobalConsensus`. So we know that the lane id will be
 	// the same on both ends of the bridge
-	let bridge_id = BridgeId::new(
-		&bridge_origin_universal_location.into(),
-		&bridge_destination_universal_location.into(),
+	let bridge_id = bridge_id_from_locations(
+		&bridge_origin_universal_location,
+		&bridge_destination_universal_location,
 	);
 
 	Ok(Box::new(BridgeLocations {
@@ -277,6 +277,17 @@ pub fn bridge_locations(
 		bridge_destination_universal_location,
 		bridge_id,
 	}))
+}
+
+/// Return `BridgeId` for bridge between two universal XCM locations.
+pub fn bridge_id_from_locations(
+	bridge_origin_universal_location: &InteriorMultiLocation,
+	bridge_destination_universal_location: &InteriorMultiLocation,
+) -> BridgeId {
+	BridgeId::new(
+		&(*bridge_origin_universal_location).into(),
+		&(*bridge_destination_universal_location).into(),
+	)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
part of #2391 that may be implemented in our repo

This PR should add:
- [ ] the per-bridge delivery fee factor - now all bridges using the same `pallet-xcm-bridge-hub-router` instance are sharing the same fee factor. Logical HRMP channels should solve that, so it'd be better to have different fee factors for different bridges;
- [ ] outbound messages queue to the `pallet-xcm-bridge-hub-router`, where messages are saved when the bridge is suspended;
- [ ] code to serve outbound messages queue from `on_idle` when the bridge is resumed.

Opening it early for visibility + maybe someone would propose better solution for problems that I've met (will leave comments).