### PR TITLE
Remove pallet_xcm_bridge_hub::SuspendedBridges

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -565,7 +565,6 @@ impl pallet_xcm_bridge_hub::Config<WithRialtoXcmBridgeHubInstance> for Runtime {
 	type BridgedNetworkId = xcm_config::RialtoNetwork;
 	type BridgeMessagesPalletInstance = WithRialtoMessagesInstance;
 
-	type MaxSuspendedBridges = ConstU32<1>;
 	type OpenBridgeOrigin = frame_support::traits::NeverEnsureOrigin<xcm::latest::MultiLocation>;
 	type BridgeOriginAccountIdConverter = xcm_config::SovereignAccountOf;
 
@@ -587,7 +586,6 @@ impl pallet_xcm_bridge_hub::Config<WithRialtoParachainXcmBridgeHubInstance> for 
 	type BridgedNetworkId = xcm_config::RialtoParachainNetwork;
 	type BridgeMessagesPalletInstance = WithRialtoParachainMessagesInstance;
 
-	type MaxSuspendedBridges = ConstU32<1>;
 	type OpenBridgeOrigin = frame_support::traits::NeverEnsureOrigin<xcm::latest::MultiLocation>;
 	type BridgeOriginAccountIdConverter = xcm_config::SovereignAccountOf;
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -454,7 +454,6 @@ impl pallet_xcm_bridge_hub::Config<WithMillauXcmBridgeHubInstance> for Runtime {
 	type BridgedNetworkId = xcm_config::MillauNetwork;
 	type BridgeMessagesPalletInstance = WithMillauMessagesInstance;
 
-	type MaxSuspendedBridges = ConstU32<1>;
 	type OpenBridgeOrigin = frame_support::traits::NeverEnsureOrigin<xcm::latest::MultiLocation>;
 	type BridgeOriginAccountIdConverter = xcm_config::SovereignAccountOf;
 

--- a/bin/rialto/runtime/src/xcm_config.rs
+++ b/bin/rialto/runtime/src/xcm_config.rs
@@ -195,13 +195,15 @@ impl pallet_xcm::Config for Runtime {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{WithMillauMessagesInstance, XcmMillauBridgeHub};
+	use crate::{WithMillauMessagesInstance, WithMillauXcmBridgeHubInstance, XcmMillauBridgeHub};
 	use bp_messages::{
 		target_chain::{DispatchMessage, DispatchMessageData, MessageDispatch},
 		MessageKey, OutboundLaneData,
 	};
+	use bp_xcm_bridge_hub::{Bridge, BridgeState};
 	use codec::Encode;
 	use pallet_bridge_messages::OutboundLanes;
+	use pallet_xcm_bridge_hub::Bridges;
 	use sp_runtime::BuildStorage;
 	use xcm_executor::XcmExecutor;
 
@@ -224,7 +226,17 @@ mod tests {
 	fn xcm_messages_to_millau_are_sent_using_bridge_exporter() {
 		new_test_ext().execute_with(|| {
 			// ensure that the there are no messages queued
-			let lane_id = crate::millau_messages::Bridge::get().lane_id();
+			let bridge_id = crate::millau_messages::Bridge::get();
+			let lane_id = bridge_id.lane_id();
+			Bridges::<Runtime, WithMillauXcmBridgeHubInstance>::insert(
+				bridge_id,
+				Bridge {
+					bridge_origin_relative_location: Box::new(MultiLocation::new(0, Here).into()),
+					state: BridgeState::Opened,
+					bridge_owner_account: [0u8; 32].into(),
+					reserve: 0,
+				},
+			);
 			OutboundLanes::<Runtime, WithMillauMessagesInstance>::insert(
 				lane_id,
 				OutboundLaneData::opened(),

--- a/modules/xcm-bridge-hub/src/exporter.rs
+++ b/modules/xcm-bridge-hub/src/exporter.rs
@@ -159,8 +159,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 		// check if the lane is already suspended. If it is, do nothing. We still accept new
 		// messages to the suspended bridge, hoping that it'll be actually suspended soon
-		let is_already_suspended = bridge.state == BridgeState::Suspended;
-		if is_already_suspended {
+		if bridge.state == BridgeState::Suspended {
 			return
 		}
 

--- a/modules/xcm-bridge-hub/src/lib.rs
+++ b/modules/xcm-bridge-hub/src/lib.rs
@@ -70,6 +70,7 @@ use xcm_builder::DispatchBlob;
 use xcm_executor::traits::ConvertLocation;
 
 pub use dispatcher::XcmBlobMessageDispatchResult;
+pub use exporter::PalletAsHaulBlobExporter;
 pub use pallet::*;
 
 mod dispatcher;
@@ -105,10 +106,6 @@ pub mod pallet {
 		/// Associated messages pallet instance that bridges us with the
 		/// `BridgedNetworkId` consensus.
 		type BridgeMessagesPalletInstance: 'static;
-
-		/// Maximal number of suspended bridges.
-		#[pallet::constant]
-		type MaxSuspendedBridges: Get<u32>;
 
 		/// A set of XCM locations within local consensus system that are allowed to open
 		/// bridges with remote destinations.
@@ -323,10 +320,6 @@ pub mod pallet {
 			inbound_lane.purge();
 			outbound_lane.purge();
 			Bridges::<T, I>::remove(locations.bridge_id);
-			SuspendedBridges::<T, I>::mutate(|suspended_bridges| {
-				suspended_bridges.retain(|b| *b != locations.bridge_id);
-				// TODO: https://github.com/paritytech/parity-bridges-common/issues/2006 send resume signal or not???
-			});
 
 			// unreserve remaining amount
 			let failed_to_unreserve =
@@ -399,12 +392,6 @@ pub mod pallet {
 	#[pallet::getter(fn bridge)]
 	pub type Bridges<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Identity, BridgeId, BridgeOf<T, I>>;
-
-	/// All currently suspended bridges.
-	#[pallet::storage]
-	#[pallet::getter(fn suspended_bridges)]
-	pub type SuspendedBridges<T: Config<I>, I: 'static = ()> =
-		StorageValue<_, BoundedVec<BridgeId, T::MaxSuspendedBridges>, ValueQuery>;
 
 	#[pallet::genesis_config]
 	#[derive(DefaultNoBound)]

--- a/modules/xcm-bridge-hub/src/mock.rs
+++ b/modules/xcm-bridge-hub/src/mock.rs
@@ -174,7 +174,6 @@ parameter_types! {
 		GlobalConsensus(RelayNetwork::get()),
 		Parachain(THIS_BRIDGE_HUB_ID),
 	);
-	pub const MaxSuspendedBridges: u32 = 2;
 	pub const Penalty: Balance = 1_000;
 }
 
@@ -264,7 +263,6 @@ impl pallet_xcm_bridge_hub::Config for TestRuntime {
 	type BridgedNetworkId = BridgedRelayNetwork;
 	type BridgeMessagesPalletInstance = ();
 
-	type MaxSuspendedBridges = MaxSuspendedBridges;
 	type OpenBridgeOrigin = OpenBridgeOrigin;
 	type BridgeOriginAccountIdConverter = LocationToAccountId;
 

--- a/primitives/xcm-bridge-hub/src/lib.rs
+++ b/primitives/xcm-bridge-hub/src/lib.rs
@@ -140,6 +140,11 @@ impl LocalXcmChannelManager for () {
 pub enum BridgeState {
 	/// Bridge is opened. Associated lanes are also opened.
 	Opened,
+	/// Bridge is suspended. Associated lanes are opened.
+	///
+	/// We keep accepting messages to the bridge. The only difference with the `Opened` state
+	/// is that we have sent the "Suspended" message/signal to the local bridge origin.
+	Suspended,
 	/// Bridge is closed. Associated lanes are also closed.
 	/// After all outbound messages will be pruned, the bridge will vanish without any traces.
 	Closed,

--- a/relays/bin-substrate/src/chains/millau.rs
+++ b/relays/bin-substrate/src/chains/millau.rs
@@ -37,7 +37,10 @@ impl CliEncodeMessage for Millau {
 			anyhow::format_err!("Unsupported target chain: {:?}", target)
 		);
 
-		Ok(millau_runtime::xcm_config::ToRialtoOrRialtoParachainSwitchExporter::validate(
+		Ok(pallet_xcm_bridge_hub::PalletAsHaulBlobExporter::<
+			millau_runtime::Runtime,
+			millau_runtime::WithRialtoXcmBridgeHubInstance,
+		>::validate(
 			target,
 			0,
 			&mut Some(Self::dummy_universal_source()?),
@@ -46,8 +49,7 @@ impl CliEncodeMessage for Millau {
 		)
 		.map_err(|e| anyhow::format_err!("Failed to prepare outbound message: {:?}", e))?
 		.0
-		 .1
-		 .1)
+		 .0)
 	}
 
 	fn encode_execute_xcm(

--- a/relays/bin-substrate/src/chains/rialto.rs
+++ b/relays/bin-substrate/src/chains/rialto.rs
@@ -33,7 +33,7 @@ impl CliEncodeMessage for Rialto {
 			anyhow::format_err!("Unsupported target chain: {:?}", target)
 		);
 
-		Ok(pallet_xcm_bridge_hub::Pallet::<
+		Ok(pallet_xcm_bridge_hub::PalletAsHaulBlobExporter::<
 			rialto_runtime::Runtime,
 			rialto_runtime::WithMillauXcmBridgeHubInstance,
 		>::validate(
@@ -45,7 +45,7 @@ impl CliEncodeMessage for Rialto {
 		)
 		.map_err(|e| anyhow::format_err!("Failed to prepare outbound message: {:?}", e))?
 		.0
-		 .1)
+		 .0)
 	}
 
 	fn encode_execute_xcm(

--- a/relays/bin-substrate/src/chains/rialto_parachain.rs
+++ b/relays/bin-substrate/src/chains/rialto_parachain.rs
@@ -33,7 +33,7 @@ impl CliEncodeMessage for RialtoParachain {
 			anyhow::format_err!("Unsupported target chain: {:?}", target)
 		);
 
-		Ok(pallet_xcm_bridge_hub::Pallet::<
+		Ok(pallet_xcm_bridge_hub::PalletAsHaulBlobExporter::<
 			rialto_parachain_runtime::Runtime,
 			rialto_parachain_runtime::WithMillauXcmBridgeHubInstance,
 		>::validate(
@@ -45,7 +45,7 @@ impl CliEncodeMessage for RialtoParachain {
 		)
 		.map_err(|e| anyhow::format_err!("Failed to prepare outbound message: {:?}", e))?
 		.0
-		 .1)
+		 .0)
 	}
 
 	fn encode_execute_xcm(


### PR DESCRIPTION
while working on #2501, I've realized that we no longer need to iterate over suspended bridges in the `pallet_xcm_bridge_hub`. It was required at some point in the past (during that dynamic-fees v1/v2 mess). So we can avoid this storage vec at all by just adding `Suspended` state.