### PR TITLE
Backport: building images from locally built binaries

### DIFF
--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,0 +1,49 @@
+# Builds images used by the bridge using locally built binaries.
+#
+# In particular, it can be used to build Substrate nodes and bridge relayers. The binary that gets
+# built can be specified with the `PROJECT` build-arg. For example, to build the `substrate-relay`
+# you would do the following:
+#
+# `docker build . -f local.Dockerfile -t local/substrate-relay --build-arg=PROJECT=substrate-relay`
+#
+# See the `deployments/README.md` for all the available `PROJECT` values.
+#
+# You may use `scripts/build-containers.sh` to build all binaries and images at once.
+
+# This image needs to be binary compatible with the host machine (where images are built).
+FROM docker.io/library/ubuntu:20.04 as runtime
+
+USER root
+WORKDIR /home/root
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
+        curl ca-certificates libssl-dev && \
+    update-ca-certificates && \
+	groupadd -g 1001 user && \
+	useradd -u 1001 -g user -s /bin/sh -m user && \
+	# apt clean up
+	apt-get autoremove -y && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+# switch to non-root user
+USER user
+
+WORKDIR /home/user
+
+ARG PROFILE=release
+ARG PROJECT=substrate-relay
+
+COPY --chown=user:user ./target/${PROFILE}/${PROJECT} ./
+
+# check if executable works in this container
+RUN ./${PROJECT} --version
+
+ENV PROJECT=$PROJECT
+ENTRYPOINT ["/bin/sh"]

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -11,7 +11,8 @@
 # You may use `scripts/build-containers.sh` to build all binaries and images at once.
 
 # This image needs to be binary compatible with the host machine (where images are built).
-FROM docker.io/library/ubuntu:20.04 as runtime
+ARG UBUNTU_RELEASE=20.04
+FROM docker.io/library/ubuntu:${UBUNTU_RELEASE} as runtime
 
 USER root
 WORKDIR /home/root

--- a/local.Dockerfile.dockerignore
+++ b/local.Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+# This file only works for `local.Dockerfile` when docker buildkit is used (see ./scripts/build-containers.sh for details)
+*
+!target/release/millau-bridge-node
+!target/release/rialto-bridge-node
+!target/release/rialto-parachain-collator
+!target/release/substrate-relay

--- a/scripts/build-containers.sh
+++ b/scripts/build-containers.sh
@@ -1,7 +1,22 @@
 #!/bin/sh
 set -eux
 
-time docker build . -t local/substrate-relay --build-arg=PROJECT=substrate-relay
-time docker build . -t local/rialto-bridge-node --build-arg=PROJECT=rialto-bridge-node
-time docker build . -t local/millau-bridge-node --build-arg=PROJECT=millau-bridge-node
-time docker build . -t local/rialto-parachain-collator --build-arg=PROJECT=rialto-parachain-collator
+if [ -z "${LOCAL:-}" ]; then
+    time docker build . -t local/substrate-relay --build-arg=PROJECT=substrate-relay
+    time docker build . -t local/rialto-bridge-node --build-arg=PROJECT=rialto-bridge-node
+    time docker build . -t local/millau-bridge-node --build-arg=PROJECT=millau-bridge-node
+    time docker build . -t local/rialto-parachain-collator --build-arg=PROJECT=rialto-parachain-collator
+else
+    if [ -z "${SKIP_BUILD:-}" ]; then
+        time cargo build -p substrate-relay --release
+        time cargo build -p rialto-bridge-node --release
+        time cargo build -p millau-bridge-node --release
+        time cargo build -p rialto-parachain-collator --release
+    fi
+
+    # following (using DOCKER_BUILDKIT) requires docker 19.03 or above
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/substrate-relay --build-arg=PROJECT=substrate-relay
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-bridge-node --build-arg=PROJECT=rialto-bridge-node
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/millau-bridge-node --build-arg=PROJECT=millau-bridge-node
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-parachain-collator --build-arg=PROJECT=rialto-parachain-collator
+fi

--- a/scripts/build-containers.sh
+++ b/scripts/build-containers.sh
@@ -8,10 +8,7 @@ if [ -z "${LOCAL:-}" ]; then
     time docker build . -t local/rialto-parachain-collator --build-arg=PROJECT=rialto-parachain-collator
 else
     if [ -z "${SKIP_BUILD:-}" ]; then
-        time cargo build -p substrate-relay --release
-        time cargo build -p rialto-bridge-node --release
-        time cargo build -p millau-bridge-node --release
-        time cargo build -p rialto-parachain-collator --release
+        time cargo build -p substrate-relay -p rialto-bridge-node -p millau-bridge-node -p rialto-parachain-collator --release
     fi
 
     # (try to) use docker image matching the host os

--- a/scripts/build-containers.sh
+++ b/scripts/build-containers.sh
@@ -14,9 +14,20 @@ else
         time cargo build -p rialto-parachain-collator --release
     fi
 
+    # (try to) use docker image matching the host os
+    export UBUNTU_RELEASE=`lsb_release -r -s`
+
     # following (using DOCKER_BUILDKIT) requires docker 19.03 or above
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/substrate-relay --build-arg=PROJECT=substrate-relay
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-bridge-node --build-arg=PROJECT=rialto-bridge-node
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/millau-bridge-node --build-arg=PROJECT=millau-bridge-node
-    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-parachain-collator --build-arg=PROJECT=rialto-parachain-collator
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/substrate-relay \
+        --build-arg=PROJECT=substrate-relay \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-bridge-node \
+        --build-arg=PROJECT=rialto-bridge-node \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/millau-bridge-node \
+        --build-arg=PROJECT=millau-bridge-node \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
+    DOCKER_BUILDKIT=1 time docker build . -f local.Dockerfile -t local/rialto-parachain-collator \
+        --build-arg=PROJECT=rialto-parachain-collator \
+        --build-arg=UBUNTU_RELEASE=${UBUNTU_RELEASE}
 fi


### PR DESCRIPTION
I had to rebuild the local containers quite a number of times when backporting equivocation detection related changes.

Backporting these changes that make it easier to building images from locally built binaries since they bring value in this kind of scenarios.