### PR TITLE
Fix benchmark with new XCM::V3 MAX_INSTRUCTIONS_TO_DECODE

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -1077,6 +1077,7 @@ impl_runtime_apis! {
 			};
 			use bp_runtime::Chain;
 			use bridge_runtime_common::messages_benchmarking::{
+				generate_xcm_builder_bridge_message_sample,
 				prepare_message_delivery_proof_from_grandpa_chain,
 				prepare_message_delivery_proof_from_parachain,
 				prepare_message_proof_from_grandpa_chain,
@@ -1113,7 +1114,7 @@ impl_runtime_apis! {
 						Runtime,
 						WithRialtoParachainsInstance,
 						WithRialtoParachainMessagesInstance,
-					>(params, xcm::v3::Junctions::Here)
+					>(params, generate_xcm_builder_bridge_message_sample(xcm::v3::Junctions::Here))
 				}
 
 				fn prepare_message_delivery_proof(
@@ -1148,7 +1149,7 @@ impl_runtime_apis! {
 						Runtime,
 						RialtoGrandpaInstance,
 						WithRialtoMessagesInstance,
-					>(params, xcm::v3::Junctions::Here)
+					>(params, generate_xcm_builder_bridge_message_sample(xcm::v3::Junctions::Here))
 				}
 
 				fn prepare_message_delivery_proof(

--- a/bin/runtime-common/src/messages_benchmarking.rs
+++ b/bin/runtime-common/src/messages_benchmarking.rs
@@ -42,7 +42,7 @@ use xcm::v3::prelude::*;
 /// Prepare inbound bridge message according to given message proof parameters.
 fn prepare_inbound_message(
 	params: &MessageProofParams,
-	successful_dispatch_message_generator: impl Fn(usize) -> MessagePayload,
+	successful_dispatch_message_generator: &impl Fn(usize) -> MessagePayload,
 ) -> MessagePayload {
 	let expected_size = params.proof_params.db_size.unwrap_or(0) as usize;
 
@@ -90,7 +90,7 @@ where
 			params.message_nonces.clone(),
 			params.outbound_lane_data.clone(),
 			params.proof_params,
-			|_| prepare_inbound_message(&params, message_generator),
+			|_| prepare_inbound_message(&params, &message_generator),
 			encode_all_messages,
 			encode_lane_data,
 			false,
@@ -137,7 +137,7 @@ where
 			params.message_nonces.clone(),
 			params.outbound_lane_data.clone(),
 			params.proof_params,
-			|_| prepare_inbound_message(&params, message_generator),
+			|_| prepare_inbound_message(&params, &message_generator),
 			encode_all_messages,
 			encode_lane_data,
 			false,

--- a/modules/messages/src/weights_ext.rs
+++ b/modules/messages/src/weights_ext.rs
@@ -29,8 +29,8 @@ pub const EXPECTED_DEFAULT_MESSAGE_LENGTH: u32 = 128;
 /// calls we're checking here would fit 1KB.
 const SIGNED_EXTENSIONS_SIZE: u32 = 1024;
 
-/// Number of extra bytes (excluding size of storage value itself) of storage proof, built at
-/// Rialto chain. This mostly depends on number of entries (and their density) in the storage trie.
+/// Number of extra bytes (excluding size of storage value itself) of storage proof.
+/// This mostly depends on number of entries (and their density) in the storage trie.
 /// Some reserve is reserved to account future chain growth.
 pub const EXTRA_STORAGE_PROOF_SIZE: u32 = 1024;
 


### PR DESCRIPTION
`receive_single_message_proof_with_dispatch` benchmark has started to [fail](https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/3499492) in monorepo: 
```
[2023-08-30 15:17:41] 2023-08-30 15:17:41 [XcmBlobMessageDispatch] DispatchBlob::dispatch_blob failed, error: InvalidEncoding - message_nonce: 21
```

Backport of this PR: https://github.com/paritytech/parity-bridges-common/pull/2514 (already merged in monorepo)