### PR TITLE
Try to fix docker build at CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,6 +240,10 @@ build:
     - mkdir -p ./artifacts
     - strip ./target/release/rialto-bridge-node
     - mv -v ./target/release/rialto-bridge-node ./artifacts/
+    - strip ./target/release/rialto-bridge-node-execute-worker
+    - mv -v ./target/release/rialto-bridge-node-execute-worker ./artifacts/
+    - strip ./target/release/rialto-bridge-node-prepare-worker
+    - mv -v ./target/release/rialto-bridge-node-prepare-worker ./artifacts/
     - strip ./target/release/rialto-parachain-collator
     - mv -v ./target/release/rialto-parachain-collator ./artifacts/
     - strip ./target/release/millau-bridge-node

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /home/user
 
 ARG PROJECT=substrate-relay
 
-COPY --chown=user:user ./${PROJECT} ./
+COPY --chown=user:user ./${PROJECT}* ./
 COPY --chown=user:user ./bridge-entrypoint.sh ./
 
 # check if executable works in this container


### PR DESCRIPTION
Looks like `rialto-bridge-node-execute-worker` and `rialto-bridge-node-prepare-worker` weren't included into latest [`rialto-bridge-node` docker image](https://hub.docker.com/layers/paritytech/rialto-bridge-node/latest/images/sha256-876ec00666c5c7b0fb305f2d75f59d9b4967a7eb932b9dd16b31c0da7874c133?context=explore). Let's try this fix