### PR TITLE
Add polkadot bulletin chain primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-polkadot-bulletin"
+version = "0.1.0"
+dependencies = [
+ "bp-header-chain",
+ "bp-messages",
+ "bp-polkadot-core",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "sp-api",
+ "sp-runtime",
+ "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+]
+
+[[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
 	"primitives/chain-kusama",
 	"primitives/chain-millau",
 	"primitives/chain-polkadot",
+	"primitives/chain-polkadot-bulletin",
 	"primitives/chain-rialto",
 	"primitives/chain-rialto-parachain",
 	"primitives/chain-rococo",

--- a/primitives/chain-millau/src/lib.rs
+++ b/primitives/chain-millau/src/lib.rs
@@ -23,10 +23,7 @@ mod millau_hash;
 
 use bp_beefy::ChainWithBeefy;
 use bp_header_chain::ChainWithGrandpa;
-use bp_messages::{
-	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
-	OutboundMessageDetails,
-};
+use bp_messages::{ChainWithMessages, MessageNonce};
 use bp_runtime::{decl_bridge_finality_runtime_apis, decl_bridge_runtime_apis, Chain, ChainId};
 use frame_support::{
 	dispatch::DispatchClass,

--- a/primitives/chain-polkadot-bulletin/Cargo.toml
+++ b/primitives/chain-polkadot-bulletin/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "bp-polkadot-bulletin"
+description = "Primitives of Polkadot Bulletin chain runtime."
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+
+[dependencies]
+
+# Bridge Dependencies
+
+bp-header-chain = { path = "../header-chain", default-features = false }
+bp-messages = { path = "../messages", default-features = false }
+bp-polkadot-core = { path = "../polkadot-core", default-features = false }
+bp-runtime = { path = "../runtime", default-features = false }
+
+# Substrate Based Dependencies
+
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"bp-header-chain/std",
+	"bp-messages/std",
+	"bp-polkadot-core/std",
+	"bp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
+	"sp-api/std",
+	"sp-runtime/std",
+	"sp-std/std",
+]

--- a/primitives/chain-polkadot-bulletin/src/lib.rs
+++ b/primitives/chain-polkadot-bulletin/src/lib.rs
@@ -1,0 +1,110 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Polkadot Bulletin Chain primitives.
+
+#![warn(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use bp_header_chain::ChainWithGrandpa;
+use bp_runtime::{
+	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, ChainId,
+};
+use frame_support::{
+	dispatch::DispatchClass,
+	parameter_types,
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+};
+use frame_system::limits;
+use sp_runtime::{Perbill, StateVersion};
+
+// This chain reuses most of Polkadot primitives.
+pub use bp_polkadot_core::{
+	AccountId, Balance, BlockNumber, Hash, Hasher, Header, Nonce, Signature,
+	AVERAGE_HEADER_SIZE_IN_JUSTIFICATION, MAX_HEADER_SIZE,
+	REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY,
+};
+
+/// Maximal number of GRANDPA authorities at Polkadot Bulletin chain.
+pub const MAX_AUTHORITIES_COUNT: u32 = 100;
+
+/// Name of the With-Polkadot Bulletin chain GRANDPA pallet instance that is deployed at bridged
+/// chains.
+pub const WITH_POLKADOT_BULLETIN_GRANDPA_PALLET_NAME: &str = "BridgePolkadotBulletinGrandpa";
+/// Name of the With-Polkadot Bulletin chain messages pallet instance that is deployed at bridged
+/// chains.
+pub const WITH_POLKADOT_BULLETIN_MESSAGES_PALLET_NAME: &str = "BridgePolkadotBulletinMessages";
+
+// There are fewer system operations on this chain (e.g. staking, governance, etc.). Use a higher
+// percentage of the block for data storage.
+const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(90);
+
+parameter_types! {
+	/// We allow for 2 seconds of compute with a 6 second average block time.
+	pub BlockWeights: limits::BlockWeights = limits::BlockWeights::with_sensible_defaults(
+			Weight::from_parts(2u64 * WEIGHT_REF_TIME_PER_SECOND, u64::MAX),
+			NORMAL_DISPATCH_RATIO,
+		);
+	// Note: Max transaction size is 8 MB. Set max block size to 10 MB to facilitate data storage.
+	// This is double the "normal" Relay Chain block length limit.
+	/// Maximal block length at Polkadot Bulletin chain.
+	pub BlockLength: limits::BlockLength = limits::BlockLength::max_with_normal_ratio(
+		10 * 1024 * 1024,
+		NORMAL_DISPATCH_RATIO,
+	);
+}
+
+/// Polkadot Bulletin Chain declaration.
+pub struct PolkadotBulletin;
+
+impl Chain for PolkadotBulletin {
+	const ID: ChainId = *b"pdbc";
+
+	type BlockNumber = BlockNumber;
+	type Hash = Hash;
+	type Hasher = Hasher;
+	type Header = Header;
+
+	type AccountId = AccountId;
+	type Balance = Balance;
+	type Nonce = Nonce;
+	type Signature = Signature;
+
+	const STATE_VERSION: StateVersion = StateVersion::V1;
+
+	fn max_extrinsic_size() -> u32 {
+		*BlockLength::get().max.get(DispatchClass::Normal)
+	}
+
+	fn max_extrinsic_weight() -> Weight {
+		BlockWeights::get()
+			.get(DispatchClass::Normal)
+			.max_extrinsic
+			.unwrap_or(Weight::MAX)
+	}
+}
+
+impl ChainWithGrandpa for PolkadotBulletin {
+	const WITH_CHAIN_GRANDPA_PALLET_NAME: &'static str = WITH_POLKADOT_BULLETIN_GRANDPA_PALLET_NAME;
+	const MAX_AUTHORITIES_COUNT: u32 = MAX_AUTHORITIES_COUNT;
+	const REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY: u32 =
+		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
+	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
+	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
+
+decl_bridge_finality_runtime_apis!(polkadot_bulletin);
+decl_bridge_messages_runtime_apis!(polkadot_bulletin);

--- a/primitives/chain-polkadot-bulletin/src/lib.rs
+++ b/primitives/chain-polkadot-bulletin/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use bp_header_chain::ChainWithGrandpa;
+use bp_messages::{ChainWithMessages, MessageNonce};
 use bp_runtime::{
 	decl_bridge_finality_runtime_apis, decl_bridge_messages_runtime_apis, Chain, ChainId,
 };
@@ -51,6 +52,16 @@ pub const WITH_POLKADOT_BULLETIN_MESSAGES_PALLET_NAME: &str = "BridgePolkadotBul
 // There are fewer system operations on this chain (e.g. staking, governance, etc.). Use a higher
 // percentage of the block for data storage.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(90);
+
+// Re following constants - we are using the same values at Cumulus parachains. They are limited
+// by the maximal transaction weight/size. Since block limits at Bulletin Chain are larger than
+// at the Cumulus Bridgeg Hubs, we could reuse the same values.
+
+/// Maximal number of unrewarded relayer entries at inbound lane for Cumulus-based parachains.
+pub const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce = 1024;
+
+/// Maximal number of unconfirmed messages at inbound lane for Cumulus-based parachains.
+pub const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce = 4096;
 
 parameter_types! {
 	/// We allow for 2 seconds of compute with a 6 second average block time.
@@ -104,6 +115,16 @@ impl ChainWithGrandpa for PolkadotBulletin {
 		REASONABLE_HEADERS_IN_JUSTIFICATON_ANCESTRY;
 	const MAX_HEADER_SIZE: u32 = MAX_HEADER_SIZE;
 	const AVERAGE_HEADER_SIZE_IN_JUSTIFICATION: u32 = AVERAGE_HEADER_SIZE_IN_JUSTIFICATION;
+}
+
+impl ChainWithMessages for PolkadotBulletin {
+	const WITH_CHAIN_MESSAGES_PALLET_NAME: &'static str =
+		WITH_POLKADOT_BULLETIN_MESSAGES_PALLET_NAME;
+
+	const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX;
+	const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce =
+		MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX;
 }
 
 decl_bridge_finality_runtime_apis!(polkadot_bulletin);

--- a/primitives/chain-rialto-parachain/src/lib.rs
+++ b/primitives/chain-rialto-parachain/src/lib.rs
@@ -19,10 +19,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use bp_messages::{
-	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
-	OutboundMessageDetails,
-};
+use bp_messages::{ChainWithMessages, MessageNonce};
 use bp_runtime::{decl_bridge_runtime_apis, Chain, ChainId, Parachain};
 use frame_support::{
 	dispatch::DispatchClass,

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -20,10 +20,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use bp_header_chain::ChainWithGrandpa;
-use bp_messages::{
-	ChainWithMessages, InboundMessageDetails, LaneId, MessageNonce, MessagePayload,
-	OutboundMessageDetails,
-};
+use bp_messages::{ChainWithMessages, MessageNonce};
 use bp_runtime::{decl_bridge_finality_runtime_apis, decl_bridge_runtime_apis, Chain, ChainId};
 use frame_support::{
 	dispatch::DispatchClass,

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -371,10 +371,10 @@ macro_rules! decl_bridge_messages_runtime_apis {
 						/// If some (or all) messages are missing from the storage, they'll also will
 						/// be missing from the resulting vector. The vector is ordered by the nonce.
 						fn message_details(
-							lane: LaneId,
-							begin: MessageNonce,
-							end: MessageNonce,
-						) -> Vec<OutboundMessageDetails>;
+							lane: bp_messages::LaneId,
+							begin: bp_messages::MessageNonce,
+							end: bp_messages::MessageNonce,
+						) -> Vec<bp_messages::OutboundMessageDetails>;
 					}
 
 					/// Inbound message lane API for messages sent by this chain.
@@ -387,9 +387,9 @@ macro_rules! decl_bridge_messages_runtime_apis {
 					pub trait [<From $chain:camel InboundLaneApi>] {
 						/// Return details of given inbound messages.
 						fn message_details(
-							lane: LaneId,
-							messages: Vec<(MessagePayload, OutboundMessageDetails)>,
-						) -> Vec<InboundMessageDetails>;
+							lane: bp_messages::LaneId,
+							messages: Vec<(bp_messages::MessagePayload, bp_messages::OutboundMessageDetails)>,
+						) -> Vec<bp_messages::InboundMessageDetails>;
 					}
 				}
 			}


### PR DESCRIPTION
This is primitives for the [Polkadot Bulletin Chain](https://github.com/zdave-parity/polkadot-bulletin-chain). It is going to be bridged with Polkadot BH. Some bridge details for bridge guys:
- Polkadot Bulletin Chain tokens have no economic value, so we are going to have whitelisted set of relayers and check it in [signed extension](https://github.com/zdave-parity/polkadot-bulletin-chain/blob/main/runtime/src/lib.rs#L415);
- at Bridge Hub, we'll just enable fee refund for useful transactions. We don't want any rewards - will probably run internal (Parity?) relayer for that;
- there'll be a separate Polkadot system parachain that will send messages to Bulletin Chain over bridge hub. So regular `ExportMessage` support. This also needs to be unpaid (?) at Polkadot.BH;
- some messages will also be headed from Bulletin Chain to this new system parachain. We also need to make sure that everything is free here. We need to trust the Bulletin Chain validators then (otherwise it could then spam us with messages and halt the BH);
- I have to add [a separate branch](https://github.com/paritytech/parity-bridges-common/tree/polkadot-v.1.0.0-audited) for this bridge, because Bulletin Chain codebase is using the `v1.0.0` branches and we need audited code there.

@zdave-parity @NachoPal In bridges we need to define chain primitives, because other (bridged) runtime need to know some facts about the chain it bridges with. In our case, Polkadot.BH will need to know primitives of Bulletin Chain and vice versa. This is also required for our offchain actors (relayers) - they should be able to craft valid transactions and make proper RPC calls. After we'll update subtree with this commit (ofc I'll need to backport it to `polkadot-v.1.0.0-audited` branch first), I'm gonna use typedefs from this crate in Bulletin Chain runtime to avoid code duplication.