### PR TITLE
Do not require sp_std::vec::Vec import when using runtime API generation macro

### DIFF
--- a/primitives/chain-bridge-hub-kusama/src/lib.rs
+++ b/primitives/chain-bridge-hub-kusama/src/lib.rs
@@ -30,7 +30,6 @@ use frame_support::{
 	sp_runtime::{MultiAddress, MultiSigner},
 };
 use sp_runtime::{RuntimeDebug, StateVersion};
-use sp_std::prelude::Vec;
 
 /// BridgeHubKusama parachain.
 #[derive(RuntimeDebug)]

--- a/primitives/chain-bridge-hub-polkadot/src/lib.rs
+++ b/primitives/chain-bridge-hub-polkadot/src/lib.rs
@@ -27,7 +27,6 @@ use bp_runtime::{
 };
 use frame_support::dispatch::DispatchClass;
 use sp_runtime::{RuntimeDebug, StateVersion};
-use sp_std::prelude::Vec;
 
 /// BridgeHubPolkadot parachain.
 #[derive(RuntimeDebug)]

--- a/primitives/chain-bridge-hub-rococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-rococo/src/lib.rs
@@ -27,7 +27,7 @@ use bp_runtime::{
 };
 use frame_support::dispatch::DispatchClass;
 use sp_runtime::{MultiAddress, MultiSigner, RuntimeDebug, StateVersion};
-use sp_std::prelude::Vec;
+
 /// BridgeHubRococo parachain.
 #[derive(RuntimeDebug)]
 pub struct BridgeHubRococo;

--- a/primitives/chain-bridge-hub-wococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-wococo/src/lib.rs
@@ -27,7 +27,6 @@ use bp_runtime::{
 };
 use frame_support::dispatch::DispatchClass;
 use sp_runtime::{RuntimeDebug, StateVersion};
-use sp_std::prelude::Vec;
 
 /// BridgeHubWococo parachain.
 #[derive(RuntimeDebug)]

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -25,7 +25,6 @@ use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId};
 use frame_support::weights::Weight;
 use sp_runtime::StateVersion;
-use sp_std::prelude::Vec;
 
 /// Kusama Chain
 pub struct Kusama;

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -27,7 +27,6 @@ use bp_runtime::{
 };
 use frame_support::weights::Weight;
 use sp_runtime::StateVersion;
-use sp_std::prelude::Vec;
 
 /// Polkadot Chain
 pub struct Polkadot;

--- a/primitives/chain-rialto-parachain/src/lib.rs
+++ b/primitives/chain-rialto-parachain/src/lib.rs
@@ -31,7 +31,6 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, Verify},
 	MultiSignature, MultiSigner, Perbill, RuntimeDebug, StateVersion,
 };
-use sp_std::vec::Vec;
 
 /// Identifier of RialtoParachain in the Rialto relay chain.
 ///

--- a/primitives/chain-rialto/src/lib.rs
+++ b/primitives/chain-rialto/src/lib.rs
@@ -32,7 +32,6 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, Verify},
 	MultiSignature, MultiSigner, Perbill, RuntimeDebug, StateVersion,
 };
-use sp_std::prelude::*;
 
 /// Number of extra bytes (excluding size of storage value itself) of storage proof, built at
 /// Rialto chain. This mostly depends on number of entries (and their density) in the storage trie.

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -25,7 +25,6 @@ use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId};
 use frame_support::weights::Weight;
 use sp_runtime::StateVersion;
-use sp_std::prelude::Vec;
 
 /// Rococo Chain
 pub struct Rococo;

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -25,7 +25,6 @@ use sp_runtime::StateVersion;
 use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId, Parachain};
 use frame_support::weights::Weight;
-use sp_std::prelude::*;
 
 /// Westend Chain
 pub struct Westend;

--- a/primitives/chain-wococo/src/lib.rs
+++ b/primitives/chain-wococo/src/lib.rs
@@ -28,7 +28,6 @@ use bp_header_chain::ChainWithGrandpa;
 use bp_runtime::{decl_bridge_finality_runtime_apis, Chain, ChainId};
 use frame_support::weights::Weight;
 use sp_runtime::StateVersion;
-use sp_std::prelude::Vec;
 
 /// Wococo Chain
 pub struct Wococo;

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -322,7 +322,7 @@ macro_rules! decl_bridge_finality_runtime_apis {
 						$(
 							/// Returns the justifications accepted in the current block.
 							fn [<synced_headers_ $consensus:lower _info>](
-							) -> Vec<$justification_type>;
+							) -> sp_std::vec::Vec<$justification_type>;
 						)?
 					}
 				}
@@ -374,7 +374,7 @@ macro_rules! decl_bridge_messages_runtime_apis {
 							lane: bp_messages::LaneId,
 							begin: bp_messages::MessageNonce,
 							end: bp_messages::MessageNonce,
-						) -> Vec<bp_messages::OutboundMessageDetails>;
+						) -> sp_std::vec::Vec<bp_messages::OutboundMessageDetails>;
 					}
 
 					/// Inbound message lane API for messages sent by this chain.
@@ -388,8 +388,8 @@ macro_rules! decl_bridge_messages_runtime_apis {
 						/// Return details of given inbound messages.
 						fn message_details(
 							lane: bp_messages::LaneId,
-							messages: Vec<(bp_messages::MessagePayload, bp_messages::OutboundMessageDetails)>,
-						) -> Vec<bp_messages::InboundMessageDetails>;
+							messages: sp_std::vec::Vec<(bp_messages::MessagePayload, bp_messages::OutboundMessageDetails)>,
+						) -> sp_std::vec::Vec<bp_messages::InboundMessageDetails>;
 					}
 				}
 			}


### PR DESCRIPTION
because it isn't clear why we need it