### PR TITLE
Support message relay limits override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14562,6 +14562,7 @@ dependencies = [
  "bp-messages",
  "bp-millau",
  "bp-parachains",
+ "bp-polkadot-bulletin",
  "bp-polkadot-core",
  "bp-rialto",
  "bp-rialto-parachain",

--- a/relays/bin-substrate/Cargo.toml
+++ b/relays/bin-substrate/Cargo.toml
@@ -27,6 +27,7 @@ bp-header-chain = { path = "../../primitives/header-chain" }
 bp-messages = { path = "../../primitives/messages" }
 bp-parachains = { path = "../../primitives/parachains" }
 bp-millau = { path = "../../primitives/chain-millau" }
+bp-polkadot-bulletin = { path = "../../primitives/chain-polkadot-bulletin" }
 bp-polkadot-core = { path = "../../primitives/polkadot-core" }
 bp-rialto = { path = "../../primitives/chain-rialto" }
 bp-rialto-parachain = { path = "../../primitives/chain-rialto-parachain" }

--- a/relays/bin-substrate/src/bridges/polkadot_bulletin/polkadot_parachains_to_polkadot_bulletin.rs
+++ b/relays/bin-substrate/src/bridges/polkadot_bulletin/polkadot_parachains_to_polkadot_bulletin.rs
@@ -17,10 +17,13 @@
 //! Polkadot-to-PolkadotBulletin parachains sync entrypoint.
 
 use crate::cli::bridge::{CliBridgeBase, MessagesCliBridge, ParachainToRelayHeadersCliBridge};
+
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
+use bp_runtime::Chain;
 use relay_substrate_client::{CallOf, HeaderIdOf};
-use substrate_relay_helper::parachains::{
-	SubmitParachainHeadsCallBuilder, SubstrateParachainsPipeline,
+use substrate_relay_helper::{
+	messages::MessagesRelayLimits,
+	parachains::{SubmitParachainHeadsCallBuilder, SubstrateParachainsPipeline},
 };
 
 /// Polkadot-to-PolkadotBulletin parachain sync description.
@@ -72,4 +75,18 @@ impl CliBridgeBase for PolkadotToPolkadotBulletinCliBridge {
 impl MessagesCliBridge for PolkadotToPolkadotBulletinCliBridge {
 	type MessagesLane =
 		crate::bridges::polkadot_bulletin::bridge_hub_polkadot_messages_to_polkadot_bulletin::BridgeHubPolkadotMessagesToPolkadotBulletinMessageLane;
+
+	fn maybe_messages_limits() -> Option<MessagesRelayLimits> {
+		// Polkadot Bulletin chain is missing the `TransactionPayment` runtime API (as well as the
+		// transaction payment pallet itself), so we can't estimate limits using runtime calls.
+		// Let's do it here.
+		//
+		// Folloiung constants are just safe **underestimations**. Normally, we are able to deliver
+		// and dispatch thousands of messages in the same transaction.
+		Some(MessagesRelayLimits {
+			max_messages_in_single_batch: 128,
+			max_messages_weight_in_single_batch:
+				bp_polkadot_bulletin::PolkadotBulletin::max_extrinsic_weight() / 20,
+		})
+	}
 }

--- a/relays/bin-substrate/src/cli/bridge.rs
+++ b/relays/bin-substrate/src/cli/bridge.rs
@@ -19,8 +19,10 @@ use pallet_bridge_parachains::{RelayBlockHash, RelayBlockHasher, RelayBlockNumbe
 use relay_substrate_client::{Chain, ChainWithTransactions, Parachain, RelayChain};
 use strum::{EnumString, EnumVariantNames};
 use substrate_relay_helper::{
-	equivocation::SubstrateEquivocationDetectionPipeline, finality::SubstrateFinalitySyncPipeline,
-	messages::SubstrateMessageLane, parachains::SubstrateParachainsPipeline,
+	equivocation::SubstrateEquivocationDetectionPipeline,
+	finality::SubstrateFinalitySyncPipeline,
+	messages::{MessagesRelayLimits, SubstrateMessageLane},
+	parachains::SubstrateParachainsPipeline,
 };
 
 #[derive(Debug, PartialEq, Eq, EnumString, EnumVariantNames)]
@@ -111,4 +113,11 @@ where
 pub trait MessagesCliBridge: CliBridgeBase {
 	/// The Source -> Destination messages synchronization pipeline.
 	type MessagesLane: SubstrateMessageLane<SourceChain = Self::Source, TargetChain = Self::Target>;
+
+	/// Optional messages delivery transaction limits that the messages relay is going
+	/// to use. If it returns `None`, limits are estimated using `TransactionPayment` API
+	/// at the target chain.
+	fn maybe_messages_limits() -> Option<MessagesRelayLimits> {
+		None
+	}
 }

--- a/relays/bin-substrate/src/cli/init_bridge.rs
+++ b/relays/bin-substrate/src/cli/init_bridge.rs
@@ -244,9 +244,14 @@ impl BridgeInitializer for PolkadotToPolkadotBulletinCliBridge {
 	fn encode_init_bridge(
 		init_data: <Self::Engine as Engine<Self::Source>>::InitializationData,
 	) -> <Self::Target as Chain>::Call {
-		relay_polkadot_bulletin_client::RuntimeCall::BridgePolkadotGrandpa(
-			relay_polkadot_bulletin_client::BridgePolkadotGrandpaCall::initialize { init_data },
-		)
+		type RuntimeCall = relay_polkadot_bulletin_client::RuntimeCall;
+		type BridgePolkadotGrandpaCall = relay_polkadot_bulletin_client::BridgePolkadotGrandpaCall;
+		type SudoCall = relay_polkadot_bulletin_client::SudoCall;
+
+		let initialize_call =
+			RuntimeCall::BridgePolkadotGrandpa(BridgePolkadotGrandpaCall::initialize { init_data });
+
+		RuntimeCall::Sudo(SudoCall::sudo { call: Box::new(initialize_call) })
 	}
 }
 

--- a/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
+++ b/relays/bin-substrate/src/cli/relay_headers_and_messages/mod.rs
@@ -81,7 +81,9 @@ use relay_substrate_client::{
 use relay_utils::metrics::MetricsParams;
 use sp_core::Pair;
 use substrate_relay_helper::{
-	messages::MessagesRelayParams, on_demand::OnDemandRelay, TaggedAccount, TransactionParams,
+	messages::{MessagesRelayLimits, MessagesRelayParams},
+	on_demand::OnDemandRelay,
+	TaggedAccount, TransactionParams,
 };
 
 /// Parameters that have the same names across all bridges.
@@ -180,6 +182,7 @@ where
 		source_to_target_headers_relay: Arc<dyn OnDemandRelay<Source, Target>>,
 		target_to_source_headers_relay: Arc<dyn OnDemandRelay<Target, Source>>,
 		lane_id: LaneId,
+		maybe_limits: Option<MessagesRelayLimits>,
 	) -> MessagesRelayParams<Bridge::MessagesLane, DefaultClient<Source>, DefaultClient<Target>> {
 		MessagesRelayParams {
 			source_client: self.source.client.clone(),
@@ -189,6 +192,7 @@ where
 			source_to_target_headers_relay: Some(source_to_target_headers_relay),
 			target_to_source_headers_relay: Some(target_to_source_headers_relay),
 			lane_id,
+			limits: maybe_limits,
 			metrics_params: self.metrics_params.clone().disable(),
 		}
 	}
@@ -387,6 +391,7 @@ where
 				left_to_right_on_demand_headers.clone(),
 				right_to_left_on_demand_headers.clone(),
 				lane,
+				Self::L2R::maybe_messages_limits(),
 			))
 			.map_err(|e| anyhow::format_err!("{}", e))
 			.boxed();
@@ -400,6 +405,7 @@ where
 				right_to_left_on_demand_headers.clone(),
 				left_to_right_on_demand_headers.clone(),
 				lane,
+				Self::R2L::maybe_messages_limits(),
 			))
 			.map_err(|e| anyhow::format_err!("{}", e))
 			.boxed();

--- a/relays/bin-substrate/src/cli/relay_messages.rs
+++ b/relays/bin-substrate/src/cli/relay_messages.rs
@@ -97,6 +97,7 @@ where
 			source_to_target_headers_relay: None,
 			target_to_source_headers_relay: None,
 			lane_id: data.lane.into(),
+			limits: Self::maybe_messages_limits(),
 			metrics_params: data.prometheus_params.into_metrics_params()?,
 		})
 		.await

--- a/relays/client-polkadot-bulletin/src/lib.rs
+++ b/relays/client-polkadot-bulletin/src/lib.rs
@@ -33,6 +33,8 @@ pub use codegen_runtime::api::runtime_types;
 
 /// Call of the Polkadot Bulletin Chain runtime.
 pub type RuntimeCall = runtime_types::polkadot_bulletin_chain_runtime::RuntimeCall;
+/// Call of the Sudo pallet.
+pub type SudoCall = runtime_types::pallet_sudo::pallet::Call;
 /// Call of the GRANDPA pallet.
 pub type GrandpaCall = runtime_types::pallet_grandpa::pallet::Call;
 /// Call of the with-PolkadotBridgeHub bridge GRANDPA pallet.

--- a/relays/client-polkadot-bulletin/src/lib.rs
+++ b/relays/client-polkadot-bulletin/src/lib.rs
@@ -33,7 +33,7 @@ pub use codegen_runtime::api::runtime_types;
 
 /// Call of the Polkadot Bulletin Chain runtime.
 pub type RuntimeCall = runtime_types::polkadot_bulletin_chain_runtime::RuntimeCall;
-/// Call of the Sudo pallet.
+/// Call of the `Sudo` pallet.
 pub type SudoCall = runtime_types::pallet_sudo::pallet::Call;
 /// Call of the GRANDPA pallet.
 pub type GrandpaCall = runtime_types::pallet_grandpa::pallet::Call;

--- a/relays/lib-substrate-relay/src/messages/mod.rs
+++ b/relays/lib-substrate-relay/src/messages/mod.rs
@@ -110,8 +110,19 @@ pub struct MessagesRelayParams<P: SubstrateMessageLane, SourceClnt, TargetClnt> 
 		Option<Arc<dyn OnDemandRelay<P::TargetChain, P::SourceChain>>>,
 	/// Identifier of lane that needs to be served.
 	pub lane_id: LaneId,
+	/// Messages relay limits. If not provided, the relay tries to determine it automatically,
+	/// using `TransactionPayment` pallet runtime API.
+	pub limits: Option<MessagesRelayLimits>,
 	/// Metrics parameters.
 	pub metrics_params: MetricsParams,
+}
+
+/// Delivery transaction limits.
+pub struct MessagesRelayLimits {
+	/// Maximal number of messages in the delivery transaction.
+	pub max_messages_in_single_batch: MessageNonce,
+	/// Maximal cumulative weight of messages in the delivery transaction.
+	pub max_messages_weight_in_single_batch: Weight,
 }
 
 /// Batch transaction that brings headers + and messages delivery/receiving confirmations to the
@@ -188,15 +199,18 @@ where
 	let max_messages_size_in_single_batch = P::TargetChain::max_extrinsic_size() / 3;
 	// we don't know exact weights of the Polkadot runtime. So to guess weights we'll be using
 	// weights from Rialto and then simply dividing it by x2.
+	let limits = match params.limits {
+		Some(limits) => limits,
+		None =>
+			select_delivery_transaction_limits_rpc::<P, SourceClnt, TargetClnt>(
+				&params,
+				P::TargetChain::max_extrinsic_weight(),
+				P::SourceChain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
+			)
+			.await?,
+	};
 	let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
-		select_delivery_transaction_limits_rpc(
-			&params,
-			P::TargetChain::max_extrinsic_weight(),
-			P::SourceChain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX,
-		)
-		.await?;
-	let (max_messages_in_single_batch, max_messages_weight_in_single_batch) =
-		(max_messages_in_single_batch / 2, max_messages_weight_in_single_batch / 2);
+		(limits.max_messages_in_single_batch / 2, limits.max_messages_weight_in_single_batch / 2);
 
 	let source_client = params.source_client;
 	let target_client = params.target_client;
@@ -462,7 +476,7 @@ async fn select_delivery_transaction_limits_rpc<P, SourceClnt, TargetClnt>(
 	params: &MessagesRelayParams<P, SourceClnt, TargetClnt>,
 	max_extrinsic_weight: Weight,
 	max_unconfirmed_messages_at_inbound_lane: MessageNonce,
-) -> anyhow::Result<(MessageNonce, Weight)>
+) -> anyhow::Result<MessagesRelayLimits>
 where
 	P: SubstrateMessageLane,
 	SourceClnt: Client<P::SourceChain>,
@@ -524,7 +538,10 @@ where
 		"Relay shall be able to deliver messages with dispatch weight = max_extrinsic_weight / 2",
 	);
 
-	Ok((max_number_of_messages, weight_for_messages_dispatch))
+	Ok(MessagesRelayLimits {
+		max_messages_in_single_batch: max_number_of_messages,
+		max_messages_weight_in_single_batch: weight_for_messages_dispatch,
+	})
 }
 
 /// Returns dummy message delivery transaction with zero messages and `1kb` proof.


### PR DESCRIPTION
To estimate maximal number of messages and their total cumulative dispatch weight in messages delivery transaction we currently [use the transaction payment runtime APIs](https://github.com/paritytech/parity-bridges-common/blob/master/relays/lib-substrate-relay/src/messages/mod.rs#L460-L528). However [on some chains](https://github.com/zdave-parity/polkadot-bulletin-chain) there's no such pallet and it doesn't make any sense to add it there just for that. So let's add an option to configure bridge limits from hardcoded constants in the code. It maybe worth to add CLI options for that, but our CLI interface is already too complicated, so let's start with hardcoded constants and see if we need CLI options for that in the future.