### PR TITLE
Additional priority boost for relayers that have explicitly registered at lane

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -399,6 +399,10 @@ impl pallet_bridge_relayers::Config for Runtime {
 		ConstU64<1_000>,
 		ConstU64<8>,
 	>;
+	type MaxRelayersPerLane = ConstU32<16>;
+	type SlotLength = ConstU64<16>;
+	type PriorityBoostPerMessage = PriorityBoostPerMessage;
+	type PriorityBoostForActiveLaneRelayer = ConstU64<0>;
 	type WeightInfo = ();
 }
 
@@ -660,7 +664,6 @@ pub type BridgeRefundRialtoParachainMessages =
 			bp_relayers::RuntimeWithUtilityPallet<Runtime>,
 			WithRialtoParachainsInstance,
 			WithRialtoParachainMessagesInstance,
-			PriorityBoostPerMessage,
 		>,
 	>;
 

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -34,7 +34,9 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, ConstBool, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdLookup, Block as BlockT, ConstU128, DispatchInfoOf, SignedExtension},
+	traits::{
+		AccountIdLookup, Block as BlockT, ConstU128, ConstU64, DispatchInfoOf, SignedExtension,
+	},
 	transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
 	ApplyExtrinsicResult,
 };
@@ -539,6 +541,10 @@ impl pallet_bridge_relayers::Config for Runtime {
 	type PaymentProcedure =
 		bp_relayers::PayRewardFromAccount<pallet_balances::Pallet<Runtime>, AccountId>;
 	type StakeAndSlash = ();
+	type MaxRelayersPerLane = ConstU32<16>;
+	type SlotLength = ConstU32<16>;
+	type PriorityBoostPerMessage = ConstU64<0>;
+	type PriorityBoostForActiveLaneRelayer = ConstU64<0>;
 	type WeightInfo = ();
 }
 

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -393,6 +393,10 @@ impl pallet_bridge_relayers::Config for Runtime {
 	type PaymentProcedure =
 		bp_relayers::PayRewardFromAccount<pallet_balances::Pallet<Runtime>, AccountId>;
 	type StakeAndSlash = ();
+	type MaxRelayersPerLane = ConstU32<16>;
+	type SlotLength = ConstU32<16>;
+	type PriorityBoostPerMessage = ConstU64<0>;
+	type PriorityBoostForActiveLaneRelayer = ConstU64<0>;
 	type WeightInfo = ();
 }
 

--- a/modules/relayers/src/extension/grandpa_adapter.rs
+++ b/modules/relayers/src/extension/grandpa_adapter.rs
@@ -33,9 +33,7 @@ use pallet_bridge_messages::{
 	CallSubType as BridgeMessagesCallSubType, Config as BridgeMessagesConfig,
 };
 use sp_runtime::{
-	traits::{Dispatchable, Get},
-	transaction_validity::{TransactionPriority, TransactionValidityError},
-	Saturating,
+	traits::Dispatchable, transaction_validity::TransactionValidityError, Saturating,
 };
 use sp_std::marker::PhantomData;
 
@@ -54,8 +52,6 @@ pub struct WithGrandpaChainExtensionConfig<
 	BridgeGrandpaPalletInstance,
 	// instance of BridgedChainthe `pallet-bridge-messages`, tracked by this extension
 	BridgeMessagesPalletInstance,
-	// message delivery transaction priority boost for every additional message
-	PriorityBoostPerMessage,
 >(
 	PhantomData<(
 		IdProvider,
@@ -63,12 +59,10 @@ pub struct WithGrandpaChainExtensionConfig<
 		BatchCallUnpacker,
 		BridgeGrandpaPalletInstance,
 		BridgeMessagesPalletInstance,
-		PriorityBoostPerMessage,
 	)>,
 );
 
-impl<ID, R, BCU, GI, MI, P> ExtensionConfig
-	for WithGrandpaChainExtensionConfig<ID, R, BCU, GI, MI, P>
+impl<ID, R, BCU, GI, MI> ExtensionConfig for WithGrandpaChainExtensionConfig<ID, R, BCU, GI, MI>
 where
 	ID: StaticStrProvider,
 	R: BridgeRelayersConfig
@@ -77,7 +71,6 @@ where
 	BCU: BatchCallUnpacker<R>,
 	GI: 'static,
 	MI: 'static,
-	P: Get<TransactionPriority>,
 	R::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>
 		+ BridgeGrandpaCallSubtype<R, GI>
 		+ BridgeMessagesCallSubType<R, MI>,
@@ -86,7 +79,6 @@ where
 	type Runtime = R;
 	type BatchCallUnpacker = BCU;
 	type BridgeMessagesPalletInstance = MI;
-	type PriorityBoostPerMessage = P;
 	type Reward = R::Reward;
 	type RemoteGrandpaChainBlockNumber = pallet_bridge_grandpa::BridgedBlockNumber<R, GI>;
 

--- a/modules/relayers/src/extension/mod.rs
+++ b/modules/relayers/src/extension/mod.rs
@@ -300,7 +300,7 @@ where
 		let priority_boost = priority::compute_priority_boost::<R>(
 			parsed_call.messages_call_info().lane_id(),
 			bundled_messages,
-			&who,
+			who,
 		);
 		let valid_transaction = ValidTransactionBuilder::default().priority(priority_boost);
 

--- a/modules/relayers/src/extension/mod.rs
+++ b/modules/relayers/src/extension/mod.rs
@@ -35,7 +35,7 @@ use frame_support::{
 	dispatch::{DispatchInfo, PostDispatchInfo},
 	CloneNoBound, DefaultNoBound, EqNoBound, PartialEqNoBound, RuntimeDebugNoBound,
 };
-use frame_system::Config as SystemConfig;
+use frame_system::{pallet_prelude::BlockNumberFor, Config as SystemConfig};
 use pallet_bridge_messages::{CallHelper as MessagesCallHelper, Config as BridgeMessagesConfig};
 use pallet_transaction_payment::{
 	Config as TransactionPaymentConfig, OnChargeTransaction, Pallet as TransactionPaymentPallet,
@@ -106,6 +106,7 @@ where
 	R::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 	<R as TransactionPaymentConfig>::OnChargeTransaction:
 		OnChargeTransaction<R, Balance = R::Reward>,
+	usize: TryFrom<BlockNumberFor<R>>,
 {
 	/// Returns number of bundled messages `Some(_)`, if the given call info is a:
 	///
@@ -117,16 +118,15 @@ where
 	/// virtually boosted. The relayer registration (we only boost priority for registered
 	/// relayer transactions) must be checked outside.
 	fn bundled_messages_for_priority_boost(
-		call_info: Option<&ExtensionCallInfo<C::RemoteGrandpaChainBlockNumber>>,
+		call_info: &ExtensionCallInfo<C::RemoteGrandpaChainBlockNumber>,
 	) -> Option<MessageNonce> {
 		// we only boost priority of message delivery transactions
-		let parsed_call = match call_info {
-			Some(parsed_call) if parsed_call.is_receive_messages_proof_call() => parsed_call,
-			_ => return None,
-		};
+		if !call_info.is_receive_messages_proof_call() {
+			return None
+		}
 
 		// compute total number of messages in transaction
-		let bundled_messages = parsed_call.messages_call_info().bundled_messages().saturating_len();
+		let bundled_messages = call_info.messages_call_info().bundled_messages().saturating_len();
 
 		// a quick check to avoid invalid high-priority transactions
 		let max_unconfirmed_messages_in_confirmation_tx = <R as BridgeMessagesConfig<C::BridgeMessagesPalletInstance>>::BridgedChain
@@ -178,8 +178,7 @@ where
 		//
 		// - when relayer is registered after `validate` is called and priority is not boosted:
 		//   relayer should be ready for slashing after registration.
-		let may_slash_relayer =
-			Self::bundled_messages_for_priority_boost(Some(&call_info)).is_some();
+		let may_slash_relayer = Self::bundled_messages_for_priority_boost(&call_info).is_some();
 		let slash_relayer_if_delivery_result = may_slash_relayer
 			.then(|| RelayerAccountAction::Slash(relayer.clone(), reward_account_params))
 			.unwrap_or(RelayerAccountAction::None);
@@ -254,6 +253,8 @@ where
 	R::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
 	<R as TransactionPaymentConfig>::OnChargeTransaction:
 		OnChargeTransaction<R, Balance = R::Reward>,
+	usize: TryFrom<BlockNumberFor<R>>,
+	usize: TryFrom<BlockNumberFor<R>>,
 {
 	const IDENTIFIER: &'static str = C::IdProvider::STR;
 	type AccountId = R::AccountId;
@@ -277,13 +278,15 @@ where
 		// we're not calling `validate` from `pre_dispatch` directly because of performance
 		// reasons, so if you're adding some code that may fail here, please check if it needs
 		// to be added to the `pre_dispatch` as well
-		let parsed_call = C::parse_and_check_for_obsolete_call(call)?;
+		let parsed_call = match C::parse_and_check_for_obsolete_call(call)? {
+			Some(parsed_call) => parsed_call,
+			None => return Ok(Default::default()),
+		};
 
 		// the following code just plays with transaction priority and never returns an error
 
 		// we only boost priority of presumably correct message delivery transactions
-		let bundled_messages = match Self::bundled_messages_for_priority_boost(parsed_call.as_ref())
-		{
+		let bundled_messages = match Self::bundled_messages_for_priority_boost(&parsed_call) {
 			Some(bundled_messages) => bundled_messages,
 			None => return Ok(Default::default()),
 		};
@@ -294,8 +297,11 @@ where
 		}
 
 		// compute priority boost
-		let priority_boost =
-			priority::compute_priority_boost::<C::PriorityBoostPerMessage>(bundled_messages);
+		let priority_boost = priority::compute_priority_boost::<R>(
+			parsed_call.messages_call_info().lane_id(),
+			bundled_messages,
+			&who,
+		);
 		let valid_transaction = ValidTransactionBuilder::default().priority(priority_boost);
 
 		log::trace!(
@@ -303,7 +309,7 @@ where
 			"{}.{:?}: has boosted priority of message delivery transaction \
 			of relayer {:?}: {} messages -> {} priority",
 			Self::IDENTIFIER,
-			parsed_call.as_ref().map(|p| p.messages_call_info().lane_id()),
+			parsed_call.messages_call_info().lane_id(),
 			who,
 			bundled_messages,
 			priority_boost,
@@ -424,7 +430,7 @@ mod tests {
 	use pallet_bridge_parachains::Call as ParachainsCall;
 	use pallet_utility::Call as UtilityCall;
 	use sp_runtime::{
-		traits::{ConstU64, Header as HeaderT},
+		traits::Header as HeaderT,
 		transaction_validity::{InvalidTransaction, ValidTransaction},
 		DispatchError,
 	};
@@ -452,7 +458,6 @@ mod tests {
 		RuntimeWithUtilityPallet<TestRuntime>,
 		(),
 		(),
-		ConstU64<1>,
 	>;
 	type TestGrandpaExtension =
 		BridgeRelayersSignedExtension<TestRuntime, TestGrandpaExtensionConfig>;
@@ -462,7 +467,6 @@ mod tests {
 		RuntimeWithUtilityPallet<TestRuntime>,
 		(),
 		(),
-		ConstU64<1>,
 	>;
 	type TestExtension = BridgeRelayersSignedExtension<TestRuntime, TestExtensionConfig>;
 

--- a/modules/relayers/src/extension/mod.rs
+++ b/modules/relayers/src/extension/mod.rs
@@ -254,7 +254,6 @@ where
 	<R as TransactionPaymentConfig>::OnChargeTransaction:
 		OnChargeTransaction<R, Balance = R::Reward>,
 	usize: TryFrom<BlockNumberFor<R>>,
-	usize: TryFrom<BlockNumberFor<R>>,
 {
 	const IDENTIFIER: &'static str = C::IdProvider::STR;
 	type AccountId = R::AccountId;

--- a/modules/relayers/src/extension/parachain_adapter.rs
+++ b/modules/relayers/src/extension/parachain_adapter.rs
@@ -38,10 +38,7 @@ use pallet_bridge_parachains::{
 	CallSubType as BridgeParachainsCallSubtype, Config as BridgeParachainsConfig,
 	SubmitParachainHeadsHelper,
 };
-use sp_runtime::{
-	traits::{Dispatchable, Get},
-	transaction_validity::{TransactionPriority, TransactionValidityError},
-};
+use sp_runtime::{traits::Dispatchable, transaction_validity::TransactionValidityError};
 use sp_std::marker::PhantomData;
 
 /// Adapter to be used in signed extension configuration, when bridging with remote parachains.
@@ -58,8 +55,6 @@ pub struct WithParachainExtensionConfig<
 	BridgeParachainsPalletInstance,
 	// instance of BridgedChainthe `pallet-bridge-messages`, tracked by this extension
 	BridgeMessagesPalletInstance,
-	// message delivery transaction priority boost for every additional message
-	PriorityBoostPerMessage,
 >(
 	PhantomData<(
 		IdProvider,
@@ -67,11 +62,10 @@ pub struct WithParachainExtensionConfig<
 		BatchCallUnpacker,
 		BridgeParachainsPalletInstance,
 		BridgeMessagesPalletInstance,
-		PriorityBoostPerMessage,
 	)>,
 );
 
-impl<ID, R, BCU, PI, MI, P> ExtensionConfig for WithParachainExtensionConfig<ID, R, BCU, PI, MI, P>
+impl<ID, R, BCU, PI, MI> ExtensionConfig for WithParachainExtensionConfig<ID, R, BCU, PI, MI>
 where
 	ID: StaticStrProvider,
 	R: BridgeRelayersConfig
@@ -81,7 +75,6 @@ where
 	BCU: BatchCallUnpacker<R>,
 	PI: 'static,
 	MI: 'static,
-	P: Get<TransactionPriority>,
 	R::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>
 		+ BridgeGrandpaCallSubtype<R, R::BridgesGrandpaPalletInstance>
 		+ BridgeParachainsCallSubtype<R, PI>
@@ -92,7 +85,6 @@ where
 	type Runtime = R;
 	type BatchCallUnpacker = BCU;
 	type BridgeMessagesPalletInstance = MI;
-	type PriorityBoostPerMessage = P;
 	type Reward = R::Reward;
 	type RemoteGrandpaChainBlockNumber =
 		pallet_bridge_grandpa::BridgedBlockNumber<R, R::BridgesGrandpaPalletInstance>;

--- a/modules/relayers/src/extension/priority.rs
+++ b/modules/relayers/src/extension/priority.rs
@@ -22,23 +22,81 @@
 //! single message with nonce `N`, then the transaction with nonces `N..=N+100` will
 //! be rejected. This can lower bridge throughput down to one message per block.
 
-use bp_messages::MessageNonce;
+use crate::{Config as RelayersConfig, Pallet as RelayersPallet};
+
+use bp_messages::{LaneId, MessageNonce};
 use frame_support::traits::Get;
-use sp_runtime::transaction_validity::TransactionPriority;
+use frame_system::{pallet_prelude::BlockNumberFor, Pallet as SystemPallet};
+use sp_runtime::{
+	traits::{One, Zero},
+	transaction_validity::TransactionPriority,
+};
 
 // reexport everything from `integrity_tests` module
 pub use integrity_tests::*;
 
-/// Compute priority boost for message delivery transaction that delivers
-/// given number of messages.
-pub fn compute_priority_boost<PriorityBoostPerMessage>(
+/// Compute total priority boost for message delivery transaction.
+pub fn compute_priority_boost<R: RelayersConfig>(
+	lane_id: LaneId,
 	messages: MessageNonce,
+	relayer: &R::AccountId,
 ) -> TransactionPriority
 where
-	PriorityBoostPerMessage: Get<TransactionPriority>,
+	usize: TryFrom<BlockNumberFor<R>>,
 {
+	compute_per_message_priority_boost::<R::PriorityBoostPerMessage>(messages)
+		.saturating_add(compute_per_lane_priority_boost::<R>(lane_id, relayer))
+}
+
+/// Compute priority boost for message delivery transaction, that depends on number
+/// of bundled messages.
+fn compute_per_message_priority_boost<PriorityBoostPerMessage: Get<TransactionPriority>>(
+	messages: MessageNonce,
+) -> TransactionPriority {
 	// we don't want any boost for transaction with single message => minus one
 	PriorityBoostPerMessage::get().saturating_mul(messages.saturating_sub(1))
+}
+
+/// Compute priority boost for message delivery transaction, that depends on
+/// the set of lane relayers and current slot.
+fn compute_per_lane_priority_boost<R: RelayersConfig>(
+	lane_id: LaneId,
+	relayer: &R::AccountId,
+) -> TransactionPriority
+where
+	usize: TryFrom<BlockNumberFor<R>>,
+{
+	// if there are no relayers, explicitly registered at this lane, noone gets additional
+	// priority boost
+	let lane_relayers = RelayersPallet::<R>::lane_relayers(&lane_id);
+	let lane_relayers_len: BlockNumberFor<R> = (lane_relayers.len() as u32).into();
+	if lane_relayers_len.is_zero() {
+		return 0
+	}
+
+	// we can't deal with slots shorter than 1 block
+	let slot_length: BlockNumberFor<R> = R::SlotLength::get().into();
+	if slot_length < One::one() {
+		return 0
+	}
+
+	// let's compute current slot number
+	let current_block_number = SystemPallet::<R>::block_number();
+	let slot = current_block_number / slot_length;
+
+	// and then get the relayer for that slot
+	let slot_relayer = match usize::try_from(slot % lane_relayers_len) {
+		Ok(slot_relayer_index) => &lane_relayers[slot_relayer_index],
+		Err(_) => return 0,
+	};
+
+	// if message delivery transaction is submitted by the relayer, assigned to the current
+	// slot, let's boost the transaction priority
+	if relayer != slot_relayer {
+		return 0
+	}
+
+	R::PriorityBoostForActiveLaneRelayer::get()
 }
 
 #[cfg(not(feature = "integrity-test"))]
@@ -46,7 +104,7 @@ mod integrity_tests {}
 
 #[cfg(feature = "integrity-test")]
 mod integrity_tests {
-	use super::compute_priority_boost;
+	use super::compute_per_message_priority_boost;
 	use bp_messages::ChainWithMessages;
 
 	use bp_messages::MessageNonce;
@@ -93,7 +151,8 @@ mod integrity_tests {
 				Runtime,
 				MessagesInstance,
 			>(messages, Zero::zero());
-			let priority_boost = compute_priority_boost::<PriorityBoostPerMessage>(messages);
+			let priority_boost =
+				compute_per_message_priority_boost::<PriorityBoostPerMessage>(messages);
 			let priority_with_boost = base_priority + priority_boost;
 
 			let tip = tip_boost_per_message.saturating_mul((messages - 1).unique_saturated_into());
@@ -108,7 +167,7 @@ mod integrity_tests {
 				panic!(
 					"The PriorityBoostPerMessage value ({}) must be fixed to: {}",
 					priority_boost_per_message,
-					compute_priority_boost_per_message::<Runtime, MessagesInstance>(
+					compute_per_message_priority_boost_per_message::<Runtime, MessagesInstance>(
 						tip_boost_per_message
 					),
 				);
@@ -118,7 +177,7 @@ mod integrity_tests {
 
 	/// Compute priority boost that we give to message delivery transaction for additional message.
 	#[cfg(feature = "integrity-test")]
-	fn compute_priority_boost_per_message<Runtime, MessagesInstance>(
+	fn compute_per_message_priority_boost_per_message<Runtime, MessagesInstance>(
 		tip_boost_per_message: BalanceOf<Runtime>,
 	) -> TransactionPriority
 	where
@@ -198,5 +257,60 @@ mod integrity_tests {
 			tip,
 			Zero::zero(),
 		)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{mock::*, LaneRelayers};
+
+	#[test]
+	fn compute_per_lane_priority_boost_works() {
+		run_test(|| {
+			// insert 3 relayers to the queue
+			let lane_id = LaneId::new(1, 2);
+			let relayer1 = 1_000;
+			let relayer2 = 2_000;
+			let relayer3 = 3_000;
+			LaneRelayers::<TestRuntime>::insert(
+				lane_id,
+				sp_runtime::BoundedVec::try_from(vec![relayer1, relayer2, relayer3]).unwrap(),
+			);
+
+			// at blocks 1..=SlotLength relayer1 gets the boost
+			System::set_block_number(0);
+			for _ in 1..SlotLength::get() {
+				System::set_block_number(System::block_number() + 1);
+				assert_eq!(
+					compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer1),
+					PriorityBoostForActiveLaneRelayer::get(),
+				);
+				assert_eq!(compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer2), 0,);
+				assert_eq!(compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer3), 0,);
+			}
+
+			// at next slot, relayer2 gets the boost
+			for _ in 1..=SlotLength::get() {
+				System::set_block_number(System::block_number() + 1);
+				assert_eq!(compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer1), 0,);
+				assert_eq!(
+					compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer2),
+					PriorityBoostForActiveLaneRelayer::get(),
+				);
+				assert_eq!(compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer3), 0,);
+			}
+
+			// at next slot, relayer3 gets the boost
+			for _ in 1..=SlotLength::get() {
+				System::set_block_number(System::block_number() + 1);
+				assert_eq!(compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer1), 0,);
+				assert_eq!(compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer2), 0,);
+				assert_eq!(
+					compute_per_lane_priority_boost::<TestRuntime>(lane_id, &relayer3),
+					PriorityBoostForActiveLaneRelayer::get(),
+				);
+			}
+		});
 	}
 }

--- a/modules/relayers/src/extension/priority.rs
+++ b/modules/relayers/src/extension/priority.rs
@@ -68,14 +68,14 @@ where
 {
 	// if there are no relayers, explicitly registered at this lane, noone gets additional
 	// priority boost
-	let lane_relayers = RelayersPallet::<R>::lane_relayers(&lane_id);
+	let lane_relayers = RelayersPallet::<R>::lane_relayers(lane_id);
 	let lane_relayers_len: BlockNumberFor<R> = (lane_relayers.len() as u32).into();
 	if lane_relayers_len.is_zero() {
 		return 0
 	}
 
 	// we can't deal with slots shorter than 1 block
-	let slot_length: BlockNumberFor<R> = R::SlotLength::get().into();
+	let slot_length: BlockNumberFor<R> = R::SlotLength::get();
 	if slot_length < One::one() {
 		return 0
 	}

--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 
+use bp_messages::LaneId;
 use bp_relayers::{
 	PaymentProcedure, Registration, RelayerRewardsKeyProvider, RewardsAccountParams, StakeAndSlash,
 };
@@ -65,8 +66,41 @@ pub mod pallet {
 		type Reward: AtLeast32BitUnsigned + Copy + Member + Parameter + MaxEncodedLen;
 		/// Pay rewards scheme.
 		type PaymentProcedure: PaymentProcedure<Self::AccountId, Self::Reward>;
+
 		/// Stake and slash scheme.
 		type StakeAndSlash: StakeAndSlash<Self::AccountId, BlockNumberFor<Self>, Self::Reward>;
+
+		/// Maximal number of relayers that can register themselves on a single lane.
+		#[pallet::constant]
+		type MaxRelayersPerLane: Get<u32>;
+		/// Length of slots in chain blocks.
+		///
+		/// Registered relayer may explicitly register himself at some lane to get priority boost
+		/// for message delivery transactions on that lane (that is done using `register_at_lane`
+		/// pallet call). All relayers, registered at the lane form an ordered queue and only
+		/// relayer at the head of that queue receives a boost at his slot (which has a length of
+		/// `SlotLength` blocks). Then the "best" relayer is removed and pushed to the tail of the
+		/// queue and next relayer gets the boost during next `SlotLength` blocks. And so on...
+		///
+		/// Shall not be too low to have an effect, because there's some (at least one block) lag
+		/// between moments when priority is computed and when active slot changes.
+		type SlotLength: Get<BlockNumberFor<Self>>;
+		/// Priority boost that the registered relayer gets for every additional message in the
+		/// message delivery transaction.
+		type PriorityBoostPerMessage: Get<TransactionPriority>;
+		/// Additional priority boost, that is added to regular `PriorityBoostPerMessage` boost for
+		/// message delivery transactions, submitted by relayer at the head of the lane relayers
+		/// queue.
+		///
+		/// In other words, if relayer has registered at some `lane`, using `register_at_lane` call
+		/// AND he is currently at the head of the lane relayers queue, his message delivery
+		/// transaction will get the following additional priority boost:
+		///
+		/// ```nocompile
+		/// T::PriorityBoostForActiveLaneRelayer::get() + T::PriorityBoostPerMessage::get() * (msgs - 1)
+		/// ```
+		type PriorityBoostForActiveLaneRelayer: Get<TransactionPriority>;
+
 		/// Pallet call weights.
 		type WeightInfo: WeightInfoExt;
 	}
@@ -447,6 +481,21 @@ pub mod pallet {
 		T::AccountId,
 		Registration<BlockNumberFor<T>, T::Reward>,
 		OptionQuery,
+	>;
+
+	/// A set of relayers that have explicitly registered themselves at a given lane.
+	///
+	/// Every relayer inside this set receives additional priority boost when it submits
+	/// message delivers messages at given lane. The boost only happens inside the slot,
+	/// assigned to relayer.
+	#[pallet::storage]
+	#[pallet::getter(fn lane_relayers)]
+	pub type LaneRelayers<T: Config> = StorageMap<
+		_,
+		Identity,
+		LaneId,
+		BoundedVec<T::AccountId, T::MaxRelayersPerLane>,
+		ValueQuery,
 	>;
 }
 

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -38,6 +38,7 @@ use pallet_transaction_payment::Multiplier;
 use sp_core::{ConstU64, ConstU8, H256};
 use sp_runtime::{
 	traits::{BlakeTwo256, ConstU32, IdentityLookup},
+	transaction_validity::TransactionPriority,
 	BuildStorage, FixedPointNumber, Perquintill, StateVersion,
 };
 
@@ -190,6 +191,8 @@ parameter_types! {
 	pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
 	pub MaximumMultiplier: Multiplier = sp_runtime::traits::Bounded::max_value();
+	pub SlotLength: u32 = 16;
+	pub PriorityBoostForActiveLaneRelayer: TransactionPriority = 1;
 }
 
 impl frame_system::Config for TestRuntime {
@@ -301,6 +304,10 @@ impl pallet_bridge_relayers::Config for TestRuntime {
 	type Reward = ThisChainBalance;
 	type PaymentProcedure = TestPaymentProcedure;
 	type StakeAndSlash = TestStakeAndSlash;
+	type MaxRelayersPerLane = ConstU32<16>;
+	type SlotLength = SlotLength;
+	type PriorityBoostPerMessage = ConstU64<1>;
+	type PriorityBoostForActiveLaneRelayer = PriorityBoostForActiveLaneRelayer;
 	type WeightInfo = ();
 }
 

--- a/primitives/relayers/src/extension.rs
+++ b/primitives/relayers/src/extension.rs
@@ -26,11 +26,7 @@ use frame_support::{
 };
 use frame_system::Config as SystemConfig;
 use pallet_utility::{Call as UtilityCall, Pallet as UtilityPallet};
-use sp_runtime::{
-	traits::Get,
-	transaction_validity::{TransactionPriority, TransactionValidityError},
-	RuntimeDebug,
-};
+use sp_runtime::{transaction_validity::TransactionValidityError, RuntimeDebug};
 use sp_std::{fmt::Debug, marker::PhantomData, vec, vec::Vec};
 
 /// Type of the call that the signed extension recognizes.
@@ -123,9 +119,6 @@ pub trait ExtensionConfig {
 	type BatchCallUnpacker: BatchCallUnpacker<Self::Runtime>;
 	/// Messages pallet instance.
 	type BridgeMessagesPalletInstance: 'static;
-	/// Additional priority that is added to base message delivery transaction priority
-	/// for every additional bundled message.
-	type PriorityBoostPerMessage: Get<TransactionPriority>;
 	/// Type of reward, that the `pallet-bridge-relayers` is using.
 	type Reward;
 	/// Block number for the remote **GRANDPA chain**. Mind that this chain is not


### PR DESCRIPTION
related #2486

All that this PR does (apart from some small refactoring) is adding the `compute_per_lane_priority_boost` function. It adds priority boost to message delivery transactions of relayer at the head of the lane relayers queue. This queue is always empty now, so no logic changes yet. But the `compute_per_lane_priority_boost` most likely won't change at all or will be changed slightly.

The reason I'm opening PR in this state is that I want some feedback on this priority-based approach. While I'm pretty sure it is the best possible option for us, it still has some drawbacks. The main one is that it isn't super scalable - i.e. if we'll have other bridges on the bridge hub (read: with-Ethereum, with-Bulletin, ...), their transactions priority boost will be zero, which could cause some issues. On the other hand, if bridge hub will be extensively used (e.g. many lanes), we will need to solve the same problem even if we won't have those priority boosts.

Detailed info may be found: https://github.com/paritytech/parity-bridges-common/issues/2486 and expecially https://gist.github.com/svyatonik/398bfd306541b693fe5afe37dc68f908