### PR TITLE
Reject transactions if bridge pallets are halted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4350,7 +4350,7 @@ checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
 dependencies = [
  "futures-io",
  "rustls 0.20.8",
- "webpki 0.22.1",
+ "webpki 0.22.2",
 ]
 
 [[package]]
@@ -5997,7 +5997,7 @@ dependencies = [
  "ring 0.16.20",
  "rustls 0.20.8",
  "thiserror",
- "webpki 0.22.1",
+ "webpki 0.22.2",
  "x509-parser 0.14.0",
  "yasna",
 ]
@@ -10253,7 +10253,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki 0.22.1",
+ "webpki 0.22.2",
 ]
 
 [[package]]
@@ -11417,7 +11417,7 @@ dependencies = [
  "log",
  "ring 0.16.20",
  "sct 0.7.0",
- "webpki 0.22.1",
+ "webpki 0.22.2",
 ]
 
 [[package]]
@@ -15265,7 +15265,7 @@ checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls 0.20.8",
  "tokio",
- "webpki 0.22.1",
+ "webpki 0.22.2",
 ]
 
 [[package]]
@@ -15658,7 +15658,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
@@ -16308,9 +16308,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
  "ring 0.16.20",
  "untrusted",
@@ -16322,7 +16322,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki 0.22.1",
+ "webpki 0.22.2",
 ]
 
 [[package]]

--- a/modules/beefy/src/lib.rs
+++ b/modules/beefy/src/lib.rs
@@ -601,7 +601,7 @@ mod tests {
 				.is_some());
 				assert_eq!(
 					ImportedBlockNumbers::<TestRuntime>::get(index),
-					Some(index + 1).map(Into::into)
+					Some(Into::into(index + 1)),
 				);
 			}
 
@@ -619,7 +619,7 @@ mod tests {
 			.is_some());
 			assert_eq!(
 				ImportedBlockNumbers::<TestRuntime>::get(0),
-				Some(commitments_to_keep + 1).map(Into::into)
+				Some(Into::into(commitments_to_keep + 1)),
 			);
 			// the side effect of the import is that the commitment#1 is pruned
 			assert!(ImportedCommitments::<TestRuntime>::get(1).is_none());
@@ -638,7 +638,7 @@ mod tests {
 			.is_some());
 			assert_eq!(
 				ImportedBlockNumbers::<TestRuntime>::get(1),
-				Some(commitments_to_keep + 2).map(Into::into)
+				Some(Into::into(commitments_to_keep + 2)),
 			);
 			// the side effect of the import is that the commitment#2 is pruned
 			assert!(ImportedCommitments::<TestRuntime>::get(1).is_none());


### PR DESCRIPTION
Halting one of bridges pallets is an extraordinary action that could only be performed by the root (governance) on live chains. We may remove this functionality (along with pallet owners) when we drop Rialto<>Millau in favor of local R<>W/P<>K bridge. 

However, we still have the code in v1 and it is a good idea to take care of careless registered relayers, who keep running the relayer while pallets are halted. Now they can be slashed if they submit transaction to the halted pallet. After this PR, our extensions will reject such transactions and they won't be "mined" => relayers won't be slashed.