### PR TITLE
Finishing "Additional priority boost for relayers that have explicitly registered at lane"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
+ "sp-arithmetic",
  "sp-runtime",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]

--- a/modules/relayers/src/extension/grandpa_adapter.rs
+++ b/modules/relayers/src/extension/grandpa_adapter.rs
@@ -86,9 +86,13 @@ where
 	type Runtime = R;
 	type BatchCallUnpacker = BCU;
 	type BridgeMessagesPalletInstance = MI;
-	type PriorityBoostPerMessage = P;
 	type Reward = R::Reward;
 	type RemoteGrandpaChainBlockNumber = pallet_bridge_grandpa::BridgedBlockNumber<R, GI>;
+
+	type SlotLength = sp_runtime::traits::ConstU32<32>; // TODO
+
+	type PriorityBoostForLaneRelayer = sp_runtime::traits::ConstU64<1>; // TODO
+	type PriorityBoostPerMessage = P;
 
 	fn parse_and_check_for_obsolete_call(
 		call: &R::RuntimeCall,

--- a/modules/relayers/src/extension/parachain_adapter.rs
+++ b/modules/relayers/src/extension/parachain_adapter.rs
@@ -92,10 +92,14 @@ where
 	type Runtime = R;
 	type BatchCallUnpacker = BCU;
 	type BridgeMessagesPalletInstance = MI;
-	type PriorityBoostPerMessage = P;
 	type Reward = R::Reward;
 	type RemoteGrandpaChainBlockNumber =
 		pallet_bridge_grandpa::BridgedBlockNumber<R, R::BridgesGrandpaPalletInstance>;
+
+	type SlotLength = sp_runtime::traits::ConstU32<32>; // TODO
+
+	type PriorityBoostForLaneRelayer = sp_runtime::traits::ConstU64<1>; // TODO
+	type PriorityBoostPerMessage = P;
 
 	fn parse_and_check_for_obsolete_call(
 		call: &R::RuntimeCall,

--- a/modules/relayers/src/extension/priority.rs
+++ b/modules/relayers/src/extension/priority.rs
@@ -283,7 +283,7 @@ mod tests {
 			assert!(relayers_set.next_set_try_push(relayer1, 0));
 			assert!(relayers_set.next_set_try_push(relayer2, 0));
 			assert!(relayers_set.next_set_try_push(relayer3, 0));
-			relayers_set.activate_next_set(0, |_| true);
+			relayers_set.activate_next_set(0);
 			LaneRelayers::<TestRuntime>::insert(lane_id, relayers_set);
 
 			// at blocks 1..=SlotLength relayer1 gets the boost

--- a/modules/relayers/src/extension/priority.rs
+++ b/modules/relayers/src/extension/priority.rs
@@ -76,13 +76,13 @@ where
 	let active_lane_relayers = lane_relayers.active_relayers();
 	let lane_relayers_len: BlockNumberFor<R> = (active_lane_relayers.len() as u32).into();
 	if lane_relayers_len.is_zero() {
-		return 0;
+		return 0
 	}
 
 	// we can't deal with slots shorter than 1 block
 	let slot_length: BlockNumberFor<R> = R::SlotLength::get().into();
 	if slot_length < One::one() {
-		return 0;
+		return 0
 	}
 
 	// let's compute current slot number
@@ -98,7 +98,7 @@ where
 	// if message delivery transaction is submitted by the relayer, assigned to the current
 	// slot, let's boost the transaction priority
 	if relayer != slot_relayer.relayer() {
-		return 0;
+		return 0
 	}
 
 	R::PriorityBoostForLaneRelayer::get()

--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -406,16 +406,18 @@ pub mod pallet {
 					Error::<T>::TooEarlyToActivateNextRelayersSet,
 				);
 
-				let next_next_set_may_enact_at = current_block_number.saturating_add(4); // TODO
+				let new_next_set_may_enact_at = current_block_number.saturating_add(4u32.into()); // TODO
 				lane_relayers.activate_next_set(
-					next_next_set_may_enact_at,
-					|relayer| Self::is_registration_active(relayer.relayer())
+					new_next_set_may_enact_at,
+					|relayer| Self::is_registration_active(relayer)
 				);
 
 				*lane_relayers_ref = Some(lane_relayers);
 
 				Ok::<_, Error<T>>(())
 			})?;
+
+			Ok(())
 		}
 	}
 
@@ -668,6 +670,10 @@ pub mod pallet {
 		TooLargeRewardToOccupyAnEntry,
 		///
 		NotRegisteredAtLane,
+		///
+		NoRelayersAtLane,
+		///
+		TooEarlyToActivateNextRelayersSet,
 	}
 
 	/// Map of the relayer => accumulated reward.

--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -18,27 +18,9 @@
 //! between relayers.
 
 // TODO: allow bridge owners to add "protected" relayers that have a guaranteed slot in the lane
-// relayers TODO: or else ONLY allow bridge owners to add registered relayers (through XCM calls)???
+// relayers
 
-// TODO: lane registration must be time-limited to force relayers to renew it and drop relayers that
-// have stopped working. Otherwise one relayer may fill up all lane slots for a fixed returnable
-// sum.
-//
-// Or we may introduce some fine for relayer for not delivering messages. This is near to impossible
-// though.
-//
-// Or we may allow to buy lane registration using relayer rewards only - i.e. has has delivered 100
-// messages and reward is 100 DOTs. He could reserve his 100 DOTs to buy lane registration slots.
-// Every slot costs 1 DOT. So after 100 slots, the registration becomes inactive. And he must renew
-// it.
-
-// TODO: additionally we could add a reward market - i.e. now we have boosts:
-// `messages_count * per_message + per_lane`. We could add another boost if relayer wants to receive
-// lower reward. E.g. if normal reward is 1 DOT per message but relayers claims that he could
-// deliver 10 messages in exchange of 1 DOT, we will prefer such transaction over transaction with
-// 10 DOTs reward.
-
-// TODO: better (easier code) handling of reserved funds. Separate calls?
+// TODO: or else ONLY allow bridge owners to add registered relayers (through XCM calls)???
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]

--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -22,6 +22,8 @@
 
 // TODO: or else ONLY allow bridge owners to add registered relayers (through XCM calls)???
 
+// TODO: remove relayer from `next_set` when he has not delivered any messages
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 

--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -291,10 +291,6 @@ pub mod pallet {
 				// let's try to claim a slot in the next set
 				LaneRelayers::<T>::try_mutate(lane, |lane_relayers| {
 					ensure!(
-						!lane_relayers.next_set_contains(relayer.clone()),
-						Error::<T>::AlreadyRegisteredAtLane,
-					);
-					ensure!(
 						lane_relayers.next_set_try_push(relayer.clone(), expected_reward),
 						Error::<T>::TooLargeRewardToOccupyAnEntry,
 					);
@@ -337,37 +333,23 @@ pub mod pallet {
 				};
 
 				// ensure that the relayer has lane registration
-				ensure!(registration.lanes.contains(&lane), Error::<T>::UnregisteredAtLane);
+				// ensure!(registration.lanes.remove(&lane), Error::<T>::UnregisteredAtLane);
 
 				// remove relayer from the `next_set` of lane relayers. So relayer is still
 				LaneRelayers::<T>::try_mutate(lane, |lane_relayers| {
 					ensure!(
-						lane_relayers.next_set_ctry_remove(relayer.clone()),
+						lane_relayers.next_set_try_remove(&relayer),
 						Error::<T>::NotRegisteredAtLane,
 					);
 					Ok::<_, Error<T>>(())
 				})?;
-
-				// cannot add another lane registration if relayer has already max allowed
-				// lane registrations
-				ensure!(registration.lanes.try_push(lane).is_ok(), Error::<T>::TooManyLaneRegistrations);
-
-				// the relayer need to stake additional amount for every additional lane
-				registration.stake = Self::update_relayer_stake(
-					&relayer,
-					registration.stake,
-					registration.required_stake(
-						Self::base_stake(),
-						Self::stake_per_lane(),
-					),
-				)?;
 
 				*maybe_registration = Some(registration);
 
 				Ok(())
 			})?;
 
-			Ok(())*/
+			Ok(())
 		}
 	}
 

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -301,6 +301,11 @@ impl pallet_bridge_relayers::Config for TestRuntime {
 	type Reward = ThisChainBalance;
 	type PaymentProcedure = TestPaymentProcedure;
 	type StakeAndSlash = TestStakeAndSlash;
+
+	type MaxLaneRelayersChanges = ConstU32<4>;
+	type MaxLanesPerRelayer = ConstU32<4>;
+	type MaxRelayersPerLane = ConstU32<4>;
+
 	type WeightInfo = ();
 }
 

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -192,6 +192,7 @@ parameter_types! {
 	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
 	pub MaximumMultiplier: Multiplier = sp_runtime::traits::Bounded::max_value();
 	pub SlotLength: u32 = 16;
+	pub MaxLanesPerRelayer: u32 = 4;
 	pub PriorityBoostForLaneRelayer: TransactionPriority = 4;
 }
 
@@ -304,7 +305,7 @@ impl pallet_bridge_relayers::Config for TestRuntime {
 	type Reward = ThisChainBalance;
 	type PaymentProcedure = TestPaymentProcedure;
 	type StakeAndSlash = TestStakeAndSlash;
-	type MaxLanesPerRelayer = ConstU32<4>;
+	type MaxLanesPerRelayer = MaxLanesPerRelayer;
 	type MaxRelayersPerLane = ConstU32<4>;
 	type SlotLength = ConstU32<16>;
 	type PriorityBoostPerMessage = ConstU64<1>;

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -302,7 +302,6 @@ impl pallet_bridge_relayers::Config for TestRuntime {
 	type PaymentProcedure = TestPaymentProcedure;
 	type StakeAndSlash = TestStakeAndSlash;
 
-	type MaxLaneRelayersChanges = ConstU32<4>;
 	type MaxLanesPerRelayer = ConstU32<4>;
 	type MaxRelayersPerLane = ConstU32<4>;
 

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -161,6 +161,7 @@ pub type TestStakeAndSlash = pallet_bridge_relayers::StakeAndSlashNamed<
 	Balances,
 	ReserveId,
 	Stake,
+	LaneStake,
 	Lease,
 >;
 
@@ -184,6 +185,7 @@ parameter_types! {
 	pub const ExistentialDeposit: ThisChainBalance = 1;
 	pub const ReserveId: [u8; 8] = *b"brdgrlrs";
 	pub const Stake: ThisChainBalance = 1_000;
+	pub const LaneStake: ThisChainBalance = 100;
 	pub const Lease: ThisChainBlockNumber = 8;
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
 	pub const TransactionBaseFee: ThisChainBalance = 0;

--- a/modules/relayers/src/payment_adapter.rs
+++ b/modules/relayers/src/payment_adapter.rs
@@ -73,14 +73,14 @@ fn register_relayers_rewards<T: Config>(
 	confirmation_relayer: &T::AccountId,
 	relayers_rewards: RelayersRewards<T::AccountId>,
 	lane_id: RewardsAccountParams,
-	delivery_fee: T::Reward,
+	message_delivery_reward: T::Reward,
 ) {
 	// reward every relayer except `confirmation_relayer`
 	let mut confirmation_relayer_reward = T::Reward::zero();
 	for (relayer, messages) in relayers_rewards {
 		// sane runtime configurations guarantee that the number of messages will be below
 		// `u32::MAX`
-		let relayer_reward = T::Reward::saturated_from(messages).saturating_mul(delivery_fee);
+		let relayer_reward = T::Reward::saturated_from(messages).saturating_mul(message_delivery_reward);
 
 		if relayer != *confirmation_relayer {
 			Pallet::<T>::register_relayer_reward(lane_id, &relayer, relayer_reward);

--- a/modules/relayers/src/payment_adapter.rs
+++ b/modules/relayers/src/payment_adapter.rs
@@ -80,7 +80,8 @@ fn register_relayers_rewards<T: Config>(
 	for (relayer, messages) in relayers_rewards {
 		// sane runtime configurations guarantee that the number of messages will be below
 		// `u32::MAX`
-		let relayer_reward = T::Reward::saturated_from(messages).saturating_mul(message_delivery_reward);
+		let relayer_reward =
+			T::Reward::saturated_from(messages).saturating_mul(message_delivery_reward);
 
 		if relayer != *confirmation_relayer {
 			Pallet::<T>::register_relayer_reward(lane_id, &relayer, relayer_reward);

--- a/modules/relayers/src/stake_adapter.rs
+++ b/modules/relayers/src/stake_adapter.rs
@@ -28,21 +28,23 @@ use sp_std::{fmt::Debug, marker::PhantomData};
 ///
 /// **WARNING**: this implementation assumes that the relayers pallet is configured to
 /// use the [`bp_relayers::PayRewardFromAccount`] as its relayers payment scheme.
-pub struct StakeAndSlashNamed<AccountId, BlockNumber, Currency, ReserveId, Stake, Lease>(
-	PhantomData<(AccountId, BlockNumber, Currency, ReserveId, Stake, Lease)>,
+pub struct StakeAndSlashNamed<AccountId, BlockNumber, Currency, ReserveId, Stake, LaneStake, Lease>(
+	PhantomData<(AccountId, BlockNumber, Currency, ReserveId, Stake, LaneStake, Lease)>,
 );
 
-impl<AccountId, BlockNumber, Currency, ReserveId, Stake, Lease>
+impl<AccountId, BlockNumber, Currency, ReserveId, Stake, LaneStake, Lease>
 	StakeAndSlash<AccountId, BlockNumber, Currency::Balance>
-	for StakeAndSlashNamed<AccountId, BlockNumber, Currency, ReserveId, Stake, Lease>
+	for StakeAndSlashNamed<AccountId, BlockNumber, Currency, ReserveId, Stake, LaneStake, Lease>
 where
 	AccountId: Codec + Debug,
 	Currency: NamedReservableCurrency<AccountId>,
 	ReserveId: Get<Currency::ReserveIdentifier>,
 	Stake: Get<Currency::Balance>,
+	LaneStake: Get<Currency::Balance>,
 	Lease: Get<BlockNumber>,
 {
 	type RequiredStake = Stake;
+	type RequiredLaneStake = LaneStake;
 	type RequiredRegistrationLease = Lease;
 
 	fn reserve(relayer: &AccountId, amount: Currency::Balance) -> DispatchResult {

--- a/primitives/relayers/Cargo.toml
+++ b/primitives/relayers/Cargo.toml
@@ -22,6 +22,7 @@ bp-runtime = { path = "../runtime", default-features = false }
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 
@@ -41,6 +42,7 @@ std = [
 	"frame-system/std",
 	"pallet-utility/std",
 	"scale-info/std",
+	"sp-arithmetic/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/primitives/relayers/src/extension.rs
+++ b/primitives/relayers/src/extension.rs
@@ -123,9 +123,6 @@ pub trait ExtensionConfig {
 	type BatchCallUnpacker: BatchCallUnpacker<Self::Runtime>;
 	/// Messages pallet instance.
 	type BridgeMessagesPalletInstance: 'static;
-	/// Additional priority that is added to base message delivery transaction priority
-	/// for every additional bundled message.
-	type PriorityBoostPerMessage: Get<TransactionPriority>;
 	/// Type of reward, that the `pallet-bridge-relayers` is using.
 	type Reward;
 	/// Block number for the remote **GRANDPA chain**. Mind that this chain is not
@@ -133,6 +130,18 @@ pub trait ExtensionConfig {
 	/// parachain, it must be its parent relay chain. If we are bridging with the
 	/// GRANDPA chain, it must be it.
 	type RemoteGrandpaChainBlockNumber: Clone + Copy + Debug;
+
+	// TODO: all constants below must be a part of the pallet configuration
+
+	/// TODO
+	type SlotLength: Get<u32>;
+
+	/// Additional priority boost that is added to base message delivery transaction
+	/// priority, submitted by the relayer, assigned to given lane at given slot.
+	type PriorityBoostForLaneRelayer: Get<TransactionPriority>;
+	/// Additional priority that is added to base message delivery transaction priority
+	/// for every additional bundled message.
+	type PriorityBoostPerMessage: Get<TransactionPriority>;
 
 	/// Given runtime call, check if it is supported by the signed extension. Additionally,
 	/// check if call (or any of batched calls) are obsolete.

--- a/primitives/relayers/src/lane_relayers.rs
+++ b/primitives/relayers/src/lane_relayers.rs
@@ -14,16 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Bridge lane relayers registration and slashing scheme.
+//! Bridge lane relayers.
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_runtime::{traits::Get, BoundedVec, RuntimeDebug};
 
 /// A relayer and the reward that it wants to receive for delivering a single message.
 #[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(AccountId, Reward))]
 pub struct RelayerAndReward<AccountId, Reward> {
 	/// A relayer account identifier.
-	pub relayer: AccountId,
+	relayer: AccountId,
 	/// A reward that is paid to relayer for delivering a single message.
-	pub reward: Reward,
+	reward: Reward,
 }
 
 /// A set of relayers that have explicitly registered themselves at a given lane.
@@ -32,7 +36,7 @@ pub struct RelayerAndReward<AccountId, Reward> {
 /// message delivers messages at given lane. The boost only happens inside the slot,
 /// assigned to relayer.
 ///
-/// The set is required to change periodically (at `next_set_enacts_at`). An interval, when
+/// The set is required to change periodically (at `next_set_may_enact_at`). An interval, when
 /// the same relayers set is active is called epoch. Every relayer in the epoch is guaranteed
 /// to have at least one slot, but epochs may have differrent lengths.
 ///
@@ -45,23 +49,75 @@ pub struct RelayerAndReward<AccountId, Reward> {
 /// relayer in the [`Self::next_set`].
 #[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(AccountId, BlockNumber, Reward))]
-pub struct LaneRelayers<AccountId, BlockNumber, Reward> {
+pub struct LaneRelayers<AccountId, BlockNumber, Reward, MaxLaneRelayers: Get<u32>> {
 	/// Number of block, where the active set has been enacted.
-	pub enacted_at: BlockNumber,
+	enacted_at: BlockNumber,
 	/// Number of block, where the active set may be replaced with the [`Self::next_set`].
 	///
 	/// We do not allow immediate changes of the [`Self::next_set`], because relayers
 	/// may change it so that they are always assigned the current slot.
-	pub next_set_enacts_at: BlockNumber,
+	next_set_may_enact_at: BlockNumber,
 	/// An active set of lane relayers.
 	///
 	/// It is a circular queue. Every relayer in the queue is assigned the slot (fixed number
 	/// of blocks), starting from [`Self::enacted_at`]. Once the slot of last relayer ends,
 	/// next slot will be assigned to the first relayer and so on.
-	pub active_set: BoundedVec<RelayerAndReward<AccountId, Reward>, MaxLaneRelayers>,
+	active_set: BoundedVec<RelayerAndReward<AccountId, Reward>, MaxLaneRelayers>,
 	/// Next set of lane relayers.
 	///
 	/// It is a bounded priority queue. Relayers that are working for larger reward are replaced
 	/// with relayers, that are working for smaller reward.
-	pub next_set: BoundedVec<RelayerAndReward<AccountId, Reward>, MaxLaneRelayers>,
+	next_set: BoundedVec<RelayerAndReward<AccountId, Reward>, MaxLaneRelayers>,
+}
+
+impl<AccountId, BlockNumber, Reward, MaxLaneRelayers> LaneRelayers<AccountId, BlockNumber, Reward, MaxLaneRelayers> where
+	AccountId: PartialOrd,	
+	Reward: Clone + Copy + Ord,
+	MaxLaneRelayers: Get<u32>,
+{
+	/// Try insert relayer into next set.
+	///
+	/// Returns `true` if relayer has been added to the set and false otherwise.
+	pub fn next_set_try_push(&mut self, relayer: AccountId, reward: Reward) -> bool {
+		// first, remove existing entry for the same relayer from the set
+		self.next_set.retain(|entry| entry.relayer != relayer);
+		// now try to insert new entry into the queue
+		self.next_set.force_insert_keep_left(
+			self.select_position_in_next_set(reward),
+			RelayerAndReward { relayer, reward },
+		).is_ok()
+	}
+
+	fn select_position_in_next_set(&self, reward: Reward) -> usize {
+		// we need to insert new entry **after** the last entry with the same `reward`. Otherwise it may be used
+		// to push relayers our of the queue
+		let mut initial_position = self
+			.next_set
+			.binary_search_by_key(&reward, |entry| entry.reward)
+			.unwrap_or_else(|position| position);
+		while self.next_set.get(initial_position + 1).map(|entry| entry.reward == reward).unwrap_or(false) {
+			initial_position += 1;
+		}
+		initial_position
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const MAX_LANE_RELAYERS: u32 = 4;
+	type TestLaneRelayers = LaneRelayers<u64, u64, u64, ConstU32<MAX_LANE_RELAYERS>>;
+
+	#[test]
+	fn next_set_try_push_works() {
+		let mut relayers: TestLaneRelayers = LaneRelayers {
+			enacted_at: 0,
+			next_set_may_enact_at: 100,
+			active_set: vec![].try_into().unwrap(),
+			next_set: vec![].try_into().unwrap(),
+		};
+
+		// first `MAX_LANE_RELAYERS` are added
+	}
 }

--- a/primitives/relayers/src/lane_relayers.rs
+++ b/primitives/relayers/src/lane_relayers.rs
@@ -22,7 +22,6 @@ use sp_runtime::{traits::{Get, Zero}, BoundedVec, RuntimeDebug};
 
 /// A relayer and the reward that it wants to receive for delivering a single message.
 #[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-#[scale_info(skip_type_params(AccountId, Reward))]
 pub struct RelayerAndReward<AccountId, Reward> {
 	/// A relayer account identifier.
 	relayer: AccountId,
@@ -79,8 +78,8 @@ pub struct LaneRelayersSet<AccountId, BlockNumber, Reward, MaxRelayersPerLane: G
 
 impl<AccountId, BlockNumber, Reward, MaxRelayersPerLane> LaneRelayersSet<AccountId, BlockNumber, Reward, MaxRelayersPerLane> where
 	AccountId: PartialOrd,	
-	BlockNumber: Zero,
-	Reward: Clone + Copy + Ord,
+	BlockNumber: Copy + Zero,
+	Reward: Copy + Ord,
 	MaxRelayersPerLane: Get<u32>,
 {
 	/// Creates new empty relayers set, where next sets enacts at given block.
@@ -91,6 +90,11 @@ impl<AccountId, BlockNumber, Reward, MaxRelayersPerLane> LaneRelayersSet<Account
 			active_set: BoundedVec::new(),
 			next_set: BoundedVec::new(),
 		}
+	}
+
+	/// Returns block, starting from which the [`Self::next_set`] may be enacted.
+	pub fn next_set_may_enact_at(&self) -> BlockNumber {
+		self.next_set_may_enact_at
 	}
 
 	/// Returns count of relayers in the active set.
@@ -123,7 +127,7 @@ impl<AccountId, BlockNumber, Reward, MaxRelayersPerLane> LaneRelayersSet<Account
 	/// Activate next set of relayers.
 	///
 	/// The [`Self::active_set`] is replaced with the [`Self::next_set`].
-	pub fn activate_next_set(&mut self, is_relayer_active: impl Fn(&AccountId) -> bool) {
+	pub fn activate_next_set(&mut self, new_next_set_may_enact_at: BlockNumber, is_relayer_active: impl Fn(&AccountId) -> bool) {
 		unimplemented!("TODO")
 	}
 

--- a/primitives/relayers/src/lane_relayers.rs
+++ b/primitives/relayers/src/lane_relayers.rs
@@ -1,0 +1,67 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Parity Bridges Common.
+
+// Parity Bridges Common is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity Bridges Common is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity Bridges Common.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Bridge lane relayers registration and slashing scheme.
+
+/// A relayer and the reward that it wants to receive for delivering a single message.
+#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[scale_info(skip_type_params(AccountId, Reward))]
+pub struct RelayerAndReward<AccountId, Reward> {
+	/// A relayer account identifier.
+	pub relayer: AccountId,
+	/// A reward that is paid to relayer for delivering a single message.
+	pub reward: Reward,
+}
+
+/// A set of relayers that have explicitly registered themselves at a given lane.
+///
+/// Every relayer inside this set receives additional priority boost when it submits
+/// message delivers messages at given lane. The boost only happens inside the slot,
+/// assigned to relayer.
+///
+/// The set is required to change periodically (at `next_set_enacts_at`). An interval, when
+/// the same relayers set is active is called epoch. Every relayer in the epoch is guaranteed
+/// to have at least one slot, but epochs may have differrent lengths.
+///
+/// We change the set to guarantee that inactive relayers are removed from the set eventually
+/// and are replaced by active relayers. The relayer will be scheduled for autoremoval if it
+/// has not delivered any messages during previous epoch.
+///
+/// Relayers are bargaining for the place in the set by offering lower reward for delivering
+/// messages. Relayer, which agress to get a lower reward will likely to replace a "more greedy"
+/// relayer in the [`Self::next_set`].
+#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[scale_info(skip_type_params(AccountId, BlockNumber, Reward))]
+pub struct LaneRelayers<AccountId, BlockNumber, Reward> {
+	/// Number of block, where the active set has been enacted.
+	pub enacted_at: BlockNumber,
+	/// Number of block, where the active set may be replaced with the [`Self::next_set`].
+	///
+	/// We do not allow immediate changes of the [`Self::next_set`], because relayers
+	/// may change it so that they are always assigned the current slot.
+	pub next_set_enacts_at: BlockNumber,
+	/// An active set of lane relayers.
+	///
+	/// It is a circular queue. Every relayer in the queue is assigned the slot (fixed number
+	/// of blocks), starting from [`Self::enacted_at`]. Once the slot of last relayer ends,
+	/// next slot will be assigned to the first relayer and so on.
+	pub active_set: BoundedVec<RelayerAndReward<AccountId, Reward>, MaxLaneRelayers>,
+	/// Next set of lane relayers.
+	///
+	/// It is a bounded priority queue. Relayers that are working for larger reward are replaced
+	/// with relayers, that are working for smaller reward.
+	pub next_set: BoundedVec<RelayerAndReward<AccountId, Reward>, MaxLaneRelayers>,
+}

--- a/primitives/relayers/src/lane_relayers.rs
+++ b/primitives/relayers/src/lane_relayers.rs
@@ -120,6 +120,13 @@ impl<AccountId, BlockNumber, Reward, MaxRelayersPerLane> LaneRelayersSet<Account
 		self.next_set.len() != len_before
 	}
 
+	/// Activate next set of relayers.
+	///
+	/// The [`Self::active_set`] is replaced with the [`Self::next_set`].
+	pub fn activate_next_set(&mut self, is_relayer_active: impl Fn(&AccountId) -> bool) {
+		unimplemented!("TODO")
+	}
+
 	fn select_position_in_next_set(&self, reward: Reward) -> usize {
 		// we need to insert new entry **after** the last entry with the same `reward`. Otherwise it may be used
 		// to push relayers our of the queue

--- a/primitives/relayers/src/lane_relayers.rs
+++ b/primitives/relayers/src/lane_relayers.rs
@@ -134,13 +134,9 @@ where
 	/// Activate next set of relayers.
 	///
 	/// The [`Self::active_set`] is replaced with the [`Self::next_set`].
-	pub fn activate_next_set(
-		&mut self,
-		new_next_set_may_enact_at: BlockNumber,
-		is_relayer_active: impl Fn(&AccountId) -> bool,
-	) {
+	pub fn activate_next_set(&mut self, new_next_set_may_enact_at: BlockNumber) {
 		self.active_set = self.next_set.clone();
-		// TODO
+		self.next_set_may_enact_at = new_next_set_may_enact_at;
 	}
 
 	fn select_position_in_next_set(&self, reward: Reward) -> usize {

--- a/primitives/relayers/src/lib.rs
+++ b/primitives/relayers/src/lib.rs
@@ -23,6 +23,7 @@ pub use extension::{
 	BatchCallUnpacker, ExtensionCallData, ExtensionCallInfo, ExtensionConfig,
 	RuntimeWithUtilityPallet,
 };
+pub use lane_relayers::LaneRelayers;
 pub use registration::{Registration, StakeAndSlash};
 
 use bp_messages::LaneId;
@@ -37,6 +38,7 @@ use sp_runtime::{
 use sp_std::{fmt::Debug, marker::PhantomData};
 
 mod extension;
+mod lane_relayers;
 mod registration;
 
 /// The owner of the sovereign account that should pay the rewards.

--- a/primitives/relayers/src/lib.rs
+++ b/primitives/relayers/src/lib.rs
@@ -23,7 +23,7 @@ pub use extension::{
 	BatchCallUnpacker, ExtensionCallData, ExtensionCallInfo, ExtensionConfig,
 	RuntimeWithUtilityPallet,
 };
-pub use lane_relayers::LaneRelayers;
+pub use lane_relayers::{LaneRelayersSet, RelayerAndReward};
 pub use registration::{Registration, StakeAndSlash};
 
 use bp_messages::LaneId;

--- a/primitives/relayers/src/registration.rs
+++ b/primitives/relayers/src/registration.rs
@@ -52,7 +52,7 @@ use sp_std::fmt::Debug;
 
 /// Relayer registration.
 #[derive(CloneNoBound, Decode, Encode, Eq, PartialEqNoBound, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen)]
-#[scale_info(skip_type_params(BlockNumber, Balance, MaxLanesPerRelayer))]
+#[scale_info(skip_type_params(MaxLanesPerRelayer))]
 pub struct Registration<BlockNumber: Clone + Debug + PartialEq, Balance: Clone + Debug + PartialEq, MaxLanesPerRelayer: Get<u32>> {
 	/// The last block number, where this registration is considered active.
 	///

--- a/primitives/relayers/src/registration.rs
+++ b/primitives/relayers/src/registration.rs
@@ -190,8 +190,12 @@ impl<
 
 /// Relayer stake-and-slash mechanism.
 pub trait StakeAndSlash<AccountId, BlockNumber, Balance> {
-	/// The stake that the relayer must have to have its transactions boosted.
+	/// The stake that the relayer must have to have its message delivery transactions boosted.
 	type RequiredStake: Get<Balance>;
+	/// Additional stake that the relayer must have for every additional lane, where he wants to
+	/// get an extra boost (in addition to `[Self::RequiredStake]`) for message delivery transactions.
+	type RequiredLaneStake: Get<Balance>;
+
 	/// Required **remaining** registration lease to be able to get transaction priority boost.
 	///
 	/// If the difference between registration's `valid_till` and the current block number
@@ -224,6 +228,7 @@ where
 	BlockNumber: Default,
 {
 	type RequiredStake = ();
+	type RequiredLaneStake = ();
 	type RequiredRegistrationLease = ();
 
 	fn reserve(_relayer: &AccountId, _amount: Balance) -> DispatchResult {

--- a/primitives/relayers/src/registration.rs
+++ b/primitives/relayers/src/registration.rs
@@ -73,6 +73,10 @@ pub struct Registration<BlockNumber: Clone + Debug + PartialEq, Balance: Clone +
 	/// priority boost.
 	///
 	/// Relayer pays additional [`StakeAndSlash::RequiredStake`] for every lane.
+	///
+	/// The entry in this vector does not guarantee that the relayer is actually in
+	/// the active or the next set of relayers at given lane. It only says that the
+	/// relayer has tried to register at the lane.
 	pub lanes: BoundedVec<LaneId, MaxLanesPerRelayer>,
 }
 

--- a/primitives/relayers/src/registration.rs
+++ b/primitives/relayers/src/registration.rs
@@ -51,9 +51,15 @@ use sp_runtime::{
 use sp_std::fmt::Debug;
 
 /// Relayer registration.
-#[derive(CloneNoBound, Decode, Encode, Eq, PartialEqNoBound, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen)]
+#[derive(
+	CloneNoBound, Decode, Encode, Eq, PartialEqNoBound, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen,
+)]
 #[scale_info(skip_type_params(MaxLanesPerRelayer))]
-pub struct Registration<BlockNumber: Clone + Debug + PartialEq, Balance: Clone + Debug + PartialEq, MaxLanesPerRelayer: Get<u32>> {
+pub struct Registration<
+	BlockNumber: Clone + Debug + PartialEq,
+	Balance: Clone + Debug + PartialEq,
+	MaxLanesPerRelayer: Get<u32>,
+> {
 	/// The last block number, where this registration is considered active.
 	///
 	/// Relayer has an option to renew his registration (this may be done before it
@@ -84,7 +90,12 @@ pub struct Registration<BlockNumber: Clone + Debug + PartialEq, Balance: Clone +
 	lanes: BoundedVec<LaneId, MaxLanesPerRelayer>,
 }
 
-impl<BlockNumber: Clone + Copy + Debug + PartialEq + PartialOrd + Saturating, Balance: BaseArithmetic + Clone + Debug + PartialEq + Zero, MaxLanesPerRelayer: Get<u32>> Registration<BlockNumber, Balance, MaxLanesPerRelayer> {
+impl<
+		BlockNumber: Clone + Copy + Debug + PartialEq + PartialOrd + Saturating,
+		Balance: BaseArithmetic + Clone + Debug + PartialEq + Zero,
+		MaxLanesPerRelayer: Get<u32>,
+	> Registration<BlockNumber, Balance, MaxLanesPerRelayer>
+{
 	/// Creates new empty registration that ends at given block.
 	pub fn new(valid_till: BlockNumber) -> Self {
 		Registration { valid_till, stake: Zero::zero(), lanes: BoundedVec::new() }
@@ -95,8 +106,9 @@ impl<BlockNumber: Clone + Copy + Debug + PartialEq + PartialOrd + Saturating, Ba
 	/// `None` is returned if current block number does not affect registration and
 	/// it shall be considered active regardless of it.
 	pub fn valid_till(&self) -> Option<BlockNumber> {
-		// TODO: could be used by attacker to bump their current transaction priority while lease ends. We need to prolong valid_till
-		// at least by [`StakeAndSlash::RequiredRegistrationLease`] if lane is removed 
+		// TODO: could be used by attacker to bump their current transaction priority while lease
+		// ends. We need to prolong valid_till at least by
+		// [`StakeAndSlash::RequiredRegistrationLease`] if lane is removed
 		if self.lanes.is_empty() {
 			Some(self.valid_till)
 		} else {
@@ -106,8 +118,9 @@ impl<BlockNumber: Clone + Copy + Debug + PartialEq + PartialOrd + Saturating, Ba
 
 	/// Returns the **actual** last block number, where this registration is considered active.
 	///
-	/// It returns the actual block number that was set by the relayer during registration. Normally, this
-	/// method shall not be used anywhere outside of the `pallet-bridge-relayers` calls.
+	/// It returns the actual block number that was set by the relayer during registration.
+	/// Normally, this method shall not be used anywhere outside of the `pallet-bridge-relayers`
+	/// calls.
 	pub fn valid_till_ignore_lanes(&self) -> BlockNumber {
 		self.valid_till
 	}
@@ -119,11 +132,7 @@ impl<BlockNumber: Clone + Copy + Debug + PartialEq + PartialOrd + Saturating, Ba
 
 	/// Returns minimal stake that the relayer need to have in reserve to be
 	/// considered active.
-	pub fn required_stake(
-		&self,
-		base_stake: Balance,
-		stake_per_lane: Balance,
-	) -> Balance {
+	pub fn required_stake(&self, base_stake: Balance, stake_per_lane: Balance) -> Balance {
 		stake_per_lane
 			.saturating_mul(Balance::try_from(self.lanes.len()).unwrap_or(Balance::max_value()))
 			.saturating_add(base_stake)


### PR DESCRIPTION
related to #2486
follow up for #2597 (hence on top of it)

Opening it to give additional context when reviewing #2597. While there's still a lot of remaining work + a ton of TODOs, it show additional pallet calls + other changes, required for #2597. A brief overview:
- new `LaneRelayersSet` structure. It contains the current active set of lane relayers + next set + a block number, when the `next_set` may replace the `active_set`;
- relayers in the `LaneRelayersSet` are ordered by the reward that they are willing to receive for delivering a single message. Relayers, which are ready to "work" for smaller reward will push our relayers, wanting larger reward. In theory it should eventually affect the message fee that is paid at the sending chain (AH) if we'll implement reporting (or sending chains will receive this information in some other way). For now it should make the bridge cheaper for mantainers;
- relayer registration is considered active even if current stake is lower than the required (i.e. if `RequiredStake` was increased after relayer has registered itself);
- relayer registration is considered IF relayer has registered itself at least at one lane. So even initially his registration should have finished at block `1_000`, registration may be active (so he can't claim his funds back) even at block `2_000` if he's registered at some lane;
- added draft prototypes for `register_at_lane` and `deregister_at_lane` calls that the relayer will be able to call;
- added `enact_next_relayers_set_at_lane` call - it shall be called explicitly by one of relayers from the `next_set` for free (or for regular fee for other submitters) to activate the `next_set`. Why separate call? Because otherwise, we need to dance with hooks (`on_initialize`, `on_idle`, ...) and this is not well-scalable.

There's a chance that I'll split this PR into several smaller PRs in the future, if it'll grow to unreviewable state.