### PR TITLE
Add reward field to unrewarded relayers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
+ "sp-runtime",
  "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -131,7 +131,7 @@ fn receive_messages<T: Config<I>, I: 'static>(nonce: MessageNonce) {
 			state: LaneState::Opened,
 			relayers: vec![UnrewardedRelayer {
 				relayer: T::bridged_relayer_id(),
-				messages: DeliveredMessages::new(nonce),
+				messages: DeliveredMessages::new(nonce, 1),
 			}]
 			.into(),
 			last_confirmed_nonce: 0,
@@ -368,7 +368,7 @@ mod benchmarks {
 				state: LaneState::Opened,
 				relayers: vec![UnrewardedRelayer {
 					relayer: relayer_id.clone(),
-					messages: DeliveredMessages::new(1),
+					messages: DeliveredMessages::new(1, 1),
 				}]
 				.into_iter()
 				.collect(),
@@ -412,7 +412,7 @@ mod benchmarks {
 			total_messages: 2,
 			last_delivered_nonce: 2,
 		};
-		let mut delivered_messages = DeliveredMessages::new(1);
+		let mut delivered_messages = DeliveredMessages::new(1, 1);
 		delivered_messages.note_dispatched_message();
 		let proof = T::prepare_message_delivery_proof(MessageDeliveryProofParams {
 			lane: T::bench_lane_id(),
@@ -472,11 +472,11 @@ mod benchmarks {
 				relayers: vec![
 					UnrewardedRelayer {
 						relayer: relayer1_id.clone(),
-						messages: DeliveredMessages::new(1),
+						messages: DeliveredMessages::new(1, 1),
 					},
 					UnrewardedRelayer {
 						relayer: relayer2_id.clone(),
-						messages: DeliveredMessages::new(2),
+						messages: DeliveredMessages::new(2, 1),
 					},
 				]
 				.into_iter()

--- a/modules/messages/src/call_ext.rs
+++ b/modules/messages/src/call_ext.rs
@@ -261,7 +261,7 @@ mod tests {
 		for n in 0..BridgedChain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX {
 			inbound_lane_state.relayers.push_back(UnrewardedRelayer {
 				relayer: Default::default(),
-				messages: DeliveredMessages { begin: n + 1, end: n + 1 },
+				messages: DeliveredMessages { begin: n + 1, end: n + 1, reward_per_message: 0 },
 			});
 		}
 		InboundLanes::<TestRuntime>::insert(test_lane_id(), inbound_lane_state);
@@ -274,6 +274,7 @@ mod tests {
 			messages: DeliveredMessages {
 				begin: 1,
 				end: BridgedChain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
+				reward_per_message: 0,
 			},
 		});
 		InboundLanes::<TestRuntime>::insert(test_lane_id(), inbound_lane_state);

--- a/modules/messages/src/call_ext.rs
+++ b/modules/messages/src/call_ext.rs
@@ -261,7 +261,11 @@ mod tests {
 		for n in 0..BridgedChain::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX {
 			inbound_lane_state.relayers.push_back(UnrewardedRelayer {
 				relayer: Default::default(),
-				messages: DeliveredMessages { begin: n + 1, end: n + 1, reward_per_message: 0 },
+				messages: DeliveredMessages {
+					begin: n + 1,
+					end: n + 1,
+					relayer_reward_per_message: 0,
+				},
 			});
 		}
 		InboundLanes::<TestRuntime>::insert(test_lane_id(), inbound_lane_state);
@@ -274,7 +278,7 @@ mod tests {
 			messages: DeliveredMessages {
 				begin: 1,
 				end: BridgedChain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
-				reward_per_message: 0,
+				relayer_reward_per_message: 0,
 			},
 		});
 		InboundLanes::<TestRuntime>::insert(test_lane_id(), inbound_lane_state);

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -21,7 +21,7 @@ use crate::{BridgedChainOf, Config};
 use bp_messages::{
 	target_chain::{DispatchMessage, DispatchMessageData, MessageDispatch},
 	ChainWithMessages, DeliveredMessages, InboundLaneData, LaneId, LaneState, MessageKey,
-	MessageNonce, OutboundLaneData, ReceivalResult, RewardAtSource, UnrewardedRelayer,
+	MessageNonce, OutboundLaneData, ReceivalResult, RelayerRewardAtSource, UnrewardedRelayer,
 };
 use bp_runtime::AccountIdOf;
 use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
@@ -186,7 +186,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		relayer_at_bridged_chain: &S::Relayer,
 		nonce: MessageNonce,
 		message_data: DispatchMessageData<Dispatch::DispatchPayload>,
-		delivery_reward_per_message: RewardAtSource,
+		relayer_reward_per_message: RelayerRewardAtSource,
 	) -> ReceivalResult<Dispatch::DispatchLevelResult> {
 		let mut data = self.storage.data();
 		if Some(nonce) != data.last_delivered_nonce().checked_add(1) {
@@ -214,14 +214,14 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		match data.relayers.back_mut() {
 			Some(entry)
 				if entry.relayer == *relayer_at_bridged_chain &&
-					entry.messages.reward_per_message == delivery_reward_per_message =>
+					entry.messages.relayer_reward_per_message == relayer_reward_per_message =>
 			{
 				entry.messages.note_dispatched_message();
 			},
 			_ => {
 				data.relayers.push_back(UnrewardedRelayer {
 					relayer: relayer_at_bridged_chain.clone(),
-					messages: DeliveredMessages::new(nonce, delivery_reward_per_message),
+					messages: DeliveredMessages::new(nonce, relayer_reward_per_message),
 				});
 			},
 		};
@@ -251,7 +251,7 @@ mod tests {
 				&TEST_RELAYER_A,
 				nonce,
 				inbound_message_data(REGULAR_PAYLOAD),
-				DELIVERY_REWARD_PER_MESSAGE,
+				RELAYER_REWARD_PER_MESSAGE,
 			),
 			ReceivalResult::Dispatched(dispatch_result(0))
 		);
@@ -379,7 +379,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					10,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::InvalidNonce
 			);
@@ -398,7 +398,7 @@ mod tests {
 						&(TEST_RELAYER_A + current_nonce),
 						current_nonce,
 						inbound_message_data(REGULAR_PAYLOAD),
-						DELIVERY_REWARD_PER_MESSAGE,
+						RELAYER_REWARD_PER_MESSAGE,
 					),
 					ReceivalResult::Dispatched(dispatch_result(0))
 				);
@@ -409,7 +409,7 @@ mod tests {
 					&(TEST_RELAYER_A + max_nonce + 1),
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::TooManyUnrewardedRelayers,
 			);
@@ -419,7 +419,7 @@ mod tests {
 					&(TEST_RELAYER_A + max_nonce),
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::TooManyUnrewardedRelayers,
 			);
@@ -437,7 +437,7 @@ mod tests {
 						&TEST_RELAYER_A,
 						current_nonce,
 						inbound_message_data(REGULAR_PAYLOAD),
-						DELIVERY_REWARD_PER_MESSAGE,
+						RELAYER_REWARD_PER_MESSAGE,
 					),
 					ReceivalResult::Dispatched(dispatch_result(0))
 				);
@@ -448,7 +448,7 @@ mod tests {
 					&TEST_RELAYER_B,
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::TooManyUnconfirmedMessages,
 			);
@@ -458,7 +458,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::TooManyUnconfirmedMessages,
 			);
@@ -474,7 +474,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -483,7 +483,7 @@ mod tests {
 					&TEST_RELAYER_B,
 					2,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -492,7 +492,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					3,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -516,7 +516,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -525,7 +525,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					2,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE + 1,
+					RELAYER_REWARD_PER_MESSAGE + 1,
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -534,15 +534,15 @@ mod tests {
 					&TEST_RELAYER_A,
 					3,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE + 1,
+					RELAYER_REWARD_PER_MESSAGE + 1,
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
 
 			let mut unrewarded_relayer_with_larger_reward =
 				unrewarded_relayer(2, 3, TEST_RELAYER_A);
-			unrewarded_relayer_with_larger_reward.messages.reward_per_message =
-				DELIVERY_REWARD_PER_MESSAGE + 1;
+			unrewarded_relayer_with_larger_reward.messages.relayer_reward_per_message =
+				RELAYER_REWARD_PER_MESSAGE + 1;
 			assert_eq!(
 				lane.storage.data().relayers,
 				vec![
@@ -562,7 +562,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -571,7 +571,7 @@ mod tests {
 					&TEST_RELAYER_B,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::InvalidNonce,
 			);
@@ -598,7 +598,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(payload),
-					DELIVERY_REWARD_PER_MESSAGE,
+					RELAYER_REWARD_PER_MESSAGE,
 				),
 				ReceivalResult::Dispatched(dispatch_result(1))
 			);

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -60,9 +60,9 @@ use bp_messages::{
 		DeliveryPayments, DispatchMessage, FromBridgedChainMessagesProof, MessageDispatch,
 		ProvedLaneMessages, ProvedMessages,
 	},
-	ChainWithMessages, DeliveredMessages, InboundLaneData, InboundMessageDetails, LaneId,
-	MessageKey, MessageNonce, MessagePayload, MessagesOperatingMode, OutboundLaneData,
-	OutboundMessageDetails, UnrewardedRelayersState, VerificationError,
+	ChainWithMessages, InboundLaneData, InboundMessageDetails, LaneId, MessageKey, MessageNonce,
+	MessagePayload, MessagesOperatingMode, OutboundLaneData, OutboundMessageDetails,
+	UnrewardedRelayersState, VerificationError,
 };
 use bp_runtime::{
 	AccountIdOf, BasicOperatingMode, HashOf, OwnedBridgeModule, PreComputedSize, RangeInclusiveExt,
@@ -268,6 +268,13 @@ pub mod pallet {
 				}
 			}
 
+			// compute the per-message reward that is paid at the bridged (source) chain to relayer
+			// that has delivered message
+			let delivery_reward_per_message = T::DeliveryPayments::delivery_reward_per_message(
+				lane_id,
+				&relayer_id_at_this_chain,
+			);
+
 			let mut messages_received_status =
 				ReceivedMessages::new(lane_id, Vec::with_capacity(lane_data.messages.len()));
 			for mut message in lane_data.messages {
@@ -294,6 +301,7 @@ pub mod pallet {
 					&relayer_id_at_bridged_chain,
 					message.key.nonce,
 					message.data,
+					delivery_reward_per_message,
 				);
 
 				// note that we're returning unspent weight to relayer even if message has been
@@ -320,6 +328,7 @@ pub mod pallet {
 
 			// let's now deal with relayer payments
 			T::DeliveryPayments::pay_reward(
+				lane_id,
 				relayer_id_at_this_chain,
 				total_messages,
 				valid_messages,
@@ -381,12 +390,12 @@ pub mod pallet {
 				)
 				.map_err(Error::<T, I>::ReceivalConfirmation)?;
 
-			if let Some(confirmed_messages) = confirmed_messages {
+			if let Some(received_range) = confirmed_messages {
 				// emit 'delivered' event
-				let received_range = confirmed_messages.begin..=confirmed_messages.end;
 				Self::deposit_event(Event::MessagesDelivered {
 					lane_id,
-					messages: confirmed_messages,
+					messages_begin: *received_range.start(),
+					messages_end: *received_range.end(),
 				});
 
 				// if some new messages have been confirmed, reward relayers
@@ -452,8 +461,10 @@ pub mod pallet {
 		MessagesDelivered {
 			/// Lane for which the delivery has been confirmed.
 			lane_id: LaneId,
-			/// Delivered messages.
-			messages: DeliveredMessages,
+			/// Nonce of the first delivered message.
+			messages_begin: MessageNonce,
+			/// Nonce of the last delivered message.
+			messages_end: MessageNonce,
 		},
 	}
 

--- a/modules/messages/src/lib.rs
+++ b/modules/messages/src/lib.rs
@@ -270,10 +270,8 @@ pub mod pallet {
 
 			// compute the per-message reward that is paid at the bridged (source) chain to relayer
 			// that has delivered message
-			let delivery_reward_per_message = T::DeliveryPayments::delivery_reward_per_message(
-				lane_id,
-				&relayer_id_at_this_chain,
-			);
+			let relayer_reward_per_message =
+				T::DeliveryPayments::relayer_reward_per_message(lane_id, &relayer_id_at_this_chain);
 
 			let mut messages_received_status =
 				ReceivedMessages::new(lane_id, Vec::with_capacity(lane_data.messages.len()));
@@ -301,7 +299,7 @@ pub mod pallet {
 					&relayer_id_at_bridged_chain,
 					message.key.nonce,
 					message.data,
-					delivery_reward_per_message,
+					relayer_reward_per_message,
 				);
 
 				// note that we're returning unspent weight to relayer even if message has been

--- a/modules/messages/src/outbound_lane.rs
+++ b/modules/messages/src/outbound_lane.rs
@@ -19,9 +19,10 @@
 use crate::{Config, LOG_TARGET};
 
 use bp_messages::{
-	ChainWithMessages, DeliveredMessages, LaneId, LaneState, MessageNonce, MessagePayload,
-	OutboundLaneData, UnrewardedRelayer, VerificationError,
+	ChainWithMessages, LaneId, LaneState, MessageNonce, MessagePayload, OutboundLaneData,
+	UnrewardedRelayer, VerificationError,
 };
+use bp_runtime::RangeInclusiveExt;
 use codec::{Decode, Encode};
 use frame_support::{traits::Get, BoundedVec, PalletError};
 use scale_info::TypeInfo;
@@ -137,19 +138,18 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 		max_allowed_messages: MessageNonce,
 		latest_delivered_nonce: MessageNonce,
 		relayers: &VecDeque<UnrewardedRelayer<RelayerId>>,
-	) -> Result<Option<DeliveredMessages>, ReceivalConfirmationError> {
+	) -> Result<Option<RangeInclusive<MessageNonce>>, ReceivalConfirmationError> {
 		let mut data = self.storage.data();
-		let confirmed_messages = DeliveredMessages {
-			begin: data.latest_received_nonce.saturating_add(1),
-			end: latest_delivered_nonce,
-		};
-		if confirmed_messages.total_messages() == 0 {
+		let confirmed_messages =
+			data.latest_received_nonce.saturating_add(1)..=latest_delivered_nonce;
+		let confirmed_messages_count = confirmed_messages.saturating_len();
+		if confirmed_messages_count == 0 {
 			return Ok(None)
 		}
-		if confirmed_messages.end > data.latest_generated_nonce {
+		if *confirmed_messages.end() > data.latest_generated_nonce {
 			return Err(ReceivalConfirmationError::FailedToConfirmFutureMessages)
 		}
-		if confirmed_messages.total_messages() > max_allowed_messages {
+		if confirmed_messages_count > max_allowed_messages {
 			// that the relayer has declared correct number of messages that the proof contains (it
 			// is checked outside of the function). But it may happen (but only if this/bridged
 			// chain storage is corrupted, though) that the actual number of confirmed messages if
@@ -158,20 +158,20 @@ impl<S: OutboundLaneStorage> OutboundLane<S> {
 			log::trace!(
 				target: LOG_TARGET,
 				"Messages delivery proof contains too many messages to confirm: {} vs declared {}",
-				confirmed_messages.total_messages(),
+				confirmed_messages_count,
 				max_allowed_messages,
 			);
 			return Err(ReceivalConfirmationError::TryingToConfirmMoreMessagesThanExpected)
 		}
 
-		ensure_unrewarded_relayers_are_correct(confirmed_messages.end, relayers)?;
+		ensure_unrewarded_relayers_are_correct(*confirmed_messages.end(), relayers)?;
 
 		// prune all confirmed messages
-		for nonce in confirmed_messages.begin..=confirmed_messages.end {
+		for nonce in *confirmed_messages.start()..=*confirmed_messages.end() {
 			self.storage.remove_message(&nonce);
 		}
 
-		data.latest_received_nonce = confirmed_messages.end;
+		data.latest_received_nonce = *confirmed_messages.end();
 		data.oldest_unpruned_nonce = data.latest_received_nonce.saturating_add(1);
 		self.storage.set_data(data);
 
@@ -238,14 +238,10 @@ mod tests {
 			.collect()
 	}
 
-	fn delivered_messages(nonces: RangeInclusive<MessageNonce>) -> DeliveredMessages {
-		DeliveredMessages { begin: *nonces.start(), end: *nonces.end() }
-	}
-
 	fn assert_3_messages_confirmation_fails(
 		latest_received_nonce: MessageNonce,
 		relayers: &VecDeque<UnrewardedRelayer<TestRelayer>>,
-	) -> Result<Option<DeliveredMessages>, ReceivalConfirmationError> {
+	) -> Result<Option<RangeInclusive<MessageNonce>>, ReceivalConfirmationError> {
 		run_test(|| {
 			let mut lane = active_outbound_lane::<TestRuntime, _>(test_lane_id()).unwrap();
 			assert_ok!(lane.send_message(outbound_message_data(REGULAR_PAYLOAD)));
@@ -281,10 +277,7 @@ mod tests {
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 0);
 			assert_eq!(lane.storage.data().oldest_unpruned_nonce, 1);
-			assert_eq!(
-				lane.confirm_delivery(3, 3, &unrewarded_relayers(1..=3)),
-				Ok(Some(delivered_messages(1..=3))),
-			);
+			assert_eq!(lane.confirm_delivery(3, 3, &unrewarded_relayers(1..=3)), Ok(Some(1..=3)),);
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 3);
 			assert_eq!(lane.storage.data().oldest_unpruned_nonce, 4);
@@ -302,18 +295,12 @@ mod tests {
 			assert_eq!(lane.storage.data().latest_received_nonce, 0);
 			assert_eq!(lane.storage.data().oldest_unpruned_nonce, 1);
 
-			assert_eq!(
-				lane.confirm_delivery(3, 2, &unrewarded_relayers(1..=2)),
-				Ok(Some(delivered_messages(1..=2))),
-			);
+			assert_eq!(lane.confirm_delivery(3, 2, &unrewarded_relayers(1..=2)), Ok(Some(1..=2)),);
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 2);
 			assert_eq!(lane.storage.data().oldest_unpruned_nonce, 3);
 
-			assert_eq!(
-				lane.confirm_delivery(3, 3, &unrewarded_relayers(3..=3)),
-				Ok(Some(delivered_messages(3..=3))),
-			);
+			assert_eq!(lane.confirm_delivery(3, 3, &unrewarded_relayers(3..=3)), Ok(Some(3..=3)),);
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 3);
 			assert_eq!(lane.storage.data().oldest_unpruned_nonce, 4);
@@ -330,10 +317,7 @@ mod tests {
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 0);
 			assert_eq!(lane.storage.data().oldest_unpruned_nonce, 1);
-			assert_eq!(
-				lane.confirm_delivery(3, 3, &unrewarded_relayers(1..=3)),
-				Ok(Some(delivered_messages(1..=3))),
-			);
+			assert_eq!(lane.confirm_delivery(3, 3, &unrewarded_relayers(1..=3)), Ok(Some(1..=3)),);
 			assert_eq!(lane.confirm_delivery(3, 3, &unrewarded_relayers(1..=3)), Ok(None),);
 			assert_eq!(lane.storage.data().latest_generated_nonce, 3);
 			assert_eq!(lane.storage.data().latest_received_nonce, 3);
@@ -415,10 +399,7 @@ mod tests {
 				lane.confirm_delivery(2, 3, &unrewarded_relayers(1..=3)),
 				Err(ReceivalConfirmationError::TryingToConfirmMoreMessagesThanExpected),
 			);
-			assert_eq!(
-				lane.confirm_delivery(3, 3, &unrewarded_relayers(1..=3)),
-				Ok(Some(delivered_messages(1..=3))),
-			);
+			assert_eq!(lane.confirm_delivery(3, 3, &unrewarded_relayers(1..=3)), Ok(Some(1..=3)),);
 		});
 	}
 }

--- a/modules/messages/src/tests/pallet_tests.rs
+++ b/modules/messages/src/tests/pallet_tests.rs
@@ -87,7 +87,7 @@ fn receive_messages_delivery_proof() {
 				last_confirmed_nonce: 1,
 				relayers: vec![UnrewardedRelayer {
 					relayer: 0,
-					messages: DeliveredMessages::new(1),
+					messages: DeliveredMessages::new(1, 0),
 				}]
 				.into(),
 			},
@@ -106,7 +106,8 @@ fn receive_messages_delivery_proof() {
 			phase: Phase::Initialization,
 			event: TestEvent::Messages(Event::MessagesDelivered {
 				lane_id: test_lane_id(),
-				messages: DeliveredMessages::new(1),
+				messages_begin: 1,
+				messages_end: 1,
 			}),
 			topics: vec![],
 		}],
@@ -533,8 +534,14 @@ fn receive_messages_delivery_proof_rewards_relayers() {
 				},
 			)
 		);
-		assert!(TestDeliveryConfirmationPayments::is_reward_paid(TEST_RELAYER_A, 1));
-		assert!(!TestDeliveryConfirmationPayments::is_reward_paid(TEST_RELAYER_B, 1));
+		assert!(TestDeliveryConfirmationPayments::is_reward_paid(
+			TEST_RELAYER_A,
+			DELIVERY_REWARD_PER_MESSAGE
+		));
+		assert!(!TestDeliveryConfirmationPayments::is_reward_paid(
+			TEST_RELAYER_B,
+			DELIVERY_REWARD_PER_MESSAGE
+		));
 
 		// this reports delivery of both message 1 and message 2 => reward is paid only to
 		// TEST_RELAYER_B
@@ -574,8 +581,14 @@ fn receive_messages_delivery_proof_rewards_relayers() {
 				},
 			)
 		);
-		assert!(!TestDeliveryConfirmationPayments::is_reward_paid(TEST_RELAYER_A, 1));
-		assert!(TestDeliveryConfirmationPayments::is_reward_paid(TEST_RELAYER_B, 1));
+		assert!(!TestDeliveryConfirmationPayments::is_reward_paid(
+			TEST_RELAYER_A,
+			DELIVERY_REWARD_PER_MESSAGE
+		));
+		assert!(TestDeliveryConfirmationPayments::is_reward_paid(
+			TEST_RELAYER_B,
+			DELIVERY_REWARD_PER_MESSAGE
+		));
 	});
 }
 
@@ -830,7 +843,7 @@ fn proof_size_refund_from_receive_messages_proof_works() {
 				relayers: vec![
 					UnrewardedRelayer {
 						relayer: 42,
-						messages: DeliveredMessages { begin: 0, end: 100 }
+						messages: DeliveredMessages { begin: 0, end: 100, reward_per_message: 0 }
 					};
 					max_entries
 				]
@@ -859,7 +872,7 @@ fn proof_size_refund_from_receive_messages_proof_works() {
 				relayers: vec![
 					UnrewardedRelayer {
 						relayer: 42,
-						messages: DeliveredMessages { begin: 0, end: 100 }
+						messages: DeliveredMessages { begin: 0, end: 100, reward_per_message: 0 }
 					};
 					max_entries - 1
 				]
@@ -972,7 +985,7 @@ fn test_bridge_messages_call_is_correctly_defined() {
 				last_confirmed_nonce: 1,
 				relayers: vec![UnrewardedRelayer {
 					relayer: 0,
-					messages: DeliveredMessages::new(1),
+					messages: DeliveredMessages::new(1, 0),
 				}]
 				.into(),
 			},
@@ -1033,7 +1046,10 @@ generate_owned_bridge_module_tests!(
 #[test]
 fn inbound_storage_extra_proof_size_bytes_works() {
 	fn relayer_entry() -> UnrewardedRelayer<TestRelayer> {
-		UnrewardedRelayer { relayer: 42u64, messages: DeliveredMessages { begin: 0, end: 100 } }
+		UnrewardedRelayer {
+			relayer: 42u64,
+			messages: DeliveredMessages { begin: 0, end: 100, reward_per_message: 0 },
+		}
 	}
 
 	fn storage(relayer_entries: usize) -> RuntimeInboundLaneStorage<TestRuntime, ()> {
@@ -1128,7 +1144,7 @@ fn receive_messages_delivery_proof_fails_if_outbound_lane_is_unknown() {
 					last_confirmed_nonce: 1,
 					relayers: vec![UnrewardedRelayer {
 						relayer: 0,
-						messages: DeliveredMessages::new(1),
+						messages: DeliveredMessages::new(1, 0),
 					}]
 					.into(),
 				},

--- a/modules/messages/src/tests/pallet_tests.rs
+++ b/modules/messages/src/tests/pallet_tests.rs
@@ -257,6 +257,15 @@ fn receive_messages_proof_works() {
 				.last_delivered_nonce(),
 			1
 		);
+		assert_eq!(
+			InboundLanes::<TestRuntime>::get(test_lane_id())
+				.unwrap()
+				.0
+				.relayers
+				.front()
+				.map(|r| r.messages.reward_per_message),
+			Some(DELIVERY_REWARD_PER_MESSAGE),
+		);
 
 		assert!(TestDeliveryPayments::is_reward_paid(1));
 	});

--- a/modules/messages/src/tests/pallet_tests.rs
+++ b/modules/messages/src/tests/pallet_tests.rs
@@ -263,8 +263,8 @@ fn receive_messages_proof_works() {
 				.0
 				.relayers
 				.front()
-				.map(|r| r.messages.reward_per_message),
-			Some(DELIVERY_REWARD_PER_MESSAGE),
+				.map(|r| r.messages.relayer_reward_per_message),
+			Some(RELAYER_REWARD_PER_MESSAGE),
 		);
 
 		assert!(TestDeliveryPayments::is_reward_paid(1));
@@ -545,11 +545,11 @@ fn receive_messages_delivery_proof_rewards_relayers() {
 		);
 		assert!(TestDeliveryConfirmationPayments::is_reward_paid(
 			TEST_RELAYER_A,
-			DELIVERY_REWARD_PER_MESSAGE
+			RELAYER_REWARD_PER_MESSAGE
 		));
 		assert!(!TestDeliveryConfirmationPayments::is_reward_paid(
 			TEST_RELAYER_B,
-			DELIVERY_REWARD_PER_MESSAGE
+			RELAYER_REWARD_PER_MESSAGE
 		));
 
 		// this reports delivery of both message 1 and message 2 => reward is paid only to
@@ -592,11 +592,11 @@ fn receive_messages_delivery_proof_rewards_relayers() {
 		);
 		assert!(!TestDeliveryConfirmationPayments::is_reward_paid(
 			TEST_RELAYER_A,
-			DELIVERY_REWARD_PER_MESSAGE
+			RELAYER_REWARD_PER_MESSAGE
 		));
 		assert!(TestDeliveryConfirmationPayments::is_reward_paid(
 			TEST_RELAYER_B,
-			DELIVERY_REWARD_PER_MESSAGE
+			RELAYER_REWARD_PER_MESSAGE
 		));
 	});
 }
@@ -852,7 +852,11 @@ fn proof_size_refund_from_receive_messages_proof_works() {
 				relayers: vec![
 					UnrewardedRelayer {
 						relayer: 42,
-						messages: DeliveredMessages { begin: 0, end: 100, reward_per_message: 0 }
+						messages: DeliveredMessages {
+							begin: 0,
+							end: 100,
+							relayer_reward_per_message: 0
+						}
 					};
 					max_entries
 				]
@@ -881,7 +885,11 @@ fn proof_size_refund_from_receive_messages_proof_works() {
 				relayers: vec![
 					UnrewardedRelayer {
 						relayer: 42,
-						messages: DeliveredMessages { begin: 0, end: 100, reward_per_message: 0 }
+						messages: DeliveredMessages {
+							begin: 0,
+							end: 100,
+							relayer_reward_per_message: 0
+						}
 					};
 					max_entries - 1
 				]
@@ -1057,7 +1065,7 @@ fn inbound_storage_extra_proof_size_bytes_works() {
 	fn relayer_entry() -> UnrewardedRelayer<TestRelayer> {
 		UnrewardedRelayer {
 			relayer: 42u64,
-			messages: DeliveredMessages { begin: 0, end: 100, reward_per_message: 0 },
+			messages: DeliveredMessages { begin: 0, end: 100, relayer_reward_per_message: 0 },
 		}
 	}
 

--- a/modules/relayers/src/extension/mod.rs
+++ b/modules/relayers/src/extension/mod.rs
@@ -1900,7 +1900,7 @@ mod tests {
 					messages: DeliveredMessages {
 						begin: 1,
 						end: best_delivered_message,
-						reward_per_message: 0,
+						relayer_reward_per_message: 0,
 					},
 				}]
 				.into(),

--- a/modules/relayers/src/extension/mod.rs
+++ b/modules/relayers/src/extension/mod.rs
@@ -1897,7 +1897,11 @@ mod tests {
 				last_confirmed_nonce: 0,
 				relayers: vec![UnrewardedRelayer {
 					relayer: relayer_account_at_bridged_chain(),
-					messages: DeliveredMessages { begin: 1, end: best_delivered_message },
+					messages: DeliveredMessages {
+						begin: 1,
+						end: best_delivered_message,
+						reward_per_message: 0,
+					},
 				}]
 				.into(),
 				..Default::default()

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -79,6 +79,9 @@ pub const TEST_BRIDGED_CHAIN_ID: ChainId = *b"brdg";
 /// Maximal extrinsic size at the `BridgedChain`.
 pub const BRIDGED_CHAIN_MAX_EXTRINSIC_SIZE: u32 = 1024;
 
+/// Maximal reward that may be paid to relayer for delivering a single message.
+pub const MAX_REWARD_PER_MESSAGE: ThisChainBalance = 100_000;
+
 /// Underlying chain of `ThisChain`.
 pub struct ThisUnderlyingChain;
 
@@ -277,6 +280,13 @@ impl pallet_bridge_parachains::Config for TestRuntime {
 	type WeightInfo = pallet_bridge_parachains::weights::BridgeWeight<TestRuntime>;
 }
 
+pub type TestDeliveryConfirmationPaymentsAdapter =
+	pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
+		TestRuntime,
+		(),
+		ConstU64<MAX_REWARD_PER_MESSAGE>,
+	>;
+
 impl pallet_bridge_messages::Config for TestRuntime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_bridge_messages::weights::BridgeWeight<TestRuntime>;
@@ -286,11 +296,7 @@ impl pallet_bridge_messages::Config for TestRuntime {
 	type InboundPayload = Vec<u8>;
 	type DeliveryPayments = ();
 
-	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
-		TestRuntime,
-		(),
-		ConstU64<100_000>,
-	>;
+	type DeliveryConfirmationPayments = TestDeliveryConfirmationPaymentsAdapter;
 	type OnMessagesDelivered = ();
 
 	type MessageDispatch = DummyMessageDispatch;
@@ -388,9 +394,18 @@ impl MessageDispatch for DummyMessageDispatch {
 	}
 }
 
+/// Lane identifier used in tests.
+pub fn test_lane_id() -> LaneId {
+	LaneId::new(1, 2)
+}
+
 /// Reward account params that we are using in tests.
 pub fn test_reward_account_param() -> RewardsAccountParams {
-	RewardsAccountParams::new(LaneId::new(1, 2), *b"test", RewardsAccountOwner::ThisChain)
+	RewardsAccountParams::new(
+		test_lane_id(),
+		TEST_BRIDGED_CHAIN_ID,
+		RewardsAccountOwner::BridgedChain,
+	)
 }
 
 /// Return test externalities to use in tests.

--- a/modules/relayers/src/payment_adapter.rs
+++ b/modules/relayers/src/payment_adapter.rs
@@ -85,7 +85,7 @@ where
 	}
 }
 
-/// Register relayer rewards for delviering messages.
+/// Register relayer rewards for delivering messages.
 fn register_relayers_rewards<T: Config>(
 	relayers_rewards: RelayersRewards<T::AccountId, T::Reward>,
 	reward_account: RewardsAccountParams,
@@ -147,7 +147,7 @@ mod tests {
 			);
 
 			assert_eq!(
-				RelayerRewards::<TestRuntime>::get(&42, test_reward_account_param()),
+				RelayerRewards::<TestRuntime>::get(42, test_reward_account_param()),
 				Some(MAX_REWARD_PER_MESSAGE * 2),
 			);
 		});

--- a/modules/relayers/src/payment_adapter.rs
+++ b/modules/relayers/src/payment_adapter.rs
@@ -20,7 +20,7 @@ use crate::{Config, Pallet};
 
 use bp_messages::{
 	source_chain::{DeliveryConfirmationPayments, RelayersRewards},
-	LaneId, MessageNonce, RewardAtSource,
+	LaneId, MessageNonce,
 };
 use bp_relayers::{RewardsAccountOwner, RewardsAccountParams};
 use bp_runtime::Chain;
@@ -46,7 +46,6 @@ impl<T, MI, MaxRewardPerMessage> DeliveryConfirmationPayments<T::AccountId>
 where
 	T: Config + pallet_bridge_messages::Config<MI>,
 	MI: 'static,
-	T::Reward: UniqueSaturatedFrom<RewardAtSource> + UniqueSaturatedFrom<MessageNonce>,
 	MaxRewardPerMessage: Get<T::Reward>,
 {
 	type Error = &'static str;

--- a/modules/relayers/src/payment_adapter.rs
+++ b/modules/relayers/src/payment_adapter.rs
@@ -32,8 +32,8 @@ use sp_std::{collections::vec_deque::VecDeque, marker::PhantomData, ops::RangeIn
 /// Adapter that allows relayers pallet to be used as a delivery+dispatch payment mechanism
 /// for the messages pallet.
 ///
-/// This adapter assumes 1:1 mapping of `RewardAtSource` to `T::Reward`. The reward for delivering
-/// a single message, will never be larger than the `MaxRewardPerMessage`.
+/// This adapter assumes 1:1 mapping of `RelayerRewardAtSource` to `T::Reward`. The reward for
+/// delivering a single message, will never be larger than the `MaxRewardPerMessage`.
 ///
 /// We assume that the confirmation transaction cost is refunded by the signed extension,
 /// implemented by the pallet. So we do not reward confirmation relayer additionally here.
@@ -60,13 +60,14 @@ where
 			bp_messages::calc_relayers_rewards_at_source::<T::AccountId, T::Reward>(
 				messages_relayers,
 				received_range,
-				|messages, reward_per_message| {
-					let reward_per_message = sp_std::cmp::min(
+				|messages, relayer_reward_per_message| {
+					let relayer_reward_per_message = sp_std::cmp::min(
 						MaxRewardPerMessage::get(),
-						reward_per_message.unique_saturated_into(),
+						relayer_reward_per_message.unique_saturated_into(),
 					);
 
-					T::Reward::unique_saturated_from(messages).saturating_mul(reward_per_message)
+					T::Reward::unique_saturated_from(messages)
+						.saturating_mul(relayer_reward_per_message)
 				},
 			);
 		let rewarded_relayers = relayers_rewards.len();

--- a/modules/relayers/src/payment_adapter.rs
+++ b/modules/relayers/src/payment_adapter.rs
@@ -20,82 +20,79 @@ use crate::{Config, Pallet};
 
 use bp_messages::{
 	source_chain::{DeliveryConfirmationPayments, RelayersRewards},
-	LaneId, MessageNonce,
+	LaneId, MessageNonce, RewardAtSource,
 };
 use bp_relayers::{RewardsAccountOwner, RewardsAccountParams};
 use bp_runtime::Chain;
-use frame_support::{sp_runtime::SaturatedConversion, traits::Get};
-use sp_arithmetic::traits::{Saturating, Zero};
+use frame_support::traits::Get;
+use sp_arithmetic::traits::{Saturating, UniqueSaturatedFrom};
+use sp_runtime::traits::UniqueSaturatedInto;
 use sp_std::{collections::vec_deque::VecDeque, marker::PhantomData, ops::RangeInclusive};
 
 /// Adapter that allows relayers pallet to be used as a delivery+dispatch payment mechanism
 /// for the messages pallet.
-pub struct DeliveryConfirmationPaymentsAdapter<T, MI, DeliveryReward>(
-	PhantomData<(T, MI, DeliveryReward)>,
+///
+/// This adapter assumes 1:1 mapping of `RewardAtSource` to `T::Reward`. The reward for delivering
+/// a single message, will never be larger than the `MaxRewardPerMessage`.
+///
+/// We assume that the confirmation transaction cost is refunded by the signed extension,
+/// implemented by the pallet. So we do not reward confirmation relayer additionally here.
+pub struct DeliveryConfirmationPaymentsAdapter<T, MI, MaxRewardPerMessage>(
+	PhantomData<(T, MI, MaxRewardPerMessage)>,
 );
 
-impl<T, MI, DeliveryReward> DeliveryConfirmationPayments<T::AccountId>
-	for DeliveryConfirmationPaymentsAdapter<T, MI, DeliveryReward>
+impl<T, MI, MaxRewardPerMessage> DeliveryConfirmationPayments<T::AccountId>
+	for DeliveryConfirmationPaymentsAdapter<T, MI, MaxRewardPerMessage>
 where
 	T: Config + pallet_bridge_messages::Config<MI>,
 	MI: 'static,
-	DeliveryReward: Get<T::Reward>,
+	T::Reward: UniqueSaturatedFrom<RewardAtSource> + UniqueSaturatedFrom<MessageNonce>,
+	MaxRewardPerMessage: Get<T::Reward>,
 {
 	type Error = &'static str;
 
 	fn pay_reward(
 		lane_id: LaneId,
 		messages_relayers: VecDeque<bp_messages::UnrewardedRelayer<T::AccountId>>,
-		confirmation_relayer: &T::AccountId,
+		_confirmation_relayer: &T::AccountId,
 		received_range: &RangeInclusive<bp_messages::MessageNonce>,
 	) -> MessageNonce {
 		let relayers_rewards =
-			bp_messages::calc_relayers_rewards::<T::AccountId>(messages_relayers, received_range);
+			bp_messages::calc_relayers_rewards_at_source::<T::AccountId, T::Reward>(
+				messages_relayers,
+				received_range,
+				|messages, reward_per_message| {
+					let reward_per_message = sp_std::cmp::min(
+						MaxRewardPerMessage::get(),
+						reward_per_message.unique_saturated_into(),
+					);
+
+					T::Reward::unique_saturated_from(messages).saturating_mul(reward_per_message)
+				},
+			);
 		let rewarded_relayers = relayers_rewards.len();
 
 		register_relayers_rewards::<T>(
-			confirmation_relayer,
 			relayers_rewards,
 			RewardsAccountParams::new(
 				lane_id,
 				T::BridgedChain::ID,
 				RewardsAccountOwner::BridgedChain,
 			),
-			DeliveryReward::get(),
 		);
 
 		rewarded_relayers as _
 	}
 }
 
-// Update rewards to given relayers, optionally rewarding confirmation relayer.
+/// Register relayer rewards for delviering messages.
 fn register_relayers_rewards<T: Config>(
-	confirmation_relayer: &T::AccountId,
-	relayers_rewards: RelayersRewards<T::AccountId>,
-	lane_id: RewardsAccountParams,
-	delivery_fee: T::Reward,
+	relayers_rewards: RelayersRewards<T::AccountId, T::Reward>,
+	reward_account: RewardsAccountParams,
 ) {
-	// reward every relayer except `confirmation_relayer`
-	let mut confirmation_relayer_reward = T::Reward::zero();
-	for (relayer, messages) in relayers_rewards {
-		// sane runtime configurations guarantee that the number of messages will be below
-		// `u32::MAX`
-		let relayer_reward = T::Reward::saturated_from(messages).saturating_mul(delivery_fee);
-
-		if relayer != *confirmation_relayer {
-			Pallet::<T>::register_relayer_reward(lane_id, &relayer, relayer_reward);
-		} else {
-			confirmation_relayer_reward =
-				confirmation_relayer_reward.saturating_add(relayer_reward);
-		}
+	for (relayer, relayer_reward) in relayers_rewards {
+		Pallet::<T>::register_relayer_reward(reward_account, &relayer, relayer_reward);
 	}
-
-	// finally - pay reward to confirmation relayer
-	Pallet::<T>::register_relayer_reward(
-		lane_id,
-		confirmation_relayer,
-		confirmation_relayer_reward,
-	);
 }
 
 #[cfg(test)]
@@ -107,48 +104,25 @@ mod tests {
 	const RELAYER_2: ThisChainAccountId = 2;
 	const RELAYER_3: ThisChainAccountId = 3;
 
-	fn relayers_rewards() -> RelayersRewards<ThisChainAccountId> {
+	fn relayers_rewards() -> RelayersRewards<ThisChainAccountId, ThisChainBalance> {
 		vec![(RELAYER_1, 2), (RELAYER_2, 3)].into_iter().collect()
-	}
-
-	#[test]
-	fn confirmation_relayer_is_rewarded_if_it_has_also_delivered_messages() {
-		run_test(|| {
-			register_relayers_rewards::<TestRuntime>(
-				&RELAYER_2,
-				relayers_rewards(),
-				test_reward_account_param(),
-				50,
-			);
-
-			assert_eq!(
-				RelayerRewards::<TestRuntime>::get(RELAYER_1, test_reward_account_param()),
-				Some(100)
-			);
-			assert_eq!(
-				RelayerRewards::<TestRuntime>::get(RELAYER_2, test_reward_account_param()),
-				Some(150)
-			);
-		});
 	}
 
 	#[test]
 	fn confirmation_relayer_is_not_rewarded_if_it_has_not_delivered_any_messages() {
 		run_test(|| {
 			register_relayers_rewards::<TestRuntime>(
-				&RELAYER_3,
 				relayers_rewards(),
 				test_reward_account_param(),
-				50,
 			);
 
 			assert_eq!(
 				RelayerRewards::<TestRuntime>::get(RELAYER_1, test_reward_account_param()),
-				Some(100)
+				Some(2)
 			);
 			assert_eq!(
 				RelayerRewards::<TestRuntime>::get(RELAYER_2, test_reward_account_param()),
-				Some(150)
+				Some(3)
 			);
 			assert_eq!(
 				RelayerRewards::<TestRuntime>::get(RELAYER_3, test_reward_account_param()),

--- a/primitives/messages/Cargo.toml
+++ b/primitives/messages/Cargo.toml
@@ -21,6 +21,7 @@ bp-header-chain = { path = "../header-chain", default-features = false }
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master", default-features = false }
 
 [dev-dependencies]
@@ -38,5 +39,6 @@ std = [
 	"serde/std",
 	"sp-core/std",
     "sp-io/std",
+	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -24,7 +24,7 @@ use bp_runtime::{
 	messages::MessageDispatchResult, BasicOperatingMode, Chain, OperatingMode, RangeInclusiveExt,
 	StorageProofError, UnderlyingChainOf, UnderlyingChainProvider,
 };
-use codec::{Decode, Encode, MaxEncodedLen};
+use codec::{Compact, Decode, Encode, MaxEncodedLen};
 use frame_support::PalletError;
 // Weight is reexported to avoid additional frame-support dependencies in related crates.
 pub use frame_support::weights::Weight;
@@ -33,6 +33,7 @@ use serde::{Deserialize, Serialize};
 use source_chain::RelayersRewards;
 use sp_core::{RuntimeDebug, TypeId, H256};
 use sp_io::hashing::blake2_256;
+use sp_runtime::traits::{Saturating, Zero};
 use sp_std::{collections::vec_deque::VecDeque, ops::RangeInclusive, prelude::*};
 
 pub use call_info::{
@@ -369,6 +370,8 @@ impl<RelayerId> InboundLaneData<RelayerId> {
 	{
 		relayers_entries
 			.checked_mul(UnrewardedRelayer::<RelayerId>::max_encoded_len())?
+			.checked_add(Compact::<u32>(relayers_entries as u32).encoded_size())?
+			.checked_add(LaneState::max_encoded_len())?
 			.checked_add(MessageNonce::max_encoded_len())
 	}
 
@@ -483,6 +486,17 @@ pub enum ReceivalResult<DispatchLevelResult> {
 	TooManyUnconfirmedMessages,
 }
 
+/// Type of reward that needs to be paid at the source chain for delivering messages to the
+/// target chain. It does not necessary mapped 1:1 onto source chain tokens (or whatever is
+/// used to pay rewards there). The `DeliveryConfirmationPayments` implementation decides how
+/// to map it and what actual reward the relayer would receive.
+///
+/// Why our code is not generic over this type? That's mostly because we are using single
+/// `pallet-bridge-relayers` instance to register rewards for all bridges. Those bridges
+/// may be connected to chains, using different `Balance` types. Why not to use encoded version?
+/// Because we need to order relayers by the reward they get for delivering a single message.
+pub type RewardAtSource = u64;
+
 /// Delivered messages with their dispatch result.
 #[derive(Clone, Default, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub struct DeliveredMessages {
@@ -490,13 +504,17 @@ pub struct DeliveredMessages {
 	pub begin: MessageNonce,
 	/// Nonce of the last message that has been delivered (inclusive).
 	pub end: MessageNonce,
+	/// Reward that needs to be paid at the source chain (during confirmation transaction)
+	/// for **every delivered message** in the `begin..=end` range. If reward has been paid
+	/// at the target chain or if no rewards assumed, it may be zero.
+	pub reward_per_message: RewardAtSource,
 }
 
 impl DeliveredMessages {
 	/// Create new `DeliveredMessages` struct that confirms delivery of single nonce with given
 	/// dispatch result.
-	pub fn new(nonce: MessageNonce) -> Self {
-		DeliveredMessages { begin: nonce, end: nonce }
+	pub fn new(nonce: MessageNonce, reward_per_message: RewardAtSource) -> Self {
+		DeliveredMessages { begin: nonce, end: nonce, reward_per_message }
 	}
 
 	/// Return total count of delivered messages.
@@ -590,23 +608,43 @@ impl Default for OutboundLaneData {
 	}
 }
 
-/// Calculate the number of messages that the relayers have delivered.
-pub fn calc_relayers_rewards<AccountId>(
+/// Calculate the total relayer reward that need to be paid at the source chain.
+///
+/// The `compute_reward` assumed to be a function that maps the `RewardAtSource` onto
+/// real reward that is paid to relayer. This function needs to compute and return
+/// the total reward for delivering given number of messages to the target (bridged)
+/// chain by relayer that has agreed to work for given reward.
+pub fn calc_relayers_rewards_at_source<AccountId, Reward>(
 	messages_relayers: VecDeque<UnrewardedRelayer<AccountId>>,
 	received_range: &RangeInclusive<MessageNonce>,
-) -> RelayersRewards<AccountId>
+	compute_reward: impl Fn(MessageNonce, RewardAtSource) -> Reward,
+) -> RelayersRewards<AccountId, Reward>
 where
 	AccountId: sp_std::cmp::Ord,
+	Reward: Copy + Saturating + Zero,
 {
 	// remember to reward relayers that have delivered messages
 	// this loop is bounded by `T::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX` on the bridged chain
-	let mut relayers_rewards = RelayersRewards::new();
+	let mut relayers_rewards: RelayersRewards<_, Reward> = RelayersRewards::new();
 	for entry in messages_relayers {
+		// if relayer does not expect any reward, do nothing
+		if entry.messages.reward_per_message == 0 {
+			continue
+		}
+
+		// if we have already paid reward for delivering those messages, do nothing
 		let nonce_begin = sp_std::cmp::max(entry.messages.begin, *received_range.start());
 		let nonce_end = sp_std::cmp::min(entry.messages.end, *received_range.end());
-		if nonce_end >= nonce_begin {
-			*relayers_rewards.entry(entry.relayer).or_default() += nonce_end - nonce_begin + 1;
+		let new_confirmations = nonce_begin..=nonce_end;
+		let new_confirmations_count = new_confirmations.saturating_len();
+		if new_confirmations_count == 0 {
+			continue
 		}
+
+		// compute and update reward in the rewards map
+		let new_reward = compute_reward(new_confirmations_count, entry.messages.reward_per_message);
+		let total_relayer_reward = relayers_rewards.entry(entry.relayer).or_insert_with(Zero::zero);
+		*total_relayer_reward = total_relayer_reward.saturating_add(new_reward);
 	}
 	relayers_rewards
 }
@@ -651,10 +689,10 @@ mod tests {
 		let lane_data = InboundLaneData {
 			state: LaneState::Opened,
 			relayers: vec![
-				UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(0) },
+				UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(0, 0) },
 				UnrewardedRelayer {
 					relayer: 2,
-					messages: DeliveredMessages::new(MessageNonce::MAX),
+					messages: DeliveredMessages::new(MessageNonce::MAX, 0),
 				},
 			]
 			.into_iter()
@@ -681,7 +719,7 @@ mod tests {
 				relayers: (1u8..=relayer_entries)
 					.map(|i| UnrewardedRelayer {
 						relayer: i,
-						messages: DeliveredMessages::new(i as _),
+						messages: DeliveredMessages::new(i as _, 0u64),
 					})
 					.collect(),
 				last_confirmed_nonce: messages_count as _,
@@ -698,7 +736,7 @@ mod tests {
 
 	#[test]
 	fn contains_result_works() {
-		let delivered_messages = DeliveredMessages { begin: 100, end: 150 };
+		let delivered_messages = DeliveredMessages { begin: 100, end: 150, reward_per_message: 0 };
 
 		assert!(!delivered_messages.contains_message(99));
 		assert!(delivered_messages.contains_message(100));

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -791,4 +791,29 @@ mod tests {
 			LaneId::new(Either::Three(1, 2, 3), Either::One(4)),
 		);
 	}
+
+	#[test]
+	fn calc_relayers_rewards_at_source_works() {
+		assert_eq!(
+			calc_relayers_rewards_at_source::<u64, u64>(
+				vec![
+					// relayer that wants zero reward => no payments expected
+					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(1, 0) },
+					// relayer wants reward => payment is expected
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(2, 77) },
+					// relayer that we met before and he wants reward => payment is expected
+					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(3, 42) },
+					// relayer that we met before and he wants reward => payment is expected
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(4, 33) },
+					// relayers that deliver messages out of range
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(0, 33) },
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(5, 33) },
+				]
+				.into(),
+				&(1..=4),
+				|_, reward_per_message| reward_per_message,
+			),
+			vec![(1, 42), (2, 110)].into_iter().collect(),
+		);
+	}
 }

--- a/primitives/messages/src/source_chain.rs
+++ b/primitives/messages/src/source_chain.rs
@@ -54,8 +54,8 @@ impl<BridgedHeaderHash> Size for FromBridgedChainMessagesDeliveryProof<BridgedHe
 	}
 }
 
-/// Number of messages, delivered by relayers.
-pub type RelayersRewards<AccountId> = BTreeMap<AccountId, MessageNonce>;
+/// Rewards that need to be paid to relayers.
+pub type RelayersRewards<AccountId, Reward> = BTreeMap<AccountId, Reward>;
 
 /// Manages payments that are happening at the source chain during delivery confirmation
 /// transaction.

--- a/primitives/messages/src/target_chain.rs
+++ b/primitives/messages/src/target_chain.rs
@@ -17,7 +17,8 @@
 //! Primitives of messages module, that are used on the target chain.
 
 use crate::{
-	LaneId, Message, MessageKey, MessageNonce, MessagePayload, OutboundLaneData, RewardAtSource,
+	LaneId, Message, MessageKey, MessageNonce, MessagePayload, OutboundLaneData,
+	RelayerRewardAtSource,
 };
 
 use bp_runtime::{messages::MessageDispatchResult, Size, UnverifiedStorageProof};
@@ -129,8 +130,8 @@ pub trait DeliveryPayments<AccountId> {
 	/// proof, so it will eventually be reported to the source chain.
 	///
 	/// Keep in mind that it is not necessary a real reward that will be paid. See
-	/// [`crate::RewardAtSource`] for more details.
-	fn delivery_reward_per_message(lane: LaneId, relayer: &AccountId) -> RewardAtSource;
+	/// [`crate::RelayerRewardAtSource`] for more details.
+	fn relayer_reward_per_message(lane: LaneId, relayer: &AccountId) -> RelayerRewardAtSource;
 
 	/// Pay rewards for delivering messages to the given relayer.
 	///
@@ -168,7 +169,7 @@ impl<DispatchPayload: Decode> From<MessagePayload> for DispatchMessageData<Dispa
 impl<AccountId> DeliveryPayments<AccountId> for () {
 	type Error = &'static str;
 
-	fn delivery_reward_per_message(_lane: LaneId, _relayer: &AccountId) -> RewardAtSource {
+	fn relayer_reward_per_message(_lane: LaneId, _relayer: &AccountId) -> RelayerRewardAtSource {
 		0
 	}
 


### PR DESCRIPTION
related to #2486

First reviewable part of the #2605. This PR:
-  adds `RewardAtSource` type, which is used to order relayer bids at the target chain (this part will be added later - for now reference to #2605). Since we are using single instance of relayers pallet to bridge with all Substrate-based chains (and it actually makes sense to do that), it is difficult to make the code generic over the actual type. So it `u64`. At the same time, the "core" code does not impose any additional meaning onto this type. So e.g. it may mean milliDOTs and the payment will be made in DOTs or `MultiAsset`s, containing DOTs;
- adds `reward_per_message: RewardAtSource` field to the unrewarded relayers vector. It is eventually reported to the source chain, where this reward is actually mapped onto real reward type (see `calc_relayers_rewards_at_source` function);
- adds method `DeliveryPayments::delivery_reward_per_message`, which shall return this `reward_per_message` field value, that is later proved to the source chain.

The most controversial stuff here is the `RewardAtSource` type, which is fixed to `u64`. Do not think we can easily get rid of that hardcoded type. We can change it to `u128` (Polkadot-like chains are using it as a native token balance type), but I do not think we expect such large rewards.