### PR TITLE
Make relayer_reward_per_message field an option

### DIFF
--- a/bin/millau/runtime/src/lib.rs
+++ b/bin/millau/runtime/src/lib.rs
@@ -482,6 +482,7 @@ impl pallet_bridge_messages::Config<WithRialtoMessagesInstance> for Runtime {
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithRialtoMessagesInstance,
+		frame_support::traits::ConstU64<0>,
 		frame_support::traits::ConstU64<100_000>,
 	>;
 	type OnMessagesDelivered = XcmRialtoBridgeHub;
@@ -511,6 +512,7 @@ impl pallet_bridge_messages::Config<WithRialtoParachainMessagesInstance> for Run
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithRialtoParachainMessagesInstance,
+		frame_support::traits::ConstU64<0>,
 		frame_support::traits::ConstU64<100_000>,
 	>;
 	type OnMessagesDelivered = XcmRialtoParachainBridgeHub;

--- a/bin/rialto-parachain/runtime/src/lib.rs
+++ b/bin/rialto-parachain/runtime/src/lib.rs
@@ -580,6 +580,7 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithMillauMessagesInstance,
+		frame_support::traits::ConstU128<0>,
 		frame_support::traits::ConstU128<100_000>,
 	>;
 	type OnMessagesDelivered = XcmMillauBridgeHub;

--- a/bin/rialto/runtime/src/lib.rs
+++ b/bin/rialto/runtime/src/lib.rs
@@ -459,6 +459,7 @@ impl pallet_bridge_messages::Config<WithMillauMessagesInstance> for Runtime {
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		Runtime,
 		WithMillauMessagesInstance,
+		frame_support::traits::ConstU128<0>,
 		frame_support::traits::ConstU128<100_000>,
 	>;
 	type OnMessagesDelivered = XcmMillauBridgeHub;

--- a/modules/messages/src/benchmarking.rs
+++ b/modules/messages/src/benchmarking.rs
@@ -131,7 +131,7 @@ fn receive_messages<T: Config<I>, I: 'static>(nonce: MessageNonce) {
 			state: LaneState::Opened,
 			relayers: vec![UnrewardedRelayer {
 				relayer: T::bridged_relayer_id(),
-				messages: DeliveredMessages::new(nonce, 1),
+				messages: DeliveredMessages::new(nonce, Some(1)),
 			}]
 			.into(),
 			last_confirmed_nonce: 0,
@@ -368,7 +368,7 @@ mod benchmarks {
 				state: LaneState::Opened,
 				relayers: vec![UnrewardedRelayer {
 					relayer: relayer_id.clone(),
-					messages: DeliveredMessages::new(1, 1),
+					messages: DeliveredMessages::new(1, Some(1)),
 				}]
 				.into_iter()
 				.collect(),
@@ -412,7 +412,7 @@ mod benchmarks {
 			total_messages: 2,
 			last_delivered_nonce: 2,
 		};
-		let mut delivered_messages = DeliveredMessages::new(1, 1);
+		let mut delivered_messages = DeliveredMessages::new(1, Some(1));
 		delivered_messages.note_dispatched_message();
 		let proof = T::prepare_message_delivery_proof(MessageDeliveryProofParams {
 			lane: T::bench_lane_id(),
@@ -472,11 +472,11 @@ mod benchmarks {
 				relayers: vec![
 					UnrewardedRelayer {
 						relayer: relayer1_id.clone(),
-						messages: DeliveredMessages::new(1, 1),
+						messages: DeliveredMessages::new(1, Some(1)),
 					},
 					UnrewardedRelayer {
 						relayer: relayer2_id.clone(),
-						messages: DeliveredMessages::new(2, 1),
+						messages: DeliveredMessages::new(2, Some(1)),
 					},
 				]
 				.into_iter()

--- a/modules/messages/src/call_ext.rs
+++ b/modules/messages/src/call_ext.rs
@@ -264,7 +264,7 @@ mod tests {
 				messages: DeliveredMessages {
 					begin: n + 1,
 					end: n + 1,
-					relayer_reward_per_message: 0,
+					relayer_reward_per_message: None,
 				},
 			});
 		}
@@ -278,7 +278,7 @@ mod tests {
 			messages: DeliveredMessages {
 				begin: 1,
 				end: BridgedChain::MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX,
-				relayer_reward_per_message: 0,
+				relayer_reward_per_message: None,
 			},
 		});
 		InboundLanes::<TestRuntime>::insert(test_lane_id(), inbound_lane_state);

--- a/modules/messages/src/inbound_lane.rs
+++ b/modules/messages/src/inbound_lane.rs
@@ -186,7 +186,7 @@ impl<S: InboundLaneStorage> InboundLane<S> {
 		relayer_at_bridged_chain: &S::Relayer,
 		nonce: MessageNonce,
 		message_data: DispatchMessageData<Dispatch::DispatchPayload>,
-		relayer_reward_per_message: RelayerRewardAtSource,
+		relayer_reward_per_message: Option<RelayerRewardAtSource>,
 	) -> ReceivalResult<Dispatch::DispatchLevelResult> {
 		let mut data = self.storage.data();
 		if Some(nonce) != data.last_delivered_nonce().checked_add(1) {
@@ -251,7 +251,7 @@ mod tests {
 				&TEST_RELAYER_A,
 				nonce,
 				inbound_message_data(REGULAR_PAYLOAD),
-				RELAYER_REWARD_PER_MESSAGE,
+				Some(RELAYER_REWARD_PER_MESSAGE),
 			),
 			ReceivalResult::Dispatched(dispatch_result(0))
 		);
@@ -379,7 +379,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					10,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::InvalidNonce
 			);
@@ -398,7 +398,7 @@ mod tests {
 						&(TEST_RELAYER_A + current_nonce),
 						current_nonce,
 						inbound_message_data(REGULAR_PAYLOAD),
-						RELAYER_REWARD_PER_MESSAGE,
+						Some(RELAYER_REWARD_PER_MESSAGE),
 					),
 					ReceivalResult::Dispatched(dispatch_result(0))
 				);
@@ -409,7 +409,7 @@ mod tests {
 					&(TEST_RELAYER_A + max_nonce + 1),
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::TooManyUnrewardedRelayers,
 			);
@@ -419,7 +419,7 @@ mod tests {
 					&(TEST_RELAYER_A + max_nonce),
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::TooManyUnrewardedRelayers,
 			);
@@ -437,7 +437,7 @@ mod tests {
 						&TEST_RELAYER_A,
 						current_nonce,
 						inbound_message_data(REGULAR_PAYLOAD),
-						RELAYER_REWARD_PER_MESSAGE,
+						Some(RELAYER_REWARD_PER_MESSAGE),
 					),
 					ReceivalResult::Dispatched(dispatch_result(0))
 				);
@@ -448,7 +448,7 @@ mod tests {
 					&TEST_RELAYER_B,
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::TooManyUnconfirmedMessages,
 			);
@@ -458,7 +458,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					max_nonce + 1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::TooManyUnconfirmedMessages,
 			);
@@ -474,7 +474,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -483,7 +483,7 @@ mod tests {
 					&TEST_RELAYER_B,
 					2,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -492,7 +492,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					3,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -516,7 +516,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -525,7 +525,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					2,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE + 1,
+					Some(RELAYER_REWARD_PER_MESSAGE + 1),
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -534,7 +534,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					3,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE + 1,
+					Some(RELAYER_REWARD_PER_MESSAGE + 1),
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -542,7 +542,7 @@ mod tests {
 			let mut unrewarded_relayer_with_larger_reward =
 				unrewarded_relayer(2, 3, TEST_RELAYER_A);
 			unrewarded_relayer_with_larger_reward.messages.relayer_reward_per_message =
-				RELAYER_REWARD_PER_MESSAGE + 1;
+				Some(RELAYER_REWARD_PER_MESSAGE + 1);
 			assert_eq!(
 				lane.storage.data().relayers,
 				vec![
@@ -562,7 +562,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::Dispatched(dispatch_result(0))
 			);
@@ -571,7 +571,7 @@ mod tests {
 					&TEST_RELAYER_B,
 					1,
 					inbound_message_data(REGULAR_PAYLOAD),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::InvalidNonce,
 			);
@@ -598,7 +598,7 @@ mod tests {
 					&TEST_RELAYER_A,
 					1,
 					inbound_message_data(payload),
-					RELAYER_REWARD_PER_MESSAGE,
+					Some(RELAYER_REWARD_PER_MESSAGE),
 				),
 				ReceivalResult::Dispatched(dispatch_result(1))
 			);

--- a/modules/messages/src/tests/mock.rs
+++ b/modules/messages/src/tests/mock.rs
@@ -332,8 +332,11 @@ impl TestDeliveryPayments {
 impl DeliveryPayments<AccountId> for TestDeliveryPayments {
 	type Error = &'static str;
 
-	fn relayer_reward_per_message(_lane_id: LaneId, _relayer: &AccountId) -> RelayerRewardAtSource {
-		RELAYER_REWARD_PER_MESSAGE
+	fn relayer_reward_per_message(
+		_lane_id: LaneId,
+		_relayer: &AccountId,
+	) -> Option<RelayerRewardAtSource> {
+		Some(RELAYER_REWARD_PER_MESSAGE)
 	}
 
 	fn pay_reward(
@@ -373,7 +376,9 @@ impl DeliveryConfirmationPayments<AccountId> for TestDeliveryConfirmationPayment
 		let relayers_rewards = calc_relayers_rewards_at_source::<AccountId, Balance>(
 			messages_relayers,
 			received_range,
-			|messages, relayer_reward_per_message| messages * relayer_reward_per_message,
+			|messages, relayer_reward_per_message| {
+				messages * relayer_reward_per_message.unwrap_or(0)
+			},
 		);
 		let rewarded_relayers = relayers_rewards.len();
 		for (relayer, reward) in &relayers_rewards {
@@ -481,7 +486,7 @@ pub fn unrewarded_relayer(
 		messages: DeliveredMessages {
 			begin,
 			end,
-			relayer_reward_per_message: RELAYER_REWARD_PER_MESSAGE,
+			relayer_reward_per_message: Some(RELAYER_REWARD_PER_MESSAGE),
 		},
 	}
 }

--- a/modules/messages/src/tests/pallet_tests.rs
+++ b/modules/messages/src/tests/pallet_tests.rs
@@ -87,7 +87,7 @@ fn receive_messages_delivery_proof() {
 				last_confirmed_nonce: 1,
 				relayers: vec![UnrewardedRelayer {
 					relayer: 0,
-					messages: DeliveredMessages::new(1, 0),
+					messages: DeliveredMessages::new(1, None),
 				}]
 				.into(),
 			},
@@ -263,7 +263,7 @@ fn receive_messages_proof_works() {
 				.0
 				.relayers
 				.front()
-				.map(|r| r.messages.relayer_reward_per_message),
+				.and_then(|r| r.messages.relayer_reward_per_message),
 			Some(RELAYER_REWARD_PER_MESSAGE),
 		);
 
@@ -855,7 +855,7 @@ fn proof_size_refund_from_receive_messages_proof_works() {
 						messages: DeliveredMessages {
 							begin: 0,
 							end: 100,
-							relayer_reward_per_message: 0
+							relayer_reward_per_message: None,
 						}
 					};
 					max_entries
@@ -888,7 +888,7 @@ fn proof_size_refund_from_receive_messages_proof_works() {
 						messages: DeliveredMessages {
 							begin: 0,
 							end: 100,
-							relayer_reward_per_message: 0
+							relayer_reward_per_message: None,
 						}
 					};
 					max_entries - 1
@@ -1002,7 +1002,7 @@ fn test_bridge_messages_call_is_correctly_defined() {
 				last_confirmed_nonce: 1,
 				relayers: vec![UnrewardedRelayer {
 					relayer: 0,
-					messages: DeliveredMessages::new(1, 0),
+					messages: DeliveredMessages::new(1, None),
 				}]
 				.into(),
 			},
@@ -1065,7 +1065,11 @@ fn inbound_storage_extra_proof_size_bytes_works() {
 	fn relayer_entry() -> UnrewardedRelayer<TestRelayer> {
 		UnrewardedRelayer {
 			relayer: 42u64,
-			messages: DeliveredMessages { begin: 0, end: 100, relayer_reward_per_message: 0 },
+			messages: DeliveredMessages {
+				begin: 0,
+				end: 100,
+				relayer_reward_per_message: Some(42),
+			},
 		}
 	}
 
@@ -1161,7 +1165,7 @@ fn receive_messages_delivery_proof_fails_if_outbound_lane_is_unknown() {
 					last_confirmed_nonce: 1,
 					relayers: vec![UnrewardedRelayer {
 						relayer: 0,
-						messages: DeliveredMessages::new(1, 0),
+						messages: DeliveredMessages::new(1, None),
 					}]
 					.into(),
 				},

--- a/modules/relayers/src/extension/mod.rs
+++ b/modules/relayers/src/extension/mod.rs
@@ -1900,7 +1900,7 @@ mod tests {
 					messages: DeliveredMessages {
 						begin: 1,
 						end: best_delivered_message,
-						relayer_reward_per_message: 0,
+						relayer_reward_per_message: None,
 					},
 				}]
 				.into(),

--- a/modules/relayers/src/mock.rs
+++ b/modules/relayers/src/mock.rs
@@ -79,6 +79,8 @@ pub const TEST_BRIDGED_CHAIN_ID: ChainId = *b"brdg";
 /// Maximal extrinsic size at the `BridgedChain`.
 pub const BRIDGED_CHAIN_MAX_EXTRINSIC_SIZE: u32 = 1024;
 
+/// Default reward that is paid to relayer for delivering a single message.
+pub const DEFAULT_REWARD_PER_MESSAGE: ThisChainBalance = 100_000;
 /// Maximal reward that may be paid to relayer for delivering a single message.
 pub const MAX_REWARD_PER_MESSAGE: ThisChainBalance = 100_000;
 
@@ -284,6 +286,7 @@ pub type TestDeliveryConfirmationPaymentsAdapter =
 	pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		TestRuntime,
 		(),
+		ConstU64<DEFAULT_REWARD_PER_MESSAGE>,
 		ConstU64<MAX_REWARD_PER_MESSAGE>,
 	>;
 

--- a/modules/relayers/src/payment_adapter.rs
+++ b/modules/relayers/src/payment_adapter.rs
@@ -33,19 +33,21 @@ use sp_std::{collections::vec_deque::VecDeque, marker::PhantomData, ops::RangeIn
 /// for the messages pallet.
 ///
 /// This adapter assumes 1:1 mapping of `RelayerRewardAtSource` to `T::Reward`. The reward for
-/// delivering a single message, will never be larger than the `MaxRewardPerMessage`.
+/// delivering a single message, will never be larger than the `MaxRewardPerMessage`. If relayer
+/// has not specified expected reward, it gets the `DefaultRewardPerMessage` for every message.
 ///
 /// We assume that the confirmation transaction cost is refunded by the signed extension,
 /// implemented by the pallet. So we do not reward confirmation relayer additionally here.
-pub struct DeliveryConfirmationPaymentsAdapter<T, MI, MaxRewardPerMessage>(
-	PhantomData<(T, MI, MaxRewardPerMessage)>,
+pub struct DeliveryConfirmationPaymentsAdapter<T, MI, DefaultRewardPerMessage, MaxRewardPerMessage>(
+	PhantomData<(T, MI, DefaultRewardPerMessage, MaxRewardPerMessage)>,
 );
 
-impl<T, MI, MaxRewardPerMessage> DeliveryConfirmationPayments<T::AccountId>
-	for DeliveryConfirmationPaymentsAdapter<T, MI, MaxRewardPerMessage>
+impl<T, MI, DefaultRewardPerMessage, MaxRewardPerMessage> DeliveryConfirmationPayments<T::AccountId>
+	for DeliveryConfirmationPaymentsAdapter<T, MI, DefaultRewardPerMessage, MaxRewardPerMessage>
 where
 	T: Config + pallet_bridge_messages::Config<MI>,
 	MI: 'static,
+	DefaultRewardPerMessage: Get<T::Reward>,
 	MaxRewardPerMessage: Get<T::Reward>,
 {
 	type Error = &'static str;
@@ -63,7 +65,9 @@ where
 				|messages, relayer_reward_per_message| {
 					let relayer_reward_per_message = sp_std::cmp::min(
 						MaxRewardPerMessage::get(),
-						relayer_reward_per_message.unique_saturated_into(),
+						relayer_reward_per_message
+							.map(|x| x.unique_saturated_into())
+							.unwrap_or_else(|| DefaultRewardPerMessage::get()),
 					);
 
 					T::Reward::unique_saturated_from(messages)
@@ -132,10 +136,33 @@ mod tests {
 	}
 
 	#[test]
+	fn reward_per_message_is_default_if_not_specified() {
+		run_test(|| {
+			let mut delivered_messages = bp_messages::DeliveredMessages::new(1, None);
+			delivered_messages.note_dispatched_message();
+
+			<TestDeliveryConfirmationPaymentsAdapter as DeliveryConfirmationPayments<
+				ThisChainAccountId,
+			>>::pay_reward(
+				test_lane_id(),
+				vec![bp_messages::UnrewardedRelayer { relayer: 42, messages: delivered_messages }]
+					.into(),
+				&43,
+				&(1..=2),
+			);
+
+			assert_eq!(
+				RelayerRewards::<TestRuntime>::get(42, test_reward_account_param()),
+				Some(DEFAULT_REWARD_PER_MESSAGE * 2),
+			);
+		});
+	}
+
+	#[test]
 	fn reward_per_message_is_never_larger_than_max_reward_per_message() {
 		run_test(|| {
 			let mut delivered_messages =
-				bp_messages::DeliveredMessages::new(1, MAX_REWARD_PER_MESSAGE + 1);
+				bp_messages::DeliveredMessages::new(1, Some(MAX_REWARD_PER_MESSAGE + 1));
 			delivered_messages.note_dispatched_message();
 
 			TestDeliveryConfirmationPaymentsAdapter::pay_reward(

--- a/primitives/messages/src/lib.rs
+++ b/primitives/messages/src/lib.rs
@@ -507,13 +507,20 @@ pub struct DeliveredMessages {
 	/// Reward that needs to be paid at the source chain (during confirmation transaction)
 	/// for **every delivered message** in the `begin..=end` range. If reward has been paid
 	/// at the target chain or if no rewards assumed, it may be zero.
-	pub relayer_reward_per_message: RelayerRewardAtSource,
+	///
+	/// If it is `None`, then the relayer has not specified expected reward at the target chain.
+	/// The reward will be determined by the `DeliveryConfirmationPayments` algorithm at
+	/// the source chain.
+	pub relayer_reward_per_message: Option<RelayerRewardAtSource>,
 }
 
 impl DeliveredMessages {
 	/// Create new `DeliveredMessages` struct that confirms delivery of single nonce with given
 	/// dispatch result.
-	pub fn new(nonce: MessageNonce, relayer_reward_per_message: RelayerRewardAtSource) -> Self {
+	pub fn new(
+		nonce: MessageNonce,
+		relayer_reward_per_message: Option<RelayerRewardAtSource>,
+	) -> Self {
 		DeliveredMessages { begin: nonce, end: nonce, relayer_reward_per_message }
 	}
 
@@ -617,7 +624,7 @@ impl Default for OutboundLaneData {
 pub fn calc_relayers_rewards_at_source<AccountId, Reward>(
 	messages_relayers: VecDeque<UnrewardedRelayer<AccountId>>,
 	received_range: &RangeInclusive<MessageNonce>,
-	compute_reward: impl Fn(MessageNonce, RelayerRewardAtSource) -> Reward,
+	compute_reward: impl Fn(MessageNonce, Option<RelayerRewardAtSource>) -> Reward,
 ) -> RelayersRewards<AccountId, Reward>
 where
 	AccountId: sp_std::cmp::Ord,
@@ -627,11 +634,6 @@ where
 	// this loop is bounded by `T::MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX` on the bridged chain
 	let mut relayers_rewards: RelayersRewards<_, Reward> = RelayersRewards::new();
 	for entry in messages_relayers {
-		// if relayer does not expect any reward, do nothing
-		if entry.messages.relayer_reward_per_message == 0 {
-			continue
-		}
-
 		// if we have already paid reward for delivering those messages, do nothing
 		let nonce_begin = sp_std::cmp::max(entry.messages.begin, *received_range.start());
 		let nonce_end = sp_std::cmp::min(entry.messages.end, *received_range.end());
@@ -644,6 +646,12 @@ where
 		// compute and update reward in the rewards map
 		let new_reward =
 			compute_reward(new_confirmations_count, entry.messages.relayer_reward_per_message);
+
+		// if relayer does not expect any reward, do nothing
+		if new_reward.is_zero() {
+			continue
+		}
+
 		let total_relayer_reward = relayers_rewards.entry(entry.relayer).or_insert_with(Zero::zero);
 		*total_relayer_reward = total_relayer_reward.saturating_add(new_reward);
 	}
@@ -690,10 +698,10 @@ mod tests {
 		let lane_data = InboundLaneData {
 			state: LaneState::Opened,
 			relayers: vec![
-				UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(0, 0) },
+				UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(0, None) },
 				UnrewardedRelayer {
 					relayer: 2,
-					messages: DeliveredMessages::new(MessageNonce::MAX, 0),
+					messages: DeliveredMessages::new(MessageNonce::MAX, None),
 				},
 			]
 			.into_iter()
@@ -720,7 +728,7 @@ mod tests {
 				relayers: (1u8..=relayer_entries)
 					.map(|i| UnrewardedRelayer {
 						relayer: i,
-						messages: DeliveredMessages::new(i as _, 0u64),
+						messages: DeliveredMessages::new(i as _, Some(42)),
 					})
 					.collect(),
 				last_confirmed_nonce: messages_count as _,
@@ -738,7 +746,7 @@ mod tests {
 	#[test]
 	fn contains_result_works() {
 		let delivered_messages =
-			DeliveredMessages { begin: 100, end: 150, relayer_reward_per_message: 0 };
+			DeliveredMessages { begin: 100, end: 150, relayer_reward_per_message: None };
 
 		assert!(!delivered_messages.contains_message(99));
 		assert!(delivered_messages.contains_message(100));
@@ -800,20 +808,21 @@ mod tests {
 			calc_relayers_rewards_at_source::<u64, u64>(
 				vec![
 					// relayer that wants zero reward => no payments expected
-					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(1, 0) },
+					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(1, Some(0)) },
+					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(1, None) },
 					// relayer wants reward => payment is expected
-					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(2, 77) },
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(2, Some(77)) },
 					// relayer that we met before and he wants reward => payment is expected
-					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(3, 42) },
+					UnrewardedRelayer { relayer: 1, messages: DeliveredMessages::new(3, Some(42)) },
 					// relayer that we met before and he wants reward => payment is expected
-					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(4, 33) },
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(4, Some(33)) },
 					// relayers that deliver messages out of range
-					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(0, 33) },
-					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(5, 33) },
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(0, Some(33)) },
+					UnrewardedRelayer { relayer: 2, messages: DeliveredMessages::new(5, Some(33)) },
 				]
 				.into(),
 				&(1..=4),
-				|_, relayer_reward_per_message| relayer_reward_per_message,
+				|_, relayer_reward_per_message| relayer_reward_per_message.unwrap_or(0),
 			),
 			vec![(1, 42), (2, 110)].into_iter().collect(),
 		);

--- a/primitives/messages/src/target_chain.rs
+++ b/primitives/messages/src/target_chain.rs
@@ -131,7 +131,14 @@ pub trait DeliveryPayments<AccountId> {
 	///
 	/// Keep in mind that it is not necessary a real reward that will be paid. See
 	/// [`crate::RelayerRewardAtSource`] for more details.
-	fn relayer_reward_per_message(lane: LaneId, relayer: &AccountId) -> RelayerRewardAtSource;
+	///
+	/// If method returns `None`, it means that the relayer has not specified its expected reward
+	/// at the target chain and it is up to the source chain `DeliveryConfirmationPayments` to
+	/// compute the reward amount.
+	fn relayer_reward_per_message(
+		lane: LaneId,
+		relayer: &AccountId,
+	) -> Option<RelayerRewardAtSource>;
 
 	/// Pay rewards for delivering messages to the given relayer.
 	///
@@ -169,8 +176,11 @@ impl<DispatchPayload: Decode> From<MessagePayload> for DispatchMessageData<Dispa
 impl<AccountId> DeliveryPayments<AccountId> for () {
 	type Error = &'static str;
 
-	fn relayer_reward_per_message(_lane: LaneId, _relayer: &AccountId) -> RelayerRewardAtSource {
-		0
+	fn relayer_reward_per_message(
+		_lane: LaneId,
+		_relayer: &AccountId,
+	) -> Option<RelayerRewardAtSource> {
+		None
 	}
 
 	fn pay_reward(


### PR DESCRIPTION
related to https://github.com/paritytech/parity-bridges-common/issues/2486
extracted from https://github.com/paritytech/parity-bridges-common/pull/2605
follow up for #2613 

In #2613 I've missed the fact that unregistered relayers may still deliver messages. We still need to reward such relayers, but how to fill the `relayer_reward_per_message` then? Unregistered relayer can't specify this value. We could use some special value (`u64::MAX`) for such entries or we could use `Option<u64>`. 1-byte overhead looks not that large, so probably it is fine to use `Option<u64>`, because it is looks more natural.

I'm also thinking of replacing all `u64` in messages runtime storage with `Compact<u64>`, it shall make values even smaller.