### PR TITLE
Deposit event when relayer reward is registered

### DIFF
--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -379,6 +379,12 @@ pub mod pallet {
 						rewards_account_params,
 						new_reward,
 					);
+
+					Self::deposit_event(Event::<T>::RewardRegistered {
+						relayer: relayer.clone(),
+						rewards_account_params,
+						reward,
+					});
 				},
 			);
 		}
@@ -423,6 +429,15 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
+		/// Relayer reward has been registered and may be claimed later.
+		RewardRegistered {
+			/// Relayer account that can claim reward.
+			relayer: T::AccountId,
+			/// Relayer can claim reward from this account.
+			rewards_account_params: RewardsAccountParams,
+			/// Reward amount.
+			reward: T::Reward,
+		},
 		/// Reward has been paid to the relayer.
 		RewardPaid {
 			/// Relayer account that has been rewarded.

--- a/modules/relayers/src/lib.rs
+++ b/modules/relayers/src/lib.rs
@@ -552,7 +552,7 @@ mod tests {
 	use super::*;
 	use mock::{RuntimeEvent as TestEvent, *};
 
-	use crate::Event::RewardPaid;
+	use crate::Event::{RewardPaid, RewardRegistered};
 	use bp_messages::LaneId;
 	use bp_relayers::RewardsAccountOwner;
 	use frame_support::{
@@ -565,6 +565,33 @@ mod tests {
 	fn get_ready_for_events() {
 		System::<TestRuntime>::set_block_number(1);
 		System::<TestRuntime>::reset_events();
+	}
+
+	#[test]
+	fn register_relayer_reward_emit_event() {
+		run_test(|| {
+			get_ready_for_events();
+
+			Pallet::<TestRuntime>::register_relayer_reward(
+				test_reward_account_param(),
+				&REGULAR_RELAYER,
+				100,
+			);
+
+			// Check if the `RewardRegistered` event was emitted.
+			assert_eq!(
+				System::<TestRuntime>::events().last(),
+				Some(&EventRecord {
+					phase: Phase::Initialization,
+					event: TestEvent::BridgeRelayers(RewardRegistered {
+						relayer: REGULAR_RELAYER,
+						rewards_account_params: test_reward_account_param(),
+						reward: 100
+					}),
+					topics: vec![],
+				}),
+			);
+		});
 	}
 
 	#[test]


### PR DESCRIPTION
Think it is a good idea - e.g. when debugging we can't see account in parachain logs.