### PR TITLE
Gitspiegel polkadot staging

### DIFF
--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -1,0 +1,20 @@
+name: gitspiegel sync
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - unlocked
+      - ready_for_review
+      - reopened
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync via API
+        run: |
+          curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
+           -H "Content-Type: application/json" \
+           -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"

--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -1,5 +1,10 @@
 name: gitspiegel sync
 
+# This workflow doesn't do anything, it's only use is to trigger "workflow_run"
+# webhook, that'll be consumed by gitspiegel
+# This way, gitspiegel won't do mirroring, unless this workflow runs,
+# and running the workflow is protected by GitHub
+
 on:
   pull_request:
     types:
@@ -13,8 +18,5 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger sync via API
-        run: |
-          curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
-           -H "Content-Type: application/json" \
-           -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"
+      - name: Do nothing
+        run: echo "let's go"


### PR DESCRIPTION
@mutantcornholio Could you, please, confirm that those two commits will fix our problem. And the problem is that when we open PRs to `polkadot-staging` branch, no checks (apart from CLA) are running on that PR. For us it is important to run the same set of checks on PRs to both `master` and `polkadot-staging` branches.

Example PRs:
- to `polkadot-staging`: https://github.com/paritytech/parity-bridges-common/pull/2692 (no any checks)
- to `main`: https://github.com/paritytech/parity-bridges-common/pull/2605