### PR TITLE
Try to fix publish-docker-image-description

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -349,6 +349,7 @@ bridges-common-relay:
 # Publish Docker images description to hub.docker.com
 
 .publish-docker-image-description:
+  <<: *kubernetes-build
   stage:                           publish-docker-description
   image:                           paritytech/dockerhub-description
   variables:
@@ -362,8 +363,6 @@ bridges-common-relay:
   script:
     - export DOCKERHUB_REPOSITORY="paritytech/${CI_JOB_NAME:10}"
     - cd / && sh entrypoint.sh
-  tags:
-    - linux-docker
 
 dockerhub-substrate-relay:
   extends:                .publish-docker-image-description


### PR DESCRIPTION
We have troubles with `publish-docker-image-description` job these days. I think the reason is in #2650, which was **partially** reverted later in #2672. I'm not sure - what's the reason of the failure, so I'm just trying to blindly guess the reason. The only thing I've found in `publish-docker-image-description` is that before those PRs ^^^, the tag for the failing job was `kubernetes-parity-build` and after it is `linux-docker`. Don't know if that's the reason - so, please, double check.

Last non-failing job: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/pipelines/405722 (27.10)
First failing job: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/pipelines/406238 (28.10)