### PR TITLE
Get rid of LaneMessageVerifier (#2168)

### DIFF
--- a/bin/runtime-common/src/mock.rs
+++ b/bin/runtime-common/src/mock.rs
@@ -21,7 +21,7 @@
 use crate::messages::{
 	source::{
 		FromThisChainMaximalOutboundPayloadSize, FromThisChainMessagePayload,
-		FromThisChainMessageVerifier, TargetHeaderChainAdapter,
+		TargetHeaderChainAdapter,
 	},
 	target::{FromBridgedChainMessagePayload, SourceHeaderChainAdapter},
 	BridgedChainWithMessages, HashOf, MessageBridge, ThisChainWithMessages,
@@ -213,7 +213,6 @@ impl pallet_bridge_messages::Config for TestRuntime {
 	type DeliveryPayments = ();
 
 	type TargetHeaderChain = TargetHeaderChainAdapter<OnThisChainBridge>;
-	type LaneMessageVerifier = FromThisChainMessageVerifier<OnThisChainBridge>;
 	type DeliveryConfirmationPayments = pallet_bridge_relayers::DeliveryConfirmationPaymentsAdapter<
 		TestRuntime,
 		(),

--- a/modules/messages/README.md
+++ b/modules/messages/README.md
@@ -116,26 +116,12 @@ maximal possible transaction size of the chain and so on. And when the relayer s
 implementation must be able to parse and verify the proof of messages delivery. Normally, you would reuse the same
 (configurable) type on all chains that are sending messages to the same bridged chain.
 
-The `pallet_bridge_messages::Config::LaneMessageVerifier` defines a single callback to verify outbound messages. The
-simplest callback may just accept all messages. But in this case you'll need to answer many questions first. Who will
-pay for the delivery and confirmation transaction? Are we sure that someone will ever deliver this message to the
-bridged chain? Are we sure that we don't bloat our runtime storage by accepting this message? What if the message is
-improperly encoded or has some fields set to invalid values? Answering all those (and similar) questions would lead to
-correct implementation.
-
-There's another thing to consider when implementing type for use in
-`pallet_bridge_messages::Config::LaneMessageVerifier`. It is whether we treat all message lanes identically, or they'll
-have different sets of verification rules? For example, you may reserve lane#1 for messages coming from some
-'wrapped-token' pallet - then you may verify in your implementation that the origin is associated with this pallet.
-Lane#2 may be reserved for 'system' messages and you may charge zero fee for such messages. You may have some rate
-limiting for messages sent over the lane#3. Or you may just verify the same rules set for all outbound messages - it is
-all up to the `pallet_bridge_messages::Config::LaneMessageVerifier` implementation.
-
-The last type is the `pallet_bridge_messages::Config::DeliveryConfirmationPayments`. When confirmation transaction is
-received, we call the `pay_reward()` method, passing the range of delivered messages. You may use the
-[`pallet-bridge-relayers`](../relayers/) pallet and its
-[`DeliveryConfirmationPaymentsAdapter`](../relayers/src/payment_adapter.rs) adapter as a possible implementation. It
-allows you to pay fixed reward for relaying the message and some of its portion for confirming delivery.
+The last type is the `pallet_bridge_messages::Config::DeliveryConfirmationPayments`. When confirmation
+transaction is received, we call the `pay_reward()` method, passing the range of delivered messages.
+You may use the [`pallet-bridge-relayers`](../relayers/) pallet and its
+[`DeliveryConfirmationPaymentsAdapter`](../relayers/src/payment_adapter.rs) adapter as a possible
+implementation. It allows you to pay fixed reward for relaying the message and some of its portion
+for confirming delivery.
 
 ### I have a Messages Module in my Runtime, but I Want to Reject all Outbound Messages. What shall I do?
 

--- a/modules/messages/src/mock.rs
+++ b/modules/messages/src/mock.rs
@@ -21,15 +21,13 @@ use crate::Config;
 
 use bp_messages::{
 	calc_relayers_rewards,
-	source_chain::{
-		DeliveryConfirmationPayments, LaneMessageVerifier, OnMessagesDelivered, TargetHeaderChain,
-	},
+	source_chain::{DeliveryConfirmationPayments, OnMessagesDelivered, TargetHeaderChain},
 	target_chain::{
 		DeliveryPayments, DispatchMessage, DispatchMessageData, MessageDispatch,
 		ProvedLaneMessages, ProvedMessages, SourceHeaderChain,
 	},
 	DeliveredMessages, InboundLaneData, LaneId, Message, MessageKey, MessageNonce, MessagePayload,
-	OutboundLaneData, UnrewardedRelayer, UnrewardedRelayersState, VerificationError,
+	UnrewardedRelayer, UnrewardedRelayersState, VerificationError,
 };
 use bp_runtime::{messages::MessageDispatchResult, Size};
 use codec::{Decode, Encode};
@@ -50,8 +48,6 @@ pub type Balance = u64;
 pub struct TestPayload {
 	/// Field that may be used to identify messages.
 	pub id: u64,
-	/// Reject this message by lane verifier?
-	pub reject_by_lane_verifier: bool,
 	/// Dispatch weight that is declared by the message sender.
 	pub declared_weight: Weight,
 	/// Message dispatch result.
@@ -120,7 +116,6 @@ impl Config for TestRuntime {
 	type DeliveryPayments = TestDeliveryPayments;
 
 	type TargetHeaderChain = TestTargetHeaderChain;
-	type LaneMessageVerifier = TestLaneMessageVerifier;
 	type DeliveryConfirmationPayments = TestDeliveryConfirmationPayments;
 	type OnMessagesDelivered = TestOnMessagesDelivered;
 
@@ -265,24 +260,6 @@ impl TargetHeaderChain<TestPayload, TestRelayer> for TestTargetHeaderChain {
 		proof: Self::MessagesDeliveryProof,
 	) -> Result<(LaneId, InboundLaneData<TestRelayer>), VerificationError> {
 		proof.0.map_err(|_| VerificationError::Other(TEST_ERROR))
-	}
-}
-
-/// Lane message verifier that is used in tests.
-#[derive(Debug, Default)]
-pub struct TestLaneMessageVerifier;
-
-impl LaneMessageVerifier<TestPayload> for TestLaneMessageVerifier {
-	fn verify_message(
-		_lane: &LaneId,
-		_lane_outbound_data: &OutboundLaneData,
-		payload: &TestPayload,
-	) -> Result<(), VerificationError> {
-		if !payload.reject_by_lane_verifier {
-			Ok(())
-		} else {
-			Err(VerificationError::Other(TEST_ERROR))
-		}
 	}
 }
 
@@ -438,7 +415,6 @@ pub fn inbound_message_data(payload: TestPayload) -> DispatchMessageData<TestPay
 pub const fn message_payload(id: u64, declared_weight: u64) -> TestPayload {
 	TestPayload {
 		id,
-		reject_by_lane_verifier: false,
 		declared_weight: Weight::from_parts(declared_weight, 0),
 		dispatch_result: dispatch_result(0),
 		extra: Vec::new(),

--- a/primitives/messages/src/source_chain.rs
+++ b/primitives/messages/src/source_chain.rs
@@ -16,7 +16,7 @@
 
 //! Primitives of messages module, that are used on the source chain.
 
-use crate::{InboundLaneData, LaneId, MessageNonce, OutboundLaneData, VerificationError};
+use crate::{InboundLaneData, LaneId, MessageNonce, VerificationError};
 
 use crate::UnrewardedRelayer;
 use bp_runtime::Size;
@@ -62,24 +62,6 @@ pub trait TargetHeaderChain<Payload, AccountId> {
 	fn verify_messages_delivery_proof(
 		proof: Self::MessagesDeliveryProof,
 	) -> Result<(LaneId, InboundLaneData<AccountId>), VerificationError>;
-}
-
-/// Lane message verifier.
-///
-/// Runtime developer may implement any additional validation logic over message-lane mechanism.
-/// E.g. if lanes should have some security (e.g. you can only accept Lane1 messages from
-/// Submitter1, Lane2 messages for those who has submitted first message to this lane, disable
-/// Lane3 until some block, ...), then it may be built using this verifier.
-///
-/// Any fee requirements should also be enforced here.
-pub trait LaneMessageVerifier<Payload> {
-	/// Verify message payload and return Ok(()) if message is valid and allowed to be sent over the
-	/// lane.
-	fn verify_message(
-		lane: &LaneId,
-		outbound_data: &OutboundLaneData,
-		payload: &Payload,
-	) -> Result<(), VerificationError>;
 }
 
 /// Manages payments that are happening at the source chain during delivery confirmation
@@ -161,7 +143,7 @@ impl<Payload> MessagesBridge<Payload> for NoopMessagesBridge {
 	}
 }
 
-/// Structure that may be used in place of `TargetHeaderChain`, `LaneMessageVerifier` and
+/// Structure that may be used in place of `TargetHeaderChain` and
 /// `MessageDeliveryAndDispatchPayment` on chains, where outbound messages are forbidden.
 pub struct ForbidOutboundMessages;
 
@@ -179,16 +161,6 @@ impl<Payload, AccountId> TargetHeaderChain<Payload, AccountId> for ForbidOutboun
 	fn verify_messages_delivery_proof(
 		_proof: Self::MessagesDeliveryProof,
 	) -> Result<(LaneId, InboundLaneData<AccountId>), VerificationError> {
-		Err(VerificationError::Other(ALL_OUTBOUND_MESSAGES_REJECTED))
-	}
-}
-
-impl<Payload> LaneMessageVerifier<Payload> for ForbidOutboundMessages {
-	fn verify_message(
-		_lane: &LaneId,
-		_outbound_data: &OutboundLaneData,
-		_payload: &Payload,
-	) -> Result<(), VerificationError> {
 		Err(VerificationError::Other(ALL_OUTBOUND_MESSAGES_REJECTED))
 	}
 }


### PR DESCRIPTION
`LaneMessageVerifier` is a noop on all our bridges, so it is safe to port to `polkadot-staging`