### PR TITLE
[polkadot-staging] Bump sysinfo from 0.29.11 to 0.30.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,16 +1956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6711,9 +6701,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -6721,14 +6711,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -9739,9 +9727,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -9749,7 +9737,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -11188,6 +11176,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/relays/utils/Cargo.toml
+++ b/relays/utils/Cargo.toml
@@ -21,7 +21,7 @@ jsonpath_lib = "0.3"
 log = "0.4.20"
 num-traits = "0.2"
 serde_json = "1.0"
-sysinfo = "0.29"
+sysinfo = "0.30"
 time = { version = "0.3", features = ["formatting", "local-offset", "std"] }
 tokio = { version = "1.35", features = ["rt"] }
 thiserror = "1.0.55"

--- a/relays/utils/src/metrics/global.rs
+++ b/relays/utils/src/metrics/global.rs
@@ -24,7 +24,7 @@ use crate::metrics::{
 use async_std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use std::time::Duration;
-use sysinfo::{ProcessExt, RefreshKind, System, SystemExt};
+use sysinfo::{RefreshKind, System};
 
 /// Global metrics update interval.
 const UPDATE_INTERVAL: Duration = Duration::from_secs(10);
@@ -73,7 +73,7 @@ impl StandaloneMetric for GlobalMetrics {
 	async fn update(&self) {
 		// update system-wide metrics
 		let mut system = self.system.lock().await;
-		let load = system.load_average();
+		let load = sysinfo::System::load_average();
 		self.system_average_load.with_label_values(&["1min"]).set(load.one);
 		self.system_average_load.with_label_values(&["5min"]).set(load.five);
 		self.system_average_load.with_label_values(&["15min"]).set(load.fifteen);


### PR DESCRIPTION
Follow-up on https://github.com/paritytech/parity-bridges-common/pull/2779

Had to do some small updates in the code after bumping `sysinfo`