### PR TITLE
Add submit_finality_proof_ex call to the GRANDPA pallet

### DIFF
--- a/bin/runtime-common/src/refund_relayer_extension.rs
+++ b/bin/runtime-common/src/refund_relayer_extension.rs
@@ -844,7 +844,7 @@ mod tests {
 	use bp_parachains::{BestParaHeadHash, ParaInfo};
 	use bp_polkadot_core::parachains::{ParaHeadsProof, ParaId};
 	use bp_runtime::{BasicOperatingMode, HeaderId};
-	use bp_test_utils::{make_default_justification, test_keyring};
+	use bp_test_utils::{make_default_justification, test_keyring, TEST_GRANDPA_SET_ID};
 	use frame_support::{
 		assert_storage_noop, parameter_types,
 		traits::{fungible::Mutate, ReservableCurrency},
@@ -929,7 +929,7 @@ mod tests {
 		let authorities = test_keyring().into_iter().map(|(a, w)| (a.into(), w)).collect();
 		let best_relay_header = HeaderId(best_relay_header_number, RelayBlockHash::default());
 		pallet_bridge_grandpa::CurrentAuthoritySet::<TestRuntime>::put(
-			StoredAuthoritySet::try_new(authorities, 0).unwrap(),
+			StoredAuthoritySet::try_new(authorities, TEST_GRANDPA_SET_ID).unwrap(),
 		);
 		pallet_bridge_grandpa::BestFinalized::<TestRuntime>::put(best_relay_header);
 
@@ -971,9 +971,10 @@ mod tests {
 		);
 		let relay_justification = make_default_justification(&relay_header);
 
-		RuntimeCall::BridgeGrandpa(GrandpaCall::submit_finality_proof {
+		RuntimeCall::BridgeGrandpa(GrandpaCall::submit_finality_proof_ex {
 			finality_target: Box::new(relay_header),
 			justification: relay_justification,
+			current_set_id: TEST_GRANDPA_SET_ID,
 		})
 	}
 
@@ -1105,6 +1106,7 @@ mod tests {
 			call_info: CallInfo::AllFinalityAndMsgs(
 				SubmitFinalityProofInfo {
 					block_number: 200,
+					current_set_id: Some(TEST_GRANDPA_SET_ID),
 					extra_weight: Weight::zero(),
 					extra_size: 0,
 				},
@@ -1134,6 +1136,7 @@ mod tests {
 			call_info: CallInfo::AllFinalityAndMsgs(
 				SubmitFinalityProofInfo {
 					block_number: 200,
+					current_set_id: Some(TEST_GRANDPA_SET_ID),
 					extra_weight: Weight::zero(),
 					extra_size: 0,
 				},
@@ -1159,6 +1162,7 @@ mod tests {
 			call_info: CallInfo::RelayFinalityAndMsgs(
 				SubmitFinalityProofInfo {
 					block_number: 200,
+					current_set_id: Some(TEST_GRANDPA_SET_ID),
 					extra_weight: Weight::zero(),
 					extra_size: 0,
 				},
@@ -1183,6 +1187,7 @@ mod tests {
 			call_info: CallInfo::RelayFinalityAndMsgs(
 				SubmitFinalityProofInfo {
 					block_number: 200,
+					current_set_id: Some(TEST_GRANDPA_SET_ID),
 					extra_weight: Weight::zero(),
 					extra_size: 0,
 				},

--- a/modules/grandpa/README.md
+++ b/modules/grandpa/README.md
@@ -38,11 +38,11 @@ There are two main things in GRANDPA that help building light clients:
 
 ## Pallet Operations
 
-The main entrypoint of the pallet is the `submit_finality_proof` call. It has two arguments - the finalized
-headers and associated GRANDPA justification. The call simply verifies the justification using current
-validators set and checks if header is better than the previous best header. If both checks are passed, the
-header (only its useful fields) is inserted into the runtime storage and may be used by other pallets to verify
-storage proofs.
+The main entrypoint of the pallet is the `submit_finality_proof_ex` call. It has three arguments - the finalized
+headers, associated GRANDPA justification and ID of the authority set that has generated this justification. The
+call simply verifies the justification using current validators set and checks if header is better than the
+previous best header. If both checks are passed, the header (only its useful fields) is inserted into the runtime
+storage and may be used by other pallets to verify storage proofs.
 
 The submitter pays regular fee for submitting all headers, except for the mandatory header. Since it is
 required for the pallet operations, submitting such header is free. So if you're ok with session-length

--- a/modules/grandpa/src/benchmarking.rs
+++ b/modules/grandpa/src/benchmarking.rs
@@ -16,8 +16,8 @@
 
 //! Benchmarks for the GRANDPA Pallet.
 //!
-//! The main dispatchable for the GRANDPA pallet is `submit_finality_proof`, so these benchmarks are
-//! based around that. There are to main factors which affect finality proof verification:
+//! The main dispatchable for the GRANDPA pallet is `submit_finality_proof_ex`, so these benchmarks
+//! are based around that. There are to main factors which affect finality proof verification:
 //!
 //! 1. The number of `votes-ancestries` in the justification
 //! 2. The number of `pre-commits` in the justification
@@ -77,7 +77,7 @@ fn precommits_range_end<T: Config<I>, I: 'static>() -> u32 {
 	required_justification_precommits(max_bridged_authorities)
 }
 
-/// Prepare header and its justification to submit using `submit_finality_proof`.
+/// Prepare header and its justification to submit using `submit_finality_proof_ex`.
 fn prepare_benchmark_data<T: Config<I>, I: 'static>(
 	precommits: u32,
 	ancestors: u32,
@@ -118,12 +118,13 @@ fn prepare_benchmark_data<T: Config<I>, I: 'static>(
 benchmarks_instance_pallet! {
 	// This is the "gold standard" benchmark for this extrinsic, and it's what should be used to
 	// annotate the weight in the pallet.
-	submit_finality_proof {
+	submit_finality_proof_ex {
 		let p in 1 .. precommits_range_end::<T, I>();
 		let v in MAX_VOTE_ANCESTRIES_RANGE_BEGIN..MAX_VOTE_ANCESTRIES_RANGE_END;
 		let caller: T::AccountId = whitelisted_caller();
 		let (header, justification) = prepare_benchmark_data::<T, I>(p, v);
-	}: submit_finality_proof(RawOrigin::Signed(caller), Box::new(header), justification)
+		let set_id = TEST_GRANDPA_SET_ID;
+	}: submit_finality_proof_ex(RawOrigin::Signed(caller), Box::new(header), justification, set_id)
 	verify {
 		let genesis_header: BridgedHeader<T, I> = bp_test_utils::test_header(Zero::zero());
 		let header: BridgedHeader<T, I> = bp_test_utils::test_header(One::one());

--- a/modules/grandpa/src/benchmarking.rs
+++ b/modules/grandpa/src/benchmarking.rs
@@ -16,8 +16,9 @@
 
 //! Benchmarks for the GRANDPA Pallet.
 //!
-//! The main dispatchable for the GRANDPA pallet is `submit_finality_proof_ex`, so these benchmarks
-//! are based around that. There are to main factors which affect finality proof verification:
+//! The main dispatchable for the GRANDPA pallet is `submit_finality_proof_ex`. Our benchmarks
+//! are based around `submit_finality_proof`, though - from weight PoV they are the same calls.
+//! There are to main factors which affect finality proof verification:
 //!
 //! 1. The number of `votes-ancestries` in the justification
 //! 2. The number of `pre-commits` in the justification
@@ -77,7 +78,7 @@ fn precommits_range_end<T: Config<I>, I: 'static>() -> u32 {
 	required_justification_precommits(max_bridged_authorities)
 }
 
-/// Prepare header and its justification to submit using `submit_finality_proof_ex`.
+/// Prepare header and its justification to submit using `submit_finality_proof`.
 fn prepare_benchmark_data<T: Config<I>, I: 'static>(
 	precommits: u32,
 	ancestors: u32,
@@ -118,13 +119,12 @@ fn prepare_benchmark_data<T: Config<I>, I: 'static>(
 benchmarks_instance_pallet! {
 	// This is the "gold standard" benchmark for this extrinsic, and it's what should be used to
 	// annotate the weight in the pallet.
-	submit_finality_proof_ex {
+	submit_finality_proof {
 		let p in 1 .. precommits_range_end::<T, I>();
 		let v in MAX_VOTE_ANCESTRIES_RANGE_BEGIN..MAX_VOTE_ANCESTRIES_RANGE_END;
 		let caller: T::AccountId = whitelisted_caller();
 		let (header, justification) = prepare_benchmark_data::<T, I>(p, v);
-		let set_id = TEST_GRANDPA_SET_ID;
-	}: submit_finality_proof_ex(RawOrigin::Signed(caller), Box::new(header), justification, set_id)
+	}: submit_finality_proof(RawOrigin::Signed(caller), Box::new(header), justification)
 	verify {
 		let genesis_header: BridgedHeader<T, I> = bp_test_utils::test_header(Zero::zero());
 		let header: BridgedHeader<T, I> = bp_test_utils::test_header(One::one());

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -159,6 +159,7 @@ pub mod pallet {
 			justification.commit.precommits.len().saturated_into(),
 			justification.votes_ancestries.len().saturated_into(),
 		))]
+		#[allow(deprecated)]
 		#[deprecated(
 			note = "`submit_finality_proof` will be removed in May 2024. Use `submit_finality_proof_ex` instead."
 		)]

--- a/modules/grandpa/src/lib.rs
+++ b/modules/grandpa/src/lib.rs
@@ -270,13 +270,13 @@ pub mod pallet {
 				finality_target
 			);
 
+			// it checks whether the `number` is better than the current best block number
+			// and whether the `current_set_id` matches the best known set id
 			SubmitFinalityProofHelper::<T, I>::check_obsolete(number, Some(current_set_id))?;
 
 			let authority_set = <CurrentAuthoritySet<T, I>>::get();
 			let unused_proof_size = authority_set.unused_proof_size();
 			let set_id = authority_set.set_id;
-			ensure!(current_set_id == set_id, <Error<T, I>>::InvalidAuthoritySetId);
-
 			let authority_set: AuthoritySet = authority_set.into();
 			verify_justification::<T, I>(&justification, hash, number, authority_set)?;
 

--- a/modules/parachains/src/lib.rs
+++ b/modules/parachains/src/lib.rs
@@ -731,6 +731,7 @@ pub(crate) mod tests {
 	};
 	use bp_test_utils::{
 		authority_list, generate_owned_bridge_module_tests, make_default_justification,
+		TEST_GRANDPA_SET_ID,
 	};
 	use frame_support::{
 		assert_noop, assert_ok,
@@ -777,10 +778,11 @@ pub(crate) mod tests {
 		let hash = header.hash();
 		let justification = make_default_justification(&header);
 		assert_ok!(
-			pallet_bridge_grandpa::Pallet::<TestRuntime, BridgesGrandpaPalletInstance>::submit_finality_proof(
+			pallet_bridge_grandpa::Pallet::<TestRuntime, BridgesGrandpaPalletInstance>::submit_finality_proof_ex(
 				RuntimeOrigin::signed(1),
 				Box::new(header),
 				justification.clone(),
+				TEST_GRANDPA_SET_ID,
 			)
 		);
 

--- a/primitives/header-chain/src/lib.rs
+++ b/primitives/header-chain/src/lib.rs
@@ -244,6 +244,16 @@ pub enum BridgeGrandpaCall<Header: HeaderT> {
 		/// All data, required to initialize the pallet.
 		init_data: InitializationData<Header>,
 	},
+	/// `pallet-bridge-grandpa::Call::submit_finality_proof_ex`
+	#[codec(index = 4)]
+	submit_finality_proof_ex {
+		/// The header that we are going to finalize.
+		finality_target: Box<Header>,
+		/// Finality justification for the `finality_target`.
+		justification: justification::GrandpaJustification<Header>,
+		/// An identifier of the validators set, that have signed the justification.
+		current_set_id: SetId,
+	},
 }
 
 /// The `BridgeGrandpaCall` used by a chain.


### PR DESCRIPTION
ref #2822

In some rare edge cases of bridged chains operations, there could be a situation where we submit a complex bridge transaction with GRANDPA justification, generated by other authorities set than the target bridge hub expects. One of examples:
1) mandatory GRANDPA header `MGH` appears at the source relay chain. This `MGH` is the header where the GRANDPA authorities set `OldSet` is switched to the `NewSet`;
2) relayer `RA` submits this `MGH` to the target bridge hub and the transaction is included into target bridge hub block `TBH_1`. So after this transaction, we expect all new justifications to be signed by the `NewSet`;
3) a dispute happens within target relay chain consensus;
4) while dispute happens, other relay `RB` finds that there are some undelivered headers and submits complex bridge transaction, containing the `MGH + 2` to the target bridge hub. Justificaton for this `MGH + 2` is signed by the `NewSet`;
5) as a result of dispute, the relay+parachain reorg happens at the target chain and `TBH_1` is no longer included into main fork of the target relay chain. So target bridge hub still sits on the `MGH - 2` (for example) with the `OldSet`;
6) since the second bridge transaction is signed by the other relayer (`RB`), it can be "mined" now and it is added to the `TBH_1'` target bridge hub block. This transaction is rejected, because it contains the justification, signed by the `NewSet` and `TBH_1'` only knows about the `OldSet`.

Outcome: If relayer has registration in the relayers pallet, it can be slashed. If it is not registered, it just loses its transaction fee.

To fix it, let's add the additional argument to the `submit_finality_proof` call - the id of GRANDPA authorities set, that have generated the bundled justification. If it mismatches the current set id from GRANPDA pallet storage, let's reject such transaction in our signed extension(s).

---

Since deploying an updated bridge version is a complicated process (we need both chains to upgrade to new runtime version + upgrade offchain relayer), let's do that incrementally. This PR adds new `submit_finality_proof_ex` call to the GRANDPA pallet. Once this PR is approved and merged, it'll propagate to the `polkadot-sdk` and eventually changes will be included in the Rococo and Westend Bridge Hub runtimes. Then we can upgrade our Rococo <> Westend relayer to use `submit_finality_proof_ex` instead of the `submit_finality_proof`. Once runtime changes are included in the Polkadot and Kusama Bridge Hub runtimes, we could also change our Polkadot <> Kusama relayer in a similar way. Then we can finally remove the old `submit_finality_proof` call and rename the `submit_finality_proof_ex` to `submit_finality_proof`.

I'll file an issue to track that update process ^^^