### PR TITLE
Pass finality proof verification context to the call builder

### DIFF
--- a/relays/lib-substrate-relay/src/finality/target.rs
+++ b/relays/lib-substrate-relay/src/finality/target.rs
@@ -109,15 +109,13 @@ impl<P: SubstrateFinalitySyncPipeline> TargetClient<FinalitySyncPipelineAdapter<
 		mut proof: SubstrateFinalityProof<P>,
 	) -> Result<Self::TransactionTracker, Error> {
 		// verify and runtime module at target chain may require optimized finality proof
-		let current_set_id =
+		let context =
 			P::FinalityEngine::verify_and_optimize_proof(&self.client, &header, &mut proof).await?;
 
 		// now we may submit optimized finality proof
 		let mortality = self.transaction_params.mortality;
 		let call = P::SubmitFinalityProofCallBuilder::build_submit_finality_proof_call(
-			header,
-			proof,
-			current_set_id,
+			header, proof, context,
 		);
 		self.client
 			.submit_and_watch_signed_extrinsic(

--- a/relays/lib-substrate-relay/src/finality/target.rs
+++ b/relays/lib-substrate-relay/src/finality/target.rs
@@ -108,13 +108,17 @@ impl<P: SubstrateFinalitySyncPipeline> TargetClient<FinalitySyncPipelineAdapter<
 		header: SyncHeader<HeaderOf<P::SourceChain>>,
 		mut proof: SubstrateFinalityProof<P>,
 	) -> Result<Self::TransactionTracker, Error> {
-		// runtime module at target chain may require optimized finality proof
-		P::FinalityEngine::optimize_proof(&self.client, &header, &mut proof).await?;
+		// verify and runtime module at target chain may require optimized finality proof
+		let current_set_id =
+			P::FinalityEngine::verify_and_optimize_proof(&self.client, &header, &mut proof).await?;
 
 		// now we may submit optimized finality proof
 		let mortality = self.transaction_params.mortality;
-		let call =
-			P::SubmitFinalityProofCallBuilder::build_submit_finality_proof_call(header, proof);
+		let call = P::SubmitFinalityProofCallBuilder::build_submit_finality_proof_call(
+			header,
+			proof,
+			current_set_id,
+		);
 		self.client
 			.submit_and_watch_signed_extrinsic(
 				&self.transaction_params.signer,

--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -146,8 +146,13 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 				finality_source.prove_block_finality(current_required_header).await?;
 			let header_id = header.id();
 
-			// optimize justification before including it into the call
-			P::FinalityEngine::optimize_proof(&self.target_client, &header, &mut proof).await?;
+			// verify and optimize justification before including it into the call
+			let current_set_id = P::FinalityEngine::verify_and_optimize_proof(
+				&self.target_client,
+				&header,
+				&mut proof,
+			)
+			.await?;
 
 			// now we have the header and its proof, but we want to minimize our losses, so let's
 			// check if we'll get the full refund for submitting this header
@@ -185,8 +190,11 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 			);
 
 			// and then craft the submit-proof call
-			let call =
-				P::SubmitFinalityProofCallBuilder::build_submit_finality_proof_call(header, proof);
+			let call = P::SubmitFinalityProofCallBuilder::build_submit_finality_proof_call(
+				header,
+				proof,
+				current_set_id,
+			);
 
 			return Ok((header_id, vec![call]));
 		}

--- a/relays/lib-substrate-relay/src/on_demand/headers.rs
+++ b/relays/lib-substrate-relay/src/on_demand/headers.rs
@@ -147,7 +147,7 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 			let header_id = header.id();
 
 			// verify and optimize justification before including it into the call
-			let current_set_id = P::FinalityEngine::verify_and_optimize_proof(
+			let context = P::FinalityEngine::verify_and_optimize_proof(
 				&self.target_client,
 				&header,
 				&mut proof,
@@ -191,9 +191,7 @@ impl<P: SubstrateFinalitySyncPipeline> OnDemandRelay<P::SourceChain, P::TargetCh
 
 			// and then craft the submit-proof call
 			let call = P::SubmitFinalityProofCallBuilder::build_submit_finality_proof_call(
-				header,
-				proof,
-				current_set_id,
+				header, proof, context,
 			);
 
 			return Ok((header_id, vec![call]));


### PR DESCRIPTION
ref #2822

No logic changes here - it just prepares everything to build new `submit_finality_proof_ex` call