### PR TITLE
Fix relay submitting extra parachain headers during reorg (#2839)

### DIFF
--- a/relays/lib-substrate-relay/src/parachains/source.rs
+++ b/relays/lib-substrate-relay/src/parachains/source.rs
@@ -124,9 +124,14 @@ where
 					// `max_header_id` is not set. There is no limit.
 					AvailableHeader::Available(on_chain_para_head_id)
 				},
-				AvailableHeader::Available(max_head_id) => {
+				AvailableHeader::Available(max_head_id) if on_chain_para_head_id >= max_head_id => {
 					// We report at most `max_header_id`.
 					AvailableHeader::Available(std::cmp::min(on_chain_para_head_id, max_head_id))
+				},
+				AvailableHeader::Available(_) => {
+					// the `max_head_id` is not yet available at the source chain => wait and avoid
+					// syncing extra headers
+					AvailableHeader::Unavailable
 				},
 			}
 		}

--- a/relays/parachains/src/parachains_loop.rs
+++ b/relays/parachains/src/parachains_loop.rs
@@ -256,7 +256,12 @@ where
 		let head_at_source =
 			read_head_at_source(&source_client, metrics.as_ref(), &best_finalized_relay_block)
 				.await?;
-		let is_update_required = is_update_required::<P>(head_at_source, head_at_target);
+		let is_update_required = is_update_required::<P>(
+			head_at_source,
+			head_at_target,
+			best_finalized_relay_block,
+			best_target_block,
+		);
 
 		if is_update_required {
 			let (head_proof, head_hash) = source_client
@@ -274,10 +279,12 @@ where
 				})?;
 			log::info!(
 				target: "bridge",
-				"Submitting {} parachain ParaId({}) head update transaction to {}",
+				"Submitting {} parachain ParaId({}) head update transaction to {}. Para hash at source relay {:?}: {:?}",
 				P::SourceRelayChain::NAME,
 				P::SourceParachain::PARACHAIN_ID,
 				P::TargetChain::NAME,
+				best_finalized_relay_block,
+				head_hash,
 			);
 
 			let transaction_tracker = target_client
@@ -304,6 +311,8 @@ where
 fn is_update_required<P: ParachainsPipeline>(
 	head_at_source: AvailableHeader<HeaderIdOf<P::SourceParachain>>,
 	head_at_target: Option<HeaderIdOf<P::SourceParachain>>,
+	best_finalized_relay_block_at_source: HeaderIdOf<P::SourceRelayChain>,
+	best_target_block: HeaderIdOf<P::TargetChain>,
 ) -> bool
 where
 	P::SourceRelayChain: Chain<BlockNumber = RelayBlockNumber>,
@@ -311,14 +320,16 @@ where
 	log::trace!(
 		target: "bridge",
 		"Checking if {} parachain ParaId({}) needs update at {}:\n\t\
-			At {}: {:?}\n\t\
-			At {}: {:?}",
+			At {} ({:?}): {:?}\n\t\
+			At {} ({:?}): {:?}",
 		P::SourceRelayChain::NAME,
 		P::SourceParachain::PARACHAIN_ID,
 		P::TargetChain::NAME,
 		P::SourceRelayChain::NAME,
+		best_finalized_relay_block_at_source,
 		head_at_source,
 		P::TargetChain::NAME,
+		best_target_block,
 		head_at_target,
 	);
 
@@ -906,16 +917,28 @@ mod tests {
 
 	#[test]
 	fn parachain_is_not_updated_if_it_is_unavailable() {
-		assert!(!is_update_required::<TestParachainsPipeline>(AvailableHeader::Unavailable, None));
 		assert!(!is_update_required::<TestParachainsPipeline>(
 			AvailableHeader::Unavailable,
-			Some(HeaderId(10, PARA_10_HASH))
+			None,
+			Default::default(),
+			Default::default(),
+		));
+		assert!(!is_update_required::<TestParachainsPipeline>(
+			AvailableHeader::Unavailable,
+			Some(HeaderId(10, PARA_10_HASH)),
+			Default::default(),
+			Default::default(),
 		));
 	}
 
 	#[test]
 	fn parachain_is_not_updated_if_it_is_unknown_to_both_clients() {
-		assert!(!is_update_required::<TestParachainsPipeline>(AvailableHeader::Missing, None),);
+		assert!(!is_update_required::<TestParachainsPipeline>(
+			AvailableHeader::Missing,
+			None,
+			Default::default(),
+			Default::default(),
+		),);
 	}
 
 	#[test]
@@ -923,6 +946,8 @@ mod tests {
 		assert!(!is_update_required::<TestParachainsPipeline>(
 			AvailableHeader::Available(HeaderId(10, Default::default())),
 			Some(HeaderId(20, Default::default())),
+			Default::default(),
+			Default::default(),
 		),);
 	}
 
@@ -931,6 +956,8 @@ mod tests {
 		assert!(is_update_required::<TestParachainsPipeline>(
 			AvailableHeader::Missing,
 			Some(HeaderId(20, Default::default())),
+			Default::default(),
+			Default::default(),
 		),);
 	}
 
@@ -939,6 +966,8 @@ mod tests {
 		assert!(is_update_required::<TestParachainsPipeline>(
 			AvailableHeader::Available(HeaderId(30, Default::default())),
 			None,
+			Default::default(),
+			Default::default(),
 		),);
 	}
 
@@ -947,6 +976,8 @@ mod tests {
 		assert!(is_update_required::<TestParachainsPipeline>(
 			AvailableHeader::Available(HeaderId(40, Default::default())),
 			Some(HeaderId(30, Default::default())),
+			Default::default(),
+			Default::default(),
 		),);
 	}
 }


### PR DESCRIPTION
* fix on-demand parachain relay behavior during target chain reorgs

* fix compilation