### PR TITLE
Prepare P<> K relay release: 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,9 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",

--- a/relays/bin-substrate/Cargo.toml
+++ b/relays/bin-substrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-relay"
-version = "1.0.1"
+version = "1.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/tools/runtime-codegen/Cargo.lock
+++ b/tools/runtime-codegen/Cargo.lock
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",


### PR DESCRIPTION
(also do the `cargo update -p mio` for dependabot on that branch)