### PR TITLE
Backport changes from polkadot-sdk

### DIFF
--- a/.config/lingua.dic
+++ b/.config/lingua.dic
@@ -84,7 +84,7 @@ SS58Prefix
 STALL_SYNC_TIMEOUT
 SURI
 ServiceFactory/MS
-SignedExtension
+TransactionExtension
 Stringified
 Submitter1
 S|N

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rayon",
 ]
 
@@ -559,12 +559,6 @@ checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 dependencies = [
  "nodrop",
 ]
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -773,7 +767,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -826,7 +820,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.10",
  "instant",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -857,8 +851,8 @@ dependencies = [
  "ark-std",
  "dleq_vrf",
  "fflonk",
- "merlin 3.0.0",
- "rand_chacha 0.3.1",
+ "merlin",
+ "rand_chacha",
  "rand_core 0.6.4",
  "ring 0.1.0",
  "sha2 0.10.7",
@@ -914,8 +908,8 @@ dependencies = [
 
 [[package]]
 name = "binary-merkle-tree"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "hash-db",
  "log",
@@ -937,7 +931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -1018,18 +1012,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
@@ -1044,15 +1026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -1072,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca548b6163b872067dc5eb82fd130c56881435e30367d2073594a3d9744120dd"
+checksum = "d32385ecb91a31bddaf908e8dcf4a15aef1bcd3913cc03ebfad02ff6d568abc1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -1116,7 +1089,7 @@ dependencies = [
  "serde",
  "sp-consensus-beefy",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1130,7 +1103,7 @@ dependencies = [
  "frame-system",
  "polkadot-primitives",
  "sp-api",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1143,7 +1116,7 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1156,7 +1129,7 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1169,7 +1142,7 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1182,7 +1155,7 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1201,7 +1174,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1213,7 +1186,7 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1229,7 +1202,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1245,7 +1218,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1257,7 +1230,7 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1274,7 +1247,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1292,7 +1265,7 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1307,7 +1280,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1319,7 +1292,7 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1340,7 +1313,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "trie-db",
 ]
@@ -1360,7 +1333,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
 ]
 
@@ -1373,14 +1346,14 @@ dependencies = [
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
 dependencies = [
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -1423,7 +1396,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "staging-xcm",
  "staging-xcm-builder",
@@ -1443,16 +1416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
 dependencies = [
  "tinyvec",
-]
-
-[[package]]
-name = "bstr"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1665,8 +1628,8 @@ dependencies = [
  "ark-std",
  "fflonk",
  "getrandom_or_panic",
- "merlin 3.0.0",
- "rand_chacha 0.3.1",
+ "merlin",
+ "rand_chacha",
 ]
 
 [[package]]
@@ -1979,16 +1942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array 0.14.7",
- "subtle 2.4.1",
-]
-
-[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,19 +1992,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b85542f99a2dfa2a1b8e192662741c9859a846b296bef1c92ef9b58b5a216"
-dependencies = [
- "byteorder",
- "digest 0.8.1",
- "rand_core 0.5.1",
- "subtle 2.4.1",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
@@ -2088,7 +2028,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2149,7 +2089,7 @@ dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "strsim 0.10.0",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2171,7 +2111,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2333,7 +2273,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2354,18 +2294,18 @@ dependencies = [
 
 [[package]]
 name = "docify"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4235e9b248e2ba4b92007fe9c646f3adf0ffde16dc74713eacc92b8bc58d8d2f"
+checksum = "7cc4fd38aaa9fb98ac70794c82a00360d1e165a87fbf96a8a91f9dfc602aaee2"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47020e12d7c7505670d1363dd53d6c23724f71a90a3ae32ff8eba40de8404626"
+checksum = "63fa215f3a0d40fb2a221b3aa90d8e1fbb8379785a990cb60d62ac71ebdc6460"
 dependencies = [
  "common-path",
  "derive-syn-parse",
@@ -2373,9 +2313,9 @@ dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.52",
  "termcolor",
- "toml 0.7.6",
+ "toml 0.8.11",
  "walkdir",
 ]
 
@@ -2426,14 +2366,15 @@ checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
 ]
@@ -2485,9 +2426,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -2498,6 +2439,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -2639,14 +2581,8 @@ dependencies = [
  "fs-err",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -2689,7 +2625,7 @@ dependencies = [
  "ark-poly",
  "ark-serialize",
  "ark-std",
- "merlin 3.0.0",
+ "merlin",
 ]
 
 [[package]]
@@ -2746,7 +2682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2800,8 +2736,8 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2817,9 +2753,9 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "static_assertions",
 ]
 
@@ -2848,8 +2784,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "aquamarine",
  "array-bytes 6.1.0",
@@ -2871,8 +2807,8 @@ dependencies = [
  "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-core-hashing-proc-macro",
- "sp-debug-derive 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -2880,8 +2816,8 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-tracing 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-weights",
  "static_assertions",
  "tt-call",
@@ -2889,8 +2825,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2902,36 +2838,36 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "sp-core-hashing 9.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "syn 2.0.48",
+ "sp-crypto-hashing",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "frame-system"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "cfg-if 1.0.0",
  "docify",
@@ -2943,7 +2879,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-version",
  "sp-weights",
 ]
@@ -3032,7 +2968,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3139,7 +3075,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
 ]
 
@@ -3172,19 +3108,6 @@ dependencies = [
  "fallible-iterator",
  "indexmap 1.9.3",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "globset"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df"
-dependencies = [
- "aho-corasick",
- "bstr",
- "fnv",
- "log",
- "regex",
 ]
 
 [[package]]
@@ -3340,16 +3263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac 0.11.1",
  "digest 0.9.0",
 ]
 
@@ -3779,19 +3692,6 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
-dependencies = [
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-proc-macros 0.16.2",
- "jsonrpsee-server",
- "jsonrpsee-types 0.16.2",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b971ce0f6cd1521ede485afc564b95b2c8e7079b9da41d4273bd9b55140a55d"
@@ -3813,6 +3713,20 @@ dependencies = [
  "jsonrpsee-core 0.20.1",
  "jsonrpsee-http-client",
  "jsonrpsee-types 0.20.1",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3ae45a64cfc0882934f963be9431b2a165d667f53140358181f262aca0702"
+dependencies = [
+ "jsonrpsee-core 0.22.2",
+ "jsonrpsee-proc-macros 0.22.2",
+ "jsonrpsee-server",
+ "jsonrpsee-types 0.22.2",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3852,32 +3766,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "jsonrpsee-core"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
-dependencies = [
- "anyhow",
- "arrayvec 0.7.4",
- "async-trait",
- "beef",
- "futures-channel",
- "futures-util",
- "globset",
- "hyper",
- "jsonrpsee-types 0.16.2",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "rustc-hash",
- "serde",
- "serde_json",
- "soketto",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -3925,6 +3813,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-core"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75568f4f9696e3a47426e1985b548e1a9fcb13372a5e320372acaf04aca30d1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "beef",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-types 0.22.2",
+ "parking_lot 0.12.1",
+ "rand",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-http-client"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,19 +3856,6 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "jsonrpsee-proc-macros"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d814a21d9a819f8de1a41b819a263ffd68e4bb5f043d936db1c49b54684bde0a"
@@ -3971,38 +3868,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-server"
-version = "0.16.2"
+name = "jsonrpsee-proc-macros"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb69dad85df79527c019659a992498d03f8495390496da2f07e6c24c2b356fc"
+checksum = "30ca066e73dd70294aebc5c2675d8ffae43be944af027c857ce0d4c51785f014"
 dependencies = [
- "futures-channel",
+ "heck 0.4.1",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e29c1bd1f9bba83c864977c73404e505f74f730fa0db89dd490ec174e36d7f0"
+dependencies = [
  "futures-util",
  "http",
  "hyper",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
+ "jsonrpsee-core 0.22.2",
+ "jsonrpsee-types 0.22.2",
+ "pin-project",
+ "route-recognizer",
  "serde",
  "serde_json",
  "soketto",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tower",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-types"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
-dependencies = [
- "anyhow",
- "beef",
- "serde",
- "serde_json",
- "thiserror",
  "tracing",
 ]
 
@@ -4035,6 +3933,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467fd35feeee179f71ab294516bdf3a81139e7aeebdd860e46897c12e1a3368"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonrpsee-ws-client"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,14 +3959,15 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2 0.10.7",
 ]
 
@@ -4197,7 +4109,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "rw-stream-sink",
  "smallvec",
  "thiserror",
@@ -4253,7 +4165,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.7",
  "thiserror",
  "zeroize",
@@ -4278,7 +4190,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.7",
  "smallvec",
  "thiserror",
@@ -4300,7 +4212,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.4.9",
  "tokio",
@@ -4336,7 +4248,7 @@ dependencies = [
  "log",
  "once_cell",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.7",
  "snow",
  "static_assertions",
@@ -4358,7 +4270,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "void",
 ]
 
@@ -4378,7 +4290,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "quinn-proto",
- "rand 0.8.5",
+ "rand",
  "rustls 0.20.8",
  "thiserror",
  "tokio",
@@ -4396,7 +4308,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.5",
+ "rand",
  "smallvec",
 ]
 
@@ -4415,7 +4327,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "tokio",
  "void",
@@ -4526,7 +4438,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -4691,7 +4603,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4705,7 +4617,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4716,7 +4628,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4727,7 +4639,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4778,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
@@ -4810,18 +4722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
-]
-
-[[package]]
-name = "merlin"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e261cf0f8b3c42ded9f7d2bb59dea03aa52bc8a1cbc7482f9fc3fd1229d3b42"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.5.1",
- "zeroize",
 ]
 
 [[package]]
@@ -4903,8 +4803,8 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_distr",
  "subtle 2.4.1",
  "thiserror",
@@ -5279,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -5315,8 +5215,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5324,14 +5224,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
+ "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -5339,13 +5240,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-beefy"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5359,13 +5260,13 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "array-bytes 6.1.0",
  "binary-merkle-tree",
@@ -5384,7 +5285,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -5401,14 +5302,14 @@ dependencies = [
  "pallet-beefy-mmr",
  "pallet-mmr",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "sp-consensus-beefy",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -5429,7 +5330,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
 ]
 
@@ -5450,7 +5351,7 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -5472,7 +5373,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
 ]
 
@@ -5494,13 +5395,13 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5517,13 +5418,13 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-mmr"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5535,13 +5436,13 @@ dependencies = [
  "sp-io",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-session"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5556,14 +5457,14 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-state-machine",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-timestamp"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5575,16 +5476,17 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -5593,13 +5495,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5610,8 +5512,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5621,7 +5523,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -5643,7 +5545,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -5663,7 +5565,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "staging-xcm",
  "staging-xcm-builder",
 ]
@@ -5812,19 +5714,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7924d1d0ad836f665c9065e26d016c673ece3993f30d340068b16f282afc1156"
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle 2.4.1",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pbkdf2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
-dependencies = [
- "crypto-mac 0.11.1",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -5833,6 +5737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
+ "password-hash",
 ]
 
 [[package]]
@@ -5877,7 +5782,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5922,20 +5827,20 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -5945,17 +5850,18 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-weights",
 ]
 
 [[package]]
 name = "polkadot-primitives"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "bitvec",
  "hex-literal",
+ "log",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
@@ -5972,8 +5878,76 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
+
+[[package]]
+name = "polkavm"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3693e5efdb2bf74e449cd25fd777a28bd7ed87e41f5d5da75eb31b4de48b94"
+dependencies = [
+ "libc",
+ "log",
+ "polkavm-assembler",
+ "polkavm-common",
+ "polkavm-linux-raw",
+]
+
+[[package]]
+name = "polkavm-assembler"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa96d6d868243acc12de813dd48e756cbadcc8e13964c70d272753266deadc1"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "polkavm-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9428a5cfcc85c5d7b9fc4b6a18c4b802d0173d768182a51cc7751640f08b92"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "polkavm-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8c4bea6f3e11cd89bb18bcdddac10bd9a24015399bd1c485ad68a985a19606"
+dependencies = [
+ "polkavm-derive-impl-macro",
+]
+
+[[package]]
+name = "polkavm-derive-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fdfc49717fb9a196e74a5d28e0bc764eb394a2c803eb11133a31ac996c60c"
+dependencies = [
+ "polkavm-common",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "polkavm-derive-impl-macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
+dependencies = [
+ "polkavm-derive-impl",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e85d3456948e650dff0cfc85603915847faf893ed1e66b020bb82ef4557120"
 
 [[package]]
 name = "polling"
@@ -6149,7 +6123,7 @@ checksum = "9b698b0b09d40e9b7c1a47b132d66a8b54bcd20583d9b6d06e4535e383b4405c"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6316,7 +6290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustc-hash",
  "rustls 0.20.8",
@@ -6353,36 +6327,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -6420,16 +6371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "rand",
 ]
 
 [[package]]
@@ -6536,7 +6478,7 @@ checksum = "68bf53dad9b6086826722cdc99140793afd9f62faa14a1ad07eb4f955e7a7216"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6780,7 +6722,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "relay-utils",
  "sc-chain-spec",
  "sc-rpc-api",
@@ -6790,7 +6732,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "sp-version",
  "staging-xcm",
@@ -6875,7 +6817,7 @@ dependencies = [
  "blake2 0.10.6",
  "common",
  "fflonk",
- "merlin 3.0.0",
+ "merlin",
 ]
 
 [[package]]
@@ -6902,6 +6844,12 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
+
+[[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rtnetlink"
@@ -7104,19 +7052,19 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "log",
  "sp-core",
- "sp-wasm-interface 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-chain-spec"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "array-bytes 6.1.0",
  "docify",
@@ -7132,6 +7080,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -7140,19 +7089,19 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sc-client-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "fnv",
  "futures",
@@ -7167,19 +7116,19 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-database",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-runtime",
  "sp-state-machine",
  "sp-statement-store",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "async-trait",
  "futures",
@@ -7203,42 +7152,55 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-executor-common",
+ "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
  "sp-api",
  "sp-core",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
+ "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror",
  "wasm-instrument",
 ]
 
 [[package]]
+name = "sc-executor-polkavm"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
+dependencies = [
+ "log",
+ "polkavm",
+ "sc-executor-common",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+]
+
+[[package]]
 name = "sc-executor-wasmtime"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.29.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -7248,15 +7210,15 @@ dependencies = [
  "rustix 0.36.15",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-wasm-interface 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-mixnet"
-version = "0.1.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.4.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -7284,8 +7246,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -7305,7 +7267,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "partial_sort",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-network-common",
  "sc-utils",
@@ -7327,8 +7289,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -7344,10 +7306,10 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.33.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
- "jsonrpsee 0.16.2",
+ "jsonrpsee 0.22.2",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-mixnet",
@@ -7364,8 +7326,8 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "15.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "chrono",
  "futures",
@@ -7373,7 +7335,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-utils",
  "serde",
  "serde_json",
@@ -7383,8 +7345,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "async-trait",
  "futures",
@@ -7399,8 +7361,8 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "async-channel",
  "futures",
@@ -7547,24 +7509,6 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "curve25519-dalek 2.1.3",
- "getrandom 0.1.16",
- "merlin 2.0.1",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "sha2 0.8.2",
- "subtle 2.4.1",
- "zeroize",
-]
-
-[[package]]
-name = "schnorrkel"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "844b7645371e6ecdf61ff246ba1958c29e802881a749ae3fb1993675d210d28d"
@@ -7572,7 +7516,7 @@ dependencies = [
  "arrayref",
  "arrayvec 0.7.4",
  "curve25519-dalek-ng",
- "merlin 3.0.0",
+ "merlin",
  "rand_core 0.6.4",
  "sha2 0.9.9",
  "subtle-ng",
@@ -7590,7 +7534,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "curve25519-dalek 4.1.1",
  "getrandom_or_panic",
- "merlin 3.0.0",
+ "merlin",
  "rand_core 0.6.4",
  "serde_bytes",
  "sha2 0.10.7",
@@ -7624,6 +7568,7 @@ dependencies = [
  "der",
  "generic-array 0.14.7",
  "pkcs8",
+ "serdect",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -7710,7 +7655,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7727,10 +7672,20 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -7745,18 +7700,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -7858,8 +7801,9 @@ dependencies = [
 
 [[package]]
 name = "simple-mermaid"
-version = "0.1.0"
-source = "git+https://github.com/kianenigma/simple-mermaid.git?rev=e48b187bcfd5cc75111acd9d241f1bd36604344b#e48b187bcfd5cc75111acd9d241f1bd36604344b"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620a1d43d70e142b1d46a929af51d44f383db9c7a2ec122de2cd992ccfcf3c18"
 
 [[package]]
 name = "siphasher"
@@ -7942,16 +7886,16 @@ dependencies = [
  "hmac 0.12.1",
  "itertools",
  "libsecp256k1",
- "merlin 3.0.0",
+ "merlin",
  "no-std-net",
  "nom",
  "num-bigint",
  "num-rational",
  "num-traits",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "pin-project",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "ruzstd",
  "schnorrkel 0.10.2",
  "serde",
@@ -7988,7 +7932,7 @@ dependencies = [
  "log",
  "lru 0.10.1",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "siphasher",
@@ -8047,14 +7991,14 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha-1",
 ]
 
 [[package]]
 name = "sp-api"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "hash-db",
  "log",
@@ -8062,11 +8006,12 @@ dependencies = [
  "scale-info",
  "sp-api-proc-macro",
  "sp-core",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-metadata-ir",
  "sp-runtime",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-state-machine",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "sp-version",
  "thiserror",
@@ -8074,8 +8019,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "15.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -8083,33 +8028,33 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-application-crypto"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "30.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "23.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "static_assertions",
 ]
 
@@ -8133,21 +8078,21 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-application-crypto",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-blockchain"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "futures",
  "log",
@@ -8164,8 +8109,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "async-trait",
  "futures",
@@ -8179,8 +8124,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -8189,17 +8134,19 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-io",
+ "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8211,25 +8158,25 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.32.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "sp-core"
-version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "28.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "array-bytes 6.1.0",
  "bandersnatch_vrfs",
@@ -8245,25 +8192,26 @@ dependencies = [
  "hash256-std-hasher",
  "impl-serde",
  "itertools",
+ "k256",
  "libsecp256k1",
  "log",
- "merlin 3.0.0",
+ "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "paste",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
  "secrecy",
  "serde",
- "sp-core-hashing 9.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-debug-derive 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -8283,37 +8231,14 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.7",
  "sha3",
- "sp-std 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 8.0.0",
  "twox-hash",
-]
-
-[[package]]
-name = "sp-core-hashing"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "digest 0.10.7",
- "sha2 0.10.7",
- "sha3",
- "twox-hash",
-]
-
-[[package]]
-name = "sp-core-hashing-proc-macro"
-version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
-dependencies = [
- "quote 1.0.35",
- "sp-core-hashing 9.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "syn 2.0.48",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
-version = "0.4.1"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.10.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -8327,14 +8252,37 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+]
+
+[[package]]
+name = "sp-crypto-hashing"
+version = "0.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "digest 0.10.7",
+ "sha2 0.10.7",
+ "sha3",
+ "twox-hash",
+]
+
+[[package]]
+name = "sp-crypto-hashing-proc-macro"
+version = "0.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
+dependencies = [
+ "quote 1.0.35",
+ "sp-crypto-hashing",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-database"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -8342,90 +8290,92 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-debug-derive"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-externalities"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.25.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-externalities"
-version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.25.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
 ]
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.7.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "serde_json",
  "sp-api",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-inherents"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-io"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "30.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "bytes",
  "ed25519-dalek",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "polkavm-derive",
  "rustversion",
  "secp256k1",
  "sp-core",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-keystore",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-state-machine",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-tracing 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -8433,8 +8383,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "31.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -8443,20 +8393,19 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.27.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.34.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sp-core",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "thiserror",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
-version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "11.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -8464,31 +8413,31 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.6.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-mixnet"
-version = "0.1.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.4.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
  "sp-application-crypto",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "ckb-merkle-mountain-range 0.5.2",
  "log",
@@ -8497,16 +8446,16 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-core",
- "sp-debug-derive 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-panic-handler"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -8515,8 +8464,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -8525,8 +8474,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "31.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "docify",
  "either",
@@ -8535,7 +8484,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -8543,76 +8492,79 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-weights",
+ "tuplex",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "24.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
+ "polkavm-derive",
  "primitive-types",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-runtime-interface-proc-macro 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-tracing 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-wasm-interface 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "24.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
+ "polkavm-derive",
  "primitive-types",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-runtime-interface-proc-macro 11.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-storage 13.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-tracing 10.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-wasm-interface 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "17.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-session"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8621,13 +8573,13 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-staking"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8635,24 +8587,24 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-state-machine"
-version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.35.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sp-core",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-panic-handler",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-trie",
  "thiserror",
  "tracing",
@@ -8661,24 +8613,25 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "10.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "aes-gcm 0.10.2",
  "curve25519-dalek 4.1.1",
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sha2 0.10.7",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-runtime",
- "sp-runtime-interface 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror",
  "x25519-dalek 2.0.0",
 ]
@@ -8691,60 +8644,60 @@ checksum = "53458e3c57df53698b3401ec0934bea8e8cfce034816873c0b0abbd83d7bac0d"
 
 [[package]]
 name = "sp-std"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 
 [[package]]
 name = "sp-std"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "14.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 
 [[package]]
 name = "sp-storage"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-storage"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "19.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
 ]
 
 [[package]]
 name = "sp-timestamp"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "26.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-tracing"
-version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "16.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -8752,11 +8705,11 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "16.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -8764,8 +8717,8 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "ahash 0.8.7",
  "hash-db",
@@ -8774,12 +8727,12 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnellru",
  "sp-core",
- "sp-externalities 0.19.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "thiserror",
  "tracing",
  "trie-db",
@@ -8788,62 +8741,62 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "29.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-core-hashing-proc-macro",
+ "sp-crypto-hashing-proc-macro",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-version-proc-macro",
  "thiserror",
 ]
 
 [[package]]
 name = "sp-version-proc-macro"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "13.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "wasmtime",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "20.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
  "wasmtime",
 ]
 
 [[package]]
 name = "sp-weights"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "27.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -8851,8 +8804,8 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic",
- "sp-debug-derive 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
@@ -8900,8 +8853,8 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-xcm"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "array-bytes 6.1.0",
  "bounded-collections",
@@ -8918,8 +8871,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8932,7 +8885,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-executor",
@@ -8940,8 +8893,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8954,7 +8907,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 8.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-weights",
  "staging-xcm",
 ]
@@ -9042,26 +8995,25 @@ dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eee6965196b32f882dd2ee85a92b1dbead41b04e53907f269de3b0dc04733c"
+version = "0.4.7"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
- "hmac 0.11.0",
- "pbkdf2 0.8.0",
- "schnorrkel 0.9.1",
- "sha2 0.9.9",
+ "hmac 0.12.1",
+ "pbkdf2",
+ "schnorrkel 0.11.4",
+ "sha2 0.10.7",
  "zeroize",
 ]
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "0.17.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "hyper",
  "log",
@@ -9211,7 +9163,7 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
- "sp-core-hashing 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core-hashing",
  "subxt-lightclient",
  "subxt-macro",
  "subxt-metadata",
@@ -9234,7 +9186,7 @@ dependencies = [
  "quote 1.0.35",
  "scale-info",
  "subxt-metadata",
- "syn 2.0.48",
+ "syn 2.0.52",
  "thiserror",
  "tokio",
 ]
@@ -9265,7 +9217,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro-error",
  "subxt-codegen",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -9277,7 +9229,7 @@ dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-core-hashing 9.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core-hashing",
  "thiserror",
 ]
 
@@ -9305,9 +9257,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -9447,7 +9399,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -9543,7 +9495,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -9565,6 +9517,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.12",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -9593,14 +9546,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.14",
+ "toml_edit 0.22.7",
 ]
 
 [[package]]
@@ -9619,10 +9572,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.2.2",
- "serde",
- "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.0",
 ]
 
 [[package]]
@@ -9633,7 +9584,20 @@ checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap 2.2.2",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.0",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+dependencies = [
+ "indexmap 2.2.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -9684,7 +9648,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -9788,7 +9752,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.4.9",
  "thiserror",
@@ -9831,14 +9795,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
+name = "tuplex"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "676ac81d5454c4dcf37955d34fa8626ede3490f744b86ca14a7b90168d2a08aa"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -10011,8 +9981,8 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_core 0.6.4",
  "sha2 0.10.7",
  "sha3",
@@ -10078,7 +10048,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -10112,7 +10082,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10125,9 +10095,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-instrument"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1dafb3e60065305741e83db35c6c2584bb3725b692b5b66148a38d72ace6cd"
+checksum = "2a47ecb37b9734d1085eaa5ae1a81e60801fd8c28d4cabdd8aedb982021918bc"
 dependencies = [
  "parity-wasm",
 ]
@@ -10373,7 +10343,7 @@ dependencies = [
  "memfd",
  "memoffset 0.8.0",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix 0.36.15",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -10759,6 +10729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10820,13 +10799,13 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#dcc76525d98a097be152293eee3389f6af5c4404"
+version = "7.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#1ead59773e2dab336d2b54295419bbc3fe7c687f"
 dependencies = [
  "Inflector",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -10839,7 +10818,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -10875,14 +10854,14 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]
@@ -10895,7 +10874,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,10 @@ complexity = { level = "deny", priority = 1 }
 #stable_sort_primitive = { level = "allow", priority = 2 }            # prefer stable sort
 #extra-unused-type-parameters = { level = "allow", priority = 2 }     # stylistic
 #default_constructed_unit_structs = { level = "allow", priority = 2 } # stylistic
+
+[workspace.dependencies]
+log = { version = "0.4.20", default-features = false }
+quote = { version = "1.0.33" }
+serde = { version = "1.0.197", default-features = false }
+serde_json = { version = "1.0.114", default-features = false }
+thiserror = { version = "1.0.48" }

--- a/bin/runtime-common/Cargo.toml
+++ b/bin/runtime-common/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 hash-db = { version = "0.16.0", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 static_assertions = { version = "1.1", optional = true }
 
@@ -93,6 +93,7 @@ runtime-benchmarks = [
 	"pallet-bridge-messages/runtime-benchmarks",
 	"pallet-bridge-parachains/runtime-benchmarks",
 	"pallet-bridge-relayers/runtime-benchmarks",
+	"pallet-transaction-payment/runtime-benchmarks",
 	"pallet-utility/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",

--- a/bin/runtime-common/src/lib.rs
+++ b/bin/runtime-common/src/lib.rs
@@ -105,43 +105,48 @@ macro_rules! generate_bridge_reject_obsolete_headers_and_messages {
 	($call:ty, $account_id:ty, $($filter_call:ty),*) => {
 		#[derive(Clone, codec::Decode, Default, codec::Encode, Eq, PartialEq, sp_runtime::RuntimeDebug, scale_info::TypeInfo)]
 		pub struct BridgeRejectObsoleteHeadersAndMessages;
-		impl sp_runtime::traits::SignedExtension for BridgeRejectObsoleteHeadersAndMessages {
+		impl sp_runtime::traits::TransactionExtensionBase for BridgeRejectObsoleteHeadersAndMessages {
 			const IDENTIFIER: &'static str = "BridgeRejectObsoleteHeadersAndMessages";
-			type AccountId = $account_id;
-			type Call = $call;
-			type AdditionalSigned = ();
+			type Implicit = ();
+		}
+		impl<Context> sp_runtime::traits::TransactionExtension<$call, Context> for BridgeRejectObsoleteHeadersAndMessages {
 			type Pre = ();
-
-			fn additional_signed(&self) -> sp_std::result::Result<
-				(),
-				sp_runtime::transaction_validity::TransactionValidityError,
-			> {
-				Ok(())
-			}
+			type Val = ();
 
 			fn validate(
 				&self,
-				_who: &Self::AccountId,
-				call: &Self::Call,
-				_info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
+				origin: <$call as sp_runtime::traits::Dispatchable>::RuntimeOrigin,
+				call: &$call,
+				_info: &sp_runtime::traits::DispatchInfoOf<$call>,
 				_len: usize,
-			) -> sp_runtime::transaction_validity::TransactionValidity {
-				let valid = sp_runtime::transaction_validity::ValidTransaction::default();
+				_context: &mut Context,
+				_self_implicit: Self::Implicit,
+				_inherited_implication: &impl codec::Encode,
+			) -> Result<
+				(
+					sp_runtime::transaction_validity::ValidTransaction,
+					Self::Val,
+					<$call as sp_runtime::traits::Dispatchable>::RuntimeOrigin,
+				), sp_runtime::transaction_validity::TransactionValidityError
+			> {
+				let tx_validity = sp_runtime::transaction_validity::ValidTransaction::default();
 				$(
-					let valid = valid
-						.combine_with(<$filter_call as $crate::BridgeRuntimeFilterCall<$call>>::validate(call)?);
+					let call_filter_validity = <$filter_call as $crate::BridgeRuntimeFilterCall<$call>>::validate(call)?;
+					let tx_validity = tx_validity.combine_with(call_filter_validity);
 				)*
-				Ok(valid)
+				Ok((tx_validity, (), origin))
 			}
 
-			fn pre_dispatch(
+			fn prepare(
 				self,
-				who: &Self::AccountId,
-				call: &Self::Call,
-				info: &sp_runtime::traits::DispatchInfoOf<Self::Call>,
-				len: usize,
+				_val: Self::Val,
+				_origin: &<$call as sp_runtime::traits::Dispatchable>::RuntimeOrigin,
+				_call: &$call,
+				_info: &sp_runtime::traits::DispatchInfoOf<$call>,
+				_len: usize,
+				_context: &Context,
 			) -> Result<Self::Pre, sp_runtime::transaction_validity::TransactionValidityError> {
-				self.validate(who, call, info, len).map(drop)
+				Ok(())
 			}
 		}
 	};
@@ -150,12 +155,14 @@ macro_rules! generate_bridge_reject_obsolete_headers_and_messages {
 #[cfg(test)]
 mod tests {
 	use crate::BridgeRuntimeFilterCall;
-	use frame_support::{assert_err, assert_ok};
+	use codec::Encode;
+	use frame_support::assert_err;
 	use sp_runtime::{
-		traits::SignedExtension,
+		traits::DispatchTransaction,
 		transaction_validity::{InvalidTransaction, TransactionValidity, ValidTransaction},
 	};
 
+	#[derive(Encode)]
 	pub struct MockCall {
 		data: u32,
 	}
@@ -206,17 +213,20 @@ mod tests {
 		);
 
 		assert_err!(
-			BridgeRejectObsoleteHeadersAndMessages.validate(&(), &MockCall { data: 1 }, &(), 0),
+			BridgeRejectObsoleteHeadersAndMessages.validate_only((), &MockCall { data: 1 }, &(), 0),
 			InvalidTransaction::Custom(1)
 		);
 
 		assert_err!(
-			BridgeRejectObsoleteHeadersAndMessages.validate(&(), &MockCall { data: 2 }, &(), 0),
+			BridgeRejectObsoleteHeadersAndMessages.validate_only((), &MockCall { data: 2 }, &(), 0),
 			InvalidTransaction::Custom(2)
 		);
 
-		assert_ok!(
-			BridgeRejectObsoleteHeadersAndMessages.validate(&(), &MockCall { data: 3 }, &(), 0),
+		assert_eq!(
+			BridgeRejectObsoleteHeadersAndMessages
+				.validate_only((), &MockCall { data: 3 }, &(), 0)
+				.unwrap()
+				.0,
 			ValidTransaction { priority: 3, ..Default::default() }
 		)
 	}

--- a/bin/runtime-common/src/mock.rs
+++ b/bin/runtime-common/src/mock.rs
@@ -164,6 +164,7 @@ impl pallet_balances::Config for TestRuntime {
 	type AccountStore = System;
 }
 
+#[derive_impl(pallet_transaction_payment::config_preludes::TestDefaultConfig as pallet_transaction_payment::DefaultConfig)]
 impl pallet_transaction_payment::Config for TestRuntime {
 	type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, ()>;
 	type OperationalFeeMultiplier = ConstU8<5>;
@@ -176,7 +177,6 @@ impl pallet_transaction_payment::Config for TestRuntime {
 		MinimumMultiplier,
 		MaximumMultiplier,
 	>;
-	type RuntimeEvent = RuntimeEvent;
 }
 
 impl pallet_bridge_grandpa::Config for TestRuntime {

--- a/bin/runtime-common/src/priority_calculator.rs
+++ b/bin/runtime-common/src/priority_calculator.rs
@@ -169,12 +169,15 @@ mod integrity_tests {
 		// nodes to the proof (x0.5 because we expect some nodes to be reused)
 		let estimated_message_size = 512;
 		// let's say all our messages have the same dispatch weight
-		let estimated_message_dispatch_weight =
-			Runtime::WeightInfo::message_dispatch_weight(estimated_message_size);
+		let estimated_message_dispatch_weight = <Runtime as pallet_bridge_messages::Config<
+			MessagesInstance,
+		>>::WeightInfo::message_dispatch_weight(
+			estimated_message_size
+		);
 		// messages proof argument size is (for every message) messages size + some additional
 		// trie nodes. Some of them are reused by different messages, so let's take 2/3 of default
 		// "overhead" constant
-		let messages_proof_size = Runtime::WeightInfo::expected_extra_storage_proof_size()
+		let messages_proof_size = <Runtime as pallet_bridge_messages::Config<MessagesInstance>>::WeightInfo::expected_extra_storage_proof_size()
 			.saturating_mul(2)
 			.saturating_div(3)
 			.saturating_add(estimated_message_size)
@@ -182,7 +185,7 @@ mod integrity_tests {
 
 		// finally we are able to estimate transaction size and weight
 		let transaction_size = base_tx_size.saturating_add(messages_proof_size);
-		let transaction_weight = Runtime::WeightInfo::receive_messages_proof_weight(
+		let transaction_weight = <Runtime as pallet_bridge_messages::Config<MessagesInstance>>::WeightInfo::receive_messages_proof_weight(
 			&PreComputedSize(transaction_size as _),
 			messages as _,
 			estimated_message_dispatch_weight.saturating_mul(messages),

--- a/modules/beefy/Cargo.toml
+++ b/modules/beefy/Cargo.toml
@@ -11,9 +11,9 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0", optional = true }
+serde = { optional = true, workspace = true }
 
 # Bridge Dependencies
 

--- a/modules/grandpa/Cargo.toml
+++ b/modules/grandpa/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 finality-grandpa = { version = "0.16.2", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge Dependencies

--- a/modules/messages/Cargo.toml
+++ b/modules/messages/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 num-traits = { version = "0.2", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 

--- a/modules/parachains/Cargo.toml
+++ b/modules/parachains/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge Dependencies

--- a/modules/relayers/Cargo.toml
+++ b/modules/relayers/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge dependencies

--- a/modules/xcm-bridge-hub-router/Cargo.toml
+++ b/modules/xcm-bridge-hub-router/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive", "serde"] }
 
 # Bridge dependencies

--- a/modules/xcm-bridge-hub/Cargo.toml
+++ b/modules/xcm-bridge-hub/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # Bridge Dependencies

--- a/primitives/beefy/Cargo.toml
+++ b/primitives/beefy/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive", "bit-vec"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde = { default-features = false, features = ["alloc", "derive"], workspace = true }
 
 # Bridge Dependencies
 

--- a/primitives/chain-bridge-hub-cumulus/src/lib.rs
+++ b/primitives/chain-bridge-hub-cumulus/src/lib.rs
@@ -26,7 +26,7 @@ pub use bp_polkadot_core::{
 };
 
 use bp_messages::*;
-use bp_polkadot_core::SuffixedCommonSignedExtension;
+use bp_polkadot_core::SuffixedCommonTransactionExtension;
 use bp_runtime::extensions::{
 	BridgeRejectObsoleteHeadersAndMessages, RefundBridgedParachainMessagesSchema,
 };
@@ -164,7 +164,7 @@ pub const MAX_UNREWARDED_RELAYERS_IN_CONFIRMATION_TX: MessageNonce = 1024;
 pub const MAX_UNCONFIRMED_MESSAGES_IN_CONFIRMATION_TX: MessageNonce = 4096;
 
 /// Signed extension that is used by all bridge hubs.
-pub type SignedExtension = SuffixedCommonSignedExtension<(
+pub type TransactionExtension = SuffixedCommonTransactionExtension<(
 	BridgeRejectObsoleteHeadersAndMessages,
 	RefundBridgedParachainMessagesSchema,
 )>;

--- a/primitives/chain-bridge-hub-rococo/src/lib.rs
+++ b/primitives/chain-bridge-hub-rococo/src/lib.rs
@@ -107,5 +107,5 @@ frame_support::parameter_types! {
 
 	/// Transaction fee that is paid at the Rococo BridgeHub for delivering single outbound message confirmation.
 	/// (initially was calculated by test `BridgeHubRococo::can_calculate_fee_for_complex_message_confirmation_transaction` + `33%`)
-	pub const BridgeHubRococoBaseConfirmationFeeInRocs: u128 = 5_380_829_647;
+	pub const BridgeHubRococoBaseConfirmationFeeInRocs: u128 = 5_380_904_835;
 }

--- a/primitives/chain-kusama/src/lib.rs
+++ b/primitives/chain-kusama/src/lib.rs
@@ -59,8 +59,8 @@ impl ChainWithGrandpa for Kusama {
 	const AVERAGE_HEADER_SIZE: u32 = AVERAGE_HEADER_SIZE;
 }
 
-// The SignedExtension used by Kusama.
-pub use bp_polkadot_core::CommonSignedExtension as SignedExtension;
+// The TransactionExtension used by Kusama.
+pub use bp_polkadot_core::CommonTransactionExtension as TransactionExtension;
 
 /// Name of the parachains pallet in the Kusama runtime.
 pub const PARAS_PALLET_NAME: &str = "Paras";

--- a/primitives/chain-polkadot/src/lib.rs
+++ b/primitives/chain-polkadot/src/lib.rs
@@ -61,8 +61,8 @@ impl ChainWithGrandpa for Polkadot {
 	const AVERAGE_HEADER_SIZE: u32 = AVERAGE_HEADER_SIZE;
 }
 
-/// The SignedExtension used by Polkadot.
-pub type SignedExtension = SuffixedCommonSignedExtension<PrevalidateAttests>;
+/// The TransactionExtension used by Polkadot.
+pub type TransactionExtension = SuffixedCommonTransactionExtension<PrevalidateAttests>;
 
 /// Name of the parachains pallet in the Polkadot runtime.
 pub const PARAS_PALLET_NAME: &str = "Paras";

--- a/primitives/chain-rococo/src/lib.rs
+++ b/primitives/chain-rococo/src/lib.rs
@@ -59,8 +59,8 @@ impl ChainWithGrandpa for Rococo {
 	const AVERAGE_HEADER_SIZE: u32 = AVERAGE_HEADER_SIZE;
 }
 
-// The SignedExtension used by Rococo.
-pub use bp_polkadot_core::CommonSignedExtension as SignedExtension;
+// The TransactionExtension used by Rococo.
+pub use bp_polkadot_core::CommonTransactionExtension as TransactionExtension;
 
 /// Name of the parachains pallet in the Rococo runtime.
 pub const PARAS_PALLET_NAME: &str = "Paras";

--- a/primitives/chain-westend/src/lib.rs
+++ b/primitives/chain-westend/src/lib.rs
@@ -59,8 +59,8 @@ impl ChainWithGrandpa for Westend {
 	const AVERAGE_HEADER_SIZE: u32 = AVERAGE_HEADER_SIZE;
 }
 
-// The SignedExtension used by Westend.
-pub use bp_polkadot_core::CommonSignedExtension as SignedExtension;
+// The TransactionExtension used by Westend.
+pub use bp_polkadot_core::CommonTransactionExtension as TransactionExtension;
 
 /// Name of the parachains pallet in the Rococo runtime.
 pub const PARAS_PALLET_NAME: &str = "Paras";

--- a/primitives/header-chain/Cargo.toml
+++ b/primitives/header-chain/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 finality-grandpa = { version = "0.16.2", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde = { features = ["alloc", "derive"], workspace = true }
 
 # Bridge dependencies
 

--- a/primitives/messages/Cargo.toml
+++ b/primitives/messages/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["bit-vec", "derive"] }
 scale-info = { version = "2.10.0", default-features = false, features = ["bit-vec", "derive"] }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde = { features = ["alloc", "derive"], workspace = true }
 
 # Bridge dependencies
 

--- a/primitives/polkadot-core/Cargo.toml
+++ b/primitives/polkadot-core/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 parity-util-mem = { version = "0.12.0", optional = true }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { default-features = false, features = ["derive"], optional = true, workspace = true }
 
 # Bridge Dependencies
 

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -13,10 +13,10 @@ workspace = true
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false }
 hash-db = { version = "0.16.0", default-features = false }
 impl-trait-for-tuples = "0.2.2"
-log = { version = "0.4.21", default-features = false }
+log = { workspace = true }
 num-traits = { version = "0.2", default-features = false }
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde = { features = ["alloc", "derive"], workspace = true }
 
 # Substrate Dependencies
 

--- a/primitives/runtime/src/chain.rs
+++ b/primitives/runtime/src/chain.rs
@@ -98,6 +98,17 @@ impl<ChainCall: Encode> Encode for EncodedOrDecodedCall<ChainCall> {
 	}
 }
 
+// dummy implementation to satisfy `SignedPayload` requirements
+impl<ChainCall> sp_runtime::traits::Dispatchable for EncodedOrDecodedCall<ChainCall> {
+	type RuntimeOrigin = ();
+	type Config = ();
+	type Info = ();
+	type PostInfo = ();
+	fn dispatch(self, _origin: ()) -> sp_runtime::DispatchResultWithInfo<()> {
+		unreachable!("never used by relayer; qed")
+	}
+}
+
 /// Minimal Substrate-based chain representation that may be used from no_std environment.
 pub trait Chain: Send + Sync + 'static {
 	/// Chain id.

--- a/primitives/runtime/src/extensions.rs
+++ b/primitives/runtime/src/extensions.rs
@@ -20,135 +20,138 @@ use codec::{Compact, Decode, Encode};
 use impl_trait_for_tuples::impl_for_tuples;
 use scale_info::{StaticTypeInfo, TypeInfo};
 use sp_runtime::{
-	traits::{DispatchInfoOf, SignedExtension},
+	impl_tx_ext_default,
+	traits::{Dispatchable, TransactionExtension, TransactionExtensionBase},
 	transaction_validity::TransactionValidityError,
 };
 use sp_std::{fmt::Debug, marker::PhantomData};
 
-/// Trait that describes some properties of a `SignedExtension` that are needed in order to send a
-/// transaction to the chain.
-pub trait SignedExtensionSchema: Encode + Decode + Debug + Eq + Clone + StaticTypeInfo {
+/// Trait that describes some properties of a `TransactionExtension` that are needed in order to
+/// send a transaction to the chain.
+pub trait TransactionExtensionSchema:
+	Encode + Decode + Debug + Eq + Clone + StaticTypeInfo
+{
 	/// A type of the data encoded as part of the transaction.
 	type Payload: Encode + Decode + Debug + Eq + Clone + StaticTypeInfo;
 	/// Parameters which are part of the payload used to produce transaction signature,
 	/// but don't end up in the transaction itself (i.e. inherent part of the runtime).
-	type AdditionalSigned: Encode + Debug + Eq + Clone + StaticTypeInfo;
+	type Implicit: Encode + Decode + Debug + Eq + Clone + StaticTypeInfo;
 }
 
-impl SignedExtensionSchema for () {
+impl TransactionExtensionSchema for () {
 	type Payload = ();
-	type AdditionalSigned = ();
+	type Implicit = ();
 }
 
-/// An implementation of `SignedExtensionSchema` using generic params.
+/// An implementation of `TransactionExtensionSchema` using generic params.
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo)]
-pub struct GenericSignedExtensionSchema<P, S>(PhantomData<(P, S)>);
+pub struct GenericTransactionExtensionSchema<P, S>(PhantomData<(P, S)>);
 
-impl<P, S> SignedExtensionSchema for GenericSignedExtensionSchema<P, S>
+impl<P, S> TransactionExtensionSchema for GenericTransactionExtensionSchema<P, S>
 where
 	P: Encode + Decode + Debug + Eq + Clone + StaticTypeInfo,
-	S: Encode + Debug + Eq + Clone + StaticTypeInfo,
+	S: Encode + Decode + Debug + Eq + Clone + StaticTypeInfo,
 {
 	type Payload = P;
-	type AdditionalSigned = S;
+	type Implicit = S;
 }
 
-/// The `SignedExtensionSchema` for `frame_system::CheckNonZeroSender`.
-pub type CheckNonZeroSender = GenericSignedExtensionSchema<(), ()>;
+/// The `TransactionExtensionSchema` for `frame_system::CheckNonZeroSender`.
+pub type CheckNonZeroSender = GenericTransactionExtensionSchema<(), ()>;
 
-/// The `SignedExtensionSchema` for `frame_system::CheckSpecVersion`.
-pub type CheckSpecVersion = GenericSignedExtensionSchema<(), u32>;
+/// The `TransactionExtensionSchema` for `frame_system::CheckSpecVersion`.
+pub type CheckSpecVersion = GenericTransactionExtensionSchema<(), u32>;
 
-/// The `SignedExtensionSchema` for `frame_system::CheckTxVersion`.
-pub type CheckTxVersion = GenericSignedExtensionSchema<(), u32>;
+/// The `TransactionExtensionSchema` for `frame_system::CheckTxVersion`.
+pub type CheckTxVersion = GenericTransactionExtensionSchema<(), u32>;
 
-/// The `SignedExtensionSchema` for `frame_system::CheckGenesis`.
-pub type CheckGenesis<Hash> = GenericSignedExtensionSchema<(), Hash>;
+/// The `TransactionExtensionSchema` for `frame_system::CheckGenesis`.
+pub type CheckGenesis<Hash> = GenericTransactionExtensionSchema<(), Hash>;
 
-/// The `SignedExtensionSchema` for `frame_system::CheckEra`.
-pub type CheckEra<Hash> = GenericSignedExtensionSchema<sp_runtime::generic::Era, Hash>;
+/// The `TransactionExtensionSchema` for `frame_system::CheckEra`.
+pub type CheckEra<Hash> = GenericTransactionExtensionSchema<sp_runtime::generic::Era, Hash>;
 
-/// The `SignedExtensionSchema` for `frame_system::CheckNonce`.
-pub type CheckNonce<TxNonce> = GenericSignedExtensionSchema<Compact<TxNonce>, ()>;
+/// The `TransactionExtensionSchema` for `frame_system::CheckNonce`.
+pub type CheckNonce<TxNonce> = GenericTransactionExtensionSchema<Compact<TxNonce>, ()>;
 
-/// The `SignedExtensionSchema` for `frame_system::CheckWeight`.
-pub type CheckWeight = GenericSignedExtensionSchema<(), ()>;
+/// The `TransactionExtensionSchema` for `frame_system::CheckWeight`.
+pub type CheckWeight = GenericTransactionExtensionSchema<(), ()>;
 
-/// The `SignedExtensionSchema` for `pallet_transaction_payment::ChargeTransactionPayment`.
-pub type ChargeTransactionPayment<Balance> = GenericSignedExtensionSchema<Compact<Balance>, ()>;
+/// The `TransactionExtensionSchema` for `pallet_transaction_payment::ChargeTransactionPayment`.
+pub type ChargeTransactionPayment<Balance> =
+	GenericTransactionExtensionSchema<Compact<Balance>, ()>;
 
-/// The `SignedExtensionSchema` for `polkadot-runtime-common::PrevalidateAttests`.
-pub type PrevalidateAttests = GenericSignedExtensionSchema<(), ()>;
+/// The `TransactionExtensionSchema` for `polkadot-runtime-common::PrevalidateAttests`.
+pub type PrevalidateAttests = GenericTransactionExtensionSchema<(), ()>;
 
-/// The `SignedExtensionSchema` for `BridgeRejectObsoleteHeadersAndMessages`.
-pub type BridgeRejectObsoleteHeadersAndMessages = GenericSignedExtensionSchema<(), ()>;
+/// The `TransactionExtensionSchema` for `BridgeRejectObsoleteHeadersAndMessages`.
+pub type BridgeRejectObsoleteHeadersAndMessages = GenericTransactionExtensionSchema<(), ()>;
 
-/// The `SignedExtensionSchema` for `RefundBridgedParachainMessages`.
+/// The `TransactionExtensionSchema` for `RefundBridgedParachainMessages`.
 /// This schema is dedicated for `RefundBridgedParachainMessages` signed extension as
 /// wildcard/placeholder, which relies on the scale encoding for `()` or `((), ())`, or `((), (),
 /// ())` is the same. So runtime can contains any kind of tuple:
 /// `(BridgeRefundBridgeHubRococoMessages)`
 /// `(BridgeRefundBridgeHubRococoMessages, BridgeRefundBridgeHubWestendMessages)`
 /// `(BridgeRefundParachainMessages1, ..., BridgeRefundParachainMessagesN)`
-pub type RefundBridgedParachainMessagesSchema = GenericSignedExtensionSchema<(), ()>;
+pub type RefundBridgedParachainMessagesSchema = GenericTransactionExtensionSchema<(), ()>;
 
 #[impl_for_tuples(1, 12)]
-impl SignedExtensionSchema for Tuple {
+impl TransactionExtensionSchema for Tuple {
 	for_tuples!( type Payload = ( #( Tuple::Payload ),* ); );
-	for_tuples!( type AdditionalSigned = ( #( Tuple::AdditionalSigned ),* ); );
+	for_tuples!( type Implicit = ( #( Tuple::Implicit ),* ); );
 }
 
 /// A simplified version of signed extensions meant for producing signed transactions
 /// and signed payloads in the client code.
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone, TypeInfo)]
-pub struct GenericSignedExtension<S: SignedExtensionSchema> {
+pub struct GenericTransactionExtension<S: TransactionExtensionSchema> {
 	/// A payload that is included in the transaction.
 	pub payload: S::Payload,
 	#[codec(skip)]
 	// It may be set to `None` if extensions are decoded. We are never reconstructing transactions
-	// (and it makes no sense to do that) => decoded version of `SignedExtensions` is only used to
-	// read fields of the `payload`. And when resigning transaction, we're reconstructing
-	// `SignedExtensions` from scratch.
-	additional_signed: Option<S::AdditionalSigned>,
+	// (and it makes no sense to do that) => decoded version of `TransactionExtensions` is only
+	// used to read fields of the `payload`. And when resigning transaction, we're reconstructing
+	// `TransactionExtensions` from scratch.
+	implicit: Option<S::Implicit>,
 }
 
-impl<S: SignedExtensionSchema> GenericSignedExtension<S> {
-	/// Create new `GenericSignedExtension` object.
-	pub fn new(payload: S::Payload, additional_signed: Option<S::AdditionalSigned>) -> Self {
-		Self { payload, additional_signed }
+impl<S: TransactionExtensionSchema> GenericTransactionExtension<S> {
+	/// Create new `GenericTransactionExtension` object.
+	pub fn new(payload: S::Payload, implicit: Option<S::Implicit>) -> Self {
+		Self { payload, implicit }
 	}
 }
 
-impl<S> SignedExtension for GenericSignedExtension<S>
+impl<S> TransactionExtensionBase for GenericTransactionExtension<S>
 where
-	S: SignedExtensionSchema,
+	S: TransactionExtensionSchema,
 	S::Payload: Send + Sync,
-	S::AdditionalSigned: Send + Sync,
+	S::Implicit: Send + Sync,
 {
 	const IDENTIFIER: &'static str = "Not needed.";
-	type AccountId = ();
-	type Call = ();
-	type AdditionalSigned = S::AdditionalSigned;
-	type Pre = ();
+	type Implicit = S::Implicit;
 
-	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+	fn implicit(&self) -> Result<Self::Implicit, TransactionValidityError> {
 		// we shall not ever see this error in relay, because we are never signing decoded
 		// transactions. Instead we're constructing and signing new transactions. So the error code
 		// is kinda random here
-		self.additional_signed.clone().ok_or(
-			frame_support::unsigned::TransactionValidityError::Unknown(
+		self.implicit
+			.clone()
+			.ok_or(frame_support::unsigned::TransactionValidityError::Unknown(
 				frame_support::unsigned::UnknownTransaction::Custom(0xFF),
-			),
-		)
+			))
 	}
+}
+impl<S, C, Context> TransactionExtension<C, Context> for GenericTransactionExtension<S>
+where
+	C: Dispatchable,
+	S: TransactionExtensionSchema,
+	S::Payload: Send + Sync,
+	S::Implicit: Send + Sync,
+{
+	type Pre = ();
+	type Val = ();
 
-	fn pre_dispatch(
-		self,
-		_who: &Self::AccountId,
-		_call: &Self::Call,
-		_info: &DispatchInfoOf<Self::Call>,
-		_len: usize,
-	) -> Result<Self::Pre, TransactionValidityError> {
-		Ok(())
-	}
+	impl_tx_ext_default!(C; Context; validate prepare);
 }

--- a/primitives/test-utils/src/lib.rs
+++ b/primitives/test-utils/src/lib.rs
@@ -129,7 +129,7 @@ pub fn make_justification_for_header<H: HeaderT>(
 			votes_ancestries.push(child.clone());
 		}
 
-		// The header we need to use when pre-commiting is the one at the highest height
+		// The header we need to use when pre-committing is the one at the highest height
 		// on our chain.
 		let precommit_candidate = chain.last().map(|h| (h.hash(), *h.number())).unwrap();
 		unsigned_precommits.push(precommit_candidate);

--- a/relays/bin-substrate/Cargo.toml
+++ b/relays/bin-substrate/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "3.1.5" }
 env_logger = "0.11"
 futures = "0.3.30"
 hex = "0.4"
-log = "0.4.21"
+log = { workspace = true }
 num-format = "0.4"
 num-traits = "0.2"
 rbtag = "0.3"

--- a/relays/bin-substrate/src/bridges/rococo_bulletin/mod.rs
+++ b/relays/bin-substrate/src/bridges/rococo_bulletin/mod.rs
@@ -125,18 +125,6 @@ impl relay_substrate_client::ChainWithTransactions for RococoAsPolkadot {
 			unsigned.switch_chain(),
 		)
 	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		relay_rococo_client::Rococo::is_signed(tx)
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		relay_rococo_client::Rococo::is_signed_by(signer, tx)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		relay_rococo_client::Rococo::parse_transaction(tx).map(|tx| tx.switch_chain())
-	}
 }
 
 impl CliChain for RococoAsPolkadot {
@@ -231,19 +219,6 @@ impl relay_substrate_client::ChainWithTransactions for BridgeHubRococoAsBridgeHu
 			},
 			unsigned.switch_chain(),
 		)
-	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		relay_bridge_hub_rococo_client::BridgeHubRococo::is_signed(tx)
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		relay_bridge_hub_rococo_client::BridgeHubRococo::is_signed_by(signer, tx)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		relay_bridge_hub_rococo_client::BridgeHubRococo::parse_transaction(tx)
-			.map(|tx| tx.switch_chain())
 	}
 }
 

--- a/relays/client-bridge-hub-kusama/src/codegen_runtime.rs
+++ b/relays/client-bridge-hub-kusama/src/codegen_runtime.rs
@@ -392,7 +392,7 @@ pub mod api {
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
 				pub struct RefundBridgedParachainMessages;
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
-				pub struct RefundSignedExtensionAdapter<_0>(pub _0);
+				pub struct RefundTransactionExtensionAdapter<_0>(pub _0);
 			}
 		}
 		pub mod cumulus_pallet_dmp_queue {

--- a/relays/client-bridge-hub-kusama/src/lib.rs
+++ b/relays/client-bridge-hub-kusama/src/lib.rs
@@ -18,8 +18,8 @@
 
 pub mod codegen_runtime;
 
-use bp_bridge_hub_kusama::{SignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_polkadot::SuffixedCommonSignedExtensionExt;
+use bp_bridge_hub_kusama::{TransactionExtension, AVERAGE_BLOCK_INTERVAL};
+use bp_polkadot::SuffixedCommonTransactionExtensionExt;
 use codec::Encode;
 use relay_substrate_client::{
 	calls::UtilityCall as MockUtilityCall, Chain, ChainWithBalances, ChainWithMessages,
@@ -36,7 +36,8 @@ pub type RuntimeCall = runtime_types::bridge_hub_kusama_runtime::RuntimeCall;
 pub type BridgeMessagesCall = runtime_types::pallet_bridge_messages::pallet::Call;
 pub type BridgeGrandpaCall = runtime_types::pallet_bridge_grandpa::pallet::Call;
 pub type BridgeParachainCall = runtime_types::pallet_bridge_parachains::pallet::Call;
-type UncheckedExtrinsic = bp_bridge_hub_kusama::UncheckedExtrinsic<RuntimeCall, SignedExtension>;
+type UncheckedExtrinsic =
+	bp_bridge_hub_kusama::UncheckedExtrinsic<RuntimeCall, TransactionExtension>;
 type UtilityCall = runtime_types::pallet_utility::pallet::Call;
 
 /// Kusama chain definition
@@ -86,7 +87,7 @@ impl ChainWithTransactions for BridgeHubKusama {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			SignedExtension::from_params(
+			TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -108,24 +109,6 @@ impl ChainWithTransactions for BridgeHubKusama {
 			extra,
 		))
 	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| {
-				*address == bp_bridge_hub_kusama::Address::Id(signer.public().into())
-			})
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()).tip(extra.tip()))
-	}
 }
 
 impl ChainWithMessages for BridgeHubKusama {
@@ -136,35 +119,4 @@ impl ChainWithMessages for BridgeHubKusama {
 		bp_bridge_hub_kusama::TO_BRIDGE_HUB_KUSAMA_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_kusama::FROM_BRIDGE_HUB_KUSAMA_MESSAGE_DETAILS_METHOD;
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use relay_substrate_client::TransactionEra;
-
-	type SystemCall = runtime_types::frame_system::pallet::Call;
-
-	#[test]
-	fn parse_transaction_works() {
-		let unsigned = UnsignedTransaction {
-			call: RuntimeCall::System(SystemCall::remark { remark: b"Hello world!".to_vec() })
-				.into(),
-			nonce: 777,
-			tip: 888,
-			era: TransactionEra::immortal(),
-		};
-		let signed_transaction = BridgeHubKusama::sign_transaction(
-			SignParam {
-				spec_version: 42,
-				transaction_version: 50000,
-				genesis_hash: [42u8; 32].into(),
-				signer: sp_core::sr25519::Pair::from_seed_slice(&[1u8; 32]).unwrap(),
-			},
-			unsigned.clone(),
-		)
-		.unwrap();
-		let parsed_transaction = BridgeHubKusama::parse_transaction(signed_transaction).unwrap();
-		assert_eq!(parsed_transaction, unsigned);
-	}
 }

--- a/relays/client-bridge-hub-kusama/src/runtime_wrapper.rs
+++ b/relays/client-bridge-hub-kusama/src/runtime_wrapper.rs
@@ -20,14 +20,14 @@
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
-pub use bp_bridge_hub_kusama::SignedExtension;
+pub use bp_bridge_hub_kusama::TransactionExtension;
 pub use bp_header_chain::BridgeGrandpaCallOf;
 pub use bp_parachains::BridgeParachainCall;
 pub use bridge_runtime_common::messages::BridgeMessagesCallOf;
 pub use relay_substrate_client::calls::{SystemCall, UtilityCall};
 
 /// Unchecked BridgeHubKusama extrinsic.
-pub type UncheckedExtrinsic = bp_bridge_hub_kusama::UncheckedExtrinsic<Call, SignedExtension>;
+pub type UncheckedExtrinsic = bp_bridge_hub_kusama::UncheckedExtrinsic<Call, TransactionExtension>;
 
 // The indirect pallet call used to sync `Polkadot` GRANDPA finality to `BHKusama`.
 pub type BridgePolkadotGrandpaCall = BridgeGrandpaCallOf<bp_polkadot::Polkadot>;

--- a/relays/client-bridge-hub-polkadot/src/codegen_runtime.rs
+++ b/relays/client-bridge-hub-polkadot/src/codegen_runtime.rs
@@ -392,7 +392,7 @@ pub mod api {
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
 				pub struct RefundBridgedParachainMessages;
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
-				pub struct RefundSignedExtensionAdapter<_0>(pub _0);
+				pub struct RefundTransactionExtensionAdapter<_0>(pub _0);
 			}
 		}
 		pub mod cumulus_pallet_dmp_queue {

--- a/relays/client-bridge-hub-polkadot/src/runtime_wrapper.rs
+++ b/relays/client-bridge-hub-polkadot/src/runtime_wrapper.rs
@@ -20,14 +20,14 @@
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 
-pub use bp_bridge_hub_polkadot::SignedExtension;
+pub use bp_bridge_hub_polkadot::TransactionExtension;
 pub use bp_header_chain::BridgeGrandpaCallOf;
 pub use bp_parachains::BridgeParachainCall;
 pub use bridge_runtime_common::messages::BridgeMessagesCallOf;
 pub use relay_substrate_client::calls::{SystemCall, UtilityCall};
 
 /// Unchecked BridgeHubPolkadot extrinsic.
-pub type UncheckedExtrinsic = bp_bridge_hub_polkadot::UncheckedExtrinsic<Call, SignedExtension>;
+pub type UncheckedExtrinsic = bp_bridge_hub_polkadot::UncheckedExtrinsic<Call, TransactionExtension>;
 
 /// The indirect pallet call used to sync `Kusama` GRANDPA finality to `BHPolkadot`.
 pub type BridgeKusamaGrandpaCall = BridgeGrandpaCallOf<bp_kusama::Kusama>;

--- a/relays/client-bridge-hub-rococo/src/codegen_runtime.rs
+++ b/relays/client-bridge-hub-rococo/src/codegen_runtime.rs
@@ -463,7 +463,7 @@ pub mod api {
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
 				pub struct RefundBridgedParachainMessages;
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
-				pub struct RefundSignedExtensionAdapter<_0>(pub _0);
+				pub struct RefundTransactionExtensionAdapter<_0>(pub _0);
 			}
 		}
 		pub mod cumulus_pallet_parachain_system {

--- a/relays/client-bridge-hub-rococo/src/lib.rs
+++ b/relays/client-bridge-hub-rococo/src/lib.rs
@@ -18,8 +18,8 @@
 
 pub mod codegen_runtime;
 
-use bp_bridge_hub_rococo::{SignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_polkadot_core::SuffixedCommonSignedExtensionExt;
+use bp_bridge_hub_rococo::{TransactionExtension, AVERAGE_BLOCK_INTERVAL};
+use bp_polkadot_core::SuffixedCommonTransactionExtensionExt;
 use codec::Encode;
 use relay_substrate_client::{
 	calls::UtilityCall as MockUtilityCall, Chain, ChainWithBalances, ChainWithMessages,
@@ -38,7 +38,8 @@ pub type BridgeBulletinMessagesCall = runtime_types::pallet_bridge_messages::pal
 pub type BridgeGrandpaCall = runtime_types::pallet_bridge_grandpa::pallet::Call;
 pub type BridgeBulletinGrandpaCall = runtime_types::pallet_bridge_grandpa::pallet::Call2;
 pub type BridgeParachainCall = runtime_types::pallet_bridge_parachains::pallet::Call;
-type UncheckedExtrinsic = bp_bridge_hub_rococo::UncheckedExtrinsic<RuntimeCall, SignedExtension>;
+type UncheckedExtrinsic =
+	bp_bridge_hub_rococo::UncheckedExtrinsic<RuntimeCall, TransactionExtension>;
 type UtilityCall = runtime_types::pallet_utility::pallet::Call;
 
 /// Rococo chain definition
@@ -88,7 +89,7 @@ impl ChainWithTransactions for BridgeHubRococo {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			SignedExtension::from_params(
+			TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -110,24 +111,6 @@ impl ChainWithTransactions for BridgeHubRococo {
 			extra,
 		))
 	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| {
-				*address == bp_bridge_hub_rococo::Address::Id(signer.public().into())
-			})
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()).tip(extra.tip()))
-	}
 }
 
 impl ChainWithMessages for BridgeHubRococo {
@@ -138,35 +121,4 @@ impl ChainWithMessages for BridgeHubRococo {
 		bp_bridge_hub_rococo::TO_BRIDGE_HUB_ROCOCO_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_rococo::FROM_BRIDGE_HUB_ROCOCO_MESSAGE_DETAILS_METHOD;
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use relay_substrate_client::TransactionEra;
-
-	type SystemCall = runtime_types::frame_system::pallet::Call;
-
-	#[test]
-	fn parse_transaction_works() {
-		let unsigned = UnsignedTransaction {
-			call: RuntimeCall::System(SystemCall::remark { remark: b"Hello world!".to_vec() })
-				.into(),
-			nonce: 777,
-			tip: 888,
-			era: TransactionEra::immortal(),
-		};
-		let signed_transaction = BridgeHubRococo::sign_transaction(
-			SignParam {
-				spec_version: 42,
-				transaction_version: 50000,
-				genesis_hash: [42u8; 32].into(),
-				signer: sp_core::sr25519::Pair::from_seed_slice(&[1u8; 32]).unwrap(),
-			},
-			unsigned.clone(),
-		)
-		.unwrap();
-		let parsed_transaction = BridgeHubRococo::parse_transaction(signed_transaction).unwrap();
-		assert_eq!(parsed_transaction, unsigned);
-	}
 }

--- a/relays/client-bridge-hub-westend/src/codegen_runtime.rs
+++ b/relays/client-bridge-hub-westend/src/codegen_runtime.rs
@@ -407,7 +407,7 @@ pub mod api {
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
 				pub struct RefundBridgedParachainMessages;
 				#[derive(:: codec :: Decode, :: codec :: Encode, Clone, Debug, PartialEq)]
-				pub struct RefundSignedExtensionAdapter<_0>(pub _0);
+				pub struct RefundTransactionExtensionAdapter<_0>(pub _0);
 			}
 		}
 		pub mod cumulus_pallet_parachain_system {

--- a/relays/client-bridge-hub-westend/src/lib.rs
+++ b/relays/client-bridge-hub-westend/src/lib.rs
@@ -18,8 +18,8 @@
 
 pub mod codegen_runtime;
 
-use bp_bridge_hub_westend::{SignedExtension, AVERAGE_BLOCK_INTERVAL};
-use bp_polkadot_core::SuffixedCommonSignedExtensionExt;
+use bp_bridge_hub_westend::{TransactionExtension, AVERAGE_BLOCK_INTERVAL};
+use bp_polkadot_core::SuffixedCommonTransactionExtensionExt;
 use codec::Encode;
 use relay_substrate_client::{
 	calls::UtilityCall as MockUtilityCall, Chain, ChainWithBalances, ChainWithMessages,
@@ -36,7 +36,8 @@ pub type RuntimeCall = runtime_types::bridge_hub_westend_runtime::RuntimeCall;
 pub type BridgeMessagesCall = runtime_types::pallet_bridge_messages::pallet::Call;
 pub type BridgeGrandpaCall = runtime_types::pallet_bridge_grandpa::pallet::Call;
 pub type BridgeParachainCall = runtime_types::pallet_bridge_parachains::pallet::Call;
-type UncheckedExtrinsic = bp_bridge_hub_westend::UncheckedExtrinsic<RuntimeCall, SignedExtension>;
+type UncheckedExtrinsic =
+	bp_bridge_hub_westend::UncheckedExtrinsic<RuntimeCall, TransactionExtension>;
 type UtilityCall = runtime_types::pallet_utility::pallet::Call;
 
 /// Westend chain definition
@@ -86,7 +87,7 @@ impl ChainWithTransactions for BridgeHubWestend {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			SignedExtension::from_params(
+			TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -108,24 +109,6 @@ impl ChainWithTransactions for BridgeHubWestend {
 			extra,
 		))
 	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| {
-				*address == bp_bridge_hub_westend::Address::Id(signer.public().into())
-			})
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()).tip(extra.tip()))
-	}
 }
 
 impl ChainWithMessages for BridgeHubWestend {
@@ -136,35 +119,4 @@ impl ChainWithMessages for BridgeHubWestend {
 		bp_bridge_hub_westend::TO_BRIDGE_HUB_WESTEND_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_westend::FROM_BRIDGE_HUB_WESTEND_MESSAGE_DETAILS_METHOD;
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-	use relay_substrate_client::TransactionEra;
-
-	type SystemCall = runtime_types::frame_system::pallet::Call;
-
-	#[test]
-	fn parse_transaction_works() {
-		let unsigned = UnsignedTransaction {
-			call: RuntimeCall::System(SystemCall::remark { remark: b"Hello world!".to_vec() })
-				.into(),
-			nonce: 777,
-			tip: 888,
-			era: TransactionEra::immortal(),
-		};
-		let signed_transaction = BridgeHubWestend::sign_transaction(
-			SignParam {
-				spec_version: 42,
-				transaction_version: 50000,
-				genesis_hash: [42u8; 32].into(),
-				signer: sp_core::sr25519::Pair::from_seed_slice(&[1u8; 32]).unwrap(),
-			},
-			unsigned.clone(),
-		)
-		.unwrap();
-		let parsed_transaction = BridgeHubWestend::parse_transaction(signed_transaction).unwrap();
-		assert_eq!(parsed_transaction, unsigned);
-	}
 }

--- a/relays/client-kusama/src/lib.rs
+++ b/relays/client-kusama/src/lib.rs
@@ -19,7 +19,7 @@
 pub mod codegen_runtime;
 
 use bp_kusama::{AccountInfoStorageMapKeyProvider, KUSAMA_SYNCED_HEADERS_GRANDPA_INFO_METHOD};
-use bp_polkadot_core::SuffixedCommonSignedExtensionExt;
+use bp_polkadot_core::SuffixedCommonTransactionExtensionExt;
 use codec::Encode;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithGrandpa, ChainWithTransactions, Error as SubstrateError,
@@ -83,7 +83,7 @@ impl RelayChain for Kusama {
 impl ChainWithTransactions for Kusama {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction =
-		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_kusama::SignedExtension>;
+		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_kusama::TransactionExtension>;
 
 	fn sign_transaction(
 		param: SignParam<Self>,
@@ -91,7 +91,7 @@ impl ChainWithTransactions for Kusama {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			bp_kusama::SignedExtension::from_params(
+			bp_kusama::TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -112,21 +112,5 @@ impl ChainWithTransactions for Kusama {
 			signature.into(),
 			extra,
 		))
-	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| *address == Address::Id(signer.public().into()))
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()).tip(extra.tip()))
 	}
 }

--- a/relays/client-polkadot-bulletin/src/lib.rs
+++ b/relays/client-polkadot-bulletin/src/lib.rs
@@ -99,8 +99,10 @@ impl ChainWithBalances for PolkadotBulletin {
 
 impl ChainWithTransactions for PolkadotBulletin {
 	type AccountKeyPair = sp_core::sr25519::Pair;
-	type SignedTransaction =
-		bp_polkadot_bulletin::UncheckedExtrinsic<Self::Call, bp_polkadot_bulletin::SignedExtension>;
+	type SignedTransaction = bp_polkadot_bulletin::UncheckedExtrinsic<
+		Self::Call,
+		bp_polkadot_bulletin::TransactionExtension,
+	>;
 
 	fn sign_transaction(
 		param: SignParam<Self>,
@@ -108,7 +110,7 @@ impl ChainWithTransactions for PolkadotBulletin {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			bp_polkadot_bulletin::SignedExtension::from_params(
+			bp_polkadot_bulletin::TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -127,21 +129,5 @@ impl ChainWithTransactions for PolkadotBulletin {
 			signature.into(),
 			extra,
 		))
-	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| *address == Address::Id(signer.public().into()))
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()))
 	}
 }

--- a/relays/client-polkadot/src/lib.rs
+++ b/relays/client-polkadot/src/lib.rs
@@ -19,7 +19,7 @@
 mod codegen_runtime;
 
 use bp_polkadot::{AccountInfoStorageMapKeyProvider, POLKADOT_SYNCED_HEADERS_GRANDPA_INFO_METHOD};
-use bp_polkadot_core::SuffixedCommonSignedExtensionExt;
+use bp_polkadot_core::SuffixedCommonTransactionExtensionExt;
 use codec::Encode;
 use relay_substrate_client::{
 	Chain, ChainWithBalances, ChainWithGrandpa, ChainWithTransactions, Error as SubstrateError,
@@ -83,7 +83,7 @@ impl RelayChain for Polkadot {
 impl ChainWithTransactions for Polkadot {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction =
-		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_polkadot::SignedExtension>;
+		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_polkadot::TransactionExtension>;
 
 	fn sign_transaction(
 		param: SignParam<Self>,
@@ -91,7 +91,7 @@ impl ChainWithTransactions for Polkadot {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			bp_polkadot::SignedExtension::from_params(
+			bp_polkadot::TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -112,21 +112,5 @@ impl ChainWithTransactions for Polkadot {
 			signature.into(),
 			extra,
 		))
-	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| *address == Address::Id(signer.public().into()))
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()).tip(extra.tip()))
 	}
 }

--- a/relays/client-rococo/src/lib.rs
+++ b/relays/client-rococo/src/lib.rs
@@ -18,7 +18,7 @@
 
 pub mod codegen_runtime;
 
-use bp_polkadot_core::SuffixedCommonSignedExtensionExt;
+use bp_polkadot_core::SuffixedCommonTransactionExtensionExt;
 use bp_rococo::ROCOCO_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 use codec::Encode;
 use relay_substrate_client::{
@@ -83,7 +83,7 @@ impl RelayChain for Rococo {
 impl ChainWithTransactions for Rococo {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction =
-		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_rococo::SignedExtension>;
+		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_rococo::TransactionExtension>;
 
 	fn sign_transaction(
 		param: SignParam<Self>,
@@ -91,7 +91,7 @@ impl ChainWithTransactions for Rococo {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			bp_rococo::SignedExtension::from_params(
+			bp_rococo::TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -112,21 +112,5 @@ impl ChainWithTransactions for Rococo {
 			signature.into(),
 			extra,
 		))
-	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| *address == Address::Id(signer.public().into()))
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()).tip(extra.tip()))
 	}
 }

--- a/relays/client-substrate/Cargo.toml
+++ b/relays/client-substrate/Cargo.toml
@@ -14,12 +14,12 @@ async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.1.5" }
 futures = "0.3.30"
 jsonrpsee = { version = "0.17", features = ["macros", "ws-client"] }
-log = "0.4.21"
+log = { workspace = true }
 num-traits = "0.2"
 rand = "0.8"
 scale-info = { version = "2.10.0", features = ["derive"] }
 tokio = { version = "1.36", features = ["rt-multi-thread"] }
-thiserror = "1.0.57"
+thiserror = { workspace = true }
 
 # Bridge dependencies
 

--- a/relays/client-substrate/src/chain.rs
+++ b/relays/client-substrate/src/chain.rs
@@ -203,17 +203,6 @@ pub trait ChainWithTransactions: Chain {
 	) -> Result<Self::SignedTransaction, crate::Error>
 	where
 		Self: Sized;
-
-	/// Returns true if transaction is signed.
-	fn is_signed(tx: &Self::SignedTransaction) -> bool;
-
-	/// Returns true if transaction is signed by given signer.
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool;
-
-	/// Parse signed transaction into its unsigned part.
-	///
-	/// Returns `None` if signed transaction has unsupported format.
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>>;
 }
 
 /// Sign transaction parameters

--- a/relays/client-westend/src/lib.rs
+++ b/relays/client-westend/src/lib.rs
@@ -18,7 +18,7 @@
 
 pub mod codegen_runtime;
 
-use bp_polkadot_core::SuffixedCommonSignedExtensionExt;
+use bp_polkadot_core::SuffixedCommonTransactionExtensionExt;
 use bp_westend::WESTEND_SYNCED_HEADERS_GRANDPA_INFO_METHOD;
 use codec::Encode;
 use relay_substrate_client::{
@@ -83,7 +83,7 @@ impl ChainWithBalances for Westend {
 impl ChainWithTransactions for Westend {
 	type AccountKeyPair = sp_core::sr25519::Pair;
 	type SignedTransaction =
-		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_westend::SignedExtension>;
+		bp_polkadot_core::UncheckedExtrinsic<Self::Call, bp_westend::TransactionExtension>;
 
 	fn sign_transaction(
 		param: SignParam<Self>,
@@ -91,7 +91,7 @@ impl ChainWithTransactions for Westend {
 	) -> Result<Self::SignedTransaction, SubstrateError> {
 		let raw_payload = SignedPayload::new(
 			unsigned.call,
-			bp_westend::SignedExtension::from_params(
+			bp_westend::TransactionExtension::from_params(
 				param.spec_version,
 				param.transaction_version,
 				unsigned.era,
@@ -112,21 +112,5 @@ impl ChainWithTransactions for Westend {
 			signature.into(),
 			extra,
 		))
-	}
-
-	fn is_signed(tx: &Self::SignedTransaction) -> bool {
-		tx.signature.is_some()
-	}
-
-	fn is_signed_by(signer: &Self::AccountKeyPair, tx: &Self::SignedTransaction) -> bool {
-		tx.signature
-			.as_ref()
-			.map(|(address, _, _)| *address == Address::Id(signer.public().into()))
-			.unwrap_or(false)
-	}
-
-	fn parse_transaction(tx: Self::SignedTransaction) -> Option<UnsignedTransaction<Self>> {
-		let extra = &tx.signature.as_ref()?.2;
-		Some(UnsignedTransaction::new(tx.function, extra.nonce()).tip(extra.tip()))
 	}
 }

--- a/relays/equivocation/Cargo.toml
+++ b/relays/equivocation/Cargo.toml
@@ -16,6 +16,6 @@ bp-header-chain = { path = "../../primitives/header-chain" }
 finality-relay = { path = "../finality" }
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
 futures = "0.3.30"
-log = "0.4.21"
+log = { workspace = true }
 num-traits = "0.2"
 relay-utils = { path = "../utils" }

--- a/relays/finality/Cargo.toml
+++ b/relays/finality/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 backoff = "0.4"
 bp-header-chain = { path = "../../primitives/header-chain" }
 futures = "0.3.30"
-log = "0.4.21"
+log = { workspace = true }
 num-traits = "0.2"
 relay-utils = { path = "../utils" }
 

--- a/relays/lib-substrate-relay/Cargo.toml
+++ b/relays/lib-substrate-relay/Cargo.toml
@@ -10,14 +10,14 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0"
-thiserror = "1.0.57"
+thiserror = { workspace = true }
 async-std = "1.9.0"
 async-trait = "0.1"
 codec = { package = "parity-scale-codec", version = "3.1.5" }
 futures = "0.3.30"
 hex = "0.4"
 num-traits = "0.2"
-log = "0.4.21"
+log = { workspace = true }
 
 # Bridge dependencies
 

--- a/relays/messages/Cargo.toml
+++ b/relays/messages/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 env_logger = "0.11"
 futures = "0.3.30"
 hex = "0.4"
-log = "0.4.21"
+log = { workspace = true }
 num-traits = "0.2"
 parking_lot = "0.12.1"
 

--- a/relays/parachains/Cargo.toml
+++ b/relays/parachains/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 async-std = "1.6.5"
 async-trait = "0.1"
 futures = "0.3.30"
-log = "0.4.21"
+log = { workspace = true }
 relay-utils = { path = "../utils" }
 
 # Bridge dependencies

--- a/relays/utils/Cargo.toml
+++ b/relays/utils/Cargo.toml
@@ -18,13 +18,13 @@ isahc = "1.2"
 env_logger = "0.11.3"
 futures = "0.3.30"
 jsonpath_lib = "0.3"
-log = "0.4.21"
+log = { workspace = true }
 num-traits = "0.2"
-serde_json = "1.0"
+serde_json = { workspace = true, default-features = true }
 sysinfo = "0.30"
 time = { version = "0.3", features = ["formatting", "local-offset", "std"] }
 tokio = { version = "1.36", features = ["rt"] }
-thiserror = "1.0.57"
+thiserror = { workspace = true }
 
 # Bridge dependencies
 

--- a/tools/runtime-codegen/Cargo.toml
+++ b/tools/runtime-codegen/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.4.6", features = ["derive", "cargo"] }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 color-eyre = "0.6.1"
 proc-macro2 = "1.0.56"
-quote = "1.0.28"
+quote = { workspace = true }
 subxt-codegen = { git = "https://github.com/paritytech/subxt", branch = "master", default-features = false, features = ["fetch-metadata"] }
 wasm-loader = { git = "https://github.com/chevdor/subwasm", branch = "master" }
 wasm-testbed = { git = "https://github.com/chevdor/subwasm", branch = "master" }


### PR DESCRIPTION
I've also removed couple of unused methods from `ChainWithTransactions` trait - they've been used before by transaction resubmitter, but now we rely on the priorities bump by signed extensions, so we don't need it now