### PR TITLE
Fixed dependency in runtime-codegen

### DIFF
--- a/tools/runtime-codegen/Cargo.toml
+++ b/tools/runtime-codegen/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.4.6", features = ["derive", "cargo"] }
 codec = { package = "parity-scale-codec", version = "3.1.5", default-features = false, features = ["derive"] }
 color-eyre = "0.6.1"
 proc-macro2 = "1.0.56"
-quote = { workspace = true }
+quote = { version = "1.0.33" }
 subxt-codegen = { git = "https://github.com/paritytech/subxt", branch = "master", default-features = false, features = ["fetch-metadata"] }
 wasm-loader = { git = "https://github.com/chevdor/subwasm", branch = "master" }
 wasm-testbed = { git = "https://github.com/chevdor/subwasm", branch = "master" }


### PR DESCRIPTION
Accidentaly broke it recently - runtime-codegen is not a part of workspace, so using "main" workspace deps there is not possible.