### PR TITLE
Relayer v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9029,7 +9029,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-relay"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-std",

--- a/relay-clients/client-bridge-hub-rococo/src/lib.rs
+++ b/relay-clients/client-bridge-hub-rococo/src/lib.rs
@@ -125,5 +125,5 @@ impl ChainWithMessages for BridgeHubRococo {
 
 impl ChainWithRuntimeVersion for BridgeHubRococo {
 	const RUNTIME_VERSION: Option<SimpleRuntimeVersion> =
-		Some(SimpleRuntimeVersion { spec_version: 1_008_000, transaction_version: 4 });
+		Some(SimpleRuntimeVersion { spec_version: 1_009_000, transaction_version: 4 });
 }

--- a/relay-clients/client-bridge-hub-westend/src/lib.rs
+++ b/relay-clients/client-bridge-hub-westend/src/lib.rs
@@ -123,5 +123,5 @@ impl ChainWithMessages for BridgeHubWestend {
 
 impl ChainWithRuntimeVersion for BridgeHubWestend {
 	const RUNTIME_VERSION: Option<SimpleRuntimeVersion> =
-		Some(SimpleRuntimeVersion { spec_version: 1_008_000, transaction_version: 4 });
+		Some(SimpleRuntimeVersion { spec_version: 1_009_000, transaction_version: 4 });
 }

--- a/relay-clients/client-rococo/src/lib.rs
+++ b/relay-clients/client-rococo/src/lib.rs
@@ -118,5 +118,5 @@ impl ChainWithTransactions for Rococo {
 
 impl ChainWithRuntimeVersion for Rococo {
 	const RUNTIME_VERSION: Option<SimpleRuntimeVersion> =
-		Some(SimpleRuntimeVersion { spec_version: 1_008_000, transaction_version: 24 });
+		Some(SimpleRuntimeVersion { spec_version: 1_009_000, transaction_version: 24 });
 }

--- a/relay-clients/client-westend/src/lib.rs
+++ b/relay-clients/client-westend/src/lib.rs
@@ -118,5 +118,5 @@ impl ChainWithTransactions for Westend {
 
 impl ChainWithRuntimeVersion for Westend {
 	const RUNTIME_VERSION: Option<SimpleRuntimeVersion> =
-		Some(SimpleRuntimeVersion { spec_version: 1_008_000, transaction_version: 24 });
+		Some(SimpleRuntimeVersion { spec_version: 1_009_000, transaction_version: 24 });
 }

--- a/substrate-relay/Cargo.toml
+++ b/substrate-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-relay"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
The main change is https://github.com/paritytech/parity-bridges-common/pull/2894 . It should help our devops team to handle upgrades better