### PR TITLE
Update CI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
   ARCH:                            "x86_64"
-  CI_IMAGE:                        "paritytech/ci-unified:latest"
+  CI_IMAGE:                        "paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408"
   RUST_BACKTRACE:                  full
   BUILDAH_IMAGE:                   "quay.io/buildah/stable:v1.29"
   BUILDAH_COMMAND:                 "buildah --storage-driver overlay2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2446,7 +2446,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
@@ -2475,7 +2475,7 @@ version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519 2.2.3",
  "hashbrown 0.14.3",
  "hex",
@@ -4918,7 +4918,7 @@ dependencies = [
  "bitflags 1.3.2",
  "blake2 0.10.6",
  "c2-chacha",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "either",
  "hashlink",
  "lioness",
@@ -5661,7 +5661,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -7807,7 +7807,7 @@ dependencies = [
  "aead",
  "arrayref",
  "arrayvec 0.7.4",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "getrandom_or_panic",
  "merlin",
  "rand_core 0.6.4",
@@ -8297,7 +8297,7 @@ dependencies = [
  "aes-gcm",
  "blake2 0.10.6",
  "chacha20poly1305",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "ring 0.17.8",
  "rustc_version",
@@ -8913,7 +8913,7 @@ version = "10.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#92e142555d45f97aa88d241665d9952d12f4ae40"
 dependencies = [
  "aes-gcm",
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "ed25519-dalek 2.1.1",
  "hkdf",
  "parity-scale-codec",
@@ -11085,7 +11085,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek 4.1.1",
+ "curve25519-dalek 4.1.2",
  "rand_core 0.6.4",
  "serde",
  "zeroize",

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-FROM docker.io/paritytech/ci-unified:latest as builder
+FROM docker.io/paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408 as builder
 USER root
 WORKDIR /parity-bridges-common
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Also you can build the repo with [Parity CI Docker
 image](https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-unified):
 
 ```bash
-docker pull paritytech/ci-unified:latest
+docker pull paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
 mkdir ~/cache
 chown 1000:1000 ~/cache #processes in the container runs as "nonroot" user with UID 1000
 docker run --rm -it -w /shellhere/parity-bridges-common \
@@ -49,7 +49,7 @@ docker run --rm -it -w /shellhere/parity-bridges-common \
                     -v "$(pwd)":/shellhere/parity-bridges-common \
                     -e CARGO_HOME=/cache/cargo/ \
                     -e SCCACHE_DIR=/cache/sccache/ \
-                    -e CARGO_TARGET_DIR=/cache/target/  paritytech/ci-unified:latest cargo build --all
+                    -e CARGO_TARGET_DIR=/cache/target/  paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408 cargo build --all
 #artifacts can be found in ~/cache/target
 ```
 


### PR DESCRIPTION
Update CI image with rust 1.77 and 2024-04-10

Fixes the dependabot CI failures: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/5923498

Related to https://github.com/paritytech/polkadot-sdk/pull/4077