### PR TITLE
Introduce compatible relayer version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "bp-bridge-hub-cumulus"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -1126,13 +1126,13 @@ dependencies = [
  "frame-system",
  "polkadot-primitives",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-kusama"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1140,13 +1140,13 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-polkadot"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1154,13 +1154,13 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-rococo"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1168,13 +1168,13 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-bridge-hub-westend"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-bridge-hub-cumulus",
  "bp-messages",
@@ -1182,13 +1182,13 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-header-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1199,26 +1199,26 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-kusama"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1227,13 +1227,13 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1244,26 +1244,26 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-polkadot"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-polkadot-bulletin"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1275,13 +1275,13 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-polkadot-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1293,13 +1293,13 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1307,26 +1307,26 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-rococo"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-runtime"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1341,7 +1341,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
  "trie-db",
 ]
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1362,35 +1362,35 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
 ]
 
 [[package]]
 name = "bp-westend"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
  "frame-support",
  "sp-api",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1401,7 +1401,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1409,6 +1409,7 @@ dependencies = [
  "bp-polkadot-core",
  "bp-relayers",
  "bp-runtime",
+ "bp-test-utils",
  "bp-xcm-bridge-hub",
  "bp-xcm-bridge-hub-router",
  "frame-support",
@@ -1422,12 +1423,13 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-utility",
  "parity-scale-codec",
+ "paste",
  "scale-info",
  "sp-api",
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
  "staging-xcm",
  "staging-xcm-builder",
@@ -2593,7 +2595,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "equivocation-detector"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2784,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "finality-relay"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2873,7 +2875,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2889,9 +2891,9 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "static_assertions",
 ]
 
@@ -2921,7 +2923,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.2",
@@ -2944,7 +2946,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-crypto-hashing-proc-macro",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
@@ -2952,8 +2954,8 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-weights",
  "static_assertions",
  "tt-call",
@@ -2962,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2974,14 +2976,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2 1.0.81",
  "quote 1.0.36",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "syn 2.0.60",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -2993,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -3003,7 +3005,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3015,7 +3017,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-version",
  "sp-weights",
 ]
@@ -4858,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "messages-relay"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5422,7 +5424,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5430,13 +5432,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5446,13 +5448,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5466,14 +5468,14 @@ dependencies = [
  "scale-info",
  "sp-consensus-grandpa",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -5485,13 +5487,13 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -5505,14 +5507,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bp-messages",
  "bp-relayers",
@@ -5526,13 +5528,13 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5549,13 +5551,13 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5570,14 +5572,14 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
 ]
 
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5589,15 +5591,15 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5607,13 +5609,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5625,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5635,13 +5637,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "parachains-relay"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5919,19 +5921,19 @@ checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -5941,14 +5943,14 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-weights",
 ]
 
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -5969,7 +5971,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
@@ -6872,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "relay-substrate-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6903,7 +6905,7 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
  "sp-version",
  "staging-xcm",
@@ -6914,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "relay-utils"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -7294,18 +7296,18 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "log",
  "sp-core",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-chain-spec"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "array-bytes 6.2.2",
  "docify",
@@ -7321,18 +7323,18 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.81",
@@ -7343,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "fnv",
  "futures",
@@ -7358,11 +7360,11 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-database",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-runtime",
  "sp-state-machine",
  "sp-statement-store",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
  "substrate-prometheus-endpoint",
 ]
@@ -7370,7 +7372,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-trait",
  "futures",
@@ -7395,7 +7397,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -7405,25 +7407,25 @@ dependencies = [
  "schnellru",
  "sp-api",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "thiserror",
  "wasm-instrument",
 ]
@@ -7431,18 +7433,18 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "log",
  "polkavm",
  "sc-executor-common",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7452,15 +7454,15 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -7489,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "array-bytes 6.2.2",
  "async-channel 1.9.0",
@@ -7540,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -7558,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bs58 0.4.0",
  "libp2p-identity",
@@ -7572,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.33.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7592,7 +7594,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "chrono",
  "futures",
@@ -7612,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-trait",
  "futures",
@@ -7628,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -8344,7 +8346,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "hash-db",
  "log",
@@ -8352,12 +8354,12 @@ dependencies = [
  "scale-info",
  "sp-api-proc-macro",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-metadata-ir",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
  "sp-version",
  "thiserror",
@@ -8366,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -8380,20 +8382,20 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -8401,7 +8403,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "static_assertions",
 ]
 
@@ -8426,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8438,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "futures",
  "log",
@@ -8456,7 +8458,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-trait",
  "futures",
@@ -8471,7 +8473,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -8488,7 +8490,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8499,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "array-bytes 6.2.2",
  "bandersnatch_vrfs",
@@ -8529,12 +8531,12 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -8580,7 +8582,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -8593,17 +8595,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "quote 1.0.36",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "syn 2.0.60",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -8612,7 +8614,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "proc-macro2 1.0.81",
  "quote 1.0.36",
@@ -8632,11 +8634,11 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
@@ -8652,7 +8654,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8664,7 +8666,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -8677,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.1.1",
@@ -8688,13 +8690,13 @@ dependencies = [
  "rustversion",
  "secp256k1",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-keystore",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -8703,7 +8705,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -8713,18 +8715,18 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -8733,7 +8735,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-metadata 16.0.0",
  "parity-scale-codec",
@@ -8743,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8754,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -8764,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -8774,7 +8776,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "docify",
  "either",
@@ -8791,26 +8793,26 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-weights",
 ]
 
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "polkavm-derive",
  "primitive-types",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "static_assertions",
 ]
 
@@ -8836,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "Inflector",
  "expander",
@@ -8862,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8876,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8889,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "hash-db",
  "log",
@@ -8898,7 +8900,7 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-panic-handler",
  "sp-trie",
  "thiserror",
@@ -8909,7 +8911,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek 4.1.2",
@@ -8922,10 +8924,10 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-runtime",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "thiserror",
  "x25519-dalek 2.0.1",
 ]
@@ -8933,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 
 [[package]]
 name = "sp-std"
@@ -8943,13 +8945,13 @@ source = "git+https://github.com/paritytech/polkadot-sdk#4eabe5e0dddc4cd31ad9dab
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
@@ -8967,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8979,7 +8981,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -9001,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "ahash 0.8.11",
  "hash-db",
@@ -9014,7 +9016,7 @@ dependencies = [
  "scale-info",
  "schnellru",
  "sp-core",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "thiserror",
  "tracing",
  "trie-db",
@@ -9024,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9033,7 +9035,7 @@ dependencies = [
  "serde",
  "sp-crypto-hashing-proc-macro",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-version-proc-macro",
  "thiserror",
 ]
@@ -9041,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2 1.0.81",
@@ -9052,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -9074,7 +9076,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -9082,7 +9084,7 @@ dependencies = [
  "serde",
  "smallvec",
  "sp-arithmetic",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
 ]
 
 [[package]]
@@ -9131,7 +9133,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "array-bytes 6.2.2",
  "bounded-collections",
@@ -9149,7 +9151,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9162,7 +9164,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-weights",
  "staging-xcm",
  "staging-xcm-executor",
@@ -9171,7 +9173,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9184,7 +9186,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests)",
  "sp-weights",
  "staging-xcm",
 ]
@@ -9276,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -9288,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "hyper",
  "log",
@@ -9354,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "substrate-relay-helper"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "anyhow",
  "async-std",
@@ -11135,7 +11137,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4eabe5e0dddc4cd31ad9dab5645350360d4d36a5"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=sv-bridge-relayer-compatibility-tests#2f3569dbb1b025f1bdb5c836a6539f515900ca18"
 dependencies = [
  "Inflector",
  "proc-macro2 1.0.81",

--- a/relay-clients/client-bridge-hub-kusama/Cargo.toml
+++ b/relay-clients/client-bridge-hub-kusama/Cargo.toml
@@ -16,17 +16,17 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-bridge-hub-kusama = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-bridge-hub-kusama = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-bridge-hub-kusama/src/lib.rs
+++ b/relay-clients/client-bridge-hub-kusama/src/lib.rs
@@ -52,6 +52,8 @@ impl Chain for BridgeHubKusama {
 	const NAME: &'static str = "BridgeHubKusama";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_kusama::BEST_FINALIZED_BRIDGE_HUB_KUSAMA_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_kusama::BRIDGE_HUB_KUSAMA_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = AVERAGE_BLOCK_INTERVAL;
 
 	type SignedBlock = bp_bridge_hub_kusama::SignedBlock;
@@ -115,6 +117,8 @@ impl ChainWithMessages for BridgeHubKusama {
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_kusama::WITH_BRIDGE_HUB_KUSAMA_RELAYERS_PALLET_NAME);
 
+	const WITH_CHAIN_COMPATIBLE_MESSAGES_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_kusama::FROM_BRIDGE_HUB_KUSAMA_MESSAGES_COMPATIBLE_RELAYER_VERSION;
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_kusama::TO_BRIDGE_HUB_KUSAMA_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =

--- a/relay-clients/client-bridge-hub-polkadot/Cargo.toml
+++ b/relay-clients/client-bridge-hub-polkadot/Cargo.toml
@@ -16,19 +16,19 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-bridge-hub-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-kusama = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-bridge-hub-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-kusama = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-bridge-hub-polkadot/src/lib.rs
+++ b/relay-clients/client-bridge-hub-polkadot/src/lib.rs
@@ -56,6 +56,8 @@ impl Chain for BridgeHubPolkadot {
 	const NAME: &'static str = "BridgeHubPolkadot";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_polkadot::BEST_FINALIZED_BRIDGE_HUB_POLKADOT_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_polkadot::BRIDGE_HUB_POLKADOT_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = AVERAGE_BLOCK_INTERVAL;
 
 	type SignedBlock = bp_bridge_hub_polkadot::SignedBlock;
@@ -119,6 +121,8 @@ impl ChainWithMessages for BridgeHubPolkadot {
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_polkadot::WITH_BRIDGE_HUB_POLKADOT_RELAYERS_PALLET_NAME);
 
+	const WITH_CHAIN_COMPATIBLE_MESSAGES_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_polkadot::FROM_BRIDGE_HUB_POLKADOT_MESSAGES_COMPATIBLE_RELAYER_VERSION;
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_polkadot::TO_BRIDGE_HUB_POLKADOT_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =

--- a/relay-clients/client-bridge-hub-rococo/Cargo.toml
+++ b/relay-clients/client-bridge-hub-rococo/Cargo.toml
@@ -16,18 +16,18 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-bridge-hub-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-bridge-hub-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
-bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-bridge-hub-rococo/src/lib.rs
+++ b/relay-clients/client-bridge-hub-rococo/src/lib.rs
@@ -54,6 +54,8 @@ impl Chain for BridgeHubRococo {
 	const NAME: &'static str = "BridgeHubRococo";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_rococo::BEST_FINALIZED_BRIDGE_HUB_ROCOCO_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_rococo::BRIDGE_HUB_ROCOCO_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = AVERAGE_BLOCK_INTERVAL;
 
 	type SignedBlock = bp_bridge_hub_rococo::SignedBlock;
@@ -117,6 +119,8 @@ impl ChainWithMessages for BridgeHubRococo {
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_rococo::WITH_BRIDGE_HUB_ROCOCO_RELAYERS_PALLET_NAME);
 
+	const WITH_CHAIN_COMPATIBLE_MESSAGES_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_rococo::FROM_BRIDGE_HUB_ROCOCO_MESSAGES_COMPATIBLE_RELAYER_VERSION;
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_rococo::TO_BRIDGE_HUB_ROCOCO_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =

--- a/relay-clients/client-bridge-hub-westend/Cargo.toml
+++ b/relay-clients/client-bridge-hub-westend/Cargo.toml
@@ -16,22 +16,22 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-bridge-hub-westend = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-bridge-hub-westend = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
-bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 [dev-dependencies]
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-bridge-hub-westend/src/lib.rs
+++ b/relay-clients/client-bridge-hub-westend/src/lib.rs
@@ -52,6 +52,8 @@ impl Chain for BridgeHubWestend {
 	const NAME: &'static str = "BridgeHubWestend";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_bridge_hub_westend::BEST_FINALIZED_BRIDGE_HUB_WESTEND_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_westend::BRIDGE_HUB_WESTEND_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = AVERAGE_BLOCK_INTERVAL;
 
 	type SignedBlock = bp_bridge_hub_westend::SignedBlock;
@@ -115,6 +117,8 @@ impl ChainWithMessages for BridgeHubWestend {
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		Some(bp_bridge_hub_westend::WITH_BRIDGE_HUB_WESTEND_RELAYERS_PALLET_NAME);
 
+	const WITH_CHAIN_COMPATIBLE_MESSAGES_RELAYER_VERSION_METHOD: &'static str =
+		bp_bridge_hub_westend::FROM_BRIDGE_HUB_WESTEND_MESSAGES_COMPATIBLE_RELAYER_VERSION;
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_bridge_hub_westend::TO_BRIDGE_HUB_WESTEND_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =

--- a/relay-clients/client-kusama/Cargo.toml
+++ b/relay-clients/client-kusama/Cargo.toml
@@ -16,17 +16,17 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-kusama = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-kusama = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-kusama/src/lib.rs
+++ b/relay-clients/client-kusama/src/lib.rs
@@ -58,6 +58,8 @@ impl Chain for Kusama {
 	const NAME: &'static str = "Kusama";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_kusama::BEST_FINALIZED_KUSAMA_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_kusama::KUSAMA_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = Duration::from_secs(6);
 
 	type SignedBlock = bp_kusama::SignedBlock;

--- a/relay-clients/client-polkadot-bulletin/Cargo.toml
+++ b/relay-clients/client-polkadot-bulletin/Cargo.toml
@@ -16,19 +16,19 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-bulletin = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-bulletin = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-polkadot-bulletin/src/lib.rs
+++ b/relay-clients/client-polkadot-bulletin/src/lib.rs
@@ -67,6 +67,8 @@ impl Chain for PolkadotBulletin {
 	const NAME: &'static str = "PolkadotBulletin";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_polkadot_bulletin::BEST_FINALIZED_POLKADOT_BULLETIN_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_polkadot_bulletin::POLKADOT_BULLETIN_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = Duration::from_secs(6);
 
 	type SignedBlock = bp_polkadot_bulletin::SignedBlock;
@@ -85,6 +87,8 @@ impl ChainWithMessages for PolkadotBulletin {
 	// to be changed when we'll polish the bridge configuration
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> = None;
 
+	const WITH_CHAIN_COMPATIBLE_MESSAGES_RELAYER_VERSION_METHOD: &'static str =
+		bp_polkadot_bulletin::FROM_POLKADOT_BULLETIN_MESSAGES_COMPATIBLE_RELAYER_VERSION;
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		bp_polkadot_bulletin::TO_POLKADOT_BULLETIN_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =

--- a/relay-clients/client-polkadot/Cargo.toml
+++ b/relay-clients/client-polkadot/Cargo.toml
@@ -16,17 +16,17 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-polkadot/src/lib.rs
+++ b/relay-clients/client-polkadot/src/lib.rs
@@ -58,6 +58,8 @@ impl Chain for Polkadot {
 	const NAME: &'static str = "Polkadot";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_polkadot::BEST_FINALIZED_POLKADOT_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_polkadot::POLKADOT_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = Duration::from_secs(6);
 
 	type SignedBlock = bp_polkadot::SignedBlock;

--- a/relay-clients/client-rococo/Cargo.toml
+++ b/relay-clients/client-rococo/Cargo.toml
@@ -16,16 +16,16 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-rococo/src/lib.rs
+++ b/relay-clients/client-rococo/src/lib.rs
@@ -58,6 +58,8 @@ impl Chain for Rococo {
 	const NAME: &'static str = "Rococo";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_rococo::BEST_FINALIZED_ROCOCO_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_rococo::ROCOCO_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = Duration::from_secs(6);
 
 	type SignedBlock = bp_rococo::SignedBlock;

--- a/relay-clients/client-westend/Cargo.toml
+++ b/relay-clients/client-westend/Cargo.toml
@@ -16,17 +16,17 @@ subxt = { version = "0.35.3", default-features = false, features = ["native"] }
 
 # Bridge dependencies
 
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-westend = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-westend = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-session = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }

--- a/relay-clients/client-westend/src/lib.rs
+++ b/relay-clients/client-westend/src/lib.rs
@@ -58,6 +58,8 @@ impl Chain for Westend {
 	const NAME: &'static str = "Westend";
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		bp_westend::BEST_FINALIZED_WESTEND_HEADER_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		bp_westend::WESTEND_FINALITY_COMPATIBLE_RELAYER_VERSION;
 	const AVERAGE_BLOCK_INTERVAL: Duration = Duration::from_secs(6);
 
 	type SignedBlock = bp_westend::SignedBlock;

--- a/substrate-relay/Cargo.toml
+++ b/substrate-relay/Cargo.toml
@@ -27,19 +27,19 @@ signal-hook-async-std = "0.2.2"
 strum = { version = "0.26.2", features = ["derive"] }
 
 # Bridge dependencies
-bp-bridge-hub-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-bridge-hub-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-bulletin = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-pallet-bridge-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-parachains-relay = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-bridge-hub-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-bridge-hub-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-header-chain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-messages = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-bulletin = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-polkadot-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-rococo = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+bridge-runtime-common = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+pallet-bridge-parachains = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+parachains-relay = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 relay-bridge-hub-kusama-client = { path = "../relay-clients/client-bridge-hub-kusama" }
 relay-bridge-hub-polkadot-client = { path = "../relay-clients/client-bridge-hub-polkadot" }
 relay-bridge-hub-rococo-client = { path = "../relay-clients/client-bridge-hub-rococo" }
@@ -48,20 +48,20 @@ relay-kusama-client = { path = "../relay-clients/client-kusama" }
 relay-polkadot-client = { path = "../relay-clients/client-polkadot" }
 relay-polkadot-bulletin-client = { path = "../relay-clients/client-polkadot-bulletin" }
 relay-rococo-client = { path = "../relay-clients/client-rococo" }
-relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+relay-substrate-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+relay-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 relay-westend-client = { path = "../relay-clients/client-westend" }
-substrate-relay-helper = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+substrate-relay-helper = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 # Substrate Dependencies
 
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 
 [dev-dependencies]
-bp-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+bp-test-utils = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 hex-literal = "0.4"
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "master" }
+sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", branch = "sv-bridge-relayer-compatibility-tests" }
 tempfile = "3.10"
 finality-grandpa = { version = "0.16.2" }

--- a/substrate-relay/src/bridges/kusama_polkadot/bridge_hub_kusama_messages_to_bridge_hub_polkadot.rs
+++ b/substrate-relay/src/bridges/kusama_polkadot/bridge_hub_kusama_messages_to_bridge_hub_polkadot.rs
@@ -16,6 +16,7 @@
 
 //! BridgeHubKusama-to-BridgeHubPolkadot messages sync entrypoint.
 
+use bp_runtime::RelayerVersion;
 use relay_bridge_hub_kusama_client::BridgeHubKusama;
 use relay_bridge_hub_polkadot_client::BridgeHubPolkadot;
 use substrate_relay_helper::{
@@ -55,6 +56,9 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct BridgeHubKusamaMessagesToBridgeHubPolkadotMessageLane;
 
 impl SubstrateMessageLane for BridgeHubKusamaMessagesToBridgeHubPolkadotMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceChain = BridgeHubKusama;
 	type TargetChain = BridgeHubPolkadot;
 

--- a/substrate-relay/src/bridges/kusama_polkadot/bridge_hub_polkadot_messages_to_bridge_hub_kusama.rs
+++ b/substrate-relay/src/bridges/kusama_polkadot/bridge_hub_polkadot_messages_to_bridge_hub_kusama.rs
@@ -16,6 +16,7 @@
 
 //! BridgeHubPolkadot-to-BridgeHubKusama messages sync entrypoint.
 
+use bp_runtime::RelayerVersion;
 use relay_bridge_hub_kusama_client::BridgeHubKusama;
 use relay_bridge_hub_polkadot_client::BridgeHubPolkadot;
 use substrate_relay_helper::{
@@ -55,6 +56,9 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct BridgeHubPolkadotMessagesToBridgeHubKusamaMessageLane;
 
 impl SubstrateMessageLane for BridgeHubPolkadotMessagesToBridgeHubKusamaMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceChain = BridgeHubPolkadot;
 	type TargetChain = BridgeHubKusama;
 

--- a/substrate-relay/src/bridges/kusama_polkadot/kusama_headers_to_bridge_hub_polkadot.rs
+++ b/substrate-relay/src/bridges/kusama_polkadot/kusama_headers_to_bridge_hub_polkadot.rs
@@ -21,6 +21,7 @@ use substrate_relay_helper::cli::bridge::{
 };
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -55,6 +56,7 @@ impl SubstrateFinalityPipeline for KusamaFinalityToBridgeHubPolkadot {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for KusamaFinalityToBridgeHubPolkadot {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/kusama_polkadot/kusama_parachains_to_bridge_hub_polkadot.rs
+++ b/substrate-relay/src/bridges/kusama_polkadot/kusama_parachains_to_bridge_hub_polkadot.rs
@@ -17,6 +17,7 @@
 //! Kusama-to-BridgeHubPolkadot parachains sync entrypoint.
 
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
+use bp_runtime::RelayerVersion;
 use relay_substrate_client::{CallOf, HeaderIdOf};
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge, ParachainToRelayHeadersCliBridge},
@@ -28,6 +29,8 @@ use substrate_relay_helper::{
 pub struct BridgeHubKusamaToBridgeHubPolkadot;
 
 impl SubstrateParachainsPipeline for BridgeHubKusamaToBridgeHubPolkadot {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceParachain = relay_bridge_hub_kusama_client::BridgeHubKusama;
 	type SourceRelayChain = relay_kusama_client::Kusama;
 	type TargetChain = relay_bridge_hub_polkadot_client::BridgeHubPolkadot;

--- a/substrate-relay/src/bridges/kusama_polkadot/polkadot_headers_to_bridge_hub_kusama.rs
+++ b/substrate-relay/src/bridges/kusama_polkadot/polkadot_headers_to_bridge_hub_kusama.rs
@@ -21,6 +21,7 @@ use substrate_relay_helper::cli::bridge::{
 };
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -55,6 +56,7 @@ impl SubstrateFinalityPipeline for PolkadotFinalityToBridgeHubKusama {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for PolkadotFinalityToBridgeHubKusama {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/kusama_polkadot/polkadot_parachains_to_bridge_hub_kusama.rs
+++ b/substrate-relay/src/bridges/kusama_polkadot/polkadot_parachains_to_bridge_hub_kusama.rs
@@ -17,6 +17,7 @@
 //! Polkadot-to-BridgeHubKusama parachains sync entrypoint.
 
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
+use bp_runtime::RelayerVersion;
 use relay_substrate_client::{CallOf, HeaderIdOf};
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge, ParachainToRelayHeadersCliBridge},
@@ -28,6 +29,8 @@ use substrate_relay_helper::{
 pub struct BridgeHubPolkadotToBridgeHubKusama;
 
 impl SubstrateParachainsPipeline for BridgeHubPolkadotToBridgeHubKusama {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceParachain = relay_bridge_hub_polkadot_client::BridgeHubPolkadot;
 	type SourceRelayChain = relay_polkadot_client::Polkadot;
 	type TargetChain = relay_bridge_hub_kusama_client::BridgeHubKusama;

--- a/substrate-relay/src/bridges/polkadot_bulletin/bridge_hub_polkadot_messages_to_polkadot_bulletin.rs
+++ b/substrate-relay/src/bridges/polkadot_bulletin/bridge_hub_polkadot_messages_to_polkadot_bulletin.rs
@@ -16,6 +16,7 @@
 
 //! BridgeHubPolkadot-to-PolkadotBulletin messages sync entrypoint.
 
+use bp_runtime::RelayerVersion;
 use relay_bridge_hub_polkadot_client::BridgeHubPolkadot;
 use relay_polkadot_bulletin_client::PolkadotBulletin;
 use substrate_relay_helper::{
@@ -56,6 +57,9 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct BridgeHubPolkadotMessagesToPolkadotBulletinMessageLane;
 
 impl SubstrateMessageLane for BridgeHubPolkadotMessagesToPolkadotBulletinMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceChain = BridgeHubPolkadot;
 	type TargetChain = PolkadotBulletin;
 

--- a/substrate-relay/src/bridges/polkadot_bulletin/polkadot_bulletin_headers_to_bridge_hub_polkadot.rs
+++ b/substrate-relay/src/bridges/polkadot_bulletin/polkadot_bulletin_headers_to_bridge_hub_polkadot.rs
@@ -17,6 +17,7 @@
 //! PolkadotBulletin-to-BridgeHubPolkadot headers sync entrypoint.
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -57,6 +58,7 @@ impl SubstrateFinalityPipeline for PolkadotBulletinFinalityToBridgeHubPolkadot {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for PolkadotBulletinFinalityToBridgeHubPolkadot {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/polkadot_bulletin/polkadot_bulletin_messages_to_bridge_hub_polkadot.rs
+++ b/substrate-relay/src/bridges/polkadot_bulletin/polkadot_bulletin_messages_to_bridge_hub_polkadot.rs
@@ -16,6 +16,7 @@
 
 //! PolkadotBulletin-to-BridgeHubPolkadot messages sync entrypoint.
 
+use bp_runtime::RelayerVersion;
 use relay_bridge_hub_polkadot_client::BridgeHubPolkadot;
 use relay_polkadot_bulletin_client::PolkadotBulletin;
 use substrate_relay_helper::{
@@ -56,6 +57,9 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct PolkadotBulletinMessagesToBridgeHubPolkadotMessageLane;
 
 impl SubstrateMessageLane for PolkadotBulletinMessagesToBridgeHubPolkadotMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceChain = PolkadotBulletin;
 	type TargetChain = BridgeHubPolkadot;
 

--- a/substrate-relay/src/bridges/polkadot_bulletin/polkadot_headers_to_polkadot_bulletin.rs
+++ b/substrate-relay/src/bridges/polkadot_bulletin/polkadot_headers_to_polkadot_bulletin.rs
@@ -17,6 +17,7 @@
 //! Polkadot-to-PolkadotBulletin headers sync entrypoint.
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -55,6 +56,7 @@ impl SubstrateFinalityPipeline for PolkadotFinalityToPolkadotBulletin {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for PolkadotFinalityToPolkadotBulletin {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/polkadot_bulletin/polkadot_parachains_to_polkadot_bulletin.rs
+++ b/substrate-relay/src/bridges/polkadot_bulletin/polkadot_parachains_to_polkadot_bulletin.rs
@@ -21,7 +21,7 @@ use substrate_relay_helper::cli::bridge::{
 };
 
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
-use bp_runtime::Chain;
+use bp_runtime::{Chain, RelayerVersion};
 use relay_substrate_client::{CallOf, HeaderIdOf};
 use substrate_relay_helper::{
 	messages_lane::MessagesRelayLimits,
@@ -33,6 +33,8 @@ use substrate_relay_helper::{
 pub struct PolkadotToPolkadotBulletin;
 
 impl SubstrateParachainsPipeline for PolkadotToPolkadotBulletin {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceParachain = relay_bridge_hub_polkadot_client::BridgeHubPolkadot;
 	type SourceRelayChain = relay_polkadot_client::Polkadot;
 	type TargetChain = relay_polkadot_bulletin_client::PolkadotBulletin;

--- a/substrate-relay/src/bridges/rococo_bulletin/bridge_hub_rococo_messages_to_rococo_bulletin.rs
+++ b/substrate-relay/src/bridges/rococo_bulletin/bridge_hub_rococo_messages_to_rococo_bulletin.rs
@@ -17,6 +17,7 @@
 //! BridgeHubRococo-to-RococoBulletin messages sync entrypoint.
 
 use super::BridgeHubRococoAsBridgeHubPolkadot;
+use bp_runtime::RelayerVersion;
 use relay_polkadot_bulletin_client::PolkadotBulletin as RococoBulletin;
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge},
@@ -55,6 +56,9 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct BridgeHubRococoMessagesToRococoBulletinMessageLane;
 
 impl SubstrateMessageLane for BridgeHubRococoMessagesToRococoBulletinMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceChain = BridgeHubRococoAsBridgeHubPolkadot;
 	type TargetChain = RococoBulletin;
 

--- a/substrate-relay/src/bridges/rococo_bulletin/mod.rs
+++ b/substrate-relay/src/bridges/rococo_bulletin/mod.rs
@@ -82,6 +82,8 @@ impl relay_substrate_client::Chain for RococoAsPolkadot {
 	const NAME: &'static str = relay_rococo_client::Rococo::NAME;
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		relay_polkadot_client::Polkadot::BEST_FINALIZED_HEADER_ID_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		relay_polkadot_client::Polkadot::WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD;
 	const AVERAGE_BLOCK_INTERVAL: Duration = relay_rococo_client::Rococo::AVERAGE_BLOCK_INTERVAL;
 
 	type SignedBlock = <relay_rococo_client::Rococo as relay_substrate_client::Chain>::SignedBlock;
@@ -181,6 +183,8 @@ impl relay_substrate_client::Chain for BridgeHubRococoAsBridgeHubPolkadot {
 	const NAME: &'static str = relay_bridge_hub_rococo_client::BridgeHubRococo::NAME;
 	const BEST_FINALIZED_HEADER_ID_METHOD: &'static str =
 		relay_bridge_hub_polkadot_client::BridgeHubPolkadot::BEST_FINALIZED_HEADER_ID_METHOD;
+	const WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD: &'static str =
+		relay_bridge_hub_rococo_client::BridgeHubRococo::WITH_CHAIN_COMPATIBLE_FINALITY_RELAYER_VERSION_METHOD;
 	const AVERAGE_BLOCK_INTERVAL: Duration =
 		relay_bridge_hub_rococo_client::BridgeHubRococo::AVERAGE_BLOCK_INTERVAL;
 
@@ -225,6 +229,8 @@ impl relay_substrate_client::ChainWithMessages for BridgeHubRococoAsBridgeHubPol
 	const WITH_CHAIN_RELAYERS_PALLET_NAME: Option<&'static str> =
 		relay_bridge_hub_polkadot_client::BridgeHubPolkadot::WITH_CHAIN_RELAYERS_PALLET_NAME;
 
+	const WITH_CHAIN_COMPATIBLE_MESSAGES_RELAYER_VERSION_METHOD: &'static str =
+	relay_bridge_hub_polkadot_client::BridgeHubPolkadot::WITH_CHAIN_COMPATIBLE_MESSAGES_RELAYER_VERSION_METHOD;
 	const TO_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =
 		relay_bridge_hub_polkadot_client::BridgeHubPolkadot::TO_CHAIN_MESSAGE_DETAILS_METHOD;
 	const FROM_CHAIN_MESSAGE_DETAILS_METHOD: &'static str =

--- a/substrate-relay/src/bridges/rococo_bulletin/rococo_bulletin_headers_to_bridge_hub_rococo.rs
+++ b/substrate-relay/src/bridges/rococo_bulletin/rococo_bulletin_headers_to_bridge_hub_rococo.rs
@@ -19,6 +19,7 @@
 use super::BridgeHubRococoAsBridgeHubPolkadot;
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -58,6 +59,7 @@ impl SubstrateFinalityPipeline for RococoBulletinFinalityToBridgeHubRococo {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for RococoBulletinFinalityToBridgeHubRococo {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/rococo_bulletin/rococo_bulletin_messages_to_bridge_hub_rococo.rs
+++ b/substrate-relay/src/bridges/rococo_bulletin/rococo_bulletin_messages_to_bridge_hub_rococo.rs
@@ -17,6 +17,7 @@
 //! RococoBulletin-to-BridgeHubRococo messages sync entrypoint.
 
 use super::BridgeHubRococoAsBridgeHubPolkadot;
+use bp_runtime::RelayerVersion;
 use relay_polkadot_bulletin_client::PolkadotBulletin as RococoBulletin;
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge},
@@ -55,6 +56,9 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct RococoBulletinMessagesToBridgeHubRococoMessageLane;
 
 impl SubstrateMessageLane for RococoBulletinMessagesToBridgeHubRococoMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceChain = RococoBulletin;
 	type TargetChain = BridgeHubRococoAsBridgeHubPolkadot;
 

--- a/substrate-relay/src/bridges/rococo_bulletin/rococo_headers_to_rococo_bulletin.rs
+++ b/substrate-relay/src/bridges/rococo_bulletin/rococo_headers_to_rococo_bulletin.rs
@@ -19,6 +19,7 @@
 use super::RococoAsPolkadot;
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -57,6 +58,7 @@ impl SubstrateFinalityPipeline for RococoFinalityToRococoBulletin {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for RococoFinalityToRococoBulletin {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/rococo_bulletin/rococo_parachains_to_rococo_bulletin.rs
+++ b/substrate-relay/src/bridges/rococo_bulletin/rococo_parachains_to_rococo_bulletin.rs
@@ -19,7 +19,7 @@
 use super::{BridgeHubRococoAsBridgeHubPolkadot, RococoAsPolkadot};
 
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
-use bp_runtime::Chain;
+use bp_runtime::{Chain, RelayerVersion};
 use relay_substrate_client::{CallOf, HeaderIdOf};
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge, ParachainToRelayHeadersCliBridge},
@@ -32,6 +32,8 @@ use substrate_relay_helper::{
 pub struct RococoToRococoBulletin;
 
 impl SubstrateParachainsPipeline for RococoToRococoBulletin {
+	const RELAYER_VERSION: Option<RelayerVersion> = None;
+
 	type SourceParachain = BridgeHubRococoAsBridgeHubPolkadot;
 	type SourceRelayChain = RococoAsPolkadot;
 	type TargetChain = relay_polkadot_bulletin_client::PolkadotBulletin;

--- a/substrate-relay/src/bridges/rococo_westend/bridge_hub_rococo_messages_to_bridge_hub_westend.rs
+++ b/substrate-relay/src/bridges/rococo_westend/bridge_hub_rococo_messages_to_bridge_hub_westend.rs
@@ -16,8 +16,11 @@
 
 //! BridgeHubRococo-to-BridgeHubWestend messages sync entrypoint.
 
+use bp_runtime::RelayerVersion;
+use hex_literal::hex;
 use relay_bridge_hub_rococo_client::BridgeHubRococo;
 use relay_bridge_hub_westend_client::BridgeHubWestend;
+use sp_core::H256;
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge},
 	messages_lane::SubstrateMessageLane,
@@ -54,6 +57,15 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct BridgeHubRococoMessagesToBridgeHubWestendMessageLane;
 
 impl SubstrateMessageLane for BridgeHubRococoMessagesToBridgeHubWestendMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
+
 	type SourceChain = BridgeHubRococo;
 	type TargetChain = BridgeHubWestend;
 

--- a/substrate-relay/src/bridges/rococo_westend/bridge_hub_westend_messages_to_bridge_hub_rococo.rs
+++ b/substrate-relay/src/bridges/rococo_westend/bridge_hub_westend_messages_to_bridge_hub_rococo.rs
@@ -16,8 +16,11 @@
 
 //! BridgeHubWestend-to-BridgeHubRococo messages sync entrypoint.
 
+use bp_runtime::RelayerVersion;
+use hex_literal::hex;
 use relay_bridge_hub_rococo_client::BridgeHubRococo;
 use relay_bridge_hub_westend_client::BridgeHubWestend;
+use sp_core::H256;
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge},
 	messages_lane::SubstrateMessageLane,
@@ -54,6 +57,15 @@ substrate_relay_helper::generate_receive_message_delivery_proof_call_builder!(
 pub struct BridgeHubWestendMessagesToBridgeHubRococoMessageLane;
 
 impl SubstrateMessageLane for BridgeHubWestendMessagesToBridgeHubRococoMessageLane {
+	const AT_SOURCE_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
+	const AT_TARGET_CHAIN_RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
+
 	type SourceChain = BridgeHubWestend;
 	type TargetChain = BridgeHubRococo;
 

--- a/substrate-relay/src/bridges/rococo_westend/rococo_headers_to_bridge_hub_westend.rs
+++ b/substrate-relay/src/bridges/rococo_westend/rococo_headers_to_bridge_hub_westend.rs
@@ -17,6 +17,9 @@
 //! Rococo-to-Westend bridge hubs headers sync entrypoint.
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
+use hex_literal::hex;
+use sp_core::H256;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -55,6 +58,10 @@ impl SubstrateFinalityPipeline for RococoFinalityToBridgeHubWestend {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for RococoFinalityToBridgeHubWestend {
+	const RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/rococo_westend/rococo_parachains_to_bridge_hub_westend.rs
+++ b/substrate-relay/src/bridges/rococo_westend/rococo_parachains_to_bridge_hub_westend.rs
@@ -17,7 +17,10 @@
 //! Westend-to-Rococo parachains sync entrypoint.
 
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
+use bp_runtime::RelayerVersion;
+use hex_literal::hex;
 use relay_substrate_client::{CallOf, HeaderIdOf};
+use sp_core::H256;
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge, ParachainToRelayHeadersCliBridge},
 	parachains::{SubmitParachainHeadsCallBuilder, SubstrateParachainsPipeline},
@@ -28,6 +31,11 @@ use substrate_relay_helper::{
 pub struct BridgeHubRococoToBridgeHubWestend;
 
 impl SubstrateParachainsPipeline for BridgeHubRococoToBridgeHubWestend {
+	const RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
+
 	type SourceParachain = relay_bridge_hub_rococo_client::BridgeHubRococo;
 	type SourceRelayChain = relay_rococo_client::Rococo;
 	type TargetChain = relay_bridge_hub_westend_client::BridgeHubWestend;

--- a/substrate-relay/src/bridges/rococo_westend/westend_headers_to_bridge_hub_rococo.rs
+++ b/substrate-relay/src/bridges/rococo_westend/westend_headers_to_bridge_hub_rococo.rs
@@ -17,6 +17,9 @@
 //! Westend-to-Rococo bridge hubs headers sync entrypoint.
 
 use async_trait::async_trait;
+use bp_runtime::RelayerVersion;
+use hex_literal::hex;
+use sp_core::H256;
 use substrate_relay_helper::{
 	equivocation::SubstrateEquivocationDetectionPipeline,
 	finality::SubstrateFinalitySyncPipeline,
@@ -55,6 +58,10 @@ impl SubstrateFinalityPipeline for WestendFinalityToBridgeHubRococo {
 
 #[async_trait]
 impl SubstrateFinalitySyncPipeline for WestendFinalityToBridgeHubRococo {
+	const RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
 	type SubmitFinalityProofCallBuilder = SubmitFinalityProofCallBuilder;
 }
 

--- a/substrate-relay/src/bridges/rococo_westend/westend_parachains_to_bridge_hub_rococo.rs
+++ b/substrate-relay/src/bridges/rococo_westend/westend_parachains_to_bridge_hub_rococo.rs
@@ -17,7 +17,10 @@
 //! Rococo-to-Westend parachains sync entrypoint.
 
 use bp_polkadot_core::parachains::{ParaHash, ParaHeadsProof, ParaId};
+use bp_runtime::RelayerVersion;
+use hex_literal::hex;
 use relay_substrate_client::{CallOf, HeaderIdOf};
+use sp_core::H256;
 use substrate_relay_helper::{
 	cli::bridge::{CliBridgeBase, MessagesCliBridge, ParachainToRelayHeadersCliBridge},
 	parachains::{SubmitParachainHeadsCallBuilder, SubstrateParachainsPipeline},
@@ -28,6 +31,11 @@ use substrate_relay_helper::{
 pub struct BridgeHubWestendToBridgeHubRococo;
 
 impl SubstrateParachainsPipeline for BridgeHubWestendToBridgeHubRococo {
+	const RELAYER_VERSION: Option<RelayerVersion> = Some(RelayerVersion {
+		manual: 0,
+		auto: H256(hex!("0000000000000000000000000000000000000000000000000000000000000000")),
+	});
+
 	type SourceParachain = relay_bridge_hub_westend_client::BridgeHubWestend;
 	type SourceRelayChain = relay_westend_client::Westend;
 	type TargetChain = relay_bridge_hub_rococo_client::BridgeHubRococo;


### PR DESCRIPTION
related to #2956

Opening this early, because I'm working on multiple branches and I don't want to get lost any of it. It is based upon https://github.com/paritytech/polkadot-sdk/tree/sv-bridge-relayer-compatibility-tests, which contains all main changes.