### PR TITLE
Update substrate-relayer version for release 1.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9761,7 +9761,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-relay"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anyhow",
  "async-std",

--- a/substrate-relay/Cargo.toml
+++ b/substrate-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-relay"
-version = "1.6.5"
+version = "1.6.6"
 authors.workspace = true
 edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"


### PR DESCRIPTION
## Testing 

- [x] polkadot-sdk tests passed: https://github.com/paritytech/parity-bridges-common/pull/3022#issuecomment-2225602169
- [x] fellows tests passed: `./run-test.sh 0001-polkadot-kusama-asset-transfer`