### PR TITLE
Fix deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,10 +107,10 @@ jobs:
             docker.io/paritytech/substrate-relay:${{ env.VERSION }}
             docker.io/paritytech/bridges-common-relay:${{ env.VERSION }}
 
-  deploy-westend:
-    name: Deploy Westend
+  deploy-chains:
+    name: Deploy Kusama/Polkadot Relay
     runs-on: ubuntu-latest
-    environment: parity-testnet
+    environment: parity-chains
     needs: [set-variables, build_push_docker]
     env:
       VERSION: ${{ needs.set-variables.outputs.VERSION }}
@@ -119,7 +119,7 @@ jobs:
       - name: Deploy to ArgoCD
         uses: paritytech/argocd-deployment-action@main
         with:
-          environment: "parity-testnet"
+          environment: "parity-chains"
           tag: "${{ env.VERSION }}"
           app_name: "bridges-common-relay"
           app_packages: "headers-a,headers-b,parachains-a,parachains-b,messages-a,messages-b"


### PR DESCRIPTION
Fixes https://github.com/paritytech/devops/issues/3599

Since rococo is removeв we don't have testnet deployment until westend-paseo bridge is setup [see](https://github.com/paritytech/devops-cloud-infra/blob/69e882718fde70c36f7d495360bc418da2c7cfe9/kubernetes/00-meta-app/values-parity-testnet.yaml#L26).

