### PR TITLE
Align rust version with CI image's Rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.81.0"
+components = ["rust-src", "rust-analyzer"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.84.1"
-components = ["rust-src", "rust-analyzer"]
+components = ["clippy", "rust-src", "rustfmt"]
 targets = [ "x86_64-unknown-linux-gnu", "wasm32v1-none" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.84.1"
 components = ["rust-src", "rust-analyzer"]
+targets = [ "x86_64-unknown-linux-gnu", "wasm32v1-none" ]


### PR DESCRIPTION
Current CI Image is paritytech/ci-unified:bullseye-1.81.0-2024-09-11-v202409111034

This also helps with Cargo.lock version issue: 
- https://github.com/polkadot-fellows/runtimes/pull/541#discussion_r1919787118
- https://github.com/paritytech/parity-bridges-common/pull/3104#discussion_r1940847270

Version of rust < 1.83 uses version "3" in Cargo.lock while version >= 1.83 uses version "4" in Cargo.lock.
This PR also solves this issue while keeping aligned with rust version used in github CI image. Which will eliminate back-and-forth build failures caused due to rust version mismatches.