### PR TITLE
Add Grafana-to-GitHub alert bridge and agent workflow

### DIFF
--- a/.github/workflows/claude-sre.yml
+++ b/.github/workflows/claude-sre.yml
@@ -1,0 +1,31 @@
+name: Claude SRE Agent
+
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # Run when:
+    # - issue is opened/labeled with "claude"
+    # - someone comments @claude on an issue
+    if: |
+      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      # Grafana API access for live metric queries.
+      # Claude can use: curl -H "Authorization: Bearer $GRAFANA_TOKEN" "$GRAFANA_URL/api/..."
+      GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+      GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          label_trigger: "claude"
+          trigger_phrase: "@claude"

--- a/deployments/bridges/grafana-github-bridge/README.md
+++ b/deployments/bridges/grafana-github-bridge/README.md
@@ -1,0 +1,45 @@
+# grafana-github-bridge
+
+Cloudflare Worker that converts Grafana Alertmanager webhook POSTs into GitHub issues assigned to `claude[bot]`.
+
+```
+Grafana alert fires → POST webhook → this Worker → GitHub Issue (label: claude)
+```
+
+## Deploy
+
+```bash
+npm install
+npx wrangler secret put GITHUB_TOKEN      # PAT with issues:write scope
+npx wrangler secret put WEBHOOK_SECRET     # optional, shared secret
+npx wrangler deploy
+```
+
+The deploy prints the worker URL, e.g. `https://grafana-github-bridge.<account>.workers.dev`.
+
+## Configure Grafana
+
+1. **Alerting → Contact points → New contact point**
+2. Name: `GitHub parity-bridges-common`
+3. Integration: `Webhook`
+4. URL: `https://grafana-github-bridge.<account>.workers.dev`
+5. (Optional) Expand **Optional Webhook settings** → add header `Authorization: Bearer <WEBHOOK_SECRET>`
+6. **Save contact point**
+7. **Alerting → Notification policies** → route bridge alerts to this contact point
+
+## Test
+
+```bash
+# Local
+npx wrangler dev
+WORKER_URL=http://localhost:8787 node test.js
+
+# Production (dry run — creates a real issue)
+WORKER_URL=https://grafana-github-bridge.<account>.workers.dev node test.js
+```
+
+## Monitor
+
+- **Worker metrics**: Cloudflare dashboard → Workers → grafana-github-bridge → Metrics (request count, errors, latency)
+- **Logs**: `npx wrangler tail` for real-time logs
+- **GitHub side**: search `label:alert label:claude` in the repo issues

--- a/deployments/bridges/grafana-github-bridge/package.json
+++ b/deployments/bridges/grafana-github-bridge/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "grafana-github-bridge",
+	"private": true,
+	"scripts": {
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy",
+		"test": "node test.js"
+	},
+	"devDependencies": {
+		"wrangler": "^3"
+	}
+}

--- a/deployments/bridges/grafana-github-bridge/src/index.js
+++ b/deployments/bridges/grafana-github-bridge/src/index.js
@@ -1,0 +1,118 @@
+/**
+ * Grafana → GitHub Issue bridge.
+ *
+ * Receives Grafana Alertmanager webhook POSTs and creates GitHub issues
+ * assigned to claude[bot] with the "claude" label.
+ *
+ * Environment variables (set as Worker secrets):
+ *   GITHUB_TOKEN  – GitHub PAT with `issues:write` scope
+ *   WEBHOOK_SECRET – (optional) shared secret for request validation
+ */
+
+const REPO = 'paritytech/parity-bridges-common';
+
+export default {
+	async fetch(request, env) {
+		if (request.method !== 'POST') {
+			return new Response('Method not allowed', { status: 405 });
+		}
+
+		if (env.WEBHOOK_SECRET) {
+			const auth = request.headers.get('Authorization');
+			if (auth !== `Bearer ${env.WEBHOOK_SECRET}`) {
+				return new Response('Unauthorized', { status: 401 });
+			}
+		}
+
+		let payload;
+		try {
+			payload = await request.json();
+		} catch {
+			return new Response('Invalid JSON', { status: 400 });
+		}
+
+		const alerts = payload.alerts || [];
+		const results = [];
+
+		for (const alert of alerts) {
+			if (alert.status !== 'firing') continue;
+
+			const alertname = alert.labels?.alertname || 'Unknown alert';
+			const title = `[Alert] ${alertname}`;
+			const body = formatBody(alert, payload);
+
+			const resp = await fetch(
+				`https://api.github.com/repos/${REPO}/issues`,
+				{
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+						Accept: 'application/vnd.github+json',
+						'User-Agent': 'grafana-github-bridge',
+					},
+					body: JSON.stringify({
+						title,
+						body,
+						labels: ['alert', 'claude'],
+						assignees: [],
+					}),
+				},
+			);
+
+			results.push({
+				alertname,
+				status: resp.status,
+				issue: resp.status === 201 ? (await resp.json()).html_url : null,
+			});
+		}
+
+		return Response.json({ processed: results.length, results });
+	},
+};
+
+function formatBody(alert, payload) {
+	const labels = alert.labels || {};
+	const annotations = alert.annotations || {};
+	const values = alert.values || {};
+
+	const lines = [
+		`**Alert:** ${labels.alertname || 'N/A'}`,
+		`**Status:** ${alert.status}`,
+		`**Severity:** ${labels.severity || 'unknown'}`,
+		`**Bridge:** ${labels.bridge || labels.domain || 'N/A'}`,
+		'',
+		annotations.summary ? `**Summary:** ${annotations.summary}` : null,
+		annotations.description
+			? `**Description:** ${annotations.description}`
+			: null,
+		'',
+		`**Started:** ${alert.startsAt || 'N/A'}`,
+		alert.generatorURL ? `**Source:** ${alert.generatorURL}` : null,
+		payload.externalURL
+			? `**Grafana:** ${payload.externalURL}`
+			: null,
+	];
+
+	// Include current metric values from the alert evaluation
+	if (Object.keys(values).length > 0) {
+		lines.push('', '### Current Metric Values', '');
+		for (const [key, val] of Object.entries(values)) {
+			lines.push(`- **${key}:** \`${val}\``);
+		}
+	}
+
+	lines.push(
+		'',
+		'---',
+		'',
+		'<details><summary>Raw alert payload</summary>',
+		'',
+		'```json',
+		JSON.stringify(alert, null, 2),
+		'```',
+		'',
+		'</details>',
+	);
+
+	return lines.filter((l) => l !== null).join('\n');
+}

--- a/deployments/bridges/grafana-github-bridge/test.js
+++ b/deployments/bridges/grafana-github-bridge/test.js
@@ -1,0 +1,48 @@
+/**
+ * Quick smoke test — sends a fake Grafana alert payload to the worker.
+ *
+ * Usage:
+ *   WORKER_URL=http://localhost:8787 node test.js
+ *   WORKER_URL=https://grafana-github-bridge.<account>.workers.dev node test.js
+ */
+
+const url = process.env.WORKER_URL || 'http://localhost:8787';
+const secret = process.env.WEBHOOK_SECRET;
+
+const payload = {
+	receiver: 'github-parity-bridges-common',
+	status: 'firing',
+	alerts: [
+		{
+			status: 'firing',
+			labels: {
+				alertname: 'Polkadot -> KusamaBridgeHub finality sync lags (00000001)',
+				severity: 'critical',
+				domain: 'parity-chains',
+				bridge: 'kusama-polkadot',
+			},
+			annotations: {
+				summary: 'Polkadot finality headers not advancing at KusamaBridgeHub',
+				description:
+					'increase(Polkadot_to_BridgeHubKusama_Sync_best_source_at_target_block_number[24h]) < 5000',
+			},
+			startsAt: new Date().toISOString(),
+			generatorURL: 'https://grafana.teleport.parity.io/alerting/list',
+		},
+	],
+	externalURL: 'https://grafana.teleport.parity.io',
+};
+
+const headers = { 'Content-Type': 'application/json' };
+if (secret) headers['Authorization'] = `Bearer ${secret}`;
+
+fetch(url, {
+	method: 'POST',
+	headers,
+	body: JSON.stringify(payload),
+})
+	.then(async (r) => {
+		console.log(`Status: ${r.status}`);
+		console.log(await r.json());
+	})
+	.catch(console.error);

--- a/deployments/bridges/grafana-github-bridge/wrangler.toml
+++ b/deployments/bridges/grafana-github-bridge/wrangler.toml
@@ -1,0 +1,7 @@
+name = "grafana-github-bridge"
+main = "src/index.js"
+compatibility_date = "2024-01-01"
+
+# Secrets (set via `wrangler secret put`):
+#   GITHUB_TOKEN   – GitHub PAT with issues:write scope
+#   WEBHOOK_SECRET – optional shared secret for Grafana Authorization header


### PR DESCRIPTION
## Summary
Wires Grafana alerts to the agent workflow:

- **Cloudflare Worker** (`deployments/bridges/grafana-github-bridge/`): receives Grafana Alertmanager webhook POSTs, extracts alert context and current metric values, creates GitHub issues with the `claude` label
- **GitHub Actions workflow** (`.github/workflows/claude-sre.yml`): triggers on labeled issues, runs the agent with repo access and operational skills

### Why a Worker is needed
Grafana's only contact point option is a generic webhook. It sends Alertmanager-format JSON which is incompatible with GitHub's Issues API format. The Worker translates between the two.

### Metric access
Live Grafana API is behind Teleport and unreachable from GitHub runners. Instead, current metric values travel through the webhook payload into the issue body.

## Setup (after merge)
1. Deploy Worker: `cd deployments/bridges/grafana-github-bridge && npm install && npx wrangler deploy`
2. Add repo secrets: `ANTHROPIC_API_KEY`
3. Grafana: create contact point with Worker URL, route bridge alerts to it

## Stack
- PR 1/3: CLAUDE.md → `master`
- PR 2/3: operational skills → PR 1
- **PR 3/3** (this) → PR 2