### PR TITLE
ci: check tools/runtime-codegen and refresh Cargo.lock on release

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -18,7 +18,7 @@ concurrency:
 # common variable is defined in the workflow
 # repo env variable doesn't work for PR from forks
 env:
-  CI_IMAGE: "paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220"
+  CI_IMAGE: "paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202507112050"
 
 #to use reusable workflow
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 # common variable is defined in the workflow
 # repo env variable doesn't work for PR from forks
 env:
-  CI_IMAGE: "paritytech/ci-unified:bullseye-1.84.1-2025-01-28-v202502131220"
+  CI_IMAGE: "paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202507112050"
 
 jobs:
   set-variables:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,19 @@ jobs:
       - name: Check
         run: SKIP_WASM_BUILD=1 time cargo check --locked  --workspace
 
+  check-runtime-codegen:
+    name: Check runtime-codegen
+    runs-on: ubuntu-latest
+    needs: [set-variables]
+    container:
+      image: ${{ needs.set-variables.outputs.CI_IMAGE }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Check
+        run: SKIP_WASM_BUILD=1 time cargo check --locked --manifest-path tools/runtime-codegen/Cargo.toml
+
   test:
     name: Test
     runs-on: parity-large

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,9 @@ jobs:
           echo "Bumping relayer version from $current_version to $new_version"
           sed -i "s/version = \"$current_version\"/version = \"$new_version\"/" substrate-relay/Cargo.toml
 
+          # Refresh Cargo.lock for the bumped workspace member only (no network, no recompile).
+          cargo update -p substrate-relay --offline
+
       - name: Fix Header generic types & Format code
         run: |
           cargo +nightly fmt --all

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See the `deployments/README.md` for all the available `PROJECT` values.
 
-FROM docker.io/paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408 as builder
+FROM docker.io/paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202507112050 as builder
 USER root
 WORKDIR /parity-bridges-common
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Also you can build the repo with [Parity CI Docker
 image](https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-unified):
 
 ```bash
-docker pull paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
+docker pull paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202507112050
 mkdir ~/cache
 chown 1000:1000 ~/cache #processes in the container runs as "nonroot" user with UID 1000
 docker run --rm -it -w /shellhere/parity-bridges-common \
@@ -49,7 +49,7 @@ docker run --rm -it -w /shellhere/parity-bridges-common \
                     -v "$(pwd)":/shellhere/parity-bridges-common \
                     -e CARGO_HOME=/cache/cargo/ \
                     -e SCCACHE_DIR=/cache/sccache/ \
-                    -e CARGO_TARGET_DIR=/cache/target/  paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408 cargo build --all
+                    -e CARGO_TARGET_DIR=/cache/target/  paritytech/ci-unified:bullseye-1.88.0-2025-06-27-v202507112050 cargo build --all
 #artifacts can be found in ~/cache/target
 ```
 


### PR DESCRIPTION
- Add a CI job that runs `cargo check` against the standalone `tools/runtime-codegen` workspace so breakage is caught on PRs.
- In the release workflow, refresh the main `Cargo.lock` via `cargo update -p substrate-relay --offline` right after the version bump so the lockfile change lands in the release PR.