### PR TITLE
fix: failed to load dep due to --offline flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,11 @@ jobs:
       - name: Bump minor version in Cargo.toml
         id: bump-version
         run: |
+          # Populate the cargo cache (incl. polkadot-sdk git deps) so the offline
+          # `cargo update` below can resolve. Runs before the version bump so the
+          # `--locked` check still sees a matching Cargo.lock. No recompile.
+          cargo fetch --locked
+
           # Get current version and bump minor version
           current_version=$(grep '^version = ' substrate-relay/Cargo.toml | cut -d'"' -f2)
           major=$(echo "$current_version" | cut -d. -f1)


### PR DESCRIPTION
Fixing CI failure: https://github.com/paritytech/parity-bridges-common/actions/runs/27418599329/job/81037846800#step:9:28


```
Caused by:
  failed to load source for dependency `bp-asset-hub-rococo`
```