### PR TITLE
dependabot: group security-update bumps into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       update-types:
         - minor
         - patch
+    # Batch security-alert bumps as well, instead of one PR per dependency.
+    cargo-security:
+      applies-to: security-updates
+      patterns:
+        - "*"
   ignore:
   # Bridges polkadot-sdk dependencies
   - dependency-name: bp-*


### PR DESCRIPTION
Security-alert PRs (like the recent keccak #3240 / rand #3268 bumps for `tools/runtime-codegen`) are opened one per dependency by default; the `cargo-minor-and-patch` group added in #3280 only applies to `version-updates`.

Add a `cargo-security` group with `applies-to: security-updates` (matching all dependencies) so security bumps get batched into a single PR per directory as well.

Note: grouping is not retroactive — any currently open security PRs stay individual until closed and re-created on the next Dependabot run.